### PR TITLE
fix: default FOV to lighter cover color, not gold (#144)

### DIFF
--- a/dist/adaptive-cover-pro-card.js
+++ b/dist/adaptive-cover-pro-card.js
@@ -259,9 +259,13 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
     }
     .fov,
     .fov-extra {
-      fill: var(--warning-color, gold);
+      /* Default (single-entry, no override): a lighter, more-transparent shade
+         of the cover colour — same identity as the cover wedge, just fainter —
+         matching how multi-entry/override mode already colours the FOV. Keeping
+         it off gold lets the gold sun dot read clearly against it. */
+      fill: var(--primary-color);
       fill-opacity: 0.22;
-      stroke: var(--warning-color, gold);
+      stroke: var(--primary-color);
       stroke-width: 1;
       stroke-opacity: 0.7;
       transition:
@@ -654,7 +658,9 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
       opacity: 0.7;
     }
     .fov-band {
-      fill: var(--warning-color, gold);
+      /* Lighter shade of the cover colour (not gold), so the gold sun-dot reads
+         clearly against it. Matches the sky-compass .fov default. */
+      fill: var(--primary-color);
       fill-opacity: 0.18;
     }
     .off-schedule-zone {
@@ -677,7 +683,9 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
       cursor: default;
     }
     .ribbon-bar {
-      fill: var(--warning-color, gold);
+      /* Fallback only — the ribbon always sets an inline per-window fill. Kept on
+         the cover colour for consistency with the FOV band. */
+      fill: var(--primary-color);
       fill-opacity: 0.85;
       cursor: default;
     }
@@ -1280,20 +1288,20 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
     :host([compact]) .head {
       display: none;
     }
-    /* Open portion of the cover — gold, matching the compass FOV wedge
-       (--warning-color at fill-opacity 0.22). */
+    /* Both segments derive from the cover colour (override, else --primary-color),
+       distinguished by opacity: open is pale, closed is solid — "lighter = more
+       open" — matching the compass FOV (light) vs cover wedge (solid) of the same
+       hue. No gold, so nothing competes with the gold sun on the compass. */
     .fill {
       height: 100%;
       flex-shrink: 0;
-      background: color-mix(in srgb, var(--warning-color, gold) 22%, transparent);
+      background: color-mix(in srgb, var(--acp-cover-color, var(--primary-color)) 18%, transparent);
       transition: width 0.3s ease;
     }
