### PR TITLE
feat: match cover bar fill to sky compass (#135)

### DIFF
--- a/dist/adaptive-cover-pro-card.js
+++ b/dist/adaptive-cover-pro-card.js
@@ -1209,6 +1209,7 @@ function e(e,t,o,i){var s,n=arguments.length,a=n<3?t:null===i?i=Object.getOwnPro
     `}_bar(e,t,o,i){const s=this.hass.states[e]?.attributes?.friendly_name??e,n=t??0,a=o??0;return q`
       <div class="cover ${i?"mismatch":""}">
         <div class="name" title=${e}>${s}</div>
+        <div class="num">${wt(t)}</div>
         <div
           class="track"
           @click=${t=>this._handleTrackClick(t,e)}
@@ -1221,7 +1222,6 @@ function e(e,t,o,i){var s,n=arguments.length,a=n<3?t:null===i?i=Object.getOwnPro
                 title=${De("covers.target_tooltip",this.hass,{pct:a})}
               ></div>`:U}
         </div>
-        <div class="num">${wt(t)}</div>
         ${i?q`<ha-icon class="warn" icon="mdi:alert-circle-outline"></ha-icon>`:U}
       </div>
     `}_handleTrackClick(e,t){const o=e.currentTarget.getBoundingClientRect(),i=Math.round((e.clientX-o.left)/o.width*100),s=Math.max(0,Math.min(100,i));this._setPosition(t,s)}};var io;oo.styles=a`
@@ -1248,7 +1248,7 @@ function e(e,t,o,i){var s,n=arguments.length,a=n<3?t:null===i?i=Object.getOwnPro
     }
     .cover {
       display: grid;
-      grid-template-columns: minmax(80px, 1fr) 3fr 48px auto;
+      grid-template-columns: minmax(80px, 1fr) 48px 3fr auto;
       gap: 8px;
       align-items: center;
       font-size: 0.82rem;
@@ -1279,7 +1279,7 @@ function e(e,t,o,i){var s,n=arguments.length,a=n<3?t:null===i?i=Object.getOwnPro
     }
     .fill {
       height: 100%;
-      background: var(--primary-color);
+      background: color-mix(in srgb, var(--primary-color) 35%, transparent);
       transition: width 0.3s ease;
     }
     .marker {

--- a/harness/src/scenarios.ts
+++ b/harness/src/scenarios.ts
@@ -635,6 +635,19 @@ export const SCENARIOS: Scenario[] = [
     },
   },
   {
+    id: 'cover-bar-open-style',
+    label: 'Cover bar — reduced-opacity fill (issue #135)',
+    description:
+      'Cover at 31% open. The bar fill appears at ~35% opacity matching the compass cover wedge. The percent label sits left of the track (between the cover name and the bar).',
+    build: () => {
+      const c = baseConfig('2026-06-21', 12 * 60);
+      c.scenario = 'cover-bar-open-style';
+      c.entries[0].target_position = 31;
+      c.entries[0].covers[0].position = 31;
+      return c;
+    },
+  },
+  {
     id: 'narrow-column-tiles',
     label: 'Narrow column tiles (repro #136)',
     description:

--- a/src/components/cover-bar.ts
+++ b/src/components/cover-bar.ts
@@ -84,6 +84,7 @@ export class CoverBar extends LitElement {
     return html`
       <div class="cover ${mismatch ? 'mismatch' : ''}">
         <div class="name" title=${entityId}>${friendly}</div>
+        <div class="num">${formatPercent(actual)}</div>
         <div
           class="track"
           @click=${(e: MouseEvent) => this._handleTrackClick(e, entityId)}
@@ -98,7 +99,6 @@ export class CoverBar extends LitElement {
               ></div>`
             : nothing}
         </div>
-        <div class="num">${formatPercent(actual)}</div>
         ${mismatch
           ? html`<ha-icon class="warn" icon="mdi:alert-circle-outline"></ha-icon>`
           : nothing}
@@ -138,7 +138,7 @@ export class CoverBar extends LitElement {
     }
     .cover {
       display: grid;
-      grid-template-columns: minmax(80px, 1fr) 3fr 48px auto;
+      grid-template-columns: minmax(80px, 1fr) 48px 3fr auto;
       gap: 8px;
       align-items: center;
       font-size: 0.82rem;
@@ -169,7 +169,7 @@ export class CoverBar extends LitElement {
     }
     .fill {
       height: 100%;
-      background: var(--primary-color);
+      background: color-mix(in srgb, var(--primary-color) 35%, transparent);
       transition: width 0.3s ease;
     }
     .marker {

--- a/tests/cover-bar.test.ts
+++ b/tests/cover-bar.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, vi } from 'vitest';
 import '../src/components/cover-bar';
+import { CoverBar } from '../src/components/cover-bar';
 import { INTEGRATION_DOMAIN } from '../src/const';
 import type { HomeAssistant } from 'custom-card-helpers';
 import type { DiscoveredEntities } from '../src/types';
+import type { CSSResult } from 'lit';
 
 interface CoverBarLike extends HTMLElement {
   updateComplete: Promise<boolean>;
@@ -17,6 +19,49 @@ const baseDiscovered: DiscoveredEntities = {
   entities: {},
   managed_covers: [],
 };
+
+describe('acp-cover-bar fill style — issue #135', () => {
+  it('fill CSS uses color-mix for reduced opacity', () => {
+    const styles = (CoverBar as unknown as { styles: CSSResult }).styles.cssText;
+    expect(styles).toContain('color-mix');
+  });
+
+  it('renders the percent label before the track', async () => {
+    const el = document.createElement('acp-cover-bar') as CoverBarLike;
+    document.body.appendChild(el);
+
+    el.hass = {
+      states: {
+        'sensor.cover_position': {
+          state: '31',
+          attributes: {
+            actual_positions: { 'cover.living_room': 31 },
+          },
+        },
+        'cover.living_room': {
+          state: 'open',
+          attributes: { friendly_name: 'Living Room' },
+        },
+      },
+      callService: vi.fn(),
+    } as unknown as HomeAssistant;
+
+    el.discovered = {
+      ...baseDiscovered,
+      entities: { target_position_sensor: 'sensor.cover_position' },
+    };
+
+    await el.updateComplete;
+
+    const cover = el.shadowRoot!.querySelector('.cover')!;
+    const children = Array.from(cover.children);
+    const numIdx = children.findIndex((c) => c.classList.contains('num'));
+    const trackIdx = children.findIndex((c) => c.classList.contains('track'));
+    expect(numIdx).toBeGreaterThanOrEqual(0);
+    expect(trackIdx).toBeGreaterThanOrEqual(0);
+    expect(numIdx).toBeLessThan(trackIdx);
+  });
+});
 
 describe('acp-cover-bar track-click → set_position', () => {
   it('calls adaptive_cover_pro.set_position when the track is clicked', async () => {


### PR DESCRIPTION
## Summary
Matches the per-cover bar to the sky compass: the fill now renders the primary color at reduced opacity (color-mix 35%) to match the compass wedge, and the percent label moves to the left of the track. Implements Option A from the issue discussion.

## Testing
- ✅ 727 tests passing (725 baseline + 2 new cover-bar assertions)
- ✅ Lint clean, build regenerated

## Related Issues
Refs #135