### PR TITLE
feat: add standalone Sky Compass card with multi-entry overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ Custom Lovelace card for the [Adaptive Cover Pro](https://github.com/jrhubott/ad
 - **Cover positions** — live actual position per cover, with the target as a marker and mismatch warnings. Click the track to set a position.
 - **Overrides panel** — manual override countdown, force-override status, motion timeout, and a one-click reset button.
 
+## Cards in this bundle
+
+| Card | Type | Summary |
+|------|------|---------|
+| Adaptive Cover Pro | `custom:adaptive-cover-pro-card` | The full card — pick one integration entry, get every section (sky, decisions, covers, overrides, climate). |
+| Adaptive Cover Pro — Sky Compass | `custom:adaptive-cover-pro-sky-compass-card` | Sky compass only. Accepts **multiple** integration entries; overlays each window's FOV, blind spot, and cover-closure wedge on a single compass with a shared sun dot. |
+
 ## Quick install
 
 **HACS (recommended):**
@@ -39,12 +46,33 @@ Custom Lovelace card for the [Adaptive Cover Pro](https://github.com/jrhubott/ad
 
 ## Usage
 
+**Full card:**
 ```yaml
 type: custom:adaptive-cover-pro-card
 entry_id: YOUR_CONFIG_ENTRY_ID   # find this under Settings → Devices & Services
 # optional:
 show_sections: [sky, decision, covers, overrides]
 compact: false
+```
+
+**Standalone Sky Compass** (one or more entries):
+```yaml
+type: custom:adaptive-cover-pro-sky-compass-card
+entry_ids:
+  - KITCHEN_ENTRY_ID
+  - LIVING_ROOM_ENTRY_ID
+# optional:
+title: West-facing windows
+compact: false
+show_legend: true
+show_stats: true
+show_moon: false
+show_blind_spot: true
+show_window_arrow: true
+show_cover_fill: true
+show_sun_path: true
+show_sunrise_sunset: true
+show_cardinals: true
 ```
 
 Find your `entry_id` on the integration's URL:

--- a/dist/adaptive-cover-pro-card.js
+++ b/dist/adaptive-cover-pro-card.js
@@ -1,5 +1,5 @@
 /*! adaptive-cover-pro-card v1.3.0 | MIT License | https://github.com/jrhubott/adaptive-cover-pro-card */
-function t(t,e,i,s){var o,n=arguments.length,r=n<3?e:null===s?s=Object.getOwnPropertyDescriptor(e,i):s;if("object"==typeof Reflect&&"function"==typeof Reflect.decorate)r=Reflect.decorate(t,e,i,s);else for(var a=t.length-1;a>=0;a--)(o=t[a])&&(r=(n<3?o(r):n>3?o(e,i,r):o(e,i))||r);return n>3&&r&&Object.defineProperty(e,i,r),r}"function"==typeof SuppressedError&&SuppressedError;const e=globalThis,i=e.ShadowRoot&&(void 0===e.ShadyCSS||e.ShadyCSS.nativeShadow)&&"adoptedStyleSheets"in Document.prototype&&"replace"in CSSStyleSheet.prototype,s=Symbol(),o=new WeakMap;let n=class{constructor(t,e,i){if(this._$cssResult$=!0,i!==s)throw Error("CSSResult is not constructable. Use `unsafeCSS` or `css` instead.");this.cssText=t,this.t=e}get styleSheet(){let t=this.o;const e=this.t;if(i&&void 0===t){const i=void 0!==e&&1===e.length;i&&(t=o.get(e)),void 0===t&&((this.o=t=new CSSStyleSheet).replaceSync(this.cssText),i&&o.set(e,t))}return t}toString(){return this.cssText}};const r=(t,...e)=>{const i=1===t.length?t[0]:e.reduce((e,i,s)=>e+(t=>{if(!0===t._$cssResult$)return t.cssText;if("number"==typeof t)return t;throw Error("Value passed to 'css' function must be a 'css' function result: "+t+". Use 'unsafeCSS' to pass non-literal values, but take care to ensure page security.")})(i)+t[s+1],t[0]);return new n(i,t,s)},a=i?t=>t:t=>t instanceof CSSStyleSheet?(t=>{let e="";for(const i of t.cssRules)e+=i.cssText;return(t=>new n("string"==typeof t?t:t+"",void 0,s))(e)})(t):t,{is:l,defineProperty:c,getOwnPropertyDescriptor:d,getOwnPropertyNames:h,getOwnPropertySymbols:p,getPrototypeOf:u}=Object,g=globalThis,v=g.trustedTypes,_=v?v.emptyScript:"",m=g.reactiveElementPolyfillSupport,f=(t,e)=>t,y={toAttribute(t,e){switch(e){case Boolean:t=t?_:null;break;case Object:case Array:t=null==t?t:JSON.stringify(t)}return t},fromAttribute(t,e){let i=t;switch(e){case Boolean:i=null!==t;break;case Number:i=null===t?null:Number(t);break;case Object:case Array:try{i=JSON.parse(t)}catch(t){i=null}}return i}},$=(t,e)=>!l(t,e),b={attribute:!0,type:String,converter:y,reflect:!1,useDefault:!1,hasChanged:$};Symbol.metadata??=Symbol("metadata"),g.litPropertyMetadata??=new WeakMap;let x=class extends HTMLElement{static addInitializer(t){this._$Ei(),(this.l??=[]).push(t)}static get observedAttributes(){return this.finalize(),this._$Eh&&[...this._$Eh.keys()]}static createProperty(t,e=b){if(e.state&&(e.attribute=!1),this._$Ei(),this.prototype.hasOwnProperty(t)&&((e=Object.create(e)).wrapped=!0),this.elementProperties.set(t,e),!e.noAccessor){const i=Symbol(),s=this.getPropertyDescriptor(t,i,e);void 0!==s&&c(this.prototype,t,s)}}static getPropertyDescriptor(t,e,i){const{get:s,set:o}=d(this.prototype,t)??{get(){return this[e]},set(t){this[e]=t}};return{get:s,set(e){const n=s?.call(this);o?.call(this,e),this.requestUpdate(t,n,i)},configurable:!0,enumerable:!0}}static getPropertyOptions(t){return this.elementProperties.get(t)??b}static _$Ei(){if(this.hasOwnProperty(f("elementProperties")))return;const t=u(this);t.finalize(),void 0!==t.l&&(this.l=[...t.l]),this.elementProperties=new Map(t.elementProperties)}static finalize(){if(this.hasOwnProperty(f("finalized")))return;if(this.finalized=!0,this._$Ei(),this.hasOwnProperty(f("properties"))){const t=this.properties,e=[...h(t),...p(t)];for(const i of e)this.createProperty(i,t[i])}const t=this[Symbol.metadata];if(null!==t){const e=litPropertyMetadata.get(t);if(void 0!==e)for(const[t,i]of e)this.elementProperties.set(t,i)}this._$Eh=new Map;for(const[t,e]of this.elementProperties){const i=this._$Eu(t,e);void 0!==i&&this._$Eh.set(i,t)}this.elementStyles=this.finalizeStyles(this.styles)}static finalizeStyles(t){const e=[];if(Array.isArray(t)){const i=new Set(t.flat(1/0).reverse());for(const t of i)e.unshift(a(t))}else void 0!==t&&e.push(a(t));return e}static _$Eu(t,e){const i=e.attribute;return!1===i?void 0:"string"==typeof i?i:"string"==typeof t?t.toLowerCase():void 0}constructor(){super(),this._$Ep=void 0,this.isUpdatePending=!1,this.hasUpdated=!1,this._$Em=null,this._$Ev()}_$Ev(){this._$ES=new Promise(t=>this.enableUpdating=t),this._$AL=new Map,this._$E_(),this.requestUpdate(),this.constructor.l?.forEach(t=>t(this))}addController(t){(this._$EO??=new Set).add(t),void 0!==this.renderRoot&&this.isConnected&&t.hostConnected?.()}removeController(t){this._$EO?.delete(t)}_$E_(){const t=new Map,e=this.constructor.elementProperties;for(const i of e.keys())this.hasOwnProperty(i)&&(t.set(i,this[i]),delete this[i]);t.size>0&&(this._$Ep=t)}createRenderRoot(){const t=this.shadowRoot??this.attachShadow(this.constructor.shadowRootOptions);return((t,s)=>{if(i)t.adoptedStyleSheets=s.map(t=>t instanceof CSSStyleSheet?t:t.styleSheet);else for(const i of s){const s=document.createElement("style"),o=e.litNonce;void 0!==o&&s.setAttribute("nonce",o),s.textContent=i.cssText,t.appendChild(s)}})(t,this.constructor.elementStyles),t}connectedCallback(){this.renderRoot??=this.createRenderRoot(),this.enableUpdating(!0),this._$EO?.forEach(t=>t.hostConnected?.())}enableUpdating(t){}disconnectedCallback(){this._$EO?.forEach(t=>t.hostDisconnected?.())}attributeChangedCallback(t,e,i){this._$AK(t,i)}_$ET(t,e){const i=this.constructor.elementProperties.get(t),s=this.constructor._$Eu(t,i);if(void 0!==s&&!0===i.reflect){const o=(void 0!==i.converter?.toAttribute?i.converter:y).toAttribute(e,i.type);this._$Em=t,null==o?this.removeAttribute(s):this.setAttribute(s,o),this._$Em=null}}_$AK(t,e){const i=this.constructor,s=i._$Eh.get(t);if(void 0!==s&&this._$Em!==s){const t=i.getPropertyOptions(s),o="function"==typeof t.converter?{fromAttribute:t.converter}:void 0!==t.converter?.fromAttribute?t.converter:y;this._$Em=s;const n=o.fromAttribute(e,t.type);this[s]=n??this._$Ej?.get(s)??n,this._$Em=null}}requestUpdate(t,e,i,s=!1,o){if(void 0!==t){const n=this.constructor;if(!1===s&&(o=this[t]),i??=n.getPropertyOptions(t),!((i.hasChanged??$)(o,e)||i.useDefault&&i.reflect&&o===this._$Ej?.get(t)&&!this.hasAttribute(n._$Eu(t,i))))return;this.C(t,e,i)}!1===this.isUpdatePending&&(this._$ES=this._$EP())}C(t,e,{useDefault:i,reflect:s,wrapped:o},n){i&&!(this._$Ej??=new Map).has(t)&&(this._$Ej.set(t,n??e??this[t]),!0!==o||void 0!==n)||(this._$AL.has(t)||(this.hasUpdated||i||(e=void 0),this._$AL.set(t,e)),!0===s&&this._$Em!==t&&(this._$Eq??=new Set).add(t))}async _$EP(){this.isUpdatePending=!0;try{await this._$ES}catch(t){Promise.reject(t)}const t=this.scheduleUpdate();return null!=t&&await t,!this.isUpdatePending}scheduleUpdate(){return this.performUpdate()}performUpdate(){if(!this.isUpdatePending)return;if(!this.hasUpdated){if(this.renderRoot??=this.createRenderRoot(),this._$Ep){for(const[t,e]of this._$Ep)this[t]=e;this._$Ep=void 0}const t=this.constructor.elementProperties;if(t.size>0)for(const[e,i]of t){const{wrapped:t}=i,s=this[e];!0!==t||this._$AL.has(e)||void 0===s||this.C(e,void 0,i,s)}}let t=!1;const e=this._$AL;try{t=this.shouldUpdate(e),t?(this.willUpdate(e),this._$EO?.forEach(t=>t.hostUpdate?.()),this.update(e)):this._$EM()}catch(e){throw t=!1,this._$EM(),e}t&&this._$AE(e)}willUpdate(t){}_$AE(t){this._$EO?.forEach(t=>t.hostUpdated?.()),this.hasUpdated||(this.hasUpdated=!0,this.firstUpdated(t)),this.updated(t)}_$EM(){this._$AL=new Map,this.isUpdatePending=!1}get updateComplete(){return this.getUpdateComplete()}getUpdateComplete(){return this._$ES}shouldUpdate(t){return!0}update(t){this._$Eq&&=this._$Eq.forEach(t=>this._$ET(t,this[t])),this._$EM()}updated(t){}firstUpdated(t){}};x.elementStyles=[],x.shadowRootOptions={mode:"open"},x[f("elementProperties")]=new Map,x[f("finalized")]=new Map,m?.({ReactiveElement:x}),(g.reactiveElementVersions??=[]).push("2.1.2");const w=globalThis,k=t=>t,A=w.trustedTypes,S=A?A.createPolicy("lit-html",{createHTML:t=>t}):void 0,E="$lit$",C=`lit$${Math.random().toFixed(9).slice(2)}$`,M="?"+C,T=`<${M}>`,z=document,P=()=>z.createComment(""),O=t=>null===t||"object"!=typeof t&&"function"!=typeof t,N=Array.isArray,I="[ \t\n\f\r]",R=/<(?:(!--|\/[^a-zA-Z])|(\/?[a-zA-Z][^>\s]*)|(\/?$))/g,U=/-->/g,D=/>/g,F=RegExp(`>|${I}(?:([^\\s"'>=/]+)(${I}*=${I}*(?:[^ \t\n\f\r"'\`<>=]|("|')|))|$)`,"g"),H=/'/g,j=/"/g,L=/^(?:script|style|textarea|title)$/i,B=t=>(e,...i)=>({_$litType$:t,strings:e,values:i}),W=B(1),V=B(2),q=Symbol.for("lit-noChange"),Z=Symbol.for("lit-nothing"),J=new WeakMap,G=z.createTreeWalker(z,129);function X(t,e){if(!N(t)||!t.hasOwnProperty("raw"))throw Error("invalid template strings array");return void 0!==S?S.createHTML(e):e}const K=(t,e)=>{const i=t.length-1,s=[];let o,n=2===e?"<svg>":3===e?"<math>":"",r=R;for(let e=0;e<i;e++){const i=t[e];let a,l,c=-1,d=0;for(;d<i.length&&(r.lastIndex=d,l=r.exec(i),null!==l);)d=r.lastIndex,r===R?"!--"===l[1]?r=U:void 0!==l[1]?r=D:void 0!==l[2]?(L.test(l[2])&&(o=RegExp("</"+l[2],"g")),r=F):void 0!==l[3]&&(r=F):r===F?">"===l[0]?(r=o??R,c=-1):void 0===l[1]?c=-2:(c=r.lastIndex-l[2].length,a=l[1],r=void 0===l[3]?F:'"'===l[3]?j:H):r===j||r===H?r=F:r===U||r===D?r=R:(r=F,o=void 0);const h=r===F&&t[e+1].startsWith("/>")?" ":"";n+=r===R?i+T:c>=0?(s.push(a),i.slice(0,c)+E+i.slice(c)+C+h):i+C+(-2===c?e:h)}return[X(t,n+(t[i]||"<?>")+(2===e?"</svg>":3===e?"</math>":"")),s]};class Q{constructor({strings:t,_$litType$:e},i){let s;this.parts=[];let o=0,n=0;const r=t.length-1,a=this.parts,[l,c]=K(t,e);if(this.el=Q.createElement(l,i),G.currentNode=this.el.content,2===e||3===e){const t=this.el.content.firstChild;t.replaceWith(...t.childNodes)}for(;null!==(s=G.nextNode())&&a.length<r;){if(1===s.nodeType){if(s.hasAttributes())for(const t of s.getAttributeNames())if(t.endsWith(E)){const e=c[n++],i=s.getAttribute(t).split(C),r=/([.?@])?(.*)/.exec(e);a.push({type:1,index:o,name:r[2],strings:i,ctor:"."===r[1]?st:"?"===r[1]?ot:"@"===r[1]?nt:it}),s.removeAttribute(t)}else t.startsWith(C)&&(a.push({type:6,index:o}),s.removeAttribute(t));if(L.test(s.tagName)){const t=s.textContent.split(C),e=t.length-1;if(e>0){s.textContent=A?A.emptyScript:"";for(let i=0;i<e;i++)s.append(t[i],P()),G.nextNode(),a.push({type:2,index:++o});s.append(t[e],P())}}}else if(8===s.nodeType)if(s.data===M)a.push({type:2,index:o});else{let t=-1;for(;-1!==(t=s.data.indexOf(C,t+1));)a.push({type:7,index:o}),t+=C.length-1}o++}}static createElement(t,e){const i=z.createElement("template");return i.innerHTML=t,i}}function Y(t,e,i=t,s){if(e===q)return e;let o=void 0!==s?i._$Co?.[s]:i._$Cl;const n=O(e)?void 0:e._$litDirective$;return o?.constructor!==n&&(o?._$AO?.(!1),void 0===n?o=void 0:(o=new n(t),o._$AT(t,i,s)),void 0!==s?(i._$Co??=[])[s]=o:i._$Cl=o),void 0!==o&&(e=Y(t,o._$AS(t,e.values),o,s)),e}class tt{constructor(t,e){this._$AV=[],this._$AN=void 0,this._$AD=t,this._$AM=e}get parentNode(){return this._$AM.parentNode}get _$AU(){return this._$AM._$AU}u(t){const{el:{content:e},parts:i}=this._$AD,s=(t?.creationScope??z).importNode(e,!0);G.currentNode=s;let o=G.nextNode(),n=0,r=0,a=i[0];for(;void 0!==a;){if(n===a.index){let e;2===a.type?e=new et(o,o.nextSibling,this,t):1===a.type?e=new a.ctor(o,a.name,a.strings,this,t):6===a.type&&(e=new rt(o,this,t)),this._$AV.push(e),a=i[++r]}n!==a?.index&&(o=G.nextNode(),n++)}return G.currentNode=z,s}p(t){let e=0;for(const i of this._$AV)void 0!==i&&(void 0!==i.strings?(i._$AI(t,i,e),e+=i.strings.length-2):i._$AI(t[e])),e++}}class et{get _$AU(){return this._$AM?._$AU??this._$Cv}constructor(t,e,i,s){this.type=2,this._$AH=Z,this._$AN=void 0,this._$AA=t,this._$AB=e,this._$AM=i,this.options=s,this._$Cv=s?.isConnected??!0}get parentNode(){let t=this._$AA.parentNode;const e=this._$AM;return void 0!==e&&11===t?.nodeType&&(t=e.parentNode),t}get startNode(){return this._$AA}get endNode(){return this._$AB}_$AI(t,e=this){t=Y(this,t,e),O(t)?t===Z||null==t||""===t?(this._$AH!==Z&&this._$AR(),this._$AH=Z):t!==this._$AH&&t!==q&&this._(t):void 0!==t._$litType$?this.$(t):void 0!==t.nodeType?this.T(t):(t=>N(t)||"function"==typeof t?.[Symbol.iterator])(t)?this.k(t):this._(t)}O(t){return this._$AA.parentNode.insertBefore(t,this._$AB)}T(t){this._$AH!==t&&(this._$AR(),this._$AH=this.O(t))}_(t){this._$AH!==Z&&O(this._$AH)?this._$AA.nextSibling.data=t:this.T(z.createTextNode(t)),this._$AH=t}$(t){const{values:e,_$litType$:i}=t,s="number"==typeof i?this._$AC(t):(void 0===i.el&&(i.el=Q.createElement(X(i.h,i.h[0]),this.options)),i);if(this._$AH?._$AD===s)this._$AH.p(e);else{const t=new tt(s,this),i=t.u(this.options);t.p(e),this.T(i),this._$AH=t}}_$AC(t){let e=J.get(t.strings);return void 0===e&&J.set(t.strings,e=new Q(t)),e}k(t){N(this._$AH)||(this._$AH=[],this._$AR());const e=this._$AH;let i,s=0;for(const o of t)s===e.length?e.push(i=new et(this.O(P()),this.O(P()),this,this.options)):i=e[s],i._$AI(o),s++;s<e.length&&(this._$AR(i&&i._$AB.nextSibling,s),e.length=s)}_$AR(t=this._$AA.nextSibling,e){for(this._$AP?.(!1,!0,e);t!==this._$AB;){const e=k(t).nextSibling;k(t).remove(),t=e}}setConnected(t){void 0===this._$AM&&(this._$Cv=t,this._$AP?.(t))}}class it{get tagName(){return this.element.tagName}get _$AU(){return this._$AM._$AU}constructor(t,e,i,s,o){this.type=1,this._$AH=Z,this._$AN=void 0,this.element=t,this.name=e,this._$AM=s,this.options=o,i.length>2||""!==i[0]||""!==i[1]?(this._$AH=Array(i.length-1).fill(new String),this.strings=i):this._$AH=Z}_$AI(t,e=this,i,s){const o=this.strings;let n=!1;if(void 0===o)t=Y(this,t,e,0),n=!O(t)||t!==this._$AH&&t!==q,n&&(this._$AH=t);else{const s=t;let r,a;for(t=o[0],r=0;r<o.length-1;r++)a=Y(this,s[i+r],e,r),a===q&&(a=this._$AH[r]),n||=!O(a)||a!==this._$AH[r],a===Z?t=Z:t!==Z&&(t+=(a??"")+o[r+1]),this._$AH[r]=a}n&&!s&&this.j(t)}j(t){t===Z?this.element.removeAttribute(this.name):this.element.setAttribute(this.name,t??"")}}class st extends it{constructor(){super(...arguments),this.type=3}j(t){this.element[this.name]=t===Z?void 0:t}}class ot extends it{constructor(){super(...arguments),this.type=4}j(t){this.element.toggleAttribute(this.name,!!t&&t!==Z)}}class nt extends it{constructor(t,e,i,s,o){super(t,e,i,s,o),this.type=5}_$AI(t,e=this){if((t=Y(this,t,e,0)??Z)===q)return;const i=this._$AH,s=t===Z&&i!==Z||t.capture!==i.capture||t.once!==i.once||t.passive!==i.passive,o=t!==Z&&(i===Z||s);s&&this.element.removeEventListener(this.name,this,i),o&&this.element.addEventListener(this.name,this,t),this._$AH=t}handleEvent(t){"function"==typeof this._$AH?this._$AH.call(this.options?.host??this.element,t):this._$AH.handleEvent(t)}}class rt{constructor(t,e,i){this.element=t,this.type=6,this._$AN=void 0,this._$AM=e,this.options=i}get _$AU(){return this._$AM._$AU}_$AI(t){Y(this,t)}}const at=w.litHtmlPolyfillSupport;at?.(Q,et),(w.litHtmlVersions??=[]).push("3.3.2");const lt=globalThis;class ct extends x{constructor(){super(...arguments),this.renderOptions={host:this},this._$Do=void 0}createRenderRoot(){const t=super.createRenderRoot();return this.renderOptions.renderBefore??=t.firstChild,t}update(t){const e=this.render();this.hasUpdated||(this.renderOptions.isConnected=this.isConnected),super.update(t),this._$Do=((t,e,i)=>{const s=i?.renderBefore??e;let o=s._$litPart$;if(void 0===o){const t=i?.renderBefore??null;s._$litPart$=o=new et(e.insertBefore(P(),t),t,void 0,i??{})}return o._$AI(t),o})(e,this.renderRoot,this.renderOptions)}connectedCallback(){super.connectedCallback(),this._$Do?.setConnected(!0)}disconnectedCallback(){super.disconnectedCallback(),this._$Do?.setConnected(!1)}render(){return q}}ct._$litElement$=!0,ct.finalized=!0,lt.litElementHydrateSupport?.({LitElement:ct});const dt=lt.litElementPolyfillSupport;dt?.({LitElement:ct}),(lt.litElementVersions??=[]).push("4.2.2");const ht=t=>(e,i)=>{void 0!==i?i.addInitializer(()=>{customElements.define(t,e)}):customElements.define(t,e)},pt={attribute:!0,type:String,converter:y,reflect:!1,hasChanged:$},ut=(t=pt,e,i)=>{const{kind:s,metadata:o}=i;let n=globalThis.litPropertyMetadata.get(o);if(void 0===n&&globalThis.litPropertyMetadata.set(o,n=new Map),"setter"===s&&((t=Object.create(t)).wrapped=!0),n.set(i.name,t),"accessor"===s){const{name:s}=i;return{set(i){const o=e.get.call(this);e.set.call(this,i),this.requestUpdate(s,o,t,!0,i)},init(e){return void 0!==e&&this.C(s,void 0,t,e),e}}}if("setter"===s){const{name:s}=i;return function(i){const o=this[s];e.call(this,i),this.requestUpdate(s,o,t,!0,i)}}throw Error("Unsupported decorator location: "+s)};function gt(t){return(e,i)=>"object"==typeof i?ut(t,e,i):((t,e,i)=>{const s=e.hasOwnProperty(i);return e.constructor.createProperty(i,t),s?Object.getOwnPropertyDescriptor(e,i):void 0})(t,e,i)}function vt(t){return gt({...t,state:!0,attribute:!1})}const _t="1.3.0",mt="adaptive-cover-pro-card",ft="adaptive-cover-pro-card-editor",yt="adaptive_cover_pro",$t=["force","weather","manual","custom_position","motion","cloud","climate","glare_zone","solar","default"],bt={force:"Force Override",weather:"Weather Safety",manual:"Manual Override",custom_position:"Custom Position",motion:"Motion Timeout",cloud:"Cloud Suppression",climate:"Climate",glare_zone:"Glare Zone",solar:"Solar Tracking",default:"Default"},xt={cover_blind:"mdi:blinds-horizontal",cover_awning:"mdi:awning-outline",cover_tilt:"mdi:blinds"},wt={integration_enabled:!0,automatic_control:!0,reset_manual_override:!0},kt={"sensor:Cover_Position":"target_position_sensor","sensor:sun_position":"sun_sensor","sensor:Start Sun":"start_sensor","sensor:End Sun":"end_sensor","sensor:control_status":"control_status_sensor","sensor:decision_trace":"decision_trace_sensor","sensor:last_cover_action":"last_action_sensor","sensor:last_skipped_action":"last_skipped_sensor","sensor:manual_override_end_time":"manual_override_end_sensor","sensor:position_verification":"position_verification_sensor","sensor:motion_status":"motion_status_sensor","sensor:force_override_triggers":"force_override_sensor","sensor:climate_status":"climate_status_sensor","binary_sensor:sun_motion":"sun_infront_binary","binary_sensor:manual_override":"manual_override_binary","binary_sensor:position_mismatch":"position_mismatch_binary","binary_sensor:glare_active":"glare_active_binary","switch:Integration Enabled":"integration_enabled_switch","switch:Automatic Control":"automatic_control_switch","switch:Manual Override":"manual_toggle_switch","switch:Climate Mode":"climate_mode_switch","switch:Motion Control":"motion_control_switch","button:Reset Manual Override":"reset_override_button"};function At(t){return`acp-card:registry:v1:${t}`}const St={get(t){try{const e=localStorage.getItem(At(t));if(!e)return null;const i=JSON.parse(e);return 1!==i.schemaVersion?null:i}catch{return null}},set(t,e){try{const i={schemaVersion:1,cardVersion:_t,fetchedAt:Date.now(),entries:e};localStorage.setItem(At(t),JSON.stringify(i))}catch{}},invalidate(t){try{localStorage.removeItem(At(t))}catch{}},clear(){try{const t="acp-card:registry:v1:",e=[];for(let i=0;i<localStorage.length;i++){const s=localStorage.key(i);s?.startsWith(t)&&e.push(s)}e.forEach(t=>localStorage.removeItem(t))}catch{}}};function Et(t){return`${t.entity_id}|${t.unique_id}|${t.platform}|${t.config_entry_id??""}`}function Ct(t,e,i){return t.filter(t=>t.config_entry_id===e&&void 0===i)}let Mt=class extends ct{constructor(){super(...arguments),this.on=!1,this.readonly=!1,this.label="",this.title=""}_handleClick(){this.readonly||this.dispatchEvent(new CustomEvent("pill-click",{bubbles:!0,composed:!0}))}render(){return W`
+function t(t,e,s,i){var o,n=arguments.length,r=n<3?e:null===i?i=Object.getOwnPropertyDescriptor(e,s):i;if("object"==typeof Reflect&&"function"==typeof Reflect.decorate)r=Reflect.decorate(t,e,s,i);else for(var a=t.length-1;a>=0;a--)(o=t[a])&&(r=(n<3?o(r):n>3?o(e,s,r):o(e,s))||r);return n>3&&r&&Object.defineProperty(e,s,r),r}"function"==typeof SuppressedError&&SuppressedError;const e=globalThis,s=e.ShadowRoot&&(void 0===e.ShadyCSS||e.ShadyCSS.nativeShadow)&&"adoptedStyleSheets"in Document.prototype&&"replace"in CSSStyleSheet.prototype,i=Symbol(),o=new WeakMap;let n=class{constructor(t,e,s){if(this._$cssResult$=!0,s!==i)throw Error("CSSResult is not constructable. Use `unsafeCSS` or `css` instead.");this.cssText=t,this.t=e}get styleSheet(){let t=this.o;const e=this.t;if(s&&void 0===t){const s=void 0!==e&&1===e.length;s&&(t=o.get(e)),void 0===t&&((this.o=t=new CSSStyleSheet).replaceSync(this.cssText),s&&o.set(e,t))}return t}toString(){return this.cssText}};const r=(t,...e)=>{const s=1===t.length?t[0]:e.reduce((e,s,i)=>e+(t=>{if(!0===t._$cssResult$)return t.cssText;if("number"==typeof t)return t;throw Error("Value passed to 'css' function must be a 'css' function result: "+t+". Use 'unsafeCSS' to pass non-literal values, but take care to ensure page security.")})(s)+t[i+1],t[0]);return new n(s,t,i)},a=s?t=>t:t=>t instanceof CSSStyleSheet?(t=>{let e="";for(const s of t.cssRules)e+=s.cssText;return(t=>new n("string"==typeof t?t:t+"",void 0,i))(e)})(t):t,{is:l,defineProperty:c,getOwnPropertyDescriptor:d,getOwnPropertyNames:h,getOwnPropertySymbols:p,getPrototypeOf:u}=Object,g=globalThis,_=g.trustedTypes,v=_?_.emptyScript:"",f=g.reactiveElementPolyfillSupport,m=(t,e)=>t,y={toAttribute(t,e){switch(e){case Boolean:t=t?v:null;break;case Object:case Array:t=null==t?t:JSON.stringify(t)}return t},fromAttribute(t,e){let s=t;switch(e){case Boolean:s=null!==t;break;case Number:s=null===t?null:Number(t);break;case Object:case Array:try{s=JSON.parse(t)}catch(t){s=null}}return s}},$=(t,e)=>!l(t,e),b={attribute:!0,type:String,converter:y,reflect:!1,useDefault:!1,hasChanged:$};Symbol.metadata??=Symbol("metadata"),g.litPropertyMetadata??=new WeakMap;let w=class extends HTMLElement{static addInitializer(t){this._$Ei(),(this.l??=[]).push(t)}static get observedAttributes(){return this.finalize(),this._$Eh&&[...this._$Eh.keys()]}static createProperty(t,e=b){if(e.state&&(e.attribute=!1),this._$Ei(),this.prototype.hasOwnProperty(t)&&((e=Object.create(e)).wrapped=!0),this.elementProperties.set(t,e),!e.noAccessor){const s=Symbol(),i=this.getPropertyDescriptor(t,s,e);void 0!==i&&c(this.prototype,t,i)}}static getPropertyDescriptor(t,e,s){const{get:i,set:o}=d(this.prototype,t)??{get(){return this[e]},set(t){this[e]=t}};return{get:i,set(e){const n=i?.call(this);o?.call(this,e),this.requestUpdate(t,n,s)},configurable:!0,enumerable:!0}}static getPropertyOptions(t){return this.elementProperties.get(t)??b}static _$Ei(){if(this.hasOwnProperty(m("elementProperties")))return;const t=u(this);t.finalize(),void 0!==t.l&&(this.l=[...t.l]),this.elementProperties=new Map(t.elementProperties)}static finalize(){if(this.hasOwnProperty(m("finalized")))return;if(this.finalized=!0,this._$Ei(),this.hasOwnProperty(m("properties"))){const t=this.properties,e=[...h(t),...p(t)];for(const s of e)this.createProperty(s,t[s])}const t=this[Symbol.metadata];if(null!==t){const e=litPropertyMetadata.get(t);if(void 0!==e)for(const[t,s]of e)this.elementProperties.set(t,s)}this._$Eh=new Map;for(const[t,e]of this.elementProperties){const s=this._$Eu(t,e);void 0!==s&&this._$Eh.set(s,t)}this.elementStyles=this.finalizeStyles(this.styles)}static finalizeStyles(t){const e=[];if(Array.isArray(t)){const s=new Set(t.flat(1/0).reverse());for(const t of s)e.unshift(a(t))}else void 0!==t&&e.push(a(t));return e}static _$Eu(t,e){const s=e.attribute;return!1===s?void 0:"string"==typeof s?s:"string"==typeof t?t.toLowerCase():void 0}constructor(){super(),this._$Ep=void 0,this.isUpdatePending=!1,this.hasUpdated=!1,this._$Em=null,this._$Ev()}_$Ev(){this._$ES=new Promise(t=>this.enableUpdating=t),this._$AL=new Map,this._$E_(),this.requestUpdate(),this.constructor.l?.forEach(t=>t(this))}addController(t){(this._$EO??=new Set).add(t),void 0!==this.renderRoot&&this.isConnected&&t.hostConnected?.()}removeController(t){this._$EO?.delete(t)}_$E_(){const t=new Map,e=this.constructor.elementProperties;for(const s of e.keys())this.hasOwnProperty(s)&&(t.set(s,this[s]),delete this[s]);t.size>0&&(this._$Ep=t)}createRenderRoot(){const t=this.shadowRoot??this.attachShadow(this.constructor.shadowRootOptions);return((t,i)=>{if(s)t.adoptedStyleSheets=i.map(t=>t instanceof CSSStyleSheet?t:t.styleSheet);else for(const s of i){const i=document.createElement("style"),o=e.litNonce;void 0!==o&&i.setAttribute("nonce",o),i.textContent=s.cssText,t.appendChild(i)}})(t,this.constructor.elementStyles),t}connectedCallback(){this.renderRoot??=this.createRenderRoot(),this.enableUpdating(!0),this._$EO?.forEach(t=>t.hostConnected?.())}enableUpdating(t){}disconnectedCallback(){this._$EO?.forEach(t=>t.hostDisconnected?.())}attributeChangedCallback(t,e,s){this._$AK(t,s)}_$ET(t,e){const s=this.constructor.elementProperties.get(t),i=this.constructor._$Eu(t,s);if(void 0!==i&&!0===s.reflect){const o=(void 0!==s.converter?.toAttribute?s.converter:y).toAttribute(e,s.type);this._$Em=t,null==o?this.removeAttribute(i):this.setAttribute(i,o),this._$Em=null}}_$AK(t,e){const s=this.constructor,i=s._$Eh.get(t);if(void 0!==i&&this._$Em!==i){const t=s.getPropertyOptions(i),o="function"==typeof t.converter?{fromAttribute:t.converter}:void 0!==t.converter?.fromAttribute?t.converter:y;this._$Em=i;const n=o.fromAttribute(e,t.type);this[i]=n??this._$Ej?.get(i)??n,this._$Em=null}}requestUpdate(t,e,s,i=!1,o){if(void 0!==t){const n=this.constructor;if(!1===i&&(o=this[t]),s??=n.getPropertyOptions(t),!((s.hasChanged??$)(o,e)||s.useDefault&&s.reflect&&o===this._$Ej?.get(t)&&!this.hasAttribute(n._$Eu(t,s))))return;this.C(t,e,s)}!1===this.isUpdatePending&&(this._$ES=this._$EP())}C(t,e,{useDefault:s,reflect:i,wrapped:o},n){s&&!(this._$Ej??=new Map).has(t)&&(this._$Ej.set(t,n??e??this[t]),!0!==o||void 0!==n)||(this._$AL.has(t)||(this.hasUpdated||s||(e=void 0),this._$AL.set(t,e)),!0===i&&this._$Em!==t&&(this._$Eq??=new Set).add(t))}async _$EP(){this.isUpdatePending=!0;try{await this._$ES}catch(t){Promise.reject(t)}const t=this.scheduleUpdate();return null!=t&&await t,!this.isUpdatePending}scheduleUpdate(){return this.performUpdate()}performUpdate(){if(!this.isUpdatePending)return;if(!this.hasUpdated){if(this.renderRoot??=this.createRenderRoot(),this._$Ep){for(const[t,e]of this._$Ep)this[t]=e;this._$Ep=void 0}const t=this.constructor.elementProperties;if(t.size>0)for(const[e,s]of t){const{wrapped:t}=s,i=this[e];!0!==t||this._$AL.has(e)||void 0===i||this.C(e,void 0,s,i)}}let t=!1;const e=this._$AL;try{t=this.shouldUpdate(e),t?(this.willUpdate(e),this._$EO?.forEach(t=>t.hostUpdate?.()),this.update(e)):this._$EM()}catch(e){throw t=!1,this._$EM(),e}t&&this._$AE(e)}willUpdate(t){}_$AE(t){this._$EO?.forEach(t=>t.hostUpdated?.()),this.hasUpdated||(this.hasUpdated=!0,this.firstUpdated(t)),this.updated(t)}_$EM(){this._$AL=new Map,this.isUpdatePending=!1}get updateComplete(){return this.getUpdateComplete()}getUpdateComplete(){return this._$ES}shouldUpdate(t){return!0}update(t){this._$Eq&&=this._$Eq.forEach(t=>this._$ET(t,this[t])),this._$EM()}updated(t){}firstUpdated(t){}};w.elementStyles=[],w.shadowRootOptions={mode:"open"},w[m("elementProperties")]=new Map,w[m("finalized")]=new Map,f?.({ReactiveElement:w}),(g.reactiveElementVersions??=[]).push("2.1.2");const x=globalThis,k=t=>t,A=x.trustedTypes,S=A?A.createPolicy("lit-html",{createHTML:t=>t}):void 0,E="$lit$",C=`lit$${Math.random().toFixed(9).slice(2)}$`,M="?"+C,P=`<${M}>`,z=document,O=()=>z.createComment(""),T=t=>null===t||"object"!=typeof t&&"function"!=typeof t,N=Array.isArray,I="[ \t\n\f\r]",R=/<(?:(!--|\/[^a-zA-Z])|(\/?[a-zA-Z][^>\s]*)|(\/?$))/g,F=/-->/g,U=/>/g,D=RegExp(`>|${I}(?:([^\\s"'>=/]+)(${I}*=${I}*(?:[^ \t\n\f\r"'\`<>=]|("|')|))|$)`,"g"),H=/'/g,L=/"/g,j=/^(?:script|style|textarea|title)$/i,B=t=>(e,...s)=>({_$litType$:t,strings:e,values:s}),W=B(1),V=B(2),q=Symbol.for("lit-noChange"),Z=Symbol.for("lit-nothing"),G=new WeakMap,J=z.createTreeWalker(z,129);function X(t,e){if(!N(t)||!t.hasOwnProperty("raw"))throw Error("invalid template strings array");return void 0!==S?S.createHTML(e):e}const K=(t,e)=>{const s=t.length-1,i=[];let o,n=2===e?"<svg>":3===e?"<math>":"",r=R;for(let e=0;e<s;e++){const s=t[e];let a,l,c=-1,d=0;for(;d<s.length&&(r.lastIndex=d,l=r.exec(s),null!==l);)d=r.lastIndex,r===R?"!--"===l[1]?r=F:void 0!==l[1]?r=U:void 0!==l[2]?(j.test(l[2])&&(o=RegExp("</"+l[2],"g")),r=D):void 0!==l[3]&&(r=D):r===D?">"===l[0]?(r=o??R,c=-1):void 0===l[1]?c=-2:(c=r.lastIndex-l[2].length,a=l[1],r=void 0===l[3]?D:'"'===l[3]?L:H):r===L||r===H?r=D:r===F||r===U?r=R:(r=D,o=void 0);const h=r===D&&t[e+1].startsWith("/>")?" ":"";n+=r===R?s+P:c>=0?(i.push(a),s.slice(0,c)+E+s.slice(c)+C+h):s+C+(-2===c?e:h)}return[X(t,n+(t[s]||"<?>")+(2===e?"</svg>":3===e?"</math>":"")),i]};class Q{constructor({strings:t,_$litType$:e},s){let i;this.parts=[];let o=0,n=0;const r=t.length-1,a=this.parts,[l,c]=K(t,e);if(this.el=Q.createElement(l,s),J.currentNode=this.el.content,2===e||3===e){const t=this.el.content.firstChild;t.replaceWith(...t.childNodes)}for(;null!==(i=J.nextNode())&&a.length<r;){if(1===i.nodeType){if(i.hasAttributes())for(const t of i.getAttributeNames())if(t.endsWith(E)){const e=c[n++],s=i.getAttribute(t).split(C),r=/([.?@])?(.*)/.exec(e);a.push({type:1,index:o,name:r[2],strings:s,ctor:"."===r[1]?it:"?"===r[1]?ot:"@"===r[1]?nt:st}),i.removeAttribute(t)}else t.startsWith(C)&&(a.push({type:6,index:o}),i.removeAttribute(t));if(j.test(i.tagName)){const t=i.textContent.split(C),e=t.length-1;if(e>0){i.textContent=A?A.emptyScript:"";for(let s=0;s<e;s++)i.append(t[s],O()),J.nextNode(),a.push({type:2,index:++o});i.append(t[e],O())}}}else if(8===i.nodeType)if(i.data===M)a.push({type:2,index:o});else{let t=-1;for(;-1!==(t=i.data.indexOf(C,t+1));)a.push({type:7,index:o}),t+=C.length-1}o++}}static createElement(t,e){const s=z.createElement("template");return s.innerHTML=t,s}}function Y(t,e,s=t,i){if(e===q)return e;let o=void 0!==i?s._$Co?.[i]:s._$Cl;const n=T(e)?void 0:e._$litDirective$;return o?.constructor!==n&&(o?._$AO?.(!1),void 0===n?o=void 0:(o=new n(t),o._$AT(t,s,i)),void 0!==i?(s._$Co??=[])[i]=o:s._$Cl=o),void 0!==o&&(e=Y(t,o._$AS(t,e.values),o,i)),e}class tt{constructor(t,e){this._$AV=[],this._$AN=void 0,this._$AD=t,this._$AM=e}get parentNode(){return this._$AM.parentNode}get _$AU(){return this._$AM._$AU}u(t){const{el:{content:e},parts:s}=this._$AD,i=(t?.creationScope??z).importNode(e,!0);J.currentNode=i;let o=J.nextNode(),n=0,r=0,a=s[0];for(;void 0!==a;){if(n===a.index){let e;2===a.type?e=new et(o,o.nextSibling,this,t):1===a.type?e=new a.ctor(o,a.name,a.strings,this,t):6===a.type&&(e=new rt(o,this,t)),this._$AV.push(e),a=s[++r]}n!==a?.index&&(o=J.nextNode(),n++)}return J.currentNode=z,i}p(t){let e=0;for(const s of this._$AV)void 0!==s&&(void 0!==s.strings?(s._$AI(t,s,e),e+=s.strings.length-2):s._$AI(t[e])),e++}}class et{get _$AU(){return this._$AM?._$AU??this._$Cv}constructor(t,e,s,i){this.type=2,this._$AH=Z,this._$AN=void 0,this._$AA=t,this._$AB=e,this._$AM=s,this.options=i,this._$Cv=i?.isConnected??!0}get parentNode(){let t=this._$AA.parentNode;const e=this._$AM;return void 0!==e&&11===t?.nodeType&&(t=e.parentNode),t}get startNode(){return this._$AA}get endNode(){return this._$AB}_$AI(t,e=this){t=Y(this,t,e),T(t)?t===Z||null==t||""===t?(this._$AH!==Z&&this._$AR(),this._$AH=Z):t!==this._$AH&&t!==q&&this._(t):void 0!==t._$litType$?this.$(t):void 0!==t.nodeType?this.T(t):(t=>N(t)||"function"==typeof t?.[Symbol.iterator])(t)?this.k(t):this._(t)}O(t){return this._$AA.parentNode.insertBefore(t,this._$AB)}T(t){this._$AH!==t&&(this._$AR(),this._$AH=this.O(t))}_(t){this._$AH!==Z&&T(this._$AH)?this._$AA.nextSibling.data=t:this.T(z.createTextNode(t)),this._$AH=t}$(t){const{values:e,_$litType$:s}=t,i="number"==typeof s?this._$AC(t):(void 0===s.el&&(s.el=Q.createElement(X(s.h,s.h[0]),this.options)),s);if(this._$AH?._$AD===i)this._$AH.p(e);else{const t=new tt(i,this),s=t.u(this.options);t.p(e),this.T(s),this._$AH=t}}_$AC(t){let e=G.get(t.strings);return void 0===e&&G.set(t.strings,e=new Q(t)),e}k(t){N(this._$AH)||(this._$AH=[],this._$AR());const e=this._$AH;let s,i=0;for(const o of t)i===e.length?e.push(s=new et(this.O(O()),this.O(O()),this,this.options)):s=e[i],s._$AI(o),i++;i<e.length&&(this._$AR(s&&s._$AB.nextSibling,i),e.length=i)}_$AR(t=this._$AA.nextSibling,e){for(this._$AP?.(!1,!0,e);t!==this._$AB;){const e=k(t).nextSibling;k(t).remove(),t=e}}setConnected(t){void 0===this._$AM&&(this._$Cv=t,this._$AP?.(t))}}class st{get tagName(){return this.element.tagName}get _$AU(){return this._$AM._$AU}constructor(t,e,s,i,o){this.type=1,this._$AH=Z,this._$AN=void 0,this.element=t,this.name=e,this._$AM=i,this.options=o,s.length>2||""!==s[0]||""!==s[1]?(this._$AH=Array(s.length-1).fill(new String),this.strings=s):this._$AH=Z}_$AI(t,e=this,s,i){const o=this.strings;let n=!1;if(void 0===o)t=Y(this,t,e,0),n=!T(t)||t!==this._$AH&&t!==q,n&&(this._$AH=t);else{const i=t;let r,a;for(t=o[0],r=0;r<o.length-1;r++)a=Y(this,i[s+r],e,r),a===q&&(a=this._$AH[r]),n||=!T(a)||a!==this._$AH[r],a===Z?t=Z:t!==Z&&(t+=(a??"")+o[r+1]),this._$AH[r]=a}n&&!i&&this.j(t)}j(t){t===Z?this.element.removeAttribute(this.name):this.element.setAttribute(this.name,t??"")}}class it extends st{constructor(){super(...arguments),this.type=3}j(t){this.element[this.name]=t===Z?void 0:t}}class ot extends st{constructor(){super(...arguments),this.type=4}j(t){this.element.toggleAttribute(this.name,!!t&&t!==Z)}}class nt extends st{constructor(t,e,s,i,o){super(t,e,s,i,o),this.type=5}_$AI(t,e=this){if((t=Y(this,t,e,0)??Z)===q)return;const s=this._$AH,i=t===Z&&s!==Z||t.capture!==s.capture||t.once!==s.once||t.passive!==s.passive,o=t!==Z&&(s===Z||i);i&&this.element.removeEventListener(this.name,this,s),o&&this.element.addEventListener(this.name,this,t),this._$AH=t}handleEvent(t){"function"==typeof this._$AH?this._$AH.call(this.options?.host??this.element,t):this._$AH.handleEvent(t)}}class rt{constructor(t,e,s){this.element=t,this.type=6,this._$AN=void 0,this._$AM=e,this.options=s}get _$AU(){return this._$AM._$AU}_$AI(t){Y(this,t)}}const at=x.litHtmlPolyfillSupport;at?.(Q,et),(x.litHtmlVersions??=[]).push("3.3.2");const lt=globalThis;class ct extends w{constructor(){super(...arguments),this.renderOptions={host:this},this._$Do=void 0}createRenderRoot(){const t=super.createRenderRoot();return this.renderOptions.renderBefore??=t.firstChild,t}update(t){const e=this.render();this.hasUpdated||(this.renderOptions.isConnected=this.isConnected),super.update(t),this._$Do=((t,e,s)=>{const i=s?.renderBefore??e;let o=i._$litPart$;if(void 0===o){const t=s?.renderBefore??null;i._$litPart$=o=new et(e.insertBefore(O(),t),t,void 0,s??{})}return o._$AI(t),o})(e,this.renderRoot,this.renderOptions)}connectedCallback(){super.connectedCallback(),this._$Do?.setConnected(!0)}disconnectedCallback(){super.disconnectedCallback(),this._$Do?.setConnected(!1)}render(){return q}}ct._$litElement$=!0,ct.finalized=!0,lt.litElementHydrateSupport?.({LitElement:ct});const dt=lt.litElementPolyfillSupport;dt?.({LitElement:ct}),(lt.litElementVersions??=[]).push("4.2.2");const ht=t=>(e,s)=>{void 0!==s?s.addInitializer(()=>{customElements.define(t,e)}):customElements.define(t,e)},pt={attribute:!0,type:String,converter:y,reflect:!1,hasChanged:$},ut=(t=pt,e,s)=>{const{kind:i,metadata:o}=s;let n=globalThis.litPropertyMetadata.get(o);if(void 0===n&&globalThis.litPropertyMetadata.set(o,n=new Map),"setter"===i&&((t=Object.create(t)).wrapped=!0),n.set(s.name,t),"accessor"===i){const{name:i}=s;return{set(s){const o=e.get.call(this);e.set.call(this,s),this.requestUpdate(i,o,t,!0,s)},init(e){return void 0!==e&&this.C(i,void 0,t,e),e}}}if("setter"===i){const{name:i}=s;return function(s){const o=this[i];e.call(this,s),this.requestUpdate(i,o,t,!0,s)}}throw Error("Unsupported decorator location: "+i)};function gt(t){return(e,s)=>"object"==typeof s?ut(t,e,s):((t,e,s)=>{const i=e.hasOwnProperty(s);return e.constructor.createProperty(s,t),i?Object.getOwnPropertyDescriptor(e,s):void 0})(t,e,s)}function _t(t){return gt({...t,state:!0,attribute:!1})}const vt="1.3.0",ft="adaptive-cover-pro-card",mt="adaptive-cover-pro-card-editor",yt="adaptive-cover-pro-sky-compass-card",$t="adaptive-cover-pro-sky-compass-card-editor",bt="adaptive_cover_pro",wt=["force","weather","manual","custom_position","motion","cloud","climate","glare_zone","solar","default"],xt={force:"Force Override",weather:"Weather Safety",manual:"Manual Override",custom_position:"Custom Position",motion:"Motion Timeout",cloud:"Cloud Suppression",climate:"Climate",glare_zone:"Glare Zone",solar:"Solar Tracking",default:"Default"},kt={cover_blind:"mdi:blinds-horizontal",cover_awning:"mdi:awning-outline",cover_tilt:"mdi:blinds"},At={integration_enabled:!0,automatic_control:!0,reset_manual_override:!0},St={"sensor:Cover_Position":"target_position_sensor","sensor:sun_position":"sun_sensor","sensor:Start Sun":"start_sensor","sensor:End Sun":"end_sensor","sensor:control_status":"control_status_sensor","sensor:decision_trace":"decision_trace_sensor","sensor:last_cover_action":"last_action_sensor","sensor:last_skipped_action":"last_skipped_sensor","sensor:manual_override_end_time":"manual_override_end_sensor","sensor:position_verification":"position_verification_sensor","sensor:motion_status":"motion_status_sensor","sensor:force_override_triggers":"force_override_sensor","sensor:climate_status":"climate_status_sensor","binary_sensor:sun_motion":"sun_infront_binary","binary_sensor:manual_override":"manual_override_binary","binary_sensor:position_mismatch":"position_mismatch_binary","binary_sensor:glare_active":"glare_active_binary","switch:Integration Enabled":"integration_enabled_switch","switch:Automatic Control":"automatic_control_switch","switch:Manual Override":"manual_toggle_switch","switch:Climate Mode":"climate_mode_switch","switch:Motion Control":"motion_control_switch","button:Reset Manual Override":"reset_override_button"};function Et(t,e,s){const i=e.entry_id;if(!i)return null;const o={},n=`${i}_`;let r=!1;for(const t of s){if(t.config_entry_id!==i)continue;if(t.platform!==bt)continue;if(r=!0,!t.unique_id.startsWith(n))continue;const e=t.unique_id.slice(n.length),s=t.entity_id.split(".")[0],a=St[`${s}:${e}`];a&&(o[a]=t.entity_id)}if(!r||0===Object.keys(o).length)return null;const a=t;let l=i;if(a.devices)for(const t of Object.values(a.devices))if(t.config_entries?.includes(i)){l=t.name_by_user??t.name??i;break}const c=[],d=o.target_position_sensor;if(d){const e=t.states[d]?.attributes?.actual_positions;e&&c.push(...Object.keys(e))}let h="cover_blind";const p=o.control_status_sensor;if(p){const e=t.states[p]?.attributes;e?.cover_type&&(h=e.cover_type)}return{entry_id:i,entry_title:l,cover_type:h,entities:o,managed_covers:c}}async function Ct(t){return t.callWS({type:"config/entity_registry/list"})}function Mt(t,e){let s=null,i=!1;return t.connection.subscribeEvents(t=>e(t.data),"entity_registry_updated").then(t=>{i?t():s=t}).catch(()=>{}),()=>{i=!0,s&&s()}}function Pt(t){return`acp-card:registry:v1:${t}`}const zt={get(t){try{const e=localStorage.getItem(Pt(t));if(!e)return null;const s=JSON.parse(e);return 1!==s.schemaVersion?null:s}catch{return null}},set(t,e){try{const s={schemaVersion:1,cardVersion:vt,fetchedAt:Date.now(),entries:e};localStorage.setItem(Pt(t),JSON.stringify(s))}catch{}},invalidate(t){try{localStorage.removeItem(Pt(t))}catch{}},clear(){try{const t="acp-card:registry:v1:",e=[];for(let s=0;s<localStorage.length;s++){const i=localStorage.key(s);i?.startsWith(t)&&e.push(i)}e.forEach(t=>localStorage.removeItem(t))}catch{}}};function Ot(t){return`${t.entity_id}|${t.unique_id}|${t.platform}|${t.config_entry_id??""}`}function Tt(t,e,s){return t.filter(t=>t.config_entry_id===e&&void 0===s)}let Nt=class extends ct{constructor(){super(...arguments),this.on=!1,this.readonly=!1,this.label="",this.title=""}_handleClick(){this.readonly||this.dispatchEvent(new CustomEvent("pill-click",{bubbles:!0,composed:!0}))}render(){return W`
       <button
         class="pill ${this.on?"on":"off"} ${this.readonly?"readonly":""}"
         title=${this.title}
@@ -9,7 +9,7 @@ function t(t,e,i,s){var o,n=arguments.length,r=n<3?e:null===s?s=Object.getOwnPro
       >
         ${this.label}
       </button>
-    `}};function Tt(t,e){const i=(t-90)*Math.PI/180;return{x:e*Math.cos(i),y:e*Math.sin(i)}}function zt(t,e,i,s=0){const o=t=>(t%360+360)%360,n=o(t),r=o(e);let a=r-n;a<0&&(a+=360);const l=a>180?1:0,c=Tt(n,i),d=Tt(r,i);if(s<=0)return`M 0 0 L ${c.x} ${c.y} A ${i} ${i} 0 ${l} 1 ${d.x} ${d.y} Z`;const h=Tt(r,s),p=Tt(n,s);return[`M ${c.x} ${c.y}`,`A ${i} ${i} 0 ${l} 1 ${d.x} ${d.y}`,`L ${h.x} ${h.y}`,`A ${s} ${s} 0 ${l} 0 ${p.x} ${p.y}`,"Z"].join(" ")}function Pt(t,e){return Tt(t,function(t){return 1-Math.max(0,Math.min(90,t))/90}(e))}function Ot(t){return(t%360+360)%360}function Nt(t){return t&&t.__esModule&&Object.prototype.hasOwnProperty.call(t,"default")?t.default:t}Mt.styles=r`
+    `}};function It(t,e){const s=(t-90)*Math.PI/180;return{x:e*Math.cos(s),y:e*Math.sin(s)}}function Rt(t,e,s,i=0){const o=t=>(t%360+360)%360,n=o(t),r=o(e);let a=r-n;a<0&&(a+=360);const l=a>180?1:0,c=It(n,s),d=It(r,s);if(i<=0)return`M 0 0 L ${c.x} ${c.y} A ${s} ${s} 0 ${l} 1 ${d.x} ${d.y} Z`;const h=It(r,i),p=It(n,i);return[`M ${c.x} ${c.y}`,`A ${s} ${s} 0 ${l} 1 ${d.x} ${d.y}`,`L ${h.x} ${h.y}`,`A ${i} ${i} 0 ${l} 0 ${p.x} ${p.y}`,"Z"].join(" ")}function Ft(t,e){return It(t,function(t){return 1-Math.max(0,Math.min(90,t))/90}(e))}function Ut(t){return(t%360+360)%360}function Dt(t){return t&&t.__esModule&&Object.prototype.hasOwnProperty.call(t,"default")?t.default:t}Nt.styles=r`
     .pill {
       padding: 2px 10px;
       border-radius: 999px;
@@ -36,94 +36,119 @@ function t(t,e,i,s){var o,n=arguments.length,r=n<3?e:null===s?s=Object.getOwnPro
     .pill.on.readonly {
       opacity: 0.85;
     }
-  `,t([gt({type:Boolean})],Mt.prototype,"on",void 0),t([gt({type:Boolean})],Mt.prototype,"readonly",void 0),t([gt({type:String})],Mt.prototype,"label",void 0),t([gt({type:String})],Mt.prototype,"title",void 0),Mt=t([ht("acp-header-pill")],Mt);var It,Rt={exports:{}};It=Rt,function(){var t=Math.PI,e=Math.sin,i=Math.cos,s=Math.tan,o=Math.asin,n=Math.atan2,r=Math.acos,a=t/180,l=864e5,c=2440588,d=2451545;function h(t){return new Date((t+.5-c)*l)}function p(t){return function(t){return t.valueOf()/l-.5+c}(t)-d}var u=23.4397*a;function g(t,o){return n(e(t)*i(u)-s(o)*e(u),i(t))}function v(t,s){return o(e(s)*i(u)+i(s)*e(u)*e(t))}function _(t,o,r){return n(e(t),i(t)*e(o)-s(r)*i(o))}function m(t,s,n){return o(e(s)*e(n)+i(s)*i(n)*i(t))}function f(t,e){return a*(280.16+360.9856235*t)-e}function y(t){return a*(357.5291+.98560028*t)}function $(i){return i+a*(1.9148*e(i)+.02*e(2*i)+3e-4*e(3*i))+102.9372*a+t}function b(t){var e=$(y(t));return{dec:v(e,0),ra:g(e,0)}}var x={getPosition:function(t,e,i){var s=a*-i,o=a*e,n=p(t),r=b(n),l=f(n,s)-r.ra;return{azimuth:_(l,o,r.dec),altitude:m(l,o,r.dec)}}},w=x.times=[[-.833,"sunrise","sunset"],[-.3,"sunriseEnd","sunsetStart"],[-6,"dawn","dusk"],[-12,"nauticalDawn","nauticalDusk"],[-18,"nightEnd","night"],[6,"goldenHourEnd","goldenHour"]];x.addTime=function(t,e,i){w.push([t,e,i])};var k=9e-4;function A(e,i,s){return k+(e+i)/(2*t)+s}function S(t,i,s){return d+t+.0053*e(i)-.0069*e(2*s)}function E(t,s,o,n,a,l,c){var d=function(t,s,o){return r((e(t)-e(s)*e(o))/(i(s)*i(o)))}(t,o,n);return S(A(d,s,a),l,c)}function C(t){var s=a*(134.963+13.064993*t),o=a*(93.272+13.22935*t),n=a*(218.316+13.176396*t)+6.289*a*e(s),r=5.128*a*e(o),l=385001-20905*i(s);return{ra:g(n,r),dec:v(n,r),dist:l}}function M(t,e){return new Date(t.valueOf()+e*l/24)}x.getTimes=function(e,i,s,o){var n,r,l,c,d,u=a*-s,g=a*i,_=function(t){return-2.076*Math.sqrt(t)/60}(o=o||0),m=function(e,i){return Math.round(e-k-i/(2*t))}(p(e),u),f=A(0,u,m),b=y(f),x=$(b),C=v(x,0),M=S(f,b,x),T={solarNoon:h(M),nadir:h(M-.5)};for(n=0,r=w.length;n<r;n+=1)d=M-((c=E(((l=w[n])[0]+_)*a,u,g,C,m,b,x))-M),T[l[1]]=h(d),T[l[2]]=h(c);return T},x.getMoonPosition=function(t,o,r){var l=a*-r,c=a*o,d=p(t),h=C(d),u=f(d,l)-h.ra,g=m(u,c,h.dec),v=n(e(u),s(c)*i(h.dec)-e(h.dec)*i(u));return g+=function(t){return t<0&&(t=0),2967e-7/Math.tan(t+.00312536/(t+.08901179))}(g),{azimuth:_(u,c,h.dec),altitude:g,distance:h.dist,parallacticAngle:v}},x.getMoonIllumination=function(t){var s=p(t||new Date),o=b(s),a=C(s),l=149598e3,c=r(e(o.dec)*e(a.dec)+i(o.dec)*i(a.dec)*i(o.ra-a.ra)),d=n(l*e(c),a.dist-l*i(c)),h=n(i(o.dec)*e(o.ra-a.ra),e(o.dec)*i(a.dec)-i(o.dec)*e(a.dec)*i(o.ra-a.ra));return{fraction:(1+i(d))/2,phase:.5+.5*d*(h<0?-1:1)/Math.PI,angle:h}},x.getMoonTimes=function(t,e,i,s){var o=new Date(t);s?o.setUTCHours(0,0,0,0):o.setHours(0,0,0,0);for(var n,r,l,c,d,h,p,u,g,v,_,m,f,y=.133*a,$=x.getMoonPosition(o,e,i).altitude-y,b=1;b<=24&&(n=x.getMoonPosition(M(o,b),e,i).altitude-y,u=((d=($+(r=x.getMoonPosition(M(o,b+1),e,i).altitude-y))/2-n)*(p=-(h=(r-$)/2)/(2*d))+h)*p+n,v=0,(g=h*h-4*d*n)>=0&&(_=p-(f=Math.sqrt(g)/(2*Math.abs(d))),m=p+f,Math.abs(_)<=1&&v++,Math.abs(m)<=1&&v++,_<-1&&(_=m)),1===v?$<0?l=b+_:c=b+_:2===v&&(l=b+(u<0?m:_),c=b+(u<0?_:m)),!l||!c);b+=2)$=r;var w={};return l&&(w.rise=M(o,l)),c&&(w.set=M(o,c)),l||c||(w[u>0?"alwaysUp":"alwaysDown"]=!0),w},It.exports=x}();var Ut=Nt(Rt.exports);function Dt(t,e,i,s=10){const o=[],n=i.getTime()+864e5;for(let r=i.getTime();r<=n;r+=60*s*1e3){const i=new Date(r),s=Ut.getPosition(i,t,e);o.push({t:i,elevation:180*s.altitude/Math.PI,azimuth:((180*s.azimuth/Math.PI+180)%360+360)%360})}return o}function Ft(t=new Date){const e=new Date(t);return e.setHours(0,0,0,0),e}function Ht(t,e,i,s){const o=((e-i)%360+360)%360;return((t-o)%360+360)%360<=((((e+s)%360+360)%360-o)%360+360)%360}function jt(t){return t<.0625||t>=.9375?"New Moon":t<.1875?"Waxing Crescent":t<.3125?"First Quarter":t<.4375?"Waxing Gibbous":t<.5625?"Full Moon":t<.6875?"Waning Gibbous":t<.8125?"Last Quarter":"Waning Crescent"}function Lt(t){return null==t||Number.isNaN(t)?"—":`${Math.round(t)}%`}function Bt(t){return null==t||Number.isNaN(t)?"—":`${t.toFixed(1)}°`}function Wt(t){if(!t)return"—";const e=new Date(t);return Number.isNaN(e.getTime())?"—":e.toLocaleTimeString([],{hour:"2-digit",minute:"2-digit"})}function Vt(t){if(!t)return"—";const e=new Date(t).getTime();if(Number.isNaN(e))return"—";const i=Math.round((e-Date.now())/1e3);return i<=0?"expired":function(t){if(null==t||Number.isNaN(t))return"—";const e=Math.max(0,Math.round(t));if(e<60)return`${e}s`;const i=Math.floor(e/60);return i<60?`${i}m ${e%60}s`:`${Math.floor(i/60)}h ${i%60}m`}(i)}const qt=110;let Zt=class extends ct{constructor(){super(...arguments),this.compact=!1,this.showStats=!0,this.showLegend=!0,this.showMoon=!1}_sun(){const t=this.discovered.entities.sun_sensor;if(!t)return null;const e=this.hass.states[t];if(!e)return null;const i=parseFloat(e.state);return Number.isNaN(i)?null:{...e.attributes,window_azimuth:e.attributes.window_azimuth}}_coverPosition(){const t=this.discovered.entities.target_position_sensor;if(!t)return null;const e=parseFloat(this.hass.states[t]?.state??"");return Number.isNaN(e)?null:e}_sunInfront(){const t=this.discovered.entities.sun_infront_binary;return!!t&&"on"===this.hass.states[t]?.state}render(){if(!this.hass||!this.discovered)return Z;const t=this._sun();if(!t)return W`<div class="placeholder">Sun sensor not yet populated.</div>`;const e=Ot(t.window_azimuth),i=Ot(e-t.fov_left),s=Ot(e+t.fov_right),o=this.discovered.entities.sun_sensor,n=parseFloat(this.hass.states[o]?.state??"0"),r=t.elevation,a=Pt(n,r),l=Tt(e,qt),{latitude:c,longitude:d}=this.hass.config,h=void 0!==c&&void 0!==d?Dt(c,d,Ft()):[],p=this.showMoon&&void 0!==c&&void 0!==d?function(t,e,i=new Date){const s=Ut.getMoonPosition(i,t,e),o=Ut.getMoonIllumination(i);return{azimuth:((180*s.azimuth/Math.PI+180)%360+360)%360,elevation:180*s.altitude/Math.PI,phase:o.phase,fraction:o.fraction,phaseName:jt(o.phase)}}(c,d):null,u=null!==p&&p.elevation>0,g=p?p.phase<.5?-24*p.phase:24*(1-p.phase):0,v=u?Pt(p.azimuth,p.elevation):null,_=v?v.x*qt:0,m=v?v.y*qt:0,f=h.filter(t=>t.elevation>0).map(t=>{const e=Pt(t.azimuth,t.elevation);return`${(e.x*qt).toFixed(1)},${(e.y*qt).toFixed(1)}`}).join(" "),{riseAzimuth:y,setAzimuth:$}=function(t){let e=-1,i=-1;for(let s=0;s<t.length;s++)t[s].elevation>0&&(-1===e&&(e=s),i=s);return{riseAzimuth:e>=0?t[e].azimuth:null,setAzimuth:i>=0?t[i].azimuth:null}}(h),b=null!==y?Tt(y,qt):null,x=null!==$?Tt($,qt):null,w=t.blind_spot_range?zt(Ot(t.blind_spot_range[0]),Ot(t.blind_spot_range[1]),qt):null,k=this._coverPosition(),A=null!==k?qt*(1-k/100):null,S=t.in_fov,E=this._sunInfront(),C=r<=0,M=!C&&E?"sun valid":!C&&S?"sun in-fov":"sun",T=`Window FOV: ${Bt(t.fov_left)} left / ${Bt(t.fov_right)} right`,z=`Window normal: ${Bt(e)}`,P=`Sun: ${Bt(n)} az / ${Bt(r)} el`,O=null!==k?`Cover closed: ${k}%`:"",N=t.blind_spot_range?`Blind spot: ${Bt(t.blind_spot_range[0])} – ${Bt(t.blind_spot_range[1])}`:"",I=null!==y?`Sunrise: ${Bt(y)}`:"",R=null!==$?`Sunset: ${Bt($)}`:"",U=null!==p?`Moon: ${p.phaseName} (${Math.round(100*p.fraction)}%)`:"";return W`
+  `,t([gt({type:Boolean})],Nt.prototype,"on",void 0),t([gt({type:Boolean})],Nt.prototype,"readonly",void 0),t([gt({type:String})],Nt.prototype,"label",void 0),t([gt({type:String})],Nt.prototype,"title",void 0),Nt=t([ht("acp-header-pill")],Nt);var Ht,Lt={exports:{}};Ht=Lt,function(){var t=Math.PI,e=Math.sin,s=Math.cos,i=Math.tan,o=Math.asin,n=Math.atan2,r=Math.acos,a=t/180,l=864e5,c=2440588,d=2451545;function h(t){return new Date((t+.5-c)*l)}function p(t){return function(t){return t.valueOf()/l-.5+c}(t)-d}var u=23.4397*a;function g(t,o){return n(e(t)*s(u)-i(o)*e(u),s(t))}function _(t,i){return o(e(i)*s(u)+s(i)*e(u)*e(t))}function v(t,o,r){return n(e(t),s(t)*e(o)-i(r)*s(o))}function f(t,i,n){return o(e(i)*e(n)+s(i)*s(n)*s(t))}function m(t,e){return a*(280.16+360.9856235*t)-e}function y(t){return a*(357.5291+.98560028*t)}function $(s){return s+a*(1.9148*e(s)+.02*e(2*s)+3e-4*e(3*s))+102.9372*a+t}function b(t){var e=$(y(t));return{dec:_(e,0),ra:g(e,0)}}var w={getPosition:function(t,e,s){var i=a*-s,o=a*e,n=p(t),r=b(n),l=m(n,i)-r.ra;return{azimuth:v(l,o,r.dec),altitude:f(l,o,r.dec)}}},x=w.times=[[-.833,"sunrise","sunset"],[-.3,"sunriseEnd","sunsetStart"],[-6,"dawn","dusk"],[-12,"nauticalDawn","nauticalDusk"],[-18,"nightEnd","night"],[6,"goldenHourEnd","goldenHour"]];w.addTime=function(t,e,s){x.push([t,e,s])};var k=9e-4;function A(e,s,i){return k+(e+s)/(2*t)+i}function S(t,s,i){return d+t+.0053*e(s)-.0069*e(2*i)}function E(t,i,o,n,a,l,c){var d=function(t,i,o){return r((e(t)-e(i)*e(o))/(s(i)*s(o)))}(t,o,n);return S(A(d,i,a),l,c)}function C(t){var i=a*(134.963+13.064993*t),o=a*(93.272+13.22935*t),n=a*(218.316+13.176396*t)+6.289*a*e(i),r=5.128*a*e(o),l=385001-20905*s(i);return{ra:g(n,r),dec:_(n,r),dist:l}}function M(t,e){return new Date(t.valueOf()+e*l/24)}w.getTimes=function(e,s,i,o){var n,r,l,c,d,u=a*-i,g=a*s,v=function(t){return-2.076*Math.sqrt(t)/60}(o=o||0),f=function(e,s){return Math.round(e-k-s/(2*t))}(p(e),u),m=A(0,u,f),b=y(m),w=$(b),C=_(w,0),M=S(m,b,w),P={solarNoon:h(M),nadir:h(M-.5)};for(n=0,r=x.length;n<r;n+=1)d=M-((c=E(((l=x[n])[0]+v)*a,u,g,C,f,b,w))-M),P[l[1]]=h(d),P[l[2]]=h(c);return P},w.getMoonPosition=function(t,o,r){var l=a*-r,c=a*o,d=p(t),h=C(d),u=m(d,l)-h.ra,g=f(u,c,h.dec),_=n(e(u),i(c)*s(h.dec)-e(h.dec)*s(u));return g+=function(t){return t<0&&(t=0),2967e-7/Math.tan(t+.00312536/(t+.08901179))}(g),{azimuth:v(u,c,h.dec),altitude:g,distance:h.dist,parallacticAngle:_}},w.getMoonIllumination=function(t){var i=p(t||new Date),o=b(i),a=C(i),l=149598e3,c=r(e(o.dec)*e(a.dec)+s(o.dec)*s(a.dec)*s(o.ra-a.ra)),d=n(l*e(c),a.dist-l*s(c)),h=n(s(o.dec)*e(o.ra-a.ra),e(o.dec)*s(a.dec)-s(o.dec)*e(a.dec)*s(o.ra-a.ra));return{fraction:(1+s(d))/2,phase:.5+.5*d*(h<0?-1:1)/Math.PI,angle:h}},w.getMoonTimes=function(t,e,s,i){var o=new Date(t);i?o.setUTCHours(0,0,0,0):o.setHours(0,0,0,0);for(var n,r,l,c,d,h,p,u,g,_,v,f,m,y=.133*a,$=w.getMoonPosition(o,e,s).altitude-y,b=1;b<=24&&(n=w.getMoonPosition(M(o,b),e,s).altitude-y,u=((d=($+(r=w.getMoonPosition(M(o,b+1),e,s).altitude-y))/2-n)*(p=-(h=(r-$)/2)/(2*d))+h)*p+n,_=0,(g=h*h-4*d*n)>=0&&(v=p-(m=Math.sqrt(g)/(2*Math.abs(d))),f=p+m,Math.abs(v)<=1&&_++,Math.abs(f)<=1&&_++,v<-1&&(v=f)),1===_?$<0?l=b+v:c=b+v:2===_&&(l=b+(u<0?f:v),c=b+(u<0?v:f)),!l||!c);b+=2)$=r;var x={};return l&&(x.rise=M(o,l)),c&&(x.set=M(o,c)),l||c||(x[u>0?"alwaysUp":"alwaysDown"]=!0),x},Ht.exports=w}();var jt=Dt(Lt.exports);function Bt(t,e,s,i=10){const o=[],n=s.getTime()+864e5;for(let r=s.getTime();r<=n;r+=60*i*1e3){const s=new Date(r),i=jt.getPosition(s,t,e);o.push({t:s,elevation:180*i.altitude/Math.PI,azimuth:((180*i.azimuth/Math.PI+180)%360+360)%360})}return o}function Wt(t=new Date){const e=new Date(t);return e.setHours(0,0,0,0),e}function Vt(t,e,s,i){const o=((e-s)%360+360)%360;return((t-o)%360+360)%360<=((((e+i)%360+360)%360-o)%360+360)%360}function qt(t,e,s=new Date){const i=jt.getMoonPosition(s,t,e),o=jt.getMoonIllumination(s);return{azimuth:((180*i.azimuth/Math.PI+180)%360+360)%360,elevation:180*i.altitude/Math.PI,phase:o.phase,fraction:o.fraction,phaseName:Zt(o.phase)}}function Zt(t){return t<.0625||t>=.9375?"New Moon":t<.1875?"Waxing Crescent":t<.3125?"First Quarter":t<.4375?"Waxing Gibbous":t<.5625?"Full Moon":t<.6875?"Waning Gibbous":t<.8125?"Last Quarter":"Waning Crescent"}function Gt(t){return null==t||Number.isNaN(t)?"—":`${Math.round(t)}%`}function Jt(t){return null==t||Number.isNaN(t)?"—":`${t.toFixed(1)}°`}function Xt(t){if(!t)return"—";const e=new Date(t);return Number.isNaN(e.getTime())?"—":e.toLocaleTimeString([],{hour:"2-digit",minute:"2-digit"})}function Kt(t){if(!t)return"—";const e=new Date(t).getTime();if(Number.isNaN(e))return"—";const s=Math.round((e-Date.now())/1e3);return s<=0?"expired":function(t){if(null==t||Number.isNaN(t))return"—";const e=Math.max(0,Math.round(t));if(e<60)return`${e}s`;const s=Math.floor(e/60);return s<60?`${s}m ${e%60}s`:`${Math.floor(s/60)}h ${s%60}m`}(s)}const Qt=["#1f77b4","#ff7f0e","#2ca02c","#d62728","#9467bd","#17becf","#e377c2"];function Yt(t){const e=Qt.length;return Qt[(t%e+e)%e]}const te=110;let ee=class extends ct{constructor(){super(...arguments),this.discovered_list=[],this.compact=!1,this.showStats=!0,this.showLegend=!0,this.showMoon=!1,this.showCardinals=!0,this.showBlindSpot=!0,this.showSunPath=!0,this.showSunriseSunset=!0,this.showCoverFill=!0,this.showWindowArrow=!0}_sunFor(t){const e=t.entities.sun_sensor;if(!e)return null;const s=this.hass.states[e];if(!s)return null;const i=parseFloat(s.state);return Number.isNaN(i)?null:{...s.attributes,window_azimuth:s.attributes.window_azimuth}}_coverPositionFor(t){const e=t.entities.target_position_sensor;if(!e)return null;const s=parseFloat(this.hass.states[e]?.state??"");return Number.isNaN(s)?null:s}_sunInfrontFor(t){const e=t.entities.sun_infront_binary;return!!e&&"on"===this.hass.states[e]?.state}_buildOverlays(){const t=[];return this.discovered_list.forEach((e,s)=>{const i=this._sunFor(e);if(!i)return;const o=e.entities.sun_sensor,n=parseFloat(this.hass.states[o]?.state??"0");t.push({d:e,sun:i,sunAzi:n,sunInfront:this._sunInfrontFor(e),coverPos:this._coverPositionFor(e),color:Yt(s),index:s})}),t}render(){if(!this.hass)return Z;if(!this.discovered_list||0===this.discovered_list.length)return W`<div class="placeholder">No Adaptive Cover Pro entries selected.</div>`;const t=this._buildOverlays();if(0===t.length)return W`<div class="placeholder">Sun sensor not yet populated.</div>`;const e=t.length>1,s=t[0],i=s.sunAzi,o=s.sun.elevation,n=Ft(i,o),r=t.some(t=>t.sun.in_fov),a=t.some(t=>t.sunInfront),l=o<=0,c=!l&&a?"sun valid":!l&&r?"sun in-fov":"sun",{latitude:d,longitude:h}=this.hass.config,p=void 0!==d&&void 0!==h?Bt(d,h,Wt()):[],u=this.showMoon&&void 0!==d&&void 0!==h?qt(d,h):null,g=null!==u&&u.elevation>0,_=u?u.phase<.5?-24*u.phase:24*(1-u.phase):0,v=g?Ft(u.azimuth,u.elevation):null,f=v?v.x*te:0,m=v?v.y*te:0,y=this.showSunPath?p.filter(t=>t.elevation>0).map(t=>{const e=Ft(t.azimuth,t.elevation);return`${(e.x*te).toFixed(1)},${(e.y*te).toFixed(1)}`}).join(" "):"",{riseAzimuth:$,setAzimuth:b}=this.showSunriseSunset?function(t){let e=-1,s=-1;for(let i=0;i<t.length;i++)t[i].elevation>0&&(-1===e&&(e=i),s=i);return{riseAzimuth:e>=0?t[e].azimuth:null,setAzimuth:s>=0?t[s].azimuth:null}}(p):{riseAzimuth:null,setAzimuth:null},w=null!==$?It($,te):null,x=null!==b?It(b,te):null,k=`Sun: ${Jt(i)} az / ${Jt(o)} el`,A=null!==$?`Sunrise: ${Jt($)}`:"",S=null!==b?`Sunset: ${Jt(b)}`:"",E=null!==u?`Moon: ${u.phaseName} (${Math.round(100*u.fraction)}%)`:"";return W`
       <div class="compass">
         <svg viewBox="${-140} ${-140} ${280} ${280}">
           ${V`
             <defs>
-              ${u?V`
+              ${g?V`
                 <mask id="moon-phase-mask">
-                  <circle cx=${_} cy=${m} r=${6} fill="white" />
-                  <circle cx=${_+g} cy=${m} r=${6} fill="black" />
+                  <circle cx=${f} cy=${m} r=${6} fill="white"></circle>
+                  <circle cx=${f+_} cy=${m} r=${6} fill="black"></circle>
                 </mask>
               `:Z}
             </defs>
-            <!-- concentric elevation rings at 30°, 60° -->
-            <circle class="grid" r=${qt} />
-            <circle class="grid" r=${220/3} />
-            <circle class="grid" r=${qt/3} />
-            <!-- cardinal direction lines -->
-            <line class="grid thin" x1="0" y1=${-110} x2="0" y2=${qt} />
-            <line class="grid thin" x1=${-110} y1="0" x2=${qt} y2="0" />
 
-            <!-- FOV wedge -->
-            <g data-tooltip=${T}>
-              <title>${T}</title>
-              <path class="fov" d=${zt(i,s,qt)} />
-            </g>
+            <circle class="grid" r=${te}></circle>
+            <circle class="grid" r=${220/3}></circle>
+            <circle class="grid" r=${te/3}></circle>
+            <line class="grid thin" x1="0" y1=${-110} x2="0" y2=${te}></line>
+            <line class="grid thin" x1=${-110} y1="0" x2=${te} y2="0"></line>
 
-            <!-- cover closure fill (inner wedge, same FOV span, radius ∝ closure) -->
-            ${null!==A&&A>.5?V`<g data-tooltip=${O}><title>${O}</title><path class="cover-fill" d=${zt(i,s,A)} /></g>`:Z}
+            ${t.map(t=>this._renderEntryLayers(t,e))}
 
-            <!-- blind spot (hatched) -->
-            ${w?V`<g data-tooltip=${N}><title>${N}</title><path class="blind-spot" d=${w} /></g>`:Z}
+            ${this.showSunPath&&y?V`<g data-tooltip="Sun path (today)"><title>Sun path (today)</title><polyline class="sun-path" points=${y}></polyline></g>`:Z}
 
-            <!-- sun path arc -->
-            ${f?V`<g data-tooltip="Sun path (today)"><title>Sun path (today)</title><polyline class="sun-path" points=${f} /></g>`:Z}
+            ${this.showSunriseSunset&&w&&null!==$?V`<g data-tooltip=${A}><title>${A}</title><circle class="rise-marker" cx=${w.x} cy=${w.y} r="4"></circle></g>`:Z}
+            ${this.showSunriseSunset&&x&&null!==b?V`<g data-tooltip=${S}><title>${S}</title><circle class="set-marker" cx=${x.x} cy=${x.y} r="4"></circle></g>`:Z}
 
-            <!-- sunrise / sunset markers -->
-            ${b&&null!==y?V`<g data-tooltip=${I}><title>${I}</title><circle class="rise-marker" cx=${b.x} cy=${b.y} r="4" /></g>`:Z}
-            ${x&&null!==$?V`<g data-tooltip=${R}><title>${R}</title><circle class="set-marker" cx=${x.x} cy=${x.y} r="4" /></g>`:Z}
+            ${this.showCardinals?V`
+              <text class="cardinal" x="0" y=${-116} text-anchor="middle">N</text>
+              <text class="cardinal" x=${120} y="4" text-anchor="middle">E</text>
+              <text class="cardinal" x="0" y=${124} text-anchor="middle">S</text>
+              <text class="cardinal" x=${-120} y="4" text-anchor="middle">W</text>
+            `:Z}
 
-            <!-- window normal arrow -->
-            <g data-tooltip=${z}>
-              <title>${z}</title>
-              <line class="window" x1="0" y1="0" x2=${l.x} y2=${l.y} />
-              <circle class="window-base" cx="0" cy="0" r="4" />
-            </g>
-
-            <!-- cardinal labels -->
-            <text class="cardinal" x="0" y=${-116} text-anchor="middle">N</text>
-            <text class="cardinal" x=${120} y="4" text-anchor="middle">E</text>
-            <text class="cardinal" x="0" y=${124} text-anchor="middle">S</text>
-            <text class="cardinal" x=${-120} y="4" text-anchor="middle">W</text>
-
-            <!-- moon dot (above-horizon only) -->
-            ${u?V`
-              <g data-tooltip=${U}>
-                <title>${U}</title>
-                <circle class="moon-outline" cx=${_} cy=${m} r=${6} />
-                <circle class="moon-lit" cx=${_} cy=${m} r=${6} mask="url(#moon-phase-mask)" />
+            ${g?V`
+              <g data-tooltip=${E}>
+                <title>${E}</title>
+                <circle class="moon-outline" cx=${f} cy=${m} r=${6}></circle>
+                <circle class="moon-lit" cx=${f} cy=${m} r=${6} mask="url(#moon-phase-mask)"></circle>
               </g>
             `:Z}
 
-            <!-- sun dot -->
-            <g data-tooltip=${P}>
-              <title>${P}</title>
-              <circle class=${M} cx=${a.x*qt} cy=${a.y*qt} r="7" />
+            <g data-tooltip=${k}>
+              <title>${k}</title>
+              <circle class=${c} cx=${n.x*te} cy=${n.y*te} r="7"></circle>
             </g>
           `}
         </svg>
-        ${this.showLegend?W`<div class="legend">
-              <div><span class="dot sun valid"></span> Sun (in FOV)</div>
-              <div><span class="dot sun"></span> Sun (outside)</div>
-              ${this.showMoon?W`<div><span class="dot moon-dot"></span> Moon</div>`:Z}
-              <div><span class="swatch fov"></span> Window FOV</div>
-              <div><span class="swatch sun-path-swatch"></span> Sun path</div>
-              <div><span class="dot rise-dot"></span> Sunrise</div>
-              <div><span class="dot set-dot"></span> Sunset</div>
-              <div><span class="swatch cover-fill-swatch"></span> Cover closed</div>
-              <div><span class="swatch window-swatch"></span> Window normal</div>
-            </div>`:Z}
-        ${this.showStats?W`<div class="stats dim">
-              <span>Azi: ${Bt(n)}</span>
-              <span>Elev: ${Bt(r)}</span>
-              <span>∠: ${Bt(t.gamma)}</span>
-              <span>Window: ${Bt(e)}</span>
-              ${this.showMoon&&p?W`<span>${p.phaseName} ${Math.round(100*p.fraction)}%</span>`:Z}
-            </div>`:Z}
+        ${this.showLegend?this._renderLegend(t,e):Z}
+        ${this.showStats?this._renderStats(t,e):Z}
       </div>
-    `}};Zt.styles=r`
+    `}_renderEntryLayers(t,e){const s=Ut(t.sun.window_azimuth),i=Ut(s-t.sun.fov_left),o=Ut(s+t.sun.fov_right),n=It(s,te),r=null!==t.coverPos?te*(1-t.coverPos/100):null,a=t.sun.blind_spot_range?Rt(Ut(t.sun.blind_spot_range[0]),Ut(t.sun.blind_spot_range[1]),te):null,l=Rt(i,o,te),c=null!==r?Rt(i,o,r):"",d=e?`${t.d.entry_title}: `:"",h=`${d}FOV ${Jt(t.sun.fov_left)} left / ${Jt(t.sun.fov_right)} right`,p=`${d}Window normal: ${Jt(s)}`,u=null!==t.coverPos?`${d}Cover closed: ${t.coverPos}%`:"",g=t.sun.blind_spot_range?`${d}Blind spot: ${Jt(t.sun.blind_spot_range[0])} – ${Jt(t.sun.blind_spot_range[1])}`:"",_=e?`fill: ${t.color}; stroke: ${t.color};`:"",v=e?`fill: ${t.color}; stroke: ${t.color};`:"",f=e?`fill: ${t.color}; stroke: ${t.color};`:"",m=e?`stroke: ${t.color};`:"",y=e?`fill: ${t.color};`:"",$=this.showCoverFill&&null!==r&&r>.5,b=this.showBlindSpot&&!!a,w=this.showWindowArrow,x=`M 0 0 L ${n.x} ${n.y}`,k="display: none;";return V`<g class="entry-overlay">
+      <g data-tooltip=${h}>
+        <title>${h}</title>
+        <path class="fov" style=${_} d=${l}></path>
+      </g>
+      <g class="arrow-group" data-tooltip=${p} style=${w?"":k}>
+        <title>${p}</title>
+        <path class="window" style=${m} d=${x}></path>
+        <circle class="window-base" style=${y} cx="0" cy="0" r="4"></circle>
+      </g>
+      <g class="cover-group" data-tooltip=${u} style=${$?"":k}>
+        <title>${u}</title>
+        <path class="cover-fill" style=${v} d=${c}></path>
+      </g>
+      <g class="blind-group" data-tooltip=${g} style=${b?"":k}>
+        <title>${g}</title>
+        <path class="blind-spot" style=${f} d=${a??""}></path>
+      </g>
+    </g>`}_renderLegend(t,e){return e?W`
+        <div class="legend">
+          ${t.map(t=>W`
+              <div>
+                <span class="swatch entry" style="background: ${t.color}"></span>
+                ${t.d.entry_title}
+                ${t.sunInfront?W`<span class="status valid">✓ in FOV</span>`:t.sun.in_fov?W`<span class="status in-fov">in FOV</span>`:W`<span class="status">—</span>`}
+              </div>
+            `)}
+          <div><span class="dot sun valid"></span> Sun</div>
+          ${this.showMoon?W`<div><span class="dot moon-dot"></span> Moon</div>`:Z}
+        </div>
+      `:W`<div class="legend">
+      <div><span class="dot sun valid"></span> Sun (in FOV)</div>
+      <div><span class="dot sun"></span> Sun (outside)</div>
+      ${this.showMoon?W`<div><span class="dot moon-dot"></span> Moon</div>`:Z}
+      <div><span class="swatch fov"></span> Window FOV</div>
+      ${this.showSunPath?W`<div><span class="swatch sun-path-swatch"></span> Sun path</div>`:Z}
+      ${this.showSunriseSunset?W`<div><span class="dot rise-dot"></span> Sunrise</div>
+            <div><span class="dot set-dot"></span> Sunset</div>`:Z}
+      ${this.showCoverFill?W`<div><span class="swatch cover-fill-swatch"></span> Cover closed</div>`:Z}
+      ${this.showWindowArrow?W`<div><span class="swatch window-swatch"></span> Window normal</div>`:Z}
+    </div>`}_renderStats(t,e){const s=t[0],i=s.sunAzi,o=s.sun.elevation,{latitude:n,longitude:r}=this.hass.config,a=this.showMoon&&void 0!==n&&void 0!==r?qt(n,r):null;return e?W`
+        <div class="stats dim">
+          <div class="stats-row">
+            <span>Sun: ${Jt(i)} / ${Jt(o)}</span>
+            ${this.showMoon&&a?W`<span>${a.phaseName} ${Math.round(100*a.fraction)}%</span>`:Z}
+          </div>
+          ${t.map(t=>W`
+              <div class="stats-row entry-row">
+                <span class="swatch entry" style="background: ${t.color}"></span>
+                <span class="entry-name">${t.d.entry_title}</span>
+                <span>∠${Jt(t.sun.gamma)}</span>
+                <span>W ${Jt(Ut(t.sun.window_azimuth))}</span>
+                ${t.sun.in_fov?W`<span class="status in-fov">✓</span>`:Z}
+              </div>
+            `)}
+        </div>
+      `:W`<div class="stats dim">
+      <span>Azi: ${Jt(i)}</span>
+      <span>Elev: ${Jt(o)}</span>
+      <span>∠: ${Jt(s.sun.gamma)}</span>
+      <span>Window: ${Jt(Ut(s.sun.window_azimuth))}</span>
+      ${this.showMoon&&a?W`<span>${a.phaseName} ${Math.round(100*a.fraction)}%</span>`:Z}
+    </div>`}};ee.styles=r`
     :host {
       display: block;
     }
@@ -177,6 +202,7 @@ function t(t,e,i,s){var o,n=arguments.length,r=n<3?e:null===s?s=Object.getOwnPro
       stroke-dasharray: 3 3;
     }
     .window {
+      fill: none;
       stroke: var(--primary-color);
       stroke-width: 3;
       stroke-linecap: round;
@@ -211,6 +237,16 @@ function t(t,e,i,s){var o,n=arguments.length,r=n<3?e:null===s?s=Object.getOwnPro
       flex-wrap: wrap;
       justify-content: center;
     }
+    .legend .status {
+      margin-left: 4px;
+      opacity: 0.8;
+    }
+    .legend .status.valid {
+      color: gold;
+    }
+    .legend .status.in-fov {
+      color: orange;
+    }
     .dot,
     .swatch {
       display: inline-block;
@@ -224,6 +260,10 @@ function t(t,e,i,s){var o,n=arguments.length,r=n<3?e:null===s?s=Object.getOwnPro
       background: gold;
       opacity: 0.4;
       border-radius: 2px;
+    }
+    .swatch.entry {
+      border-radius: 2px;
+      opacity: 0.9;
     }
     .dot.sun {
       background: var(--secondary-text-color);
@@ -255,10 +295,23 @@ function t(t,e,i,s){var o,n=arguments.length,r=n<3?e:null===s?s=Object.getOwnPro
     }
     .stats {
       display: flex;
-      gap: 12px;
+      flex-direction: column;
+      gap: 4px;
       font-size: 0.78rem;
+      align-items: center;
+    }
+    .stats-row {
+      display: flex;
+      gap: 10px;
       flex-wrap: wrap;
       justify-content: center;
+    }
+    .entry-row .entry-name {
+      font-weight: 500;
+      color: var(--primary-text-color);
+    }
+    .entry-row .status.in-fov {
+      color: orange;
     }
     .dim {
       color: var(--secondary-text-color);
@@ -303,13 +356,13 @@ function t(t,e,i,s){var o,n=arguments.length,r=n<3?e:null===s?s=Object.getOwnPro
     g[data-tooltip] {
       cursor: help;
     }
-  `,t([gt({attribute:!1})],Zt.prototype,"hass",void 0),t([gt({attribute:!1})],Zt.prototype,"discovered",void 0),t([gt({type:Boolean,reflect:!0})],Zt.prototype,"compact",void 0),t([gt({attribute:!1})],Zt.prototype,"showStats",void 0),t([gt({attribute:!1})],Zt.prototype,"showLegend",void 0),t([gt({attribute:!1})],Zt.prototype,"showMoon",void 0),Zt=t([ht("acp-sky-compass")],Zt);let Jt=class extends ct{constructor(){super(...arguments),this.compact=!1}_sunAttrs(){const t=this.discovered.entities.sun_sensor;if(!t)return null;const e=this.hass.states[t];return e?e.attributes:null}render(){if(!this.hass||!this.discovered)return Z;const t=this._sunAttrs(),{latitude:e,longitude:i}=this.hass.config;if(void 0===e||void 0===i||!t)return W`<div class="placeholder">Sun elevation chart unavailable.</div>`;const s=Ft(),o=Dt(e,i,s),n=new Date,r=function(t,e,i,s){let o=-1,n=-1,r=-1;for(let a=0;a<t.length;a++){const l=t[a];l.elevation>0&&Ht(l.azimuth,e,i,s)?(-1===r&&(r=a),a-r>n-o&&(o=r,n=a)):r=-1}return-1===o?null:{startIdx:o,endIdx:n}}(o,t.window_azimuth,t.fov_left,t.fov_right),a=t=>32+(t.getTime()-s.getTime())/864e5*360,l=t=>138-(t- -10)/100*128,c=o.map(t=>`${a(t.t).toFixed(1)},${l(t.elevation).toFixed(1)}`).join(" "),d=l(0),h=a(n),p=this._interpAt(o,n),u=p?l(p.elevation):null,g=r?o[r.startIdx].t:null,v=r?o[r.endIdx].t:null,_=g?a(g):null,m=v?a(v):null;return W`
+  `,t([gt({attribute:!1})],ee.prototype,"hass",void 0),t([gt({attribute:!1})],ee.prototype,"discovered_list",void 0),t([gt({type:Boolean,reflect:!0})],ee.prototype,"compact",void 0),t([gt({attribute:!1})],ee.prototype,"showStats",void 0),t([gt({attribute:!1})],ee.prototype,"showLegend",void 0),t([gt({attribute:!1})],ee.prototype,"showMoon",void 0),t([gt({attribute:!1})],ee.prototype,"showCardinals",void 0),t([gt({attribute:!1})],ee.prototype,"showBlindSpot",void 0),t([gt({attribute:!1})],ee.prototype,"showSunPath",void 0),t([gt({attribute:!1})],ee.prototype,"showSunriseSunset",void 0),t([gt({attribute:!1})],ee.prototype,"showCoverFill",void 0),t([gt({attribute:!1})],ee.prototype,"showWindowArrow",void 0),ee=t([ht("acp-sky-compass")],ee);let se=class extends ct{constructor(){super(...arguments),this.compact=!1}_sunAttrs(){const t=this.discovered.entities.sun_sensor;if(!t)return null;const e=this.hass.states[t];return e?e.attributes:null}render(){if(!this.hass||!this.discovered)return Z;const t=this._sunAttrs(),{latitude:e,longitude:s}=this.hass.config;if(void 0===e||void 0===s||!t)return W`<div class="placeholder">Sun elevation chart unavailable.</div>`;const i=Wt(),o=Bt(e,s,i),n=new Date,r=function(t,e,s,i){let o=-1,n=-1,r=-1;for(let a=0;a<t.length;a++){const l=t[a];l.elevation>0&&Vt(l.azimuth,e,s,i)?(-1===r&&(r=a),a-r>n-o&&(o=r,n=a)):r=-1}return-1===o?null:{startIdx:o,endIdx:n}}(o,t.window_azimuth,t.fov_left,t.fov_right),a=t=>32+(t.getTime()-i.getTime())/864e5*360,l=t=>138-(t- -10)/100*128,c=o.map(t=>`${a(t.t).toFixed(1)},${l(t.elevation).toFixed(1)}`).join(" "),d=l(0),h=a(n),p=this._interpAt(o,n),u=p?l(p.elevation):null,g=r?o[r.startIdx].t:null,_=r?o[r.endIdx].t:null,v=g?a(g):null,f=_?a(_):null;return W`
       <div class="wrap">
         <div class="head">
           <span class="label">Sun today</span>
-          ${g&&v?W`<span class="dim"
-                >FOV: ${Wt(g.toISOString())} →
-                ${Wt(v.toISOString())}</span
+          ${g&&_?W`<span class="dim"
+                >FOV: ${Xt(g.toISOString())} →
+                ${Xt(_.toISOString())}</span
               >`:W`<span class="dim">Sun does not enter FOV today</span>`}
         </div>
         <svg viewBox="0 0 ${400} ${160}" preserveAspectRatio="none">
@@ -321,7 +374,7 @@ function t(t,e,i,s){var o,n=arguments.length,r=n<3?e:null===s?s=Object.getOwnPro
             `)}
 
             <!-- x-axis gridlines at every 6h -->
-            ${[0,6,12,18,24].map(t=>{const e=new Date(s.getTime()+36e5*t);return V`
+            ${[0,6,12,18,24].map(t=>{const e=new Date(i.getTime()+36e5*t);return V`
                 <line class="grid faint" x1=${a(e)} y1=${10} x2=${a(e)} y2=${138} />
                 <text class="tick" x=${a(e)} y=${152} text-anchor="middle">${t.toString().padStart(2,"0")}:00</text>
               `})}
@@ -330,11 +383,11 @@ function t(t,e,i,s){var o,n=arguments.length,r=n<3?e:null===s?s=Object.getOwnPro
             <line class="horizon" x1=${32} y1=${d} x2=${392} y2=${d} />
 
             <!-- FOV shaded band (only the time the sun is actually in FOV + above horizon) -->
-            ${null!==_&&null!==m?V`<rect
+            ${null!==v&&null!==f?V`<rect
                   class="fov-band"
-                  x=${_}
+                  x=${v}
                   y=${10}
-                  width=${m-_}
+                  width=${f-v}
                   height=${128}
                 />`:Z}
 
@@ -349,7 +402,7 @@ function t(t,e,i,s){var o,n=arguments.length,r=n<3?e:null===s?s=Object.getOwnPro
           `}
         </svg>
       </div>
-    `}_interpAt(t,e){if(0===t.length)return null;const i=e.getTime();if(i<=t[0].t.getTime())return t[0];if(i>=t[t.length-1].t.getTime())return t[t.length-1];for(let s=1;s<t.length;s++)if(t[s].t.getTime()>=i){const o=t[s-1],n=t[s],r=(i-o.t.getTime())/(n.t.getTime()-o.t.getTime());return{t:e,elevation:o.elevation+(n.elevation-o.elevation)*r,azimuth:o.azimuth+(n.azimuth-o.azimuth)*r}}return t[t.length-1]}};Jt.styles=r`
+    `}_interpAt(t,e){if(0===t.length)return null;const s=e.getTime();if(s<=t[0].t.getTime())return t[0];if(s>=t[t.length-1].t.getTime())return t[t.length-1];for(let i=1;i<t.length;i++)if(t[i].t.getTime()>=s){const o=t[i-1],n=t[i],r=(s-o.t.getTime())/(n.t.getTime()-o.t.getTime());return{t:e,elevation:o.elevation+(n.elevation-o.elevation)*r,azimuth:o.azimuth+(n.azimuth-o.azimuth)*r}}return t[t.length-1]}};se.styles=r`
     :host {
       display: block;
     }
@@ -425,7 +478,7 @@ function t(t,e,i,s){var o,n=arguments.length,r=n<3?e:null===s?s=Object.getOwnPro
       text-align: center;
       padding: 20px;
     }
-  `,t([gt({attribute:!1})],Jt.prototype,"hass",void 0),t([gt({attribute:!1})],Jt.prototype,"discovered",void 0),t([gt({type:Boolean,reflect:!0})],Jt.prototype,"compact",void 0),Jt=t([ht("acp-elevation-chart")],Jt);let Gt=class extends ct{constructor(){super(...arguments),this.compact=!1,this.hideInactive=!1}_trace(){const t=this.discovered.entities.decision_trace_sensor;if(!t)return null;const e=this.hass.states[t];if(!e)return null;const i=e.attributes;if(!i?.trace)return null;const s=new Map;for(const t of i.trace)s.set(Xt(t.handler),{matched:t.matched,reason:t.reason,position:t.position});return{winner:e.state,reason:i.reason??"",steps:s}}render(){if(!this.hass||!this.discovered)return Z;const t=this._trace();if(!t)return W`<div class="placeholder">Decision trace not yet populated.</div>`;const e=(i=$t,s=t.steps,o=t.winner,this.hideInactive?i.filter(t=>t===o||!0===s.get(t)?.matched):[...i]);var i,s,o;return W`
+  `,t([gt({attribute:!1})],se.prototype,"hass",void 0),t([gt({attribute:!1})],se.prototype,"discovered",void 0),t([gt({type:Boolean,reflect:!0})],se.prototype,"compact",void 0),se=t([ht("acp-elevation-chart")],se);let ie=class extends ct{constructor(){super(...arguments),this.compact=!1,this.hideInactive=!1}_trace(){const t=this.discovered.entities.decision_trace_sensor;if(!t)return null;const e=this.hass.states[t];if(!e)return null;const s=e.attributes;if(!s?.trace)return null;const i=new Map;for(const t of s.trace)i.set(oe(t.handler),{matched:t.matched,reason:t.reason,position:t.position});return{winner:e.state,reason:s.reason??"",steps:i}}render(){if(!this.hass||!this.discovered)return Z;const t=this._trace();if(!t)return W`<div class="placeholder">Decision trace not yet populated.</div>`;const e=(s=wt,i=t.steps,o=t.winner,this.hideInactive?s.filter(t=>t===o||!0===i.get(t)?.matched):[...s]);var s,i,o;return W`
       <div class="wrap">
         <div class="head">
           <span class="label">Pipeline</span>
@@ -434,15 +487,15 @@ function t(t,e,i,s){var o,n=arguments.length,r=n<3?e:null===s?s=Object.getOwnPro
         <div class="rows">${e.map(e=>this._row(e,t.steps.get(e),t.winner===e))}</div>
         <div class="reason dim">${t.reason}</div>
       </div>
-    `}_row(t,e,i){const s=e?.matched??!1,o=e?.reason??"not evaluated",n=e?.position;return W`
-      <div class="row ${i?"winner":s?"match":"skip"}">
-        <span class="name">${bt[t]}</span>
-        <span class="dots" aria-hidden="true">${s?"████":"────"}</span>
-        <span class="pos">${null!=n?Lt(n):""}</span>
+    `}_row(t,e,s){const i=e?.matched??!1,o=e?.reason??"not evaluated",n=e?.position;return W`
+      <div class="row ${s?"winner":i?"match":"skip"}">
+        <span class="name">${xt[t]}</span>
+        <span class="dots" aria-hidden="true">${i?"████":"────"}</span>
+        <span class="pos">${null!=n?Gt(n):""}</span>
         <span class="reason-inline dim">${o}</span>
-        ${i?W`<span class="badge">✓</span>`:Z}
+        ${s?W`<span class="badge">✓</span>`:Z}
       </div>
-    `}};function Xt(t){return t.replace(/Handler$/,"").replace(/([a-z])([A-Z])/g,"$1_$2").toLowerCase().replace(/^force_override$/,"force").replace(/^weather_override$/,"weather").replace(/^manual_override$/,"manual").replace(/^motion_timeout$/,"motion").replace(/^cloud_suppression$/,"cloud")}Gt.styles=r`
+    `}};function oe(t){return t.replace(/Handler$/,"").replace(/([a-z])([A-Z])/g,"$1_$2").toLowerCase().replace(/^force_override$/,"force").replace(/^weather_override$/,"weather").replace(/^manual_override$/,"manual").replace(/^motion_timeout$/,"motion").replace(/^cloud_suppression$/,"cloud")}ie.styles=r`
     :host {
       display: block;
     }
@@ -536,16 +589,16 @@ function t(t,e,i,s){var o,n=arguments.length,r=n<3?e:null===s?s=Object.getOwnPro
       padding: 16px;
       text-align: center;
     }
-  `,t([gt({attribute:!1})],Gt.prototype,"hass",void 0),t([gt({attribute:!1})],Gt.prototype,"discovered",void 0),t([gt({type:Boolean,reflect:!0})],Gt.prototype,"compact",void 0),t([gt({type:Boolean,reflect:!0,attribute:"hide-inactive"})],Gt.prototype,"hideInactive",void 0),Gt=t([ht("acp-decision-strip")],Gt);let Kt=class extends ct{constructor(){super(...arguments),this.compact=!1}_target(){const t=this.discovered.entities.target_position_sensor;if(!t)return{target:null,covers:{}};const e=this.hass.states[t];if(!e)return{target:null,covers:{}};const i=parseFloat(e.state),s=e.attributes;return{target:Number.isNaN(i)?null:i,covers:s?.actual_positions??{}}}_mismatched(){const t=this.discovered.entities.position_mismatch_binary;if(!t)return new Set;const e=this.hass.states[t];if("on"!==e?.state)return new Set;const i=e.attributes.entities;return i?new Set(Object.entries(i).filter(([,t])=>t.mismatch).map(([t])=>t)):new Set}_setPosition(t,e){this.hass.callService("cover","set_cover_position",{entity_id:t,position:e})}render(){if(!this.hass||!this.discovered)return Z;const{target:t,covers:e}=this._target(),i=this._mismatched(),s=Object.entries(e);return 0===s.length?W`<div class="placeholder">No covers reported by the integration.</div>`:W`
+  `,t([gt({attribute:!1})],ie.prototype,"hass",void 0),t([gt({attribute:!1})],ie.prototype,"discovered",void 0),t([gt({type:Boolean,reflect:!0})],ie.prototype,"compact",void 0),t([gt({type:Boolean,reflect:!0,attribute:"hide-inactive"})],ie.prototype,"hideInactive",void 0),ie=t([ht("acp-decision-strip")],ie);let ne=class extends ct{constructor(){super(...arguments),this.compact=!1}_target(){const t=this.discovered.entities.target_position_sensor;if(!t)return{target:null,covers:{}};const e=this.hass.states[t];if(!e)return{target:null,covers:{}};const s=parseFloat(e.state),i=e.attributes;return{target:Number.isNaN(s)?null:s,covers:i?.actual_positions??{}}}_mismatched(){const t=this.discovered.entities.position_mismatch_binary;if(!t)return new Set;const e=this.hass.states[t];if("on"!==e?.state)return new Set;const s=e.attributes.entities;return s?new Set(Object.entries(s).filter(([,t])=>t.mismatch).map(([t])=>t)):new Set}_setPosition(t,e){this.hass.callService("cover","set_cover_position",{entity_id:t,position:e})}render(){if(!this.hass||!this.discovered)return Z;const{target:t,covers:e}=this._target(),s=this._mismatched(),i=Object.entries(e);return 0===i.length?W`<div class="placeholder">No covers reported by the integration.</div>`:W`
       <div class="wrap">
         <div class="head">
           <span class="label">Covers</span>
-          <span class="target">Target: ${Lt(t)}</span>
+          <span class="target">Target: ${Gt(t)}</span>
         </div>
-        ${s.map(([e,s])=>this._bar(e,s,t,i.has(e)))}
+        ${i.map(([e,i])=>this._bar(e,i,t,s.has(e)))}
       </div>
-    `}_bar(t,e,i,s){const o=this.hass.states[t]?.attributes?.friendly_name??t,n=i??0;return W`
-      <div class="cover ${s?"mismatch":""}">
+    `}_bar(t,e,s,i){const o=this.hass.states[t]?.attributes?.friendly_name??t,n=s??0;return W`
+      <div class="cover ${i?"mismatch":""}">
         <div class="name" title=${t}>${o}</div>
         <div
           class="track"
@@ -553,16 +606,16 @@ function t(t,e,i,s){var o,n=arguments.length,r=n<3?e:null===s?s=Object.getOwnPro
           title="Click to set position"
         >
           <div class="fill" style="width:${e??0}%"></div>
-          ${null!==i?W`<div
+          ${null!==s?W`<div
                 class="marker"
                 style="left:${n}%"
                 title="Target ${n}%"
               ></div>`:Z}
         </div>
-        <div class="num">${Lt(e)}</div>
-        ${s?W`<ha-icon class="warn" icon="mdi:alert-circle-outline"></ha-icon>`:Z}
+        <div class="num">${Gt(e)}</div>
+        ${i?W`<ha-icon class="warn" icon="mdi:alert-circle-outline"></ha-icon>`:Z}
       </div>
-    `}_handleTrackClick(t,e){const i=t.currentTarget.getBoundingClientRect(),s=Math.round((t.clientX-i.left)/i.width*100),o=Math.max(0,Math.min(100,s));this._setPosition(e,o)}};Kt.styles=r`
+    `}_handleTrackClick(t,e){const s=t.currentTarget.getBoundingClientRect(),i=Math.round((t.clientX-s.left)/s.width*100),o=Math.max(0,Math.min(100,i));this._setPosition(e,o)}};ne.styles=r`
     :host {
       display: block;
     }
@@ -643,25 +696,25 @@ function t(t,e,i,s){var o,n=arguments.length,r=n<3?e:null===s?s=Object.getOwnPro
       text-align: center;
       padding: 16px;
     }
-  `,t([gt({attribute:!1})],Kt.prototype,"hass",void 0),t([gt({attribute:!1})],Kt.prototype,"discovered",void 0),t([gt({type:Boolean,reflect:!0})],Kt.prototype,"compact",void 0),Kt=t([ht("acp-cover-bar")],Kt);let Qt=class extends ct{constructor(){super(...arguments),this.compact=!1,this.resetEnabled=!0}_manualActive(){const t=this.discovered.entities.manual_override_binary;return!!t&&"on"===this.hass.states[t]?.state}_manualEndIso(){const t=this.discovered.entities.manual_override_end_sensor;if(!t)return null;const e=this.hass.states[t];return e&&"unknown"!==e.state&&"unavailable"!==e.state?e.state:null}_motionStatus(){const t=this.discovered.entities.motion_status_sensor;if(!t)return null;const e=this.hass.states[t];if(!e)return null;const i=e.attributes.motion_timeout_end_time;return{state:e.state,endIso:i??null}}_forceActive(){const t=this.discovered.entities.force_override_sensor;if(!t)return 0;const e=this.hass.states[t];return e&&parseInt(e.state,10)||0}_resetManual(){const t=this.discovered.entities.reset_override_button;t&&this.hass.callService("button","press",{entity_id:t})}render(){if(!this.hass||!this.discovered)return Z;const t=this._manualActive(),e=this._manualEndIso(),i=this._motionStatus(),s=this._forceActive(),o=this.discovered.entities.reset_override_button;return W`
+  `,t([gt({attribute:!1})],ne.prototype,"hass",void 0),t([gt({attribute:!1})],ne.prototype,"discovered",void 0),t([gt({type:Boolean,reflect:!0})],ne.prototype,"compact",void 0),ne=t([ht("acp-cover-bar")],ne);let re=class extends ct{constructor(){super(...arguments),this.compact=!1,this.resetEnabled=!0}_manualActive(){const t=this.discovered.entities.manual_override_binary;return!!t&&"on"===this.hass.states[t]?.state}_manualEndIso(){const t=this.discovered.entities.manual_override_end_sensor;if(!t)return null;const e=this.hass.states[t];return e&&"unknown"!==e.state&&"unavailable"!==e.state?e.state:null}_motionStatus(){const t=this.discovered.entities.motion_status_sensor;if(!t)return null;const e=this.hass.states[t];if(!e)return null;const s=e.attributes.motion_timeout_end_time;return{state:e.state,endIso:s??null}}_forceActive(){const t=this.discovered.entities.force_override_sensor;if(!t)return 0;const e=this.hass.states[t];return e&&parseInt(e.state,10)||0}_resetManual(){const t=this.discovered.entities.reset_override_button;t&&this.hass.callService("button","press",{entity_id:t})}render(){if(!this.hass||!this.discovered)return Z;const t=this._manualActive(),e=this._manualEndIso(),s=this._motionStatus(),i=this._forceActive(),o=this.discovered.entities.reset_override_button;return W`
       <div class="wrap">
         <div class="label dim">Overrides</div>
         <div class="grid">
           <div class="tile ${t?"active":""}">
             <div class="tile-label">Manual</div>
             <div class="tile-value">${t?"Active":"Off"}</div>
-            ${e?W`<div class="tile-sub dim">ends in ${Vt(e)}</div>`:Z}
+            ${e?W`<div class="tile-sub dim">ends in ${Kt(e)}</div>`:Z}
           </div>
 
-          <div class="tile ${s>0?"active warning":""}">
+          <div class="tile ${i>0?"active warning":""}">
             <div class="tile-label">Force</div>
-            <div class="tile-value">${s>0?`${s} active`:"Off"}</div>
+            <div class="tile-value">${i>0?`${i} active`:"Off"}</div>
           </div>
 
-          ${i?W`<div class="tile ${"motion_detected"===i.state?"active":""}">
+          ${s?W`<div class="tile ${"motion_detected"===s.state?"active":""}">
                 <div class="tile-label">Motion</div>
-                <div class="tile-value">${i.state.replace(/_/g," ")}</div>
-                ${i.endIso?W`<div class="tile-sub dim">timeout ${Vt(i.endIso)}</div>`:Z}
+                <div class="tile-value">${s.state.replace(/_/g," ")}</div>
+                ${s.endIso?W`<div class="tile-sub dim">timeout ${Kt(s.endIso)}</div>`:Z}
               </div>`:Z}
           ${o?this.resetEnabled?W`<button class="tile action" @click=${this._resetManual}>
                   <ha-icon icon="mdi:restore"></ha-icon>
@@ -672,7 +725,7 @@ function t(t,e,i,s){var o,n=arguments.length,r=n<3?e:null===s?s=Object.getOwnPro
                 </button>`:Z}
         </div>
       </div>
-    `}};Qt.styles=r`
+    `}};re.styles=r`
     :host {
       display: block;
     }
@@ -759,18 +812,18 @@ function t(t,e,i,s){var o,n=arguments.length,r=n<3?e:null===s?s=Object.getOwnPro
     ha-icon {
       --mdc-icon-size: 18px;
     }
-  `,t([gt({attribute:!1})],Qt.prototype,"hass",void 0),t([gt({attribute:!1})],Qt.prototype,"discovered",void 0),t([gt({type:Boolean,reflect:!0})],Qt.prototype,"compact",void 0),t([gt({type:Boolean,attribute:"reset-enabled"})],Qt.prototype,"resetEnabled",void 0),Qt=t([ht("acp-overrides-panel")],Qt);const Yt={"Summer Mode":"mdi:weather-sunny","Winter Mode":"mdi:snowflake",Intermediate:"mdi:weather-partly-cloudy"};let te=class extends ct{constructor(){super(...arguments),this.compact=!1}render(){if(!this.hass||!this.discovered)return Z;const t=this.discovered.entities.climate_status_sensor;if(!t)return Z;const e=this.hass.states[t];if(!e||"unavailable"===e.state)return Z;const i=e.state,s=e.attributes??{},o=Yt[i]??"mdi:thermostat",n=s.temperature_unit??"°",r=[void 0!==s.indoor_temperature?{label:"Indoor",value:s.indoor_temperature,unit:n}:null,void 0!==s.outdoor_temperature?{label:"Outdoor",value:s.outdoor_temperature,unit:n}:null].filter(t=>null!==t),a=[{label:"Presence",value:s.is_presence,icon:"mdi:account-check"},{label:"Sunny",value:s.is_sunny,icon:"mdi:white-balance-sunny"},{label:"Lux",value:s.lux_active,icon:"mdi:brightness-7"},{label:"Irradiance",value:s.irradiance_active,icon:"mdi:solar-power"}].filter(t=>void 0!==t.value);return W`
+  `,t([gt({attribute:!1})],re.prototype,"hass",void 0),t([gt({attribute:!1})],re.prototype,"discovered",void 0),t([gt({type:Boolean,reflect:!0})],re.prototype,"compact",void 0),t([gt({type:Boolean,attribute:"reset-enabled"})],re.prototype,"resetEnabled",void 0),re=t([ht("acp-overrides-panel")],re);const ae={"Summer Mode":"mdi:weather-sunny","Winter Mode":"mdi:snowflake",Intermediate:"mdi:weather-partly-cloudy"};let le=class extends ct{constructor(){super(...arguments),this.compact=!1}render(){if(!this.hass||!this.discovered)return Z;const t=this.discovered.entities.climate_status_sensor;if(!t)return Z;const e=this.hass.states[t];if(!e||"unavailable"===e.state)return Z;const s=e.state,i=e.attributes??{},o=ae[s]??"mdi:thermostat",n=i.temperature_unit??"°",r=[void 0!==i.indoor_temperature?{label:"Indoor",value:i.indoor_temperature,unit:n}:null,void 0!==i.outdoor_temperature?{label:"Outdoor",value:i.outdoor_temperature,unit:n}:null].filter(t=>null!==t),a=[{label:"Presence",value:i.is_presence,icon:"mdi:account-check"},{label:"Sunny",value:i.is_sunny,icon:"mdi:white-balance-sunny"},{label:"Lux",value:i.lux_active,icon:"mdi:brightness-7"},{label:"Irradiance",value:i.irradiance_active,icon:"mdi:solar-power"}].filter(t=>void 0!==t.value);return W`
       <div class="wrap">
         <div class="head">
           <span class="label">Climate</span>
           <span class="dim"
             >Active:
-            ${void 0!==s.active_temperature?`${s.active_temperature.toFixed(1)}${n}`:"—"}</span
+            ${void 0!==i.active_temperature?`${i.active_temperature.toFixed(1)}${n}`:"—"}</span
           >
         </div>
         <div class="strategy">
           <ha-icon icon=${o}></ha-icon>
-          <span class="strategy-name">${i}</span>
+          <span class="strategy-name">${s}</span>
         </div>
         ${r.length?W`
               <div class="temps">
@@ -793,7 +846,7 @@ function t(t,e,i,s){var o,n=arguments.length,r=n<3?e:null===s?s=Object.getOwnPro
               </div>
             `:Z}
       </div>
-    `}};te.styles=r`
+    `}};async function ce(t){return(await t.callWS({type:"config_entries/get",domain:bt})).filter(t=>t.domain===bt).map(t=>({entry_id:t.entry_id,title:t.title}))}le.styles=r`
     :host {
       display: block;
     }
@@ -883,7 +936,7 @@ function t(t,e,i,s){var o,n=arguments.length,r=n<3?e:null===s?s=Object.getOwnPro
     .dim {
       color: var(--secondary-text-color);
     }
-  `,t([gt({attribute:!1})],te.prototype,"hass",void 0),t([gt({attribute:!1})],te.prototype,"discovered",void 0),t([gt({type:Boolean,reflect:!0})],te.prototype,"compact",void 0),te=t([ht("acp-climate-panel")],te);const ee=[{key:"sky",label:"Sky compass",description:"Sun vs. window FOV, polar plot"},{key:"elevation",label:"Sun today",description:"Elevation-vs-time chart with FOV band and current-time cursor"},{key:"decision",label:"Decision strip",description:"All 10 pipeline handlers with the winning row highlighted"},{key:"covers",label:"Cover positions",description:"Per-cover live vs. target bars; click to set position"},{key:"overrides",label:"Overrides panel",description:"Manual, force, motion tiles + reset button"},{key:"climate",label:"Climate panel",description:"Summer/winter/intermediate strategy (auto-hidden if climate mode is off)"}],ie=ee.map(t=>t.key);let se=class extends ct{constructor(){super(...arguments),this._entries=null,this._entriesError=null,this._fetchInFlight=!1}setConfig(t){this._config=t}updated(t){t.has("hass")&&this.hass&&!this._entries&&!this._fetchInFlight&&(this._fetchInFlight=!0,async function(t){return(await t.callWS({type:"config_entries/get",domain:yt})).filter(t=>t.domain===yt).map(t=>({entry_id:t.entry_id,title:t.title}))}(this.hass).then(t=>{this._entries=t,this._entriesError=null,this._config?.entry_id||1!==t.length||this._emit({...this._config??{type:"",entry_id:""},entry_id:t[0].entry_id})}).catch(t=>{this._entriesError=t?.message??"failed to load config entries"}).finally(()=>{this._fetchInFlight=!1}))}get _currentSections(){return this._config?.show_sections??ie}_emit(t){this._config=t,this.dispatchEvent(new CustomEvent("config-changed",{detail:{config:t},bubbles:!0,composed:!0}))}_onEntryChange(t){const e=t.target.value;this._emit({...this._config??{type:"",entry_id:""},entry_id:e})}_onSectionToggle(t,e){const i=new Set(this._currentSections);e?i.add(t):i.delete(t);const s=ee.map(t=>t.key).filter(t=>i.has(t));this._emit({...this._config??{type:"",entry_id:""},show_sections:s})}_onCompactToggle(t){this._emit({...this._config??{type:"",entry_id:""},compact:t})}_onVersionToggle(t){this._emit({...this._config??{type:"",entry_id:""},show_version:t})}_onCompassStatsToggle(t){this._emit({...this._config??{type:"",entry_id:""},show_compass_stats:t})}_onCompassLegendToggle(t){this._emit({...this._config??{type:"",entry_id:""},show_compass_legend:t})}_onMoonToggle(t){this._emit({...this._config??{type:"",entry_id:""},show_moon:t})}_onHideInactiveToggle(t){this._emit({...this._config??{type:"",entry_id:""},hide_inactive_handlers:t})}_onControlToggle(t,e){const i=this._config??{type:"",entry_id:""};this._emit({...i,controls:{...i.controls,[t]:e}})}render(){if(!this._config)return Z;const t=new Set(this._currentSections);return W`
+  `,t([gt({attribute:!1})],le.prototype,"hass",void 0),t([gt({attribute:!1})],le.prototype,"discovered",void 0),t([gt({type:Boolean,reflect:!0})],le.prototype,"compact",void 0),le=t([ht("acp-climate-panel")],le);const de=[{key:"sky",label:"Sky compass",description:"Sun vs. window FOV, polar plot"},{key:"elevation",label:"Sun today",description:"Elevation-vs-time chart with FOV band and current-time cursor"},{key:"decision",label:"Decision strip",description:"All 10 pipeline handlers with the winning row highlighted"},{key:"covers",label:"Cover positions",description:"Per-cover live vs. target bars; click to set position"},{key:"overrides",label:"Overrides panel",description:"Manual, force, motion tiles + reset button"},{key:"climate",label:"Climate panel",description:"Summer/winter/intermediate strategy (auto-hidden if climate mode is off)"}],he=de.map(t=>t.key);let pe=class extends ct{constructor(){super(...arguments),this._entries=null,this._entriesError=null,this._fetchInFlight=!1}setConfig(t){this._config=t}updated(t){t.has("hass")&&this.hass&&!this._entries&&!this._fetchInFlight&&(this._fetchInFlight=!0,ce(this.hass).then(t=>{this._entries=t,this._entriesError=null,this._config?.entry_id||1!==t.length||this._emit({...this._config??{type:"",entry_id:""},entry_id:t[0].entry_id})}).catch(t=>{this._entriesError=t?.message??"failed to load config entries"}).finally(()=>{this._fetchInFlight=!1}))}get _currentSections(){return this._config?.show_sections??he}_emit(t){this._config=t,this.dispatchEvent(new CustomEvent("config-changed",{detail:{config:t},bubbles:!0,composed:!0}))}_onEntryChange(t){const e=t.target.value;this._emit({...this._config??{type:"",entry_id:""},entry_id:e})}_onSectionToggle(t,e){const s=new Set(this._currentSections);e?s.add(t):s.delete(t);const i=de.map(t=>t.key).filter(t=>s.has(t));this._emit({...this._config??{type:"",entry_id:""},show_sections:i})}_onCompactToggle(t){this._emit({...this._config??{type:"",entry_id:""},compact:t})}_onVersionToggle(t){this._emit({...this._config??{type:"",entry_id:""},show_version:t})}_onCompassStatsToggle(t){this._emit({...this._config??{type:"",entry_id:""},show_compass_stats:t})}_onCompassLegendToggle(t){this._emit({...this._config??{type:"",entry_id:""},show_compass_legend:t})}_onMoonToggle(t){this._emit({...this._config??{type:"",entry_id:""},show_moon:t})}_onHideInactiveToggle(t){this._emit({...this._config??{type:"",entry_id:""},hide_inactive_handlers:t})}_onControlToggle(t,e){const s=this._config??{type:"",entry_id:""};this._emit({...s,controls:{...s.controls,[t]:e}})}render(){if(!this._config)return Z;const t=new Set(this._currentSections);return W`
       <div class="form">
         <div class="section">
           <label class="field-label">Adaptive Cover Pro instance</label>
@@ -893,7 +946,7 @@ function t(t,e,i,s){var o,n=arguments.length,r=n<3?e:null===s?s=Object.getOwnPro
         <div class="section">
           <label class="field-label">Sections</label>
           <div class="hint">Toggle which parts of the card are shown.</div>
-          ${ee.map(e=>W`
+          ${de.map(e=>W`
               <label class="toggle-row">
                 <input
                   type="checkbox"
@@ -1045,7 +1098,7 @@ function t(t,e,i,s){var o,n=arguments.length,r=n<3?e:null===s?s=Object.getOwnPro
             </option>
           `)}
       </select>
-    `:W`<div class="hint">Loading Adaptive Cover Pro config entries…</div>`}};se.styles=r`
+    `:W`<div class="hint">Loading Adaptive Cover Pro config entries…</div>`}};pe.styles=r`
     :host {
       display: block;
     }
@@ -1120,17 +1173,209 @@ function t(t,e,i,s){var o,n=arguments.length,r=n<3?e:null===s?s=Object.getOwnPro
       border-radius: 3px;
       font-size: 0.85em;
     }
-  `,t([gt({attribute:!1})],se.prototype,"hass",void 0),t([vt()],se.prototype,"_config",void 0),t([vt()],se.prototype,"_entries",void 0),t([vt()],se.prototype,"_entriesError",void 0),se=t([ht(ft)],se);const oe=["sky","elevation","decision","covers","overrides","climate"];let ne=class extends ct{constructor(){super(...arguments),this._registry=null,this._registryError=null,this._discovered=null,this._unsubRegistry=null,this._fetchInFlight=!1,this._memo=function(){let t=null,e=null;return(i,s,o)=>{const n=s.entry_id??"";return null!==t&&t.registry===o&&t.hass===i&&t.entryId===n||(t={registry:o,hass:i,entryId:n},e=function(t,e,i){const s=e.entry_id;if(!s)return null;const o={},n=`${s}_`;let r=!1;for(const t of i){if(t.config_entry_id!==s)continue;if(t.platform!==yt)continue;if(r=!0,!t.unique_id.startsWith(n))continue;const e=t.unique_id.slice(n.length),i=t.entity_id.split(".")[0],a=kt[`${i}:${e}`];a&&(o[a]=t.entity_id)}if(!r||0===Object.keys(o).length)return null;const a=t;let l=s;if(a.devices)for(const t of Object.values(a.devices))if(t.config_entries?.includes(s)){l=t.name_by_user??t.name??s;break}const c=[],d=o.target_position_sensor;if(d){const e=t.states[d]?.attributes?.actual_positions;e&&c.push(...Object.keys(e))}let h="cover_blind";const p=o.control_status_sensor;if(p){const e=t.states[p]?.attributes;e?.cover_type&&(h=e.cover_type)}return{entry_id:s,entry_title:l,cover_type:h,entities:o,managed_covers:c}}(i,s,o)),e}}(),this._debounceTimer=null,this._debounceFirstAt=null,this._DEBOUNCE_DELAY=500,this._DEBOUNCE_MAX=2e3}setConfig(t){if(!t?.entry_id)throw new Error("adaptive-cover-pro-card: `entry_id` is required");if(this._config={...t},null===this._registry){const e=St.get(t.entry_id);e&&(this._registry=e.entries)}}getCardSize(){return 6}static async getConfigElement(){return document.createElement(ft)}static getStubConfig(){return{type:`custom:${mt}`,entry_id:""}}connectedCallback(){super.connectedCallback(),this.hass&&this._ensureRegistry()}disconnectedCallback(){super.disconnectedCallback(),this._unsubRegistry&&(this._unsubRegistry(),this._unsubRegistry=null),null!==this._debounceTimer&&(clearTimeout(this._debounceTimer),this._debounceTimer=null,this._debounceFirstAt=null)}updated(t){t.has("hass")&&this.hass&&this._ensureRegistry()}willUpdate(t){null!==this._registry&&this._config&&this.hass&&(t.has("hass")||t.has("_registry")||t.has("_config"))&&(this._discovered=this._memo(this.hass,this._config,this._registry))}_ensureRegistry(){this._fetchRegistry(),this._unsubRegistry||(this._unsubRegistry=function(t,e){let i=null,s=!1;return t.connection.subscribeEvents(t=>e(t.data),"entity_registry_updated").then(t=>{s?t():i=t}).catch(()=>{}),()=>{s=!0,i&&i()}}(this.hass,t=>{const e=new Set(Ct(this._registry??[],this._config?.entry_id??"").map(t=>t.entity_id));(function(t,e){return"create"===t.action||e.has(t.entity_id)})(t,e)&&this._scheduleRefetch()}))}_fetchRegistry(){this._fetchInFlight||(this._fetchInFlight=!0,async function(t){return t.callWS({type:"config/entity_registry/list"})}(this.hass).then(t=>{const e=this._config?.entry_id;if(e){const i=Ct(t,e);(null===this._registry||function(t,e){if(t.length!==e.length)return!0;const i=new Map(t.map(t=>[t.entity_id,Et(t)]));for(const t of e)if(i.get(t.entity_id)!==Et(t))return!0;return!1}(Ct(this._registry,e),i))&&(this._registry=t,St.set(e,i))}else this._registry=t;this._registryError=null}).catch(t=>{this._registryError=t?.message??"entity registry fetch failed"}).finally(()=>{this._fetchInFlight=!1}))}_scheduleRefetch(){const t=Date.now();null===this._debounceFirstAt&&(this._debounceFirstAt=t);const e=t-this._debounceFirstAt,i=this._DEBOUNCE_MAX-e,s=Math.min(this._DEBOUNCE_DELAY,i);if(null!==this._debounceTimer&&clearTimeout(this._debounceTimer),s<=0)return this._debounceFirstAt=null,void this._fetchRegistry();this._debounceTimer=setTimeout(()=>{this._debounceTimer=null,this._debounceFirstAt=null,this._fetchRegistry()},s)}get _sections(){return this._config?.show_sections??oe}_renderHeader(t,e){const i=xt[t.cover_type]??"mdi:window-shutter",s=t.entities.integration_enabled_switch,o=t.entities.automatic_control_switch,n=!s||"on"===this.hass.states[s]?.state,r=!o||"on"===this.hass.states[o]?.state;return W`
+  `,t([gt({attribute:!1})],pe.prototype,"hass",void 0),t([_t()],pe.prototype,"_config",void 0),t([_t()],pe.prototype,"_entries",void 0),t([_t()],pe.prototype,"_entriesError",void 0),pe=t([ht(mt)],pe);const ue=[{key:"compact",label:"Compact mode",description:"Smaller SVG, legend hidden.",defaultOn:!1},{key:"show_legend",label:"Legend",description:"Color swatches + entry labels below compass.",defaultOn:!0},{key:"show_stats",label:"Stats",description:"Sun + per-window numeric rows.",defaultOn:!0},{key:"show_moon",label:"Moon",description:"Render moon position and phase.",defaultOn:!1},{key:"show_cardinals",label:"Cardinal labels",description:"N/E/S/W letters around the compass.",defaultOn:!0},{key:"show_blind_spot",label:"Blind spots",description:"Hatched wedges for each window’s blind range.",defaultOn:!0},{key:"show_sun_path",label:"Sun path",description:"Today’s sun arc across the sky.",defaultOn:!0},{key:"show_sunrise_sunset",label:"Sunrise / sunset markers",description:"Small dots at rise and set azimuths.",defaultOn:!0},{key:"show_cover_fill",label:"Cover closure fill",description:"Inner wedge showing how closed each cover is.",defaultOn:!0},{key:"show_window_arrow",label:"Window-normal arrow",description:"Line from center toward each window’s azimuth.",defaultOn:!0}];let ge=class extends ct{constructor(){super(...arguments),this._entries=null,this._entriesError=null,this._fetchInFlight=!1}setConfig(t){this._config=t}updated(t){t.has("hass")&&this.hass&&!this._entries&&!this._fetchInFlight&&(this._fetchInFlight=!0,ce(this.hass).then(t=>{this._entries=t,this._entriesError=null}).catch(t=>{this._entriesError=t?.message??"failed to load config entries"}).finally(()=>{this._fetchInFlight=!1}))}_emit(t){this._config=t,this.dispatchEvent(new CustomEvent("config-changed",{detail:{config:t},bubbles:!0,composed:!0}))}_baseConfig(){return this._config??{type:`custom:${yt}`,entry_ids:[]}}_onEntryToggle(t,e){const s=this._baseConfig(),i=new Set(s.entry_ids);e?i.add(t):i.delete(t);const o=(this._entries??[]).map(t=>t.entry_id).filter(t=>i.has(t));this._emit({...s,entry_ids:o})}_onToggle(t,e){this._emit({...this._baseConfig(),[t]:e})}_onTitleChange(t){const e=t.target.value,s=this._baseConfig();if(e)this._emit({...s,title:e});else{const{title:t,...e}=s;this._emit(e)}}render(){if(!this._config)return Z;const t=new Set(this._config.entry_ids);return W`
+      <div class="form">
+        <div class="section">
+          <label class="field-label">Adaptive Cover Pro instances</label>
+          <div class="hint">
+            Pick one or more. Each selected entry adds an overlay to the compass.
+          </div>
+          ${this._renderEntryPicker(t)}
+        </div>
+
+        <div class="section">
+          <label class="field-label">Title (optional)</label>
+          <input
+            type="text"
+            class="text-input"
+            .value=${this._config.title??""}
+            placeholder="e.g. West-facing windows"
+            @change=${this._onTitleChange}
+          />
+        </div>
+
+        <div class="section">
+          <label class="field-label">Display</label>
+          ${ue.map(t=>W`
+              <label class="toggle-row">
+                <input
+                  type="checkbox"
+                  .checked=${this._config[t.key]??t.defaultOn}
+                  @change=${e=>this._onToggle(t.key,e.target.checked)}
+                />
+                <span class="toggle-text">
+                  <span class="toggle-label">${t.label}</span>
+                  <span class="toggle-desc">${t.description}</span>
+                </span>
+              </label>
+            `)}
+        </div>
+      </div>
+    `}_renderEntryPicker(t){return this._entriesError?W`<div class="error">Failed to load config entries: ${this._entriesError}</div>`:this._entries?0===this._entries.length?W`
+        <div class="error">
+          No Adaptive Cover Pro config entries found. Add an instance under
+          <code>Settings → Devices &amp; Services</code>, then come back.
+        </div>
+      `:W`
+      <div class="entry-list">
+        ${this._entries.map(e=>W`
+            <label class="toggle-row">
+              <input
+                type="checkbox"
+                .checked=${t.has(e.entry_id)}
+                @change=${t=>this._onEntryToggle(e.entry_id,t.target.checked)}
+              />
+              <span class="toggle-text">
+                <span class="toggle-label">${e.title}</span>
+                <span class="toggle-desc">${e.entry_id}</span>
+              </span>
+            </label>
+          `)}
+      </div>
+    `:W`<div class="hint">Loading Adaptive Cover Pro config entries…</div>`}};ge.styles=r`
+    :host {
+      display: block;
+    }
+    .form {
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+      padding: 8px 0;
+    }
+    .section {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+    .field-label {
+      font-weight: 500;
+      font-size: 0.88rem;
+      color: var(--primary-text-color);
+    }
+    .hint {
+      font-size: 0.78rem;
+      color: var(--secondary-text-color);
+    }
+    .error {
+      font-size: 0.82rem;
+      color: var(--error-color, crimson);
+    }
+    .text-input {
+      width: 100%;
+      padding: 8px 10px;
+      border: 1px solid var(--divider-color);
+      border-radius: 6px;
+      background: var(--card-background-color, transparent);
+      color: var(--primary-text-color);
+      font-size: 0.9rem;
+      font-family: inherit;
+    }
+    .text-input:focus {
+      outline: none;
+      border-color: var(--primary-color);
+    }
+    .toggle-row {
+      display: flex;
+      align-items: flex-start;
+      gap: 10px;
+      padding: 6px 0;
+      cursor: pointer;
+    }
+    .toggle-row input[type='checkbox'] {
+      margin-top: 3px;
+      accent-color: var(--primary-color);
+      width: 16px;
+      height: 16px;
+    }
+    .toggle-text {
+      display: flex;
+      flex-direction: column;
+    }
+    .toggle-label {
+      font-size: 0.88rem;
+      color: var(--primary-text-color);
+    }
+    .toggle-desc {
+      font-size: 0.74rem;
+      color: var(--secondary-text-color);
+    }
+    .entry-list {
+      display: flex;
+      flex-direction: column;
+    }
+    code {
+      background: var(--code-editor-background-color, rgba(0, 0, 0, 0.08));
+      padding: 1px 5px;
+      border-radius: 3px;
+      font-size: 0.85em;
+    }
+  `,t([gt({attribute:!1})],ge.prototype,"hass",void 0),t([_t()],ge.prototype,"_config",void 0),t([_t()],ge.prototype,"_entries",void 0),t([_t()],ge.prototype,"_entriesError",void 0),ge=t([ht($t)],ge);let _e=class extends ct{constructor(){super(...arguments),this._registry=null,this._registryError=null,this._unsubRegistry=null,this._fetchInFlight=!1}setConfig(t){if(!t||!Array.isArray(t.entry_ids)||0===t.entry_ids.length)throw new Error("adaptive-cover-pro-sky-compass-card: `entry_ids` must be a non-empty array");if(t.entry_ids.some(t=>"string"!=typeof t||0===t.length))throw new Error("adaptive-cover-pro-sky-compass-card: every `entry_ids` entry must be a non-empty string");this._config={...t,entry_ids:[...t.entry_ids]}}getCardSize(){return 4}static async getConfigElement(){return document.createElement($t)}static getStubConfig(){return{type:`custom:${yt}`,entry_ids:[]}}connectedCallback(){super.connectedCallback(),this.hass&&this._ensureRegistry()}disconnectedCallback(){super.disconnectedCallback(),this._unsubRegistry&&(this._unsubRegistry(),this._unsubRegistry=null)}updated(t){t.has("hass")&&this.hass&&this._ensureRegistry()}_ensureRegistry(){null!==this._registry||this._fetchInFlight||this._fetchRegistry(),this._unsubRegistry||(this._unsubRegistry=Mt(this.hass,()=>{this._fetchRegistry()}))}_fetchRegistry(){this._fetchInFlight||(this._fetchInFlight=!0,Ct(this.hass).then(t=>{this._registry=t,this._registryError=null}).catch(t=>{this._registryError=t?.message??"entity registry fetch failed"}).finally(()=>{this._fetchInFlight=!1}))}render(){if(!this._config||!this.hass)return Z;if(null===this._registry)return W`<ha-card>
+        <div class="empty">
+          <p class="dim">
+            ${this._registryError?`Registry fetch failed: ${this._registryError}`:"Loading Adaptive Cover Pro registry…"}
+          </p>
+        </div>
+      </ha-card>`;const t=[],e=[];for(const s of this._config.entry_ids){const i=Et(this.hass,{type:this._config.type,entry_id:s},this._registry);i?t.push(i):e.push(s)}if(0===t.length)return W`<ha-card>
+        <div class="empty">
+          <p><strong>No matching Adaptive Cover Pro entities</strong></p>
+          <p class="dim">Configured entries: ${this._config.entry_ids.join(", ")}</p>
+        </div>
+      </ha-card>`;const s=this._config;return W`
+      <ha-card>
+        ${s.title?W`<div class="card-header">${s.title}</div>`:Z}
+        <acp-sky-compass
+          .hass=${this.hass}
+          .discovered_list=${t}
+          ?compact=${!!s.compact}
+          .showLegend=${s.show_legend??!0}
+          .showStats=${s.show_stats??!0}
+          .showMoon=${s.show_moon??!1}
+          .showCardinals=${s.show_cardinals??!0}
+          .showBlindSpot=${s.show_blind_spot??!0}
+          .showSunPath=${s.show_sun_path??!0}
+          .showSunriseSunset=${s.show_sunrise_sunset??!0}
+          .showCoverFill=${s.show_cover_fill??!0}
+          .showWindowArrow=${s.show_window_arrow??!0}
+        ></acp-sky-compass>
+        ${e.length>0?W`<div class="warn dim">Entries not found: ${e.join(", ")}</div>`:Z}
+      </ha-card>
+    `}};_e.styles=r`
+    :host {
+      display: block;
+    }
+    ha-card {
+      padding: 12px 14px 10px;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+    .card-header {
+      font-size: 1.05rem;
+      font-weight: 500;
+      color: var(--primary-text-color);
+    }
+    .empty {
+      padding: 16px;
+      text-align: center;
+    }
+    .dim {
+      color: var(--secondary-text-color);
+    }
+    .warn {
+      font-size: 0.78rem;
+      text-align: center;
+    }
+  `,t([gt({attribute:!1})],_e.prototype,"hass",void 0),t([_t()],_e.prototype,"_config",void 0),t([_t()],_e.prototype,"_registry",void 0),t([_t()],_e.prototype,"_registryError",void 0),_e=t([ht(yt)],_e),window.customCards=window.customCards||[],window.customCards.some(t=>t.type===yt)||window.customCards.push({type:yt,name:"Adaptive Cover Pro — Sky Compass",description:"Polar sun-vs-FOV plot; overlay one or more Adaptive Cover Pro entries on a single compass.",preview:!0,documentationURL:"https://github.com/jrhubott/adaptive-cover-pro/wiki/Lovelace-Card"});const ve=["sky","elevation","decision","covers","overrides","climate"];let fe=class extends ct{constructor(){super(...arguments),this._registry=null,this._registryError=null,this._discovered=null,this._unsubRegistry=null,this._fetchInFlight=!1,this._memo=function(){let t=null,e=null;return(s,i,o)=>{const n=i.entry_id??"";return null!==t&&t.registry===o&&t.hass===s&&t.entryId===n||(t={registry:o,hass:s,entryId:n},e=Et(s,i,o)),e}}(),this._debounceTimer=null,this._debounceFirstAt=null,this._DEBOUNCE_DELAY=500,this._DEBOUNCE_MAX=2e3}setConfig(t){if(!t?.entry_id)throw new Error("adaptive-cover-pro-card: `entry_id` is required");if(this._config={...t},null===this._registry){const e=zt.get(t.entry_id);e&&(this._registry=e.entries)}}getCardSize(){return 6}static async getConfigElement(){return document.createElement(mt)}static getStubConfig(){return{type:`custom:${ft}`,entry_id:""}}connectedCallback(){super.connectedCallback(),this.hass&&this._ensureRegistry()}disconnectedCallback(){super.disconnectedCallback(),this._unsubRegistry&&(this._unsubRegistry(),this._unsubRegistry=null),null!==this._debounceTimer&&(clearTimeout(this._debounceTimer),this._debounceTimer=null,this._debounceFirstAt=null)}updated(t){t.has("hass")&&this.hass&&this._ensureRegistry()}willUpdate(t){null!==this._registry&&this._config&&this.hass&&(t.has("hass")||t.has("_registry")||t.has("_config"))&&(this._discovered=this._memo(this.hass,this._config,this._registry))}_ensureRegistry(){this._fetchRegistry(),this._unsubRegistry||(this._unsubRegistry=Mt(this.hass,t=>{const e=new Set(Tt(this._registry??[],this._config?.entry_id??"").map(t=>t.entity_id));(function(t,e){return"create"===t.action||e.has(t.entity_id)})(t,e)&&this._scheduleRefetch()}))}_fetchRegistry(){this._fetchInFlight||(this._fetchInFlight=!0,Ct(this.hass).then(t=>{const e=this._config?.entry_id;if(e){const s=Tt(t,e);(null===this._registry||function(t,e){if(t.length!==e.length)return!0;const s=new Map(t.map(t=>[t.entity_id,Ot(t)]));for(const t of e)if(s.get(t.entity_id)!==Ot(t))return!0;return!1}(Tt(this._registry,e),s))&&(this._registry=t,zt.set(e,s))}else this._registry=t;this._registryError=null}).catch(t=>{this._registryError=t?.message??"entity registry fetch failed"}).finally(()=>{this._fetchInFlight=!1}))}_scheduleRefetch(){const t=Date.now();null===this._debounceFirstAt&&(this._debounceFirstAt=t);const e=t-this._debounceFirstAt,s=this._DEBOUNCE_MAX-e,i=Math.min(this._DEBOUNCE_DELAY,s);if(null!==this._debounceTimer&&clearTimeout(this._debounceTimer),i<=0)return this._debounceFirstAt=null,void this._fetchRegistry();this._debounceTimer=setTimeout(()=>{this._debounceTimer=null,this._debounceFirstAt=null,this._fetchRegistry()},i)}get _sections(){return this._config?.show_sections??ve}_renderHeader(t,e){const s=kt[t.cover_type]??"mdi:window-shutter",i=t.entities.integration_enabled_switch,o=t.entities.automatic_control_switch,n=!i||"on"===this.hass.states[i]?.state,r=!o||"on"===this.hass.states[o]?.state;return W`
       <div class="header">
-        <ha-icon .icon=${i}></ha-icon>
+        <ha-icon .icon=${s}></ha-icon>
         <span class="title">${t.entry_title}</span>
         <span class="spacer"></span>
-        ${s?W`<acp-header-pill
+        ${i?W`<acp-header-pill
               .on=${n}
               .readonly=${!e.integration_enabled}
               .label=${n?"ON":"OFF"}
               title="Integration Enabled"
-              @pill-click=${()=>this._toggle(s)}
+              @pill-click=${()=>this._toggle(i)}
             ></acp-header-pill>`:Z}
         ${o?W`<acp-header-pill
               .on=${r}
@@ -1146,15 +1391,15 @@ function t(t,e,i,s){var o,n=arguments.length,r=n<3?e:null===s?s=Object.getOwnPro
           <p class="dim">Loading Adaptive Cover Pro registry…</p>
         </div>
       </ha-card>
-    `}_renderEmpty(t){const e=this._config.entry_id,i=this._registry?.length??0,s=this._registry?.filter(t=>t.config_entry_id===e&&"adaptive_cover_pro"===t.platform).length;return W`
+    `}_renderEmpty(t){const e=this._config.entry_id,s=this._registry?.length??0,i=this._registry?.filter(t=>t.config_entry_id===e&&"adaptive_cover_pro"===t.platform).length;return W`
       <ha-card>
         <div class="empty">
           <p><strong>No Adaptive Cover Pro entities found</strong></p>
           <p class="dim">Configured <code>entry_id</code>: <code>${e}</code></p>
           <ul class="diag">
             <li>Reason: <code>${t}</code></li>
-            <li>Registry entries loaded: <code>${i}</code></li>
-            <li>ACP entities matching entry_id: <code>${s??"—"}</code></li>
+            <li>Registry entries loaded: <code>${s}</code></li>
+            <li>ACP entities matching entry_id: <code>${i??"—"}</code></li>
             ${this._registryError?W`<li>Registry fetch error: <code>${this._registryError}</code></li>`:Z}
           </ul>
           <p class="dim">
@@ -1164,49 +1409,49 @@ function t(t,e,i,s){var o,n=arguments.length,r=n<3?e:null===s?s=Object.getOwnPro
           </p>
         </div>
       </ha-card>
-    `}render(){if(!this._config||!this.hass)return Z;if(null===this._registry)return this._registryError?this._renderEmpty("registry fetch failed"):this._renderLoading();const t=this._discovered;if(!t)return this._renderEmpty("no matching entities after unique_id lookup");const e=(i=this._config,{...wt,...i?.controls});var i;const s=this._sections;return W`
+    `}render(){if(!this._config||!this.hass)return Z;if(null===this._registry)return this._registryError?this._renderEmpty("registry fetch failed"):this._renderLoading();const t=this._discovered;if(!t)return this._renderEmpty("no matching entities after unique_id lookup");const e=(s=this._config,{...At,...s?.controls});var s;const i=this._sections;return W`
       <ha-card>
         ${this._renderHeader(t,e)}
         <div class="body ${this._config.compact?"compact":""}">
-          ${s.includes("sky")?W`<acp-sky-compass
+          ${i.includes("sky")?W`<acp-sky-compass
                 .hass=${this.hass}
-                .discovered=${t}
+                .discovered_list=${[t]}
                 ?compact=${!!this._config.compact}
                 .showStats=${this._config.show_compass_stats??!0}
                 .showLegend=${this._config.show_compass_legend??!0}
                 .showMoon=${this._config.show_moon??!1}
               ></acp-sky-compass>`:Z}
-          ${s.includes("elevation")?W`<acp-elevation-chart
+          ${i.includes("elevation")?W`<acp-elevation-chart
                 .hass=${this.hass}
                 .discovered=${t}
                 ?compact=${!!this._config.compact}
               ></acp-elevation-chart>`:Z}
-          ${s.includes("decision")?W`<acp-decision-strip
+          ${i.includes("decision")?W`<acp-decision-strip
                 .hass=${this.hass}
                 .discovered=${t}
                 ?compact=${!!this._config.compact}
                 ?hide-inactive=${!!this._config.hide_inactive_handlers||!!this._config.compact}
               ></acp-decision-strip>`:Z}
-          ${s.includes("covers")?W`<acp-cover-bar
+          ${i.includes("covers")?W`<acp-cover-bar
                 .hass=${this.hass}
                 .discovered=${t}
                 ?compact=${!!this._config.compact}
               ></acp-cover-bar>`:Z}
-          ${s.includes("overrides")?W`<acp-overrides-panel
+          ${i.includes("overrides")?W`<acp-overrides-panel
                 .hass=${this.hass}
                 .discovered=${t}
                 ?compact=${!!this._config.compact}
                 .resetEnabled=${e.reset_manual_override}
               ></acp-overrides-panel>`:Z}
-          ${s.includes("climate")?W`<acp-climate-panel
+          ${i.includes("climate")?W`<acp-climate-panel
                 .hass=${this.hass}
                 .discovered=${t}
                 ?compact=${!!this._config.compact}
               ></acp-climate-panel>`:Z}
         </div>
-        ${this._config.show_version?W`<div class="footer dim">adaptive-cover-pro-card v${_t}</div>`:Z}
+        ${this._config.show_version?W`<div class="footer dim">adaptive-cover-pro-card v${vt}</div>`:Z}
       </ha-card>
-    `}};ne.styles=r`
+    `}};fe.styles=r`
     :host {
       display: block;
     }
@@ -1263,4 +1508,4 @@ function t(t,e,i,s){var o,n=arguments.length,r=n<3?e:null===s?s=Object.getOwnPro
     .dim {
       color: var(--secondary-text-color);
     }
-  `,t([gt({attribute:!1})],ne.prototype,"hass",void 0),t([vt()],ne.prototype,"_config",void 0),t([vt()],ne.prototype,"_registry",void 0),t([vt()],ne.prototype,"_registryError",void 0),t([vt()],ne.prototype,"_discovered",void 0),ne=t([ht(mt)],ne),window.customCards=window.customCards||[],window.customCards.push({type:mt,name:"Adaptive Cover Pro",description:"Visualize sun/window geometry, the pipeline decision trace, and live cover positions with inline controls.",preview:!0,documentationURL:"https://github.com/jrhubott/adaptive-cover-pro-card"}),console.info(`%c adaptive-cover-pro-card %c v${_t} `,"color: white; background: #3f51b5; font-weight: 700;","color: #3f51b5; background: white; font-weight: 700;");export{ne as AdaptiveCoverProCard};
+  `,t([gt({attribute:!1})],fe.prototype,"hass",void 0),t([_t()],fe.prototype,"_config",void 0),t([_t()],fe.prototype,"_registry",void 0),t([_t()],fe.prototype,"_registryError",void 0),t([_t()],fe.prototype,"_discovered",void 0),fe=t([ht(ft)],fe),window.customCards=window.customCards||[],window.customCards.push({type:ft,name:"Adaptive Cover Pro",description:"Visualize sun/window geometry, the pipeline decision trace, and live cover positions with inline controls.",preview:!0,documentationURL:"https://github.com/jrhubott/adaptive-cover-pro-card"}),console.info(`%c adaptive-cover-pro-card %c v${vt} `,"color: white; background: #3f51b5; font-weight: 700;","color: #3f51b5; background: white; font-weight: 700;");export{fe as AdaptiveCoverProCard};

--- a/scripts/deploy
+++ b/scripts/deploy
@@ -108,7 +108,14 @@ cleanup() {
     if $MOUNTED_BY_US && [[ -n "${MOUNT_POINT:-}" ]]; then
         if mount | grep -q "on ${MOUNT_POINT} "; then
             echo "==> Unmounting ${MOUNT_POINT}..."
-            diskutil unmount force "${MOUNT_POINT}" 2>/dev/null || umount "${MOUNT_POINT}" 2>/dev/null || true
+            case "$(uname)" in
+                Darwin)
+                    diskutil unmount force "${MOUNT_POINT}" 2>/dev/null || umount "${MOUNT_POINT}" 2>/dev/null || true
+                    ;;
+                *)
+                    sudo umount "${MOUNT_POINT}" 2>/dev/null || umount "${MOUNT_POINT}" 2>/dev/null || true
+                    ;;
+            esac
         fi
         rmdir "${MOUNT_POINT}" 2>/dev/null || true
     fi
@@ -117,13 +124,15 @@ cleanup() {
 # ── Build with dev version stamped into CARD_VERSION ─────────────────────────
 ORIGINAL_CONST="$(cat src/const.ts)"
 trap cleanup EXIT
-sed -i '' "s/export const CARD_VERSION = '.*'/export const CARD_VERSION = '${DEV_VERSION}'/" src/const.ts
+# Portable sed -i: -i.bak works on both GNU (Linux) and BSD (macOS) sed.
+sed -i.bak "s/export const CARD_VERSION = '.*'/export const CARD_VERSION = '${DEV_VERSION}'/" src/const.ts
+rm -f src/const.ts.bak
 echo "==> Building (version ${DEV_VERSION})"
 npm run build
 echo "$ORIGINAL_CONST" > src/const.ts
 ORIGINAL_CONST=""  # disarm cleanup restore
 
-# ── Build SMB URL ────────────────────────────────────────────────────────────
+# ── Build SMB URL (macOS mount_smbfs form) ───────────────────────────────────
 if [[ -n "${HA_SMB_USER:-}" ]]; then
     PASS_PART=""
     if [[ -n "${HA_SMB_PASS:-}" ]]; then
@@ -134,6 +143,44 @@ else
     SMB_URL="//${HA_SMB_HOST}/${HA_SMB_SHARE}"
 fi
 
+# Pick the mount command based on OS. macOS uses mount_smbfs; Linux uses
+# mount.cifs (from cifs-utils). On Linux the mount syscall needs root, so we
+# call it via sudo — configure passwordless sudo for mount.cifs if you want
+# this fully hands-off. Pre-mounting manually also works; the existing-mount
+# check below reuses an existing mount and skips this entirely.
+do_mount() {
+    local mount_point="$1"
+    case "$(uname)" in
+        Darwin)
+            if $VERBOSE; then
+                mount_smbfs "${SMB_URL}" "${mount_point}"
+            else
+                mount_smbfs "${SMB_URL}" "${mount_point}" 2>/dev/null
+            fi
+            ;;
+        Linux)
+            if ! command -v mount.cifs >/dev/null 2>&1; then
+                echo "    mount.cifs not found — install cifs-utils (sudo apt install cifs-utils)" >&2
+                return 1
+            fi
+            local opts="uid=$(id -u),gid=$(id -g)"
+            if [[ -n "${HA_SMB_USER:-}" ]]; then
+                opts="${opts},username=${HA_SMB_USER}"
+                if [[ -n "${HA_SMB_PASS:-}" ]]; then
+                    opts="${opts},password=${HA_SMB_PASS}"
+                fi
+            else
+                opts="${opts},guest"
+            fi
+            sudo mount -t cifs "//${HA_SMB_HOST}/${HA_SMB_SHARE}" "${mount_point}" -o "${opts}"
+            ;;
+        *)
+            echo "    Unsupported OS: $(uname)" >&2
+            return 1
+            ;;
+    esac
+}
+
 # ── Mount (reuse existing mount if present) ───────────────────────────────────
 EXISTING_MOUNT="$(mount | grep -i "${HA_SMB_HOST}/${HA_SMB_SHARE}" | awk '{print $3}' | head -1)"
 if [[ -n "$EXISTING_MOUNT" ]]; then
@@ -142,18 +189,15 @@ if [[ -n "$EXISTING_MOUNT" ]]; then
 else
     MOUNT_POINT="$(mktemp -d)"
     MOUNTED_BY_US=true
-    echo "==> Mounting smb://${HA_SMB_HOST}/${HA_SMB_SHARE} → ${MOUNT_POINT}..."
-    if $VERBOSE; then
-        mount_smbfs "${SMB_URL}" "${MOUNT_POINT}" || true
-    else
-        mount_smbfs "${SMB_URL}" "${MOUNT_POINT}" 2>/dev/null || true
-    fi
+    echo "==> Mounting //${HA_SMB_HOST}/${HA_SMB_SHARE} → ${MOUNT_POINT}..."
+    do_mount "${MOUNT_POINT}" || true
     if ! mount | grep -q "on ${MOUNT_POINT} "; then
-        echo "    Guest access failed; trying with credentials..."
-        read -r -p "    SMB username: " SMB_USER
-        read -r -s -p "    SMB password: " SMB_PASS
+        echo "    First mount attempt failed; trying with credentials..."
+        read -r -p "    SMB username: " HA_SMB_USER
+        read -r -s -p "    SMB password: " HA_SMB_PASS
         echo
-        mount_smbfs "//${SMB_USER}:${SMB_PASS}@${HA_SMB_HOST}/${HA_SMB_SHARE}" "${MOUNT_POINT}"
+        export HA_SMB_USER HA_SMB_PASS
+        do_mount "${MOUNT_POINT}"
     fi
 fi
 

--- a/src/adaptive-cover-pro-card.ts
+++ b/src/adaptive-cover-pro-card.ts
@@ -27,6 +27,7 @@ import './components/cover-bar';
 import './components/overrides-panel';
 import './components/climate-panel';
 import './adaptive-cover-pro-card-editor';
+import './adaptive-cover-pro-sky-compass-card';
 
 const DEFAULT_SECTIONS: CardSection[] = [
   'sky',
@@ -287,7 +288,7 @@ export class AdaptiveCoverProCard extends LitElement {
           ${sections.includes('sky')
             ? html`<acp-sky-compass
                 .hass=${this.hass}
-                .discovered=${discovered}
+                .discovered_list=${[discovered]}
                 ?compact=${!!this._config.compact}
                 .showStats=${this._config.show_compass_stats ?? true}
                 .showLegend=${this._config.show_compass_legend ?? true}

--- a/src/adaptive-cover-pro-sky-compass-card-editor.ts
+++ b/src/adaptive-cover-pro-sky-compass-card-editor.ts
@@ -1,0 +1,323 @@
+import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import type { HomeAssistant, LovelaceCardEditor } from 'custom-card-helpers';
+
+import { SKY_COMPASS_CARD_EDITOR_NAME, SKY_COMPASS_CARD_NAME } from './const';
+import { fetchAcpConfigEntries, type AcpConfigEntry } from './lib/config-entries';
+import type { SkyCompassCardConfig } from './types';
+
+type ToggleKey =
+  | 'compact'
+  | 'show_legend'
+  | 'show_stats'
+  | 'show_moon'
+  | 'show_cardinals'
+  | 'show_blind_spot'
+  | 'show_sun_path'
+  | 'show_sunrise_sunset'
+  | 'show_cover_fill'
+  | 'show_window_arrow';
+
+interface ToggleRow {
+  key: ToggleKey;
+  label: string;
+  description: string;
+  defaultOn: boolean;
+}
+
+const TOGGLE_ROWS: ToggleRow[] = [
+  {
+    key: 'compact',
+    label: 'Compact mode',
+    description: 'Smaller SVG, legend hidden.',
+    defaultOn: false,
+  },
+  {
+    key: 'show_legend',
+    label: 'Legend',
+    description: 'Color swatches + entry labels below compass.',
+    defaultOn: true,
+  },
+  {
+    key: 'show_stats',
+    label: 'Stats',
+    description: 'Sun + per-window numeric rows.',
+    defaultOn: true,
+  },
+  {
+    key: 'show_moon',
+    label: 'Moon',
+    description: 'Render moon position and phase.',
+    defaultOn: false,
+  },
+  {
+    key: 'show_cardinals',
+    label: 'Cardinal labels',
+    description: 'N/E/S/W letters around the compass.',
+    defaultOn: true,
+  },
+  {
+    key: 'show_blind_spot',
+    label: 'Blind spots',
+    description: 'Hatched wedges for each window’s blind range.',
+    defaultOn: true,
+  },
+  {
+    key: 'show_sun_path',
+    label: 'Sun path',
+    description: 'Today’s sun arc across the sky.',
+    defaultOn: true,
+  },
+  {
+    key: 'show_sunrise_sunset',
+    label: 'Sunrise / sunset markers',
+    description: 'Small dots at rise and set azimuths.',
+    defaultOn: true,
+  },
+  {
+    key: 'show_cover_fill',
+    label: 'Cover closure fill',
+    description: 'Inner wedge showing how closed each cover is.',
+    defaultOn: true,
+  },
+  {
+    key: 'show_window_arrow',
+    label: 'Window-normal arrow',
+    description: 'Line from center toward each window’s azimuth.',
+    defaultOn: true,
+  },
+];
+
+@customElement(SKY_COMPASS_CARD_EDITOR_NAME)
+export class AdaptiveCoverProSkyCompassCardEditor extends LitElement implements LovelaceCardEditor {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+  @state() private _config?: SkyCompassCardConfig;
+  @state() private _entries: AcpConfigEntry[] | null = null;
+  @state() private _entriesError: string | null = null;
+  private _fetchInFlight = false;
+
+  public setConfig(config: SkyCompassCardConfig): void {
+    this._config = config;
+  }
+
+  protected updated(changed: Map<string, unknown>): void {
+    if (changed.has('hass') && this.hass && !this._entries && !this._fetchInFlight) {
+      this._fetchInFlight = true;
+      fetchAcpConfigEntries(this.hass)
+        .then((entries) => {
+          this._entries = entries;
+          this._entriesError = null;
+        })
+        .catch((err: Error) => {
+          this._entriesError = err?.message ?? 'failed to load config entries';
+        })
+        .finally(() => {
+          this._fetchInFlight = false;
+        });
+    }
+  }
+
+  private _emit(next: SkyCompassCardConfig): void {
+    this._config = next;
+    this.dispatchEvent(
+      new CustomEvent('config-changed', {
+        detail: { config: next },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  private _baseConfig(): SkyCompassCardConfig {
+    return this._config ?? { type: `custom:${SKY_COMPASS_CARD_NAME}`, entry_ids: [] };
+  }
+
+  private _onEntryToggle(entryId: string, enabled: boolean): void {
+    const base = this._baseConfig();
+    const current = new Set(base.entry_ids);
+    if (enabled) current.add(entryId);
+    else current.delete(entryId);
+    // Preserve discovery order for consistency.
+    const ordered = (this._entries ?? []).map((e) => e.entry_id).filter((id) => current.has(id));
+    this._emit({ ...base, entry_ids: ordered });
+  }
+
+  private _onToggle(key: ToggleKey, enabled: boolean): void {
+    this._emit({ ...this._baseConfig(), [key]: enabled });
+  }
+
+  private _onTitleChange(e: Event): void {
+    const value = (e.target as HTMLInputElement).value;
+    const base = this._baseConfig();
+    if (value) this._emit({ ...base, title: value });
+    else {
+      const { title: _title, ...rest } = base;
+      void _title;
+      this._emit(rest as SkyCompassCardConfig);
+    }
+  }
+
+  protected render(): TemplateResult | typeof nothing {
+    if (!this._config) return nothing;
+    const selected = new Set(this._config.entry_ids);
+    return html`
+      <div class="form">
+        <div class="section">
+          <label class="field-label">Adaptive Cover Pro instances</label>
+          <div class="hint">
+            Pick one or more. Each selected entry adds an overlay to the compass.
+          </div>
+          ${this._renderEntryPicker(selected)}
+        </div>
+
+        <div class="section">
+          <label class="field-label">Title (optional)</label>
+          <input
+            type="text"
+            class="text-input"
+            .value=${this._config.title ?? ''}
+            placeholder="e.g. West-facing windows"
+            @change=${this._onTitleChange}
+          />
+        </div>
+
+        <div class="section">
+          <label class="field-label">Display</label>
+          ${TOGGLE_ROWS.map(
+            (row) => html`
+              <label class="toggle-row">
+                <input
+                  type="checkbox"
+                  .checked=${((this._config as Record<string, unknown>)[row.key] as boolean) ??
+                  row.defaultOn}
+                  @change=${(e: Event) =>
+                    this._onToggle(row.key, (e.target as HTMLInputElement).checked)}
+                />
+                <span class="toggle-text">
+                  <span class="toggle-label">${row.label}</span>
+                  <span class="toggle-desc">${row.description}</span>
+                </span>
+              </label>
+            `,
+          )}
+        </div>
+      </div>
+    `;
+  }
+
+  private _renderEntryPicker(selected: Set<string>): TemplateResult {
+    if (this._entriesError) {
+      return html`<div class="error">Failed to load config entries: ${this._entriesError}</div>`;
+    }
+    if (!this._entries) {
+      return html`<div class="hint">Loading Adaptive Cover Pro config entries…</div>`;
+    }
+    if (this._entries.length === 0) {
+      return html`
+        <div class="error">
+          No Adaptive Cover Pro config entries found. Add an instance under
+          <code>Settings → Devices &amp; Services</code>, then come back.
+        </div>
+      `;
+    }
+    return html`
+      <div class="entry-list">
+        ${this._entries.map(
+          (e) => html`
+            <label class="toggle-row">
+              <input
+                type="checkbox"
+                .checked=${selected.has(e.entry_id)}
+                @change=${(evt: Event) =>
+                  this._onEntryToggle(e.entry_id, (evt.target as HTMLInputElement).checked)}
+              />
+              <span class="toggle-text">
+                <span class="toggle-label">${e.title}</span>
+                <span class="toggle-desc">${e.entry_id}</span>
+              </span>
+            </label>
+          `,
+        )}
+      </div>
+    `;
+  }
+
+  public static styles = css`
+    :host {
+      display: block;
+    }
+    .form {
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+      padding: 8px 0;
+    }
+    .section {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+    .field-label {
+      font-weight: 500;
+      font-size: 0.88rem;
+      color: var(--primary-text-color);
+    }
+    .hint {
+      font-size: 0.78rem;
+      color: var(--secondary-text-color);
+    }
+    .error {
+      font-size: 0.82rem;
+      color: var(--error-color, crimson);
+    }
+    .text-input {
+      width: 100%;
+      padding: 8px 10px;
+      border: 1px solid var(--divider-color);
+      border-radius: 6px;
+      background: var(--card-background-color, transparent);
+      color: var(--primary-text-color);
+      font-size: 0.9rem;
+      font-family: inherit;
+    }
+    .text-input:focus {
+      outline: none;
+      border-color: var(--primary-color);
+    }
+    .toggle-row {
+      display: flex;
+      align-items: flex-start;
+      gap: 10px;
+      padding: 6px 0;
+      cursor: pointer;
+    }
+    .toggle-row input[type='checkbox'] {
+      margin-top: 3px;
+      accent-color: var(--primary-color);
+      width: 16px;
+      height: 16px;
+    }
+    .toggle-text {
+      display: flex;
+      flex-direction: column;
+    }
+    .toggle-label {
+      font-size: 0.88rem;
+      color: var(--primary-text-color);
+    }
+    .toggle-desc {
+      font-size: 0.74rem;
+      color: var(--secondary-text-color);
+    }
+    .entry-list {
+      display: flex;
+      flex-direction: column;
+    }
+    code {
+      background: var(--code-editor-background-color, rgba(0, 0, 0, 0.08));
+      padding: 1px 5px;
+      border-radius: 3px;
+      font-size: 0.85em;
+    }
+  `;
+}

--- a/src/adaptive-cover-pro-sky-compass-card.ts
+++ b/src/adaptive-cover-pro-sky-compass-card.ts
@@ -1,0 +1,209 @@
+import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import type { HomeAssistant } from 'custom-card-helpers';
+
+import { SKY_COMPASS_CARD_EDITOR_NAME, SKY_COMPASS_CARD_NAME } from './const';
+import { discoverEntities } from './lib/entity-discovery';
+import {
+  fetchEntityRegistry,
+  subscribeEntityRegistry,
+  type EntityRegistryEntry,
+} from './lib/entity-registry';
+import type { DiscoveredEntities, SkyCompassCardConfig } from './types';
+
+import './components/sky-compass';
+import './adaptive-cover-pro-sky-compass-card-editor';
+
+@customElement(SKY_COMPASS_CARD_NAME)
+export class AdaptiveCoverProSkyCompassCard extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @state() private _config?: SkyCompassCardConfig;
+  @state() private _registry: EntityRegistryEntry[] | null = null;
+  @state() private _registryError: string | null = null;
+
+  private _unsubRegistry: (() => void) | null = null;
+  private _fetchInFlight = false;
+
+  public setConfig(config: SkyCompassCardConfig): void {
+    if (!config || !Array.isArray(config.entry_ids) || config.entry_ids.length === 0) {
+      throw new Error('adaptive-cover-pro-sky-compass-card: `entry_ids` must be a non-empty array');
+    }
+    if (config.entry_ids.some((id) => typeof id !== 'string' || id.length === 0)) {
+      throw new Error(
+        'adaptive-cover-pro-sky-compass-card: every `entry_ids` entry must be a non-empty string',
+      );
+    }
+    this._config = { ...config, entry_ids: [...config.entry_ids] };
+  }
+
+  public getCardSize(): number {
+    return 4;
+  }
+
+  public static async getConfigElement(): Promise<HTMLElement> {
+    return document.createElement(SKY_COMPASS_CARD_EDITOR_NAME);
+  }
+
+  public static getStubConfig(): SkyCompassCardConfig {
+    return {
+      type: `custom:${SKY_COMPASS_CARD_NAME}`,
+      entry_ids: [],
+    };
+  }
+
+  public connectedCallback(): void {
+    super.connectedCallback();
+    if (this.hass) this._ensureRegistry();
+  }
+
+  public disconnectedCallback(): void {
+    super.disconnectedCallback();
+    if (this._unsubRegistry) {
+      this._unsubRegistry();
+      this._unsubRegistry = null;
+    }
+  }
+
+  protected updated(changed: Map<string, unknown>): void {
+    if (changed.has('hass') && this.hass) this._ensureRegistry();
+  }
+
+  private _ensureRegistry(): void {
+    if (this._registry === null && !this._fetchInFlight) this._fetchRegistry();
+    if (!this._unsubRegistry) {
+      this._unsubRegistry = subscribeEntityRegistry(this.hass, () => {
+        this._fetchRegistry();
+      });
+    }
+  }
+
+  private _fetchRegistry(): void {
+    if (this._fetchInFlight) return;
+    this._fetchInFlight = true;
+    fetchEntityRegistry(this.hass)
+      .then((entries) => {
+        this._registry = entries;
+        this._registryError = null;
+      })
+      .catch((err: Error) => {
+        this._registryError = err?.message ?? 'entity registry fetch failed';
+      })
+      .finally(() => {
+        this._fetchInFlight = false;
+      });
+  }
+
+  protected render(): TemplateResult | typeof nothing {
+    if (!this._config || !this.hass) return nothing;
+
+    if (this._registry === null) {
+      return html`<ha-card>
+        <div class="empty">
+          <p class="dim">
+            ${this._registryError
+              ? `Registry fetch failed: ${this._registryError}`
+              : 'Loading Adaptive Cover Pro registry…'}
+          </p>
+        </div>
+      </ha-card>`;
+    }
+
+    const discoveredList: DiscoveredEntities[] = [];
+    const missing: string[] = [];
+    for (const entryId of this._config.entry_ids) {
+      const d = discoverEntities(
+        this.hass,
+        { type: this._config.type, entry_id: entryId },
+        this._registry,
+      );
+      if (d) discoveredList.push(d);
+      else missing.push(entryId);
+    }
+
+    if (discoveredList.length === 0) {
+      return html`<ha-card>
+        <div class="empty">
+          <p><strong>No matching Adaptive Cover Pro entities</strong></p>
+          <p class="dim">Configured entries: ${this._config.entry_ids.join(', ')}</p>
+        </div>
+      </ha-card>`;
+    }
+
+    const cfg = this._config;
+    return html`
+      <ha-card>
+        ${cfg.title ? html`<div class="card-header">${cfg.title}</div>` : nothing}
+        <acp-sky-compass
+          .hass=${this.hass}
+          .discovered_list=${discoveredList}
+          ?compact=${!!cfg.compact}
+          .showLegend=${cfg.show_legend ?? true}
+          .showStats=${cfg.show_stats ?? true}
+          .showMoon=${cfg.show_moon ?? false}
+          .showCardinals=${cfg.show_cardinals ?? true}
+          .showBlindSpot=${cfg.show_blind_spot ?? true}
+          .showSunPath=${cfg.show_sun_path ?? true}
+          .showSunriseSunset=${cfg.show_sunrise_sunset ?? true}
+          .showCoverFill=${cfg.show_cover_fill ?? true}
+          .showWindowArrow=${cfg.show_window_arrow ?? true}
+        ></acp-sky-compass>
+        ${missing.length > 0
+          ? html`<div class="warn dim">Entries not found: ${missing.join(', ')}</div>`
+          : nothing}
+      </ha-card>
+    `;
+  }
+
+  public static styles = css`
+    :host {
+      display: block;
+    }
+    ha-card {
+      padding: 12px 14px 10px;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+    .card-header {
+      font-size: 1.05rem;
+      font-weight: 500;
+      color: var(--primary-text-color);
+    }
+    .empty {
+      padding: 16px;
+      text-align: center;
+    }
+    .dim {
+      color: var(--secondary-text-color);
+    }
+    .warn {
+      font-size: 0.78rem;
+      text-align: center;
+    }
+  `;
+}
+
+declare global {
+  interface Window {
+    customCards: Array<{
+      type: string;
+      name: string;
+      description: string;
+      preview?: boolean;
+      documentationURL?: string;
+    }>;
+  }
+}
+
+window.customCards = window.customCards || [];
+if (!window.customCards.some((c) => c.type === SKY_COMPASS_CARD_NAME)) {
+  window.customCards.push({
+    type: SKY_COMPASS_CARD_NAME,
+    name: 'Adaptive Cover Pro — Sky Compass',
+    description:
+      'Polar sun-vs-FOV plot; overlay one or more Adaptive Cover Pro entries on a single compass.',
+    preview: true,
+    documentationURL: 'https://github.com/jrhubott/adaptive-cover-pro/wiki/Lovelace-Card',
+  });
+}

--- a/src/components/sky-compass.ts
+++ b/src/components/sky-compass.ts
@@ -6,6 +6,7 @@ import type { DiscoveredEntities, SunPositionAttributes } from '../types';
 import { azimuthToCartesian, normalizeAzimuth, sunDotPosition, wedgePath } from '../lib/geometry';
 import { sampleDay, startOfDay, sunriseSetAzimuths, getMoonData } from '../lib/sun-model';
 import { formatDegrees } from '../lib/formatters';
+import { colorForIndex } from '../lib/palette';
 
 // viewBox must have ~30 px of padding beyond OUTER_R so cardinal labels
 // (positioned at OUTER_R + 6..14) don't clip when rendered with
@@ -13,17 +14,33 @@ import { formatDegrees } from '../lib/formatters';
 const VIEWBOX = 280;
 const OUTER_R = 110;
 
+interface EntryOverlay {
+  d: DiscoveredEntities;
+  sun: SunPositionAttributes;
+  sunAzi: number;
+  sunInfront: boolean;
+  coverPos: number | null;
+  color: string;
+  index: number;
+}
+
 @customElement('acp-sky-compass')
 export class SkyCompass extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
-  @property({ attribute: false }) public discovered!: DiscoveredEntities;
+  @property({ attribute: false }) public discovered_list: DiscoveredEntities[] = [];
   @property({ type: Boolean, reflect: true }) public compact = false;
   @property({ attribute: false }) public showStats = true;
   @property({ attribute: false }) public showLegend = true;
   @property({ attribute: false }) public showMoon = false;
+  @property({ attribute: false }) public showCardinals = true;
+  @property({ attribute: false }) public showBlindSpot = true;
+  @property({ attribute: false }) public showSunPath = true;
+  @property({ attribute: false }) public showSunriseSunset = true;
+  @property({ attribute: false }) public showCoverFill = true;
+  @property({ attribute: false }) public showWindowArrow = true;
 
-  private _sun(): SunPositionAttributes | null {
-    const id = this.discovered.entities.sun_sensor;
+  private _sunFor(d: DiscoveredEntities): SunPositionAttributes | null {
+    const id = d.entities.sun_sensor;
     if (!id) return null;
     const state = this.hass.states[id];
     if (!state) return null;
@@ -35,34 +52,60 @@ export class SkyCompass extends LitElement {
     };
   }
 
-  private _coverPosition(): number | null {
-    const id = this.discovered.entities.target_position_sensor;
+  private _coverPositionFor(d: DiscoveredEntities): number | null {
+    const id = d.entities.target_position_sensor;
     if (!id) return null;
     const val = parseFloat(this.hass.states[id]?.state ?? '');
     return Number.isNaN(val) ? null : val;
   }
 
-  private _sunInfront(): boolean {
-    const id = this.discovered.entities.sun_infront_binary;
+  private _sunInfrontFor(d: DiscoveredEntities): boolean {
+    const id = d.entities.sun_infront_binary;
     if (!id) return false;
     return this.hass.states[id]?.state === 'on';
   }
 
+  private _buildOverlays(): EntryOverlay[] {
+    const out: EntryOverlay[] = [];
+    this.discovered_list.forEach((d, i) => {
+      const sun = this._sunFor(d);
+      if (!sun) return;
+      const sunSensorId = d.entities.sun_sensor;
+      const sunAzi = parseFloat(this.hass.states[sunSensorId!]?.state ?? '0');
+      out.push({
+        d,
+        sun,
+        sunAzi,
+        sunInfront: this._sunInfrontFor(d),
+        coverPos: this._coverPositionFor(d),
+        color: colorForIndex(i),
+        index: i,
+      });
+    });
+    return out;
+  }
+
   protected render(): TemplateResult | typeof nothing {
-    if (!this.hass || !this.discovered) return nothing;
-    const sun = this._sun();
-    if (!sun) {
+    if (!this.hass) return nothing;
+    if (!this.discovered_list || this.discovered_list.length === 0) {
+      return html`<div class="placeholder">No Adaptive Cover Pro entries selected.</div>`;
+    }
+
+    const overlays = this._buildOverlays();
+    if (overlays.length === 0) {
       return html`<div class="placeholder">Sun sensor not yet populated.</div>`;
     }
 
-    const windowAzi = normalizeAzimuth(sun.window_azimuth);
-    const fovStart = normalizeAzimuth(windowAzi - sun.fov_left);
-    const fovEnd = normalizeAzimuth(windowAzi + sun.fov_right);
-    const sunSensorId = this.discovered.entities.sun_sensor;
-    const sunAzi = parseFloat(this.hass.states[sunSensorId!]?.state ?? '0');
-    const sunElev = sun.elevation;
+    const multi = overlays.length > 1;
+    const first = overlays[0];
+    const sunAzi = first.sunAzi;
+    const sunElev = first.sun.elevation;
     const sunPt = sunDotPosition(sunAzi, sunElev);
-    const windowArrow = azimuthToCartesian(windowAzi, OUTER_R);
+    const anyInFov = overlays.some((o) => o.sun.in_fov);
+    const anyValid = overlays.some((o) => o.sunInfront);
+    const belowHorizon = sunElev <= 0;
+    const sunDotClass =
+      !belowHorizon && anyValid ? 'sun valid' : !belowHorizon && anyInFov ? 'sun in-fov' : 'sun';
 
     const { latitude, longitude } = this.hass.config as unknown as {
       latitude?: number;
@@ -88,42 +131,23 @@ export class SkyCompass extends LitElement {
     const moonX = moonPt ? moonPt.x * OUTER_R : 0;
     const moonY = moonPt ? moonPt.y * OUTER_R : 0;
 
-    const pathPoints = samples
-      .filter((s) => s.elevation > 0)
-      .map((s) => {
-        const pt = sunDotPosition(s.azimuth, s.elevation);
-        return `${(pt.x * OUTER_R).toFixed(1)},${(pt.y * OUTER_R).toFixed(1)}`;
-      })
-      .join(' ');
+    const pathPoints = this.showSunPath
+      ? samples
+          .filter((s) => s.elevation > 0)
+          .map((s) => {
+            const pt = sunDotPosition(s.azimuth, s.elevation);
+            return `${(pt.x * OUTER_R).toFixed(1)},${(pt.y * OUTER_R).toFixed(1)}`;
+          })
+          .join(' ')
+      : '';
 
-    const { riseAzimuth, setAzimuth } = sunriseSetAzimuths(samples);
+    const { riseAzimuth, setAzimuth } = this.showSunriseSunset
+      ? sunriseSetAzimuths(samples)
+      : { riseAzimuth: null, setAzimuth: null };
     const risePt = riseAzimuth !== null ? azimuthToCartesian(riseAzimuth, OUTER_R) : null;
     const setPt = setAzimuth !== null ? azimuthToCartesian(setAzimuth, OUTER_R) : null;
 
-    const blindSpot = sun.blind_spot_range
-      ? wedgePath(
-          normalizeAzimuth(sun.blind_spot_range[0]),
-          normalizeAzimuth(sun.blind_spot_range[1]),
-          OUTER_R,
-        )
-      : null;
-
-    const coverPos = this._coverPosition();
-    const coverR = coverPos !== null ? OUTER_R * (1 - coverPos / 100) : null;
-
-    const inFov = sun.in_fov;
-    const sunValid = this._sunInfront();
-    const belowHorizon = sunElev <= 0;
-    const sunDotClass =
-      !belowHorizon && sunValid ? 'sun valid' : !belowHorizon && inFov ? 'sun in-fov' : 'sun';
-
-    const ttFov = `Window FOV: ${formatDegrees(sun.fov_left)} left / ${formatDegrees(sun.fov_right)} right`;
-    const ttWindow = `Window normal: ${formatDegrees(windowAzi)}`;
     const ttSun = `Sun: ${formatDegrees(sunAzi)} az / ${formatDegrees(sunElev)} el`;
-    const ttCoverFill = coverPos !== null ? `Cover closed: ${coverPos}%` : '';
-    const ttBlindSpot = sun.blind_spot_range
-      ? `Blind spot: ${formatDegrees(sun.blind_spot_range[0])} – ${formatDegrees(sun.blind_spot_range[1])}`
-      : '';
     const ttRise = riseAzimuth !== null ? `Sunrise: ${formatDegrees(riseAzimuth)}` : '';
     const ttSet = setAzimuth !== null ? `Sunset: ${formatDegrees(setAzimuth)}` : '';
     const ttMoon =
@@ -138,99 +162,219 @@ export class SkyCompass extends LitElement {
                 moonAboveHorizon
                   ? svg`
                 <mask id="moon-phase-mask">
-                  <circle cx=${moonX} cy=${moonY} r=${MOON_R} fill="white" />
-                  <circle cx=${moonX + moonShadowDx} cy=${moonY} r=${MOON_R} fill="black" />
+                  <circle cx=${moonX} cy=${moonY} r=${MOON_R} fill="white"></circle>
+                  <circle cx=${moonX + moonShadowDx} cy=${moonY} r=${MOON_R} fill="black"></circle>
                 </mask>
               `
                   : nothing
               }
             </defs>
-            <!-- concentric elevation rings at 30°, 60° -->
-            <circle class="grid" r=${OUTER_R} />
-            <circle class="grid" r=${(OUTER_R * 2) / 3} />
-            <circle class="grid" r=${OUTER_R / 3} />
-            <!-- cardinal direction lines -->
-            <line class="grid thin" x1="0" y1=${-OUTER_R} x2="0" y2=${OUTER_R} />
-            <line class="grid thin" x1=${-OUTER_R} y1="0" x2=${OUTER_R} y2="0" />
 
-            <!-- FOV wedge -->
-            <g data-tooltip=${ttFov}>
-              <title>${ttFov}</title>
-              <path class="fov" d=${wedgePath(fovStart, fovEnd, OUTER_R)} />
-            </g>
+            <circle class="grid" r=${OUTER_R}></circle>
+            <circle class="grid" r=${(OUTER_R * 2) / 3}></circle>
+            <circle class="grid" r=${OUTER_R / 3}></circle>
+            <line class="grid thin" x1="0" y1=${-OUTER_R} x2="0" y2=${OUTER_R}></line>
+            <line class="grid thin" x1=${-OUTER_R} y1="0" x2=${OUTER_R} y2="0"></line>
 
-            <!-- cover closure fill (inner wedge, same FOV span, radius ∝ closure) -->
-            ${coverR !== null && coverR > 0.5 ? svg`<g data-tooltip=${ttCoverFill}><title>${ttCoverFill}</title><path class="cover-fill" d=${wedgePath(fovStart, fovEnd, coverR)} /></g>` : nothing}
+            ${overlays.map((o) => this._renderEntryLayers(o, multi))}
 
-            <!-- blind spot (hatched) -->
-            ${blindSpot ? svg`<g data-tooltip=${ttBlindSpot}><title>${ttBlindSpot}</title><path class="blind-spot" d=${blindSpot} /></g>` : nothing}
+            ${
+              this.showSunPath && pathPoints
+                ? svg`<g data-tooltip="Sun path (today)"><title>Sun path (today)</title><polyline class="sun-path" points=${pathPoints}></polyline></g>`
+                : nothing
+            }
 
-            <!-- sun path arc -->
-            ${pathPoints ? svg`<g data-tooltip="Sun path (today)"><title>Sun path (today)</title><polyline class="sun-path" points=${pathPoints} /></g>` : nothing}
+            ${
+              this.showSunriseSunset && risePt && riseAzimuth !== null
+                ? svg`<g data-tooltip=${ttRise}><title>${ttRise}</title><circle class="rise-marker" cx=${risePt.x} cy=${risePt.y} r="4"></circle></g>`
+                : nothing
+            }
+            ${
+              this.showSunriseSunset && setPt && setAzimuth !== null
+                ? svg`<g data-tooltip=${ttSet}><title>${ttSet}</title><circle class="set-marker" cx=${setPt.x} cy=${setPt.y} r="4"></circle></g>`
+                : nothing
+            }
 
-            <!-- sunrise / sunset markers -->
-            ${risePt && riseAzimuth !== null ? svg`<g data-tooltip=${ttRise}><title>${ttRise}</title><circle class="rise-marker" cx=${risePt.x} cy=${risePt.y} r="4" /></g>` : nothing}
-            ${setPt && setAzimuth !== null ? svg`<g data-tooltip=${ttSet}><title>${ttSet}</title><circle class="set-marker" cx=${setPt.x} cy=${setPt.y} r="4" /></g>` : nothing}
+            ${
+              this.showCardinals
+                ? svg`
+              <text class="cardinal" x="0" y=${-OUTER_R - 6} text-anchor="middle">N</text>
+              <text class="cardinal" x=${OUTER_R + 10} y="4" text-anchor="middle">E</text>
+              <text class="cardinal" x="0" y=${OUTER_R + 14} text-anchor="middle">S</text>
+              <text class="cardinal" x=${-OUTER_R - 10} y="4" text-anchor="middle">W</text>
+            `
+                : nothing
+            }
 
-            <!-- window normal arrow -->
-            <g data-tooltip=${ttWindow}>
-              <title>${ttWindow}</title>
-              <line class="window" x1="0" y1="0" x2=${windowArrow.x} y2=${windowArrow.y} />
-              <circle class="window-base" cx="0" cy="0" r="4" />
-            </g>
-
-            <!-- cardinal labels -->
-            <text class="cardinal" x="0" y=${-OUTER_R - 6} text-anchor="middle">N</text>
-            <text class="cardinal" x=${OUTER_R + 10} y="4" text-anchor="middle">E</text>
-            <text class="cardinal" x="0" y=${OUTER_R + 14} text-anchor="middle">S</text>
-            <text class="cardinal" x=${-OUTER_R - 10} y="4" text-anchor="middle">W</text>
-
-            <!-- moon dot (above-horizon only) -->
             ${
               moonAboveHorizon
                 ? svg`
               <g data-tooltip=${ttMoon}>
                 <title>${ttMoon}</title>
-                <circle class="moon-outline" cx=${moonX} cy=${moonY} r=${MOON_R} />
-                <circle class="moon-lit" cx=${moonX} cy=${moonY} r=${MOON_R} mask="url(#moon-phase-mask)" />
+                <circle class="moon-outline" cx=${moonX} cy=${moonY} r=${MOON_R}></circle>
+                <circle class="moon-lit" cx=${moonX} cy=${moonY} r=${MOON_R} mask="url(#moon-phase-mask)"></circle>
               </g>
             `
                 : nothing
             }
 
-            <!-- sun dot -->
             <g data-tooltip=${ttSun}>
               <title>${ttSun}</title>
-              <circle class=${sunDotClass} cx=${sunPt.x * OUTER_R} cy=${sunPt.y * OUTER_R} r="7" />
+              <circle class=${sunDotClass} cx=${sunPt.x * OUTER_R} cy=${sunPt.y * OUTER_R} r="7"></circle>
             </g>
           `}
         </svg>
-        ${this.showLegend
-          ? html`<div class="legend">
-              <div><span class="dot sun valid"></span> Sun (in FOV)</div>
-              <div><span class="dot sun"></span> Sun (outside)</div>
-              ${this.showMoon ? html`<div><span class="dot moon-dot"></span> Moon</div>` : nothing}
-              <div><span class="swatch fov"></span> Window FOV</div>
-              <div><span class="swatch sun-path-swatch"></span> Sun path</div>
-              <div><span class="dot rise-dot"></span> Sunrise</div>
-              <div><span class="dot set-dot"></span> Sunset</div>
-              <div><span class="swatch cover-fill-swatch"></span> Cover closed</div>
-              <div><span class="swatch window-swatch"></span> Window normal</div>
-            </div>`
-          : nothing}
-        ${this.showStats
-          ? html`<div class="stats dim">
-              <span>Azi: ${formatDegrees(sunAzi)}</span>
-              <span>Elev: ${formatDegrees(sunElev)}</span>
-              <span>∠: ${formatDegrees(sun.gamma)}</span>
-              <span>Window: ${formatDegrees(windowAzi)}</span>
-              ${this.showMoon && moon
-                ? html`<span>${moon.phaseName} ${Math.round(moon.fraction * 100)}%</span>`
-                : nothing}
-            </div>`
-          : nothing}
+        ${this.showLegend ? this._renderLegend(overlays, multi) : nothing}
+        ${this.showStats ? this._renderStats(overlays, multi) : nothing}
       </div>
     `;
+  }
+
+  private _renderEntryLayers(o: EntryOverlay, multi: boolean) {
+    const windowAzi = normalizeAzimuth(o.sun.window_azimuth);
+    const fovStart = normalizeAzimuth(windowAzi - o.sun.fov_left);
+    const fovEnd = normalizeAzimuth(windowAzi + o.sun.fov_right);
+    const windowArrow = azimuthToCartesian(windowAzi, OUTER_R);
+    const coverR = o.coverPos !== null ? OUTER_R * (1 - o.coverPos / 100) : null;
+    const blindSpot = o.sun.blind_spot_range
+      ? wedgePath(
+          normalizeAzimuth(o.sun.blind_spot_range[0]),
+          normalizeAzimuth(o.sun.blind_spot_range[1]),
+          OUTER_R,
+        )
+      : null;
+    const fovPath = wedgePath(fovStart, fovEnd, OUTER_R);
+    const coverPath = coverR !== null ? wedgePath(fovStart, fovEnd, coverR) : '';
+
+    const label = multi ? `${o.d.entry_title}: ` : '';
+    const ttFov = `${label}FOV ${formatDegrees(o.sun.fov_left)} left / ${formatDegrees(o.sun.fov_right)} right`;
+    const ttWindow = `${label}Window normal: ${formatDegrees(windowAzi)}`;
+    const ttCoverFill = o.coverPos !== null ? `${label}Cover closed: ${o.coverPos}%` : '';
+    const ttBlindSpot = o.sun.blind_spot_range
+      ? `${label}Blind spot: ${formatDegrees(o.sun.blind_spot_range[0])} – ${formatDegrees(o.sun.blind_spot_range[1])}`
+      : '';
+
+    const fovStyle = multi ? `fill: ${o.color}; stroke: ${o.color};` : '';
+    const coverStyle = multi ? `fill: ${o.color}; stroke: ${o.color};` : '';
+    const blindStyle = multi ? `fill: ${o.color}; stroke: ${o.color};` : '';
+    const arrowStyle = multi ? `stroke: ${o.color};` : '';
+    const arrowBaseStyle = multi ? `fill: ${o.color};` : '';
+
+    const showCover = this.showCoverFill && coverR !== null && coverR > 0.5;
+    const showBlind = this.showBlindSpot && !!blindSpot;
+    const showArrow = this.showWindowArrow;
+    const arrowPath = `M 0 0 L ${windowArrow.x} ${windowArrow.y}`;
+    const hideStyle = 'display: none;';
+
+    return svg`<g class="entry-overlay">
+      <g data-tooltip=${ttFov}>
+        <title>${ttFov}</title>
+        <path class="fov" style=${fovStyle} d=${fovPath}></path>
+      </g>
+      <g class="arrow-group" data-tooltip=${ttWindow} style=${showArrow ? '' : hideStyle}>
+        <title>${ttWindow}</title>
+        <path class="window" style=${arrowStyle} d=${arrowPath}></path>
+        <circle class="window-base" style=${arrowBaseStyle} cx="0" cy="0" r="4"></circle>
+      </g>
+      <g class="cover-group" data-tooltip=${ttCoverFill} style=${showCover ? '' : hideStyle}>
+        <title>${ttCoverFill}</title>
+        <path class="cover-fill" style=${coverStyle} d=${coverPath}></path>
+      </g>
+      <g class="blind-group" data-tooltip=${ttBlindSpot} style=${showBlind ? '' : hideStyle}>
+        <title>${ttBlindSpot}</title>
+        <path class="blind-spot" style=${blindStyle} d=${blindSpot ?? ''}></path>
+      </g>
+    </g>`;
+  }
+
+  private _renderLegend(overlays: EntryOverlay[], multi: boolean): TemplateResult {
+    if (multi) {
+      return html`
+        <div class="legend">
+          ${overlays.map(
+            (o) => html`
+              <div>
+                <span class="swatch entry" style="background: ${o.color}"></span>
+                ${o.d.entry_title}
+                ${o.sunInfront
+                  ? html`<span class="status valid">✓ in FOV</span>`
+                  : o.sun.in_fov
+                    ? html`<span class="status in-fov">in FOV</span>`
+                    : html`<span class="status">—</span>`}
+              </div>
+            `,
+          )}
+          <div><span class="dot sun valid"></span> Sun</div>
+          ${this.showMoon ? html`<div><span class="dot moon-dot"></span> Moon</div>` : nothing}
+        </div>
+      `;
+    }
+    return html`<div class="legend">
+      <div><span class="dot sun valid"></span> Sun (in FOV)</div>
+      <div><span class="dot sun"></span> Sun (outside)</div>
+      ${this.showMoon ? html`<div><span class="dot moon-dot"></span> Moon</div>` : nothing}
+      <div><span class="swatch fov"></span> Window FOV</div>
+      ${this.showSunPath
+        ? html`<div><span class="swatch sun-path-swatch"></span> Sun path</div>`
+        : nothing}
+      ${this.showSunriseSunset
+        ? html`<div><span class="dot rise-dot"></span> Sunrise</div>
+            <div><span class="dot set-dot"></span> Sunset</div>`
+        : nothing}
+      ${this.showCoverFill
+        ? html`<div><span class="swatch cover-fill-swatch"></span> Cover closed</div>`
+        : nothing}
+      ${this.showWindowArrow
+        ? html`<div><span class="swatch window-swatch"></span> Window normal</div>`
+        : nothing}
+    </div>`;
+  }
+
+  private _renderStats(overlays: EntryOverlay[], multi: boolean): TemplateResult {
+    const first = overlays[0];
+    const sunAzi = first.sunAzi;
+    const sunElev = first.sun.elevation;
+    const { latitude, longitude } = this.hass.config as unknown as {
+      latitude?: number;
+      longitude?: number;
+    };
+    const moon =
+      this.showMoon && latitude !== undefined && longitude !== undefined
+        ? getMoonData(latitude, longitude)
+        : null;
+
+    if (multi) {
+      return html`
+        <div class="stats dim">
+          <div class="stats-row">
+            <span>Sun: ${formatDegrees(sunAzi)} / ${formatDegrees(sunElev)}</span>
+            ${this.showMoon && moon
+              ? html`<span>${moon.phaseName} ${Math.round(moon.fraction * 100)}%</span>`
+              : nothing}
+          </div>
+          ${overlays.map(
+            (o) => html`
+              <div class="stats-row entry-row">
+                <span class="swatch entry" style="background: ${o.color}"></span>
+                <span class="entry-name">${o.d.entry_title}</span>
+                <span>∠${formatDegrees(o.sun.gamma)}</span>
+                <span>W ${formatDegrees(normalizeAzimuth(o.sun.window_azimuth))}</span>
+                ${o.sun.in_fov ? html`<span class="status in-fov">✓</span>` : nothing}
+              </div>
+            `,
+          )}
+        </div>
+      `;
+    }
+    return html`<div class="stats dim">
+      <span>Azi: ${formatDegrees(sunAzi)}</span>
+      <span>Elev: ${formatDegrees(sunElev)}</span>
+      <span>∠: ${formatDegrees(first.sun.gamma)}</span>
+      <span>Window: ${formatDegrees(normalizeAzimuth(first.sun.window_azimuth))}</span>
+      ${this.showMoon && moon
+        ? html`<span>${moon.phaseName} ${Math.round(moon.fraction * 100)}%</span>`
+        : nothing}
+    </div>`;
   }
 
   public static styles = css`
@@ -287,6 +431,7 @@ export class SkyCompass extends LitElement {
       stroke-dasharray: 3 3;
     }
     .window {
+      fill: none;
       stroke: var(--primary-color);
       stroke-width: 3;
       stroke-linecap: round;
@@ -321,6 +466,16 @@ export class SkyCompass extends LitElement {
       flex-wrap: wrap;
       justify-content: center;
     }
+    .legend .status {
+      margin-left: 4px;
+      opacity: 0.8;
+    }
+    .legend .status.valid {
+      color: gold;
+    }
+    .legend .status.in-fov {
+      color: orange;
+    }
     .dot,
     .swatch {
       display: inline-block;
@@ -334,6 +489,10 @@ export class SkyCompass extends LitElement {
       background: gold;
       opacity: 0.4;
       border-radius: 2px;
+    }
+    .swatch.entry {
+      border-radius: 2px;
+      opacity: 0.9;
     }
     .dot.sun {
       background: var(--secondary-text-color);
@@ -365,10 +524,23 @@ export class SkyCompass extends LitElement {
     }
     .stats {
       display: flex;
-      gap: 12px;
+      flex-direction: column;
+      gap: 4px;
       font-size: 0.78rem;
+      align-items: center;
+    }
+    .stats-row {
+      display: flex;
+      gap: 10px;
       flex-wrap: wrap;
       justify-content: center;
+    }
+    .entry-row .entry-name {
+      font-weight: 500;
+      color: var(--primary-text-color);
+    }
+    .entry-row .status.in-fov {
+      color: orange;
     }
     .dim {
       color: var(--secondary-text-color);

--- a/src/const.ts
+++ b/src/const.ts
@@ -1,6 +1,8 @@
 export const CARD_VERSION = '1.3.0';
 export const CARD_NAME = 'adaptive-cover-pro-card';
 export const CARD_EDITOR_NAME = 'adaptive-cover-pro-card-editor';
+export const SKY_COMPASS_CARD_NAME = 'adaptive-cover-pro-sky-compass-card';
+export const SKY_COMPASS_CARD_EDITOR_NAME = 'adaptive-cover-pro-sky-compass-card-editor';
 
 export const INTEGRATION_DOMAIN = 'adaptive_cover_pro';
 

--- a/src/lib/palette.ts
+++ b/src/lib/palette.ts
@@ -1,0 +1,14 @@
+export const PALETTE: readonly string[] = [
+  '#1f77b4',
+  '#ff7f0e',
+  '#2ca02c',
+  '#d62728',
+  '#9467bd',
+  '#17becf',
+  '#e377c2',
+];
+
+export function colorForIndex(i: number): string {
+  const n = PALETTE.length;
+  return PALETTE[((i % n) + n) % n];
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,22 @@ export interface AdaptiveCoverProCardConfig extends LovelaceCardConfig {
   };
 }
 
+export interface SkyCompassCardConfig extends LovelaceCardConfig {
+  type: string;
+  entry_ids: string[];
+  title?: string;
+  compact?: boolean;
+  show_legend?: boolean;
+  show_stats?: boolean;
+  show_moon?: boolean;
+  show_cardinals?: boolean;
+  show_blind_spot?: boolean;
+  show_sun_path?: boolean;
+  show_sunrise_sunset?: boolean;
+  show_cover_fill?: boolean;
+  show_window_arrow?: boolean;
+}
+
 export interface DiscoveredEntities {
   entry_id: string;
   entry_title: string;

--- a/tests/palette.test.ts
+++ b/tests/palette.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { PALETTE, colorForIndex } from '../src/lib/palette';
+
+describe('palette', () => {
+  it('returns the first color for index 0', () => {
+    expect(colorForIndex(0)).toBe(PALETTE[0]);
+  });
+
+  it('wraps on overflow', () => {
+    expect(colorForIndex(PALETTE.length)).toBe(PALETTE[0]);
+    expect(colorForIndex(PALETTE.length + 2)).toBe(PALETTE[2]);
+  });
+
+  it('handles negative indices by wrapping', () => {
+    expect(colorForIndex(-1)).toBe(PALETTE[PALETTE.length - 1]);
+    expect(colorForIndex(-PALETTE.length)).toBe(PALETTE[0]);
+  });
+
+  it('every palette entry is a hex color string', () => {
+    for (const c of PALETTE) {
+      expect(c).toMatch(/^#[0-9a-f]{6}$/i);
+    }
+  });
+});

--- a/tests/sky-compass-card.test.ts
+++ b/tests/sky-compass-card.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import '../src/adaptive-cover-pro-sky-compass-card';
+import type { HomeAssistant } from 'custom-card-helpers';
+import type { SkyCompassCardConfig } from '../src/types';
+
+interface CardLike extends HTMLElement {
+  updateComplete: Promise<boolean>;
+  hass?: HomeAssistant;
+  setConfig(config: SkyCompassCardConfig): void;
+}
+
+function makeCard(): CardLike {
+  return document.createElement('adaptive-cover-pro-sky-compass-card') as CardLike;
+}
+
+describe('adaptive-cover-pro-sky-compass-card setConfig', () => {
+  it('throws when entry_ids is missing', () => {
+    const el = makeCard();
+    expect(() =>
+      el.setConfig({ type: 'custom:adaptive-cover-pro-sky-compass-card' } as SkyCompassCardConfig),
+    ).toThrow(/entry_ids/);
+  });
+
+  it('throws when entry_ids is empty', () => {
+    const el = makeCard();
+    expect(() =>
+      el.setConfig({
+        type: 'custom:adaptive-cover-pro-sky-compass-card',
+        entry_ids: [],
+      }),
+    ).toThrow(/entry_ids/);
+  });
+
+  it('throws when entry_ids contains a non-string', () => {
+    const el = makeCard();
+    expect(() =>
+      el.setConfig({
+        type: 'custom:adaptive-cover-pro-sky-compass-card',
+        entry_ids: [123 as unknown as string],
+      }),
+    ).toThrow();
+  });
+
+  it('throws when entry_ids contains an empty string', () => {
+    const el = makeCard();
+    expect(() =>
+      el.setConfig({
+        type: 'custom:adaptive-cover-pro-sky-compass-card',
+        entry_ids: [''],
+      }),
+    ).toThrow();
+  });
+
+  it('accepts a valid single-entry config', () => {
+    const el = makeCard();
+    expect(() =>
+      el.setConfig({
+        type: 'custom:adaptive-cover-pro-sky-compass-card',
+        entry_ids: ['abc'],
+      }),
+    ).not.toThrow();
+  });
+
+  it('accepts a valid multi-entry config', () => {
+    const el = makeCard();
+    expect(() =>
+      el.setConfig({
+        type: 'custom:adaptive-cover-pro-sky-compass-card',
+        entry_ids: ['abc', 'def'],
+        compact: true,
+        show_legend: false,
+      }),
+    ).not.toThrow();
+  });
+
+  it('defensively copies entry_ids so callers can mutate their input', () => {
+    const el = makeCard();
+    const input = ['a', 'b'];
+    el.setConfig({
+      type: 'custom:adaptive-cover-pro-sky-compass-card',
+      entry_ids: input,
+    });
+    input.push('c');
+    // No direct getter; just assert the call did not throw and input mutation doesn't crash re-render.
+    expect(input.length).toBe(3);
+  });
+});

--- a/tests/sky-compass.test.ts
+++ b/tests/sky-compass.test.ts
@@ -6,52 +6,180 @@ import type { DiscoveredEntities } from '../src/types';
 interface SkyCompassLike extends HTMLElement {
   updateComplete: Promise<boolean>;
   hass?: HomeAssistant;
-  discovered?: DiscoveredEntities;
+  discovered_list?: DiscoveredEntities[];
+  showLegend?: boolean;
+  showStats?: boolean;
+  showCardinals?: boolean;
+  showBlindSpot?: boolean;
+  showSunPath?: boolean;
+  showSunriseSunset?: boolean;
+  showCoverFill?: boolean;
+  showWindowArrow?: boolean;
 }
 
-const baseDiscovered: DiscoveredEntities = {
-  entry_id: 'entry1',
-  entry_title: 'Test',
-  cover_type: 'cover_blind',
-  entities: { sun_sensor: 'sensor.sun_pos' },
-  managed_covers: [],
-};
+function makeDiscovered(entryId: string, title: string): DiscoveredEntities {
+  return {
+    entry_id: entryId,
+    entry_title: title,
+    cover_type: 'cover_blind',
+    entities: { sun_sensor: `sensor.sun_pos_${entryId}` },
+    managed_covers: [],
+  };
+}
 
-const baseHass = {
-  states: {
-    'sensor.sun_pos': {
+function makeHass(
+  entries: { sensorId: string; windowAzimuth: number; blindSpot?: [number, number] }[],
+): HomeAssistant {
+  const states: Record<string, { state: string; attributes: Record<string, unknown> }> = {};
+  for (const e of entries) {
+    states[e.sensorId] = {
       state: '180',
       attributes: {
         elevation: 30,
         gamma: 0,
-        window_azimuth: 180,
+        window_azimuth: e.windowAzimuth,
         fov_left: 45,
         fov_right: 45,
-        azimuth_min: 135,
-        azimuth_max: 225,
+        azimuth_min: e.windowAzimuth - 45,
+        azimuth_max: e.windowAzimuth + 45,
         in_fov: true,
-        blind_spot_range: null,
+        blind_spot_range: e.blindSpot ?? null,
       },
-    },
-  },
-  config: {
-    latitude: 47.6,
-    longitude: -122.3,
-  },
-} as unknown as HomeAssistant;
+    };
+  }
+  return {
+    states,
+    config: { latitude: 47.6, longitude: -122.3 },
+  } as unknown as HomeAssistant;
+}
 
-async function mountCompass(): Promise<SkyCompassLike> {
+async function mountCompass(
+  discovered_list: DiscoveredEntities[],
+  hass: HomeAssistant,
+  props: Partial<SkyCompassLike> = {},
+): Promise<SkyCompassLike> {
   const el = document.createElement('acp-sky-compass') as SkyCompassLike;
   document.body.appendChild(el);
-  el.hass = baseHass;
-  el.discovered = baseDiscovered;
+  el.hass = hass;
+  el.discovered_list = discovered_list;
+  Object.assign(el, props);
   await el.updateComplete;
   return el;
 }
 
-describe('acp-sky-compass legend', () => {
-  it('legend contains a "Window normal" entry', async () => {
-    const el = await mountCompass();
+describe('acp-sky-compass (single entry)', () => {
+  it('legend contains "Window normal" entry by default', async () => {
+    const d = makeDiscovered('entry1', 'Kitchen');
+    const hass = makeHass([{ sensorId: 'sensor.sun_pos_entry1', windowAzimuth: 180 }]);
+    const el = await mountCompass([d], hass);
     expect(el.shadowRoot!.textContent).toContain('Window normal');
+  });
+
+  it('empty discovered_list shows placeholder', async () => {
+    const hass = makeHass([]);
+    const el = await mountCompass([], hass);
+    expect(el.shadowRoot!.textContent).toContain('No Adaptive Cover Pro entries selected');
+  });
+});
+
+describe('acp-sky-compass (multi-entry overlay)', () => {
+  it('renders one FOV wedge per entry', async () => {
+    const d1 = makeDiscovered('entry1', 'Kitchen');
+    const d2 = makeDiscovered('entry2', 'Living');
+    const hass = makeHass([
+      { sensorId: 'sensor.sun_pos_entry1', windowAzimuth: 180 },
+      { sensorId: 'sensor.sun_pos_entry2', windowAzimuth: 90 },
+    ]);
+    const el = await mountCompass([d1, d2], hass);
+    const fovs = el.shadowRoot!.querySelectorAll('path.fov');
+    expect(fovs.length).toBe(2);
+  });
+
+  it('renders one window arrow per entry', async () => {
+    const d1 = makeDiscovered('entry1', 'Kitchen');
+    const d2 = makeDiscovered('entry2', 'Living');
+    const hass = makeHass([
+      { sensorId: 'sensor.sun_pos_entry1', windowAzimuth: 180 },
+      { sensorId: 'sensor.sun_pos_entry2', windowAzimuth: 90 },
+    ]);
+    const el = await mountCompass([d1, d2], hass);
+    // Each arrow is a <line> + paired <circle class="window-base">; use the circle as a
+    // happy-dom-safe marker since its class attribute is reliably reflected.
+    const arrowBases = el.shadowRoot!.querySelectorAll('circle.window-base');
+    expect(arrowBases.length).toBe(2);
+  });
+
+  it('multi-entry legend shows each entry title', async () => {
+    const d1 = makeDiscovered('entry1', 'Kitchen');
+    const d2 = makeDiscovered('entry2', 'Living');
+    const hass = makeHass([
+      { sensorId: 'sensor.sun_pos_entry1', windowAzimuth: 180 },
+      { sensorId: 'sensor.sun_pos_entry2', windowAzimuth: 90 },
+    ]);
+    const el = await mountCompass([d1, d2], hass);
+    const text = el.shadowRoot!.textContent ?? '';
+    expect(text).toContain('Kitchen');
+    expect(text).toContain('Living');
+  });
+
+  it('skips entries whose sun sensor is missing without throwing', async () => {
+    const good = makeDiscovered('entry1', 'Kitchen');
+    const missing: DiscoveredEntities = {
+      entry_id: 'entry2',
+      entry_title: 'Living',
+      cover_type: 'cover_blind',
+      entities: {},
+      managed_covers: [],
+    };
+    const hass = makeHass([{ sensorId: 'sensor.sun_pos_entry1', windowAzimuth: 180 }]);
+    const el = await mountCompass([good, missing], hass);
+    const fovs = el.shadowRoot!.querySelectorAll('path.fov');
+    expect(fovs.length).toBe(1);
+  });
+});
+
+describe('acp-sky-compass visual toggles', () => {
+  const d = () => makeDiscovered('entry1', 'Kitchen');
+  const hass = () =>
+    makeHass([{ sensorId: 'sensor.sun_pos_entry1', windowAzimuth: 180, blindSpot: [0, 45] }]);
+
+  it('showLegend=false hides legend block', async () => {
+    const el = await mountCompass([d()], hass(), { showLegend: false });
+    expect(el.shadowRoot!.querySelector('.legend')).toBeNull();
+  });
+
+  it('showStats=false hides stats block', async () => {
+    const el = await mountCompass([d()], hass(), { showStats: false });
+    expect(el.shadowRoot!.querySelector('.stats')).toBeNull();
+  });
+
+  it('showCardinals=false hides cardinal labels', async () => {
+    const el = await mountCompass([d()], hass(), { showCardinals: false });
+    expect(el.shadowRoot!.querySelector('text.cardinal')).toBeNull();
+  });
+
+  it('showBlindSpot=false hides blind-spot group', async () => {
+    const el = await mountCompass([d()], hass(), { showBlindSpot: false });
+    const group = el.shadowRoot!.querySelector('g.blind-group') as SVGGElement | null;
+    expect(group).not.toBeNull();
+    expect(group!.getAttribute('style') ?? '').toContain('display: none');
+  });
+
+  it('showWindowArrow=false hides arrow group', async () => {
+    const el = await mountCompass([d()], hass(), { showWindowArrow: false });
+    const group = el.shadowRoot!.querySelector('g.arrow-group') as SVGGElement | null;
+    expect(group).not.toBeNull();
+    expect(group!.getAttribute('style') ?? '').toContain('display: none');
+  });
+
+  it('showSunPath=false hides sun-path polyline', async () => {
+    const el = await mountCompass([d()], hass(), { showSunPath: false });
+    expect(el.shadowRoot!.querySelector('polyline.sun-path')).toBeNull();
+  });
+
+  it('showSunriseSunset=false hides rise/set markers', async () => {
+    const el = await mountCompass([d()], hass(), { showSunriseSunset: false });
+    expect(el.shadowRoot!.querySelector('circle.rise-marker')).toBeNull();
+    expect(el.shadowRoot!.querySelector('circle.set-marker')).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

- Splits the sky compass into a second Lovelace card (`custom:adaptive-cover-pro-sky-compass-card`) that lives in the same bundle.
- Accepts `entry_ids: string[]` and overlays each window's FOV, blind spot, window-normal arrow, and cover-closure wedge on a single compass (shared sun dot + sun path). Per-entry elements are color-coded via a fixed 7-color palette (`src/lib/palette.ts`).
- New editor with multi-select entries + all display toggles: `compact`, `show_legend`, `show_stats`, `show_moon`, `show_cardinals`, `show_blind_spot`, `show_window_arrow`, `show_cover_fill`, `show_sun_path`, `show_sunrise_sunset`.
- Main card is unchanged from a user perspective — still takes a single `entry_id`. Internally, the `<acp-sky-compass>` prop was renamed `discovered` → `discovered_list`, and the main card now passes `[discovered]`.
- Also fixes `scripts/deploy` for Linux: portable `sed -i.bak` (was `sed -i ''`, BSD-only) and an OS-detecting mount helper (`mount.cifs` on Linux, `mount_smbfs` on macOS).

## Testing

- ✅ `npm run test` — 135 passing (3 new test files: `palette`, `sky-compass-card`, extended `sky-compass`)
- ✅ `npm run lint` — clean
- ✅ `npm run build` — `dist/adaptive-cover-pro-card.js` contains both `adaptive-cover-pro-card` and `adaptive-cover-pro-sky-compass-card` registrations (93 KB, up from 79 KB)
- ⏳ Live HA deploy + screenshots — pending

## Notes

Nested svg-tagged-template conditionals (`svg${cond ? svg`...` : nothing}`) silently render nothing in happy-dom; per-entry layers always render and use `style="display: none"` for visibility toggles. Production browsers handle the nested ternary fine.