-    /* Closed portion — the user-selected cover colour, falling back to blue
-       (--primary-color), matching the compass cover wedge at fill-opacity 0.3. */
     .fill-closed {
       height: 100%;
       flex-shrink: 0;
-      background: color-mix(in srgb, var(--acp-cover-color, var(--primary-color)) 30%, transparent);
+      background: color-mix(in srgb, var(--acp-cover-color, var(--primary-color)) 50%, transparent);
       transition: width 0.3s ease;
     }
     .marker {

--- a/harness/src/scenarios.ts
+++ b/harness/src/scenarios.ts
@@ -192,7 +192,7 @@ export const SCENARIOS: Scenario[] = [
     id: 'single-entry-cover-color',
     label: 'Single entry — custom cover color',
     description:
-      'A single-entry main card with a cover-color override. #132 Problem B: the FOV/window follows the chosen shade (not the themed gold), matching the standalone compass card.',
+      'A single-entry main card with a cover-color override. #132 Problem B: the FOV/window follows the chosen shade (not the themed default), matching the standalone compass card.',
     build: () => {
       const c = baseConfig('2026-06-21', 12 * 60);
       c.scenario = 'single-entry-cover-color';
@@ -693,7 +693,7 @@ export const SCENARIOS: Scenario[] = [
     id: 'cover-bar-open-style',
     label: 'Cover bar — two-tone open/closed fill (issue #135)',
     description:
-      "Cover at 69% open. The bar splits into two segments matching the sky compass: the open portion (left) is gold like the FOV wedge, the closed portion (right) uses the selected cover colour like the cover wedge. Change entry 0's colour in the control panel to watch both the compass wedge and the bar's closed segment track it. The percent label sits left of the track.",
+      "Cover at 69% open. The bar splits into two segments matching the sky compass: both use the cover colour (default blue, or the override), the open portion (left) a pale shade like the FOV wedge and the closed portion (right) a solid shade like the cover wedge — no gold. Change entry 0's colour in the control panel to watch both compass wedges and both bar segments track it. The percent label sits left of the track.",
     build: () => {
       const c = baseConfig('2026-06-21', 12 * 60);
       c.scenario = 'cover-bar-open-style';

--- a/src/components/cover-bar.ts
+++ b/src/components/cover-bar.ts
@@ -173,20 +173,20 @@ export class CoverBar extends LitElement {
     :host([compact]) .head {
       display: none;
     }
-    /* Open portion of the cover — gold, matching the compass FOV wedge
-       (--warning-color at fill-opacity 0.22). */
+    /* Both segments derive from the cover colour (override, else --primary-color),
+       distinguished by opacity: open is pale, closed is solid — "lighter = more
+       open" — matching the compass FOV (light) vs cover wedge (solid) of the same
+       hue. No gold, so nothing competes with the gold sun on the compass. */
     .fill {
       height: 100%;
       flex-shrink: 0;
-      background: color-mix(in srgb, var(--warning-color, gold) 22%, transparent);
+      background: color-mix(in srgb, var(--acp-cover-color, var(--primary-color)) 18%, transparent);
       transition: width 0.3s ease;
     }
-    /* Closed portion — the user-selected cover colour, falling back to blue
-       (--primary-color), matching the compass cover wedge at fill-opacity 0.3. */
     .fill-closed {
       height: 100%;
       flex-shrink: 0;
-      background: color-mix(in srgb, var(--acp-cover-color, var(--primary-color)) 30%, transparent);
+      background: color-mix(in srgb, var(--acp-cover-color, var(--primary-color)) 50%, transparent);
       transition: width 0.3s ease;
     }
     .marker {

--- a/src/components/elevation-chart.ts
+++ b/src/components/elevation-chart.ts
@@ -507,7 +507,9 @@ export class ElevationChart extends LitElement {
       opacity: 0.7;
     }
     .fov-band {
-      fill: var(--warning-color, gold);
+      /* Lighter shade of the cover colour (not gold), so the gold sun-dot reads
+         clearly against it. Matches the sky-compass .fov default. */
+      fill: var(--primary-color);
       fill-opacity: 0.18;
     }
     .off-schedule-zone {
@@ -530,7 +532,9 @@ export class ElevationChart extends LitElement {
       cursor: default;
     }
     .ribbon-bar {
-      fill: var(--warning-color, gold);
+      /* Fallback only — the ribbon always sets an inline per-window fill. Kept on
+         the cover colour for consistency with the FOV band. */
+      fill: var(--primary-color);
       fill-opacity: 0.85;
       cursor: default;
     }

--- a/src/components/sky-compass.ts
+++ b/src/components/sky-compass.ts
@@ -865,9 +865,13 @@ export class SkyCompass extends LitElement {
     }
     .fov,
     .fov-extra {
-      fill: var(--warning-color, gold);
+      /* Default (single-entry, no override): a lighter, more-transparent shade
+         of the cover colour — same identity as the cover wedge, just fainter —
+         matching how multi-entry/override mode already colours the FOV. Keeping
+         it off gold lets the gold sun dot read clearly against it. */
+      fill: var(--primary-color);
       fill-opacity: 0.22;
-      stroke: var(--warning-color, gold);
+      stroke: var(--primary-color);
       stroke-width: 1;
       stroke-opacity: 0.7;
       transition:

--- a/tests/cover-bar.test.ts
+++ b/tests/cover-bar.test.ts
@@ -64,12 +64,17 @@ describe('acp-cover-bar fill style — issue #135', () => {
 });
 
 describe('acp-cover-bar two-tone fill — issue #135 follow-up', () => {
-  it('open segment is gold and closed segment is blue, matching the compass', () => {
+  it('both segments derive from the cover colour — open pale, closed solid', () => {
     const styles = (CoverBar as unknown as { styles: CSSResult }).styles.cssText;
-    // Open portion (.fill) borrows the compass FOV gold (--warning-color);
-    // closed portion (.fill-closed) borrows the compass cover blue (--primary-color).
-    expect(styles).toMatch(/\.fill\s*{[^}]*--warning-color/);
-    expect(styles).toMatch(/\.fill-closed\s*{[^}]*--primary-color/);
+    // Open portion (.fill) and closed portion (.fill-closed) share the cover hue
+    // (override, else --primary-color); no gold, so nothing competes with the
+    // gold sun on the compass. Open is the fainter mix, closed the stronger.
+    expect(styles).toMatch(/\.fill\s*{[^}]*--acp-cover-color,\s*var\(--primary-color\)\)\s*18%/);
+    expect(styles).toMatch(
+      /\.fill-closed\s*{[^}]*--acp-cover-color,\s*var\(--primary-color\)\)\s*50%/,
+    );
+    // The fills no longer borrow the FOV gold (.warn still uses --warning-color).
+    expect(styles).not.toMatch(/\.fill[^}]*--warning-color/);
   });
 
   it('splits the track into open + closed widths summing to 100%', async () => {

--- a/tests/elevation-chart.test.ts
+++ b/tests/elevation-chart.test.ts
@@ -112,7 +112,7 @@ describe('acp-elevation-chart: single-window (legacy, unchanged)', () => {
     expect(parseFloat(rect!.getAttribute('height')!)).toBeCloseTo(128);
   });
 
-  it('keeps legacy gold fill (no inline style) for a single window', async () => {
+  it('keeps the themed default fill (no inline style) for a single window', async () => {
     const el = await mount({ hass: hass({}), discoveredList: [discovered] });
     const rect = el.shadowRoot!.querySelector('rect.fov-band');
     expect(rect).toBeTruthy();

--- a/tests/sky-compass.test.ts
+++ b/tests/sky-compass.test.ts
@@ -445,9 +445,10 @@ describe('acp-sky-compass coverColors', () => {
     expect(swatch!.getAttribute('style') ?? '').toContain('#ff3366');
   });
 
-  it('single-entry WITHOUT override keeps the FOV themed gold (no inline color)', async () => {
-    // #132 Problem B regression: with no cover-color override the default look is
-    // preserved — the FOV path and legend FOV swatch carry no inline color.
+  it('single-entry WITHOUT override leaves the FOV on its themed default (no inline color)', async () => {
+    // #132 Problem B regression: with no cover-color override the FOV path and
+    // legend FOV swatch carry no inline color — they fall to the CSS default
+    // (--primary-color since #144, formerly gold).
     const targetSensorId = 'sensor.target_pos_entry1';
     const d = makeDiscovered('entry1', 'Kitchen', { targetSensorId });
     const hass = makeHass([


### PR DESCRIPTION
## Summary

The gold FOV / sun-exposure zone sat directly behind the gold sun dot (both `var(--warning-color, gold)`), so the sun was hard to read against the zone it should stand out from. This gold only appeared in **one** path — single-entry with no color override; multi-entry and overrides already color the FOV with the cover's own hue at lower opacity.

This makes the default behave like all the others: the FOV / exposure zone is now a lighter, more-transparent shade of the cover color (`--primary-color` by default) instead of gold. **The sun dot stays gold**, so it now pops against a cool FOV.

- **Compass** (`sky-compass.ts`): `.fov` default → `--primary-color`.
- **Position bar** (`cover-bar.ts`): open + closed both derive from the cover hue — open pale (18%), closed solid (50%) — "lighter = more open". No gold.
- **Elevation chart** (`elevation-chart.ts`): `.fov-band` / `.ribbon-bar` defaults → `--primary-color`.
- Sun-dot colors untouched.
- Harness scenario descriptions for the cover-color override and cover-bar two-tone updated to drop the stale "gold" wording.

## Testing
- ✅ `npm run test` — 752 passing
- ✅ `./scripts/lint` clean (eslint + prettier)
- ✅ `npm run build` — dist rebuilt and committed
- Structural verification only (no browser, per CLAUDE.md). The existing #137 "sun in FOV" scenarios already exercise the gold-sun-on-now-blue-FOV contrast.

## Related Issues
Closes #144