### PR TITLE
feat: custom floating tooltip (#134)

### DIFF
--- a/dist/adaptive-cover-pro-card.js
+++ b/dist/adaptive-cover-pro-card.js
@@ -2110,7 +2110,7 @@ function e(e,t,o,s){var i,n=arguments.length,r=n<3?t:null===s?s=Object.getOwnPro
               ></ha-icon>`:Y}
         </div>
         <div class="label">
-          <div class="title" ${ut(e.entry_title)}>${o}</div>
+          <div class="title">${o}</div>
           ${y&&!h?L`<div class="summary">${y}</div>`:Y}
           ${b?L`<div class="summary inline-summary" ${ut(y)}>${y}</div>`:Y}
         </div>

--- a/dist/adaptive-cover-pro-card.js
+++ b/dist/adaptive-cover-pro-card.js
@@ -1,15 +1,43 @@
 /*! adaptive-cover-pro-card v2.6.0 | MIT License | https://github.com/jrhubott/adaptive-cover-pro-card */
-function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPropertyDescriptor(t,o):i;if("object"==typeof Reflect&&"function"==typeof Reflect.decorate)r=Reflect.decorate(e,t,o,i);else for(var a=e.length-1;a>=0;a--)(s=e[a])&&(r=(n<3?s(r):n>3?s(t,o,r):s(t,o))||r);return n>3&&r&&Object.defineProperty(t,o,r),r}"function"==typeof SuppressedError&&SuppressedError;const t=globalThis,o=t.ShadowRoot&&(void 0===t.ShadyCSS||t.ShadyCSS.nativeShadow)&&"adoptedStyleSheets"in Document.prototype&&"replace"in CSSStyleSheet.prototype,i=Symbol(),s=new WeakMap;let n=class{constructor(e,t,o){if(this._$cssResult$=!0,o!==i)throw Error("CSSResult is not constructable. Use `unsafeCSS` or `css` instead.");this.cssText=e,this.t=t}get styleSheet(){let e=this.o;const t=this.t;if(o&&void 0===e){const o=void 0!==t&&1===t.length;o&&(e=s.get(t)),void 0===e&&((this.o=e=new CSSStyleSheet).replaceSync(this.cssText),o&&s.set(t,e))}return e}toString(){return this.cssText}};const r=(e,...t)=>{const o=1===e.length?e[0]:t.reduce((t,o,i)=>t+(e=>{if(!0===e._$cssResult$)return e.cssText;if("number"==typeof e)return e;throw Error("Value passed to 'css' function must be a 'css' function result: "+e+". Use 'unsafeCSS' to pass non-literal values, but take care to ensure page security.")})(o)+e[i+1],e[0]);return new n(o,e,i)},a=o?e=>e:e=>e instanceof CSSStyleSheet?(e=>{let t="";for(const o of e.cssRules)t+=o.cssText;return(e=>new n("string"==typeof e?e:e+"",void 0,i))(t)})(e):e,{is:l,defineProperty:c,getOwnPropertyDescriptor:d,getOwnPropertyNames:h,getOwnPropertySymbols:u,getPrototypeOf:p}=Object,g=globalThis,m=g.trustedTypes,_=m?m.emptyScript:"",f=g.reactiveElementPolyfillSupport,v=(e,t)=>e,y={toAttribute(e,t){switch(t){case Boolean:e=e?_:null;break;case Object:case Array:e=null==e?e:JSON.stringify(e)}return e},fromAttribute(e,t){let o=e;switch(t){case Boolean:o=null!==e;break;case Number:o=null===e?null:Number(e);break;case Object:case Array:try{o=JSON.parse(e)}catch(e){o=null}}return o}},b=(e,t)=>!l(e,t),w={attribute:!0,type:String,converter:y,reflect:!1,useDefault:!1,hasChanged:b};Symbol.metadata??=Symbol("metadata"),g.litPropertyMetadata??=new WeakMap;let x=class extends HTMLElement{static addInitializer(e){this._$Ei(),(this.l??=[]).push(e)}static get observedAttributes(){return this.finalize(),this._$Eh&&[...this._$Eh.keys()]}static createProperty(e,t=w){if(t.state&&(t.attribute=!1),this._$Ei(),this.prototype.hasOwnProperty(e)&&((t=Object.create(t)).wrapped=!0),this.elementProperties.set(e,t),!t.noAccessor){const o=Symbol(),i=this.getPropertyDescriptor(e,o,t);void 0!==i&&c(this.prototype,e,i)}}static getPropertyDescriptor(e,t,o){const{get:i,set:s}=d(this.prototype,e)??{get(){return this[t]},set(e){this[t]=e}};return{get:i,set(t){const n=i?.call(this);s?.call(this,t),this.requestUpdate(e,n,o)},configurable:!0,enumerable:!0}}static getPropertyOptions(e){return this.elementProperties.get(e)??w}static _$Ei(){if(this.hasOwnProperty(v("elementProperties")))return;const e=p(this);e.finalize(),void 0!==e.l&&(this.l=[...e.l]),this.elementProperties=new Map(e.elementProperties)}static finalize(){if(this.hasOwnProperty(v("finalized")))return;if(this.finalized=!0,this._$Ei(),this.hasOwnProperty(v("properties"))){const e=this.properties,t=[...h(e),...u(e)];for(const o of t)this.createProperty(o,e[o])}const e=this[Symbol.metadata];if(null!==e){const t=litPropertyMetadata.get(e);if(void 0!==t)for(const[e,o]of t)this.elementProperties.set(e,o)}this._$Eh=new Map;for(const[e,t]of this.elementProperties){const o=this._$Eu(e,t);void 0!==o&&this._$Eh.set(o,e)}this.elementStyles=this.finalizeStyles(this.styles)}static finalizeStyles(e){const t=[];if(Array.isArray(e)){const o=new Set(e.flat(1/0).reverse());for(const e of o)t.unshift(a(e))}else void 0!==e&&t.push(a(e));return t}static _$Eu(e,t){const o=t.attribute;return!1===o?void 0:"string"==typeof o?o:"string"==typeof e?e.toLowerCase():void 0}constructor(){super(),this._$Ep=void 0,this.isUpdatePending=!1,this.hasUpdated=!1,this._$Em=null,this._$Ev()}_$Ev(){this._$ES=new Promise(e=>this.enableUpdating=e),this._$AL=new Map,this._$E_(),this.requestUpdate(),this.constructor.l?.forEach(e=>e(this))}addController(e){(this._$EO??=new Set).add(e),void 0!==this.renderRoot&&this.isConnected&&e.hostConnected?.()}removeController(e){this._$EO?.delete(e)}_$E_(){const e=new Map,t=this.constructor.elementProperties;for(const o of t.keys())this.hasOwnProperty(o)&&(e.set(o,this[o]),delete this[o]);e.size>0&&(this._$Ep=e)}createRenderRoot(){const e=this.shadowRoot??this.attachShadow(this.constructor.shadowRootOptions);return((e,i)=>{if(o)e.adoptedStyleSheets=i.map(e=>e instanceof CSSStyleSheet?e:e.styleSheet);else for(const o of i){const i=document.createElement("style"),s=t.litNonce;void 0!==s&&i.setAttribute("nonce",s),i.textContent=o.cssText,e.appendChild(i)}})(e,this.constructor.elementStyles),e}connectedCallback(){this.renderRoot??=this.createRenderRoot(),this.enableUpdating(!0),this._$EO?.forEach(e=>e.hostConnected?.())}enableUpdating(e){}disconnectedCallback(){this._$EO?.forEach(e=>e.hostDisconnected?.())}attributeChangedCallback(e,t,o){this._$AK(e,o)}_$ET(e,t){const o=this.constructor.elementProperties.get(e),i=this.constructor._$Eu(e,o);if(void 0!==i&&!0===o.reflect){const s=(void 0!==o.converter?.toAttribute?o.converter:y).toAttribute(t,o.type);this._$Em=e,null==s?this.removeAttribute(i):this.setAttribute(i,s),this._$Em=null}}_$AK(e,t){const o=this.constructor,i=o._$Eh.get(e);if(void 0!==i&&this._$Em!==i){const e=o.getPropertyOptions(i),s="function"==typeof e.converter?{fromAttribute:e.converter}:void 0!==e.converter?.fromAttribute?e.converter:y;this._$Em=i;const n=s.fromAttribute(t,e.type);this[i]=n??this._$Ej?.get(i)??n,this._$Em=null}}requestUpdate(e,t,o,i=!1,s){if(void 0!==e){const n=this.constructor;if(!1===i&&(s=this[e]),o??=n.getPropertyOptions(e),!((o.hasChanged??b)(s,t)||o.useDefault&&o.reflect&&s===this._$Ej?.get(e)&&!this.hasAttribute(n._$Eu(e,o))))return;this.C(e,t,o)}!1===this.isUpdatePending&&(this._$ES=this._$EP())}C(e,t,{useDefault:o,reflect:i,wrapped:s},n){o&&!(this._$Ej??=new Map).has(e)&&(this._$Ej.set(e,n??t??this[e]),!0!==s||void 0!==n)||(this._$AL.has(e)||(this.hasUpdated||o||(t=void 0),this._$AL.set(e,t)),!0===i&&this._$Em!==e&&(this._$Eq??=new Set).add(e))}async _$EP(){this.isUpdatePending=!0;try{await this._$ES}catch(e){Promise.reject(e)}const e=this.scheduleUpdate();return null!=e&&await e,!this.isUpdatePending}scheduleUpdate(){return this.performUpdate()}performUpdate(){if(!this.isUpdatePending)return;if(!this.hasUpdated){if(this.renderRoot??=this.createRenderRoot(),this._$Ep){for(const[e,t]of this._$Ep)this[e]=t;this._$Ep=void 0}const e=this.constructor.elementProperties;if(e.size>0)for(const[t,o]of e){const{wrapped:e}=o,i=this[t];!0!==e||this._$AL.has(t)||void 0===i||this.C(t,void 0,o,i)}}let e=!1;const t=this._$AL;try{e=this.shouldUpdate(t),e?(this.willUpdate(t),this._$EO?.forEach(e=>e.hostUpdate?.()),this.update(t)):this._$EM()}catch(t){throw e=!1,this._$EM(),t}e&&this._$AE(t)}willUpdate(e){}_$AE(e){this._$EO?.forEach(e=>e.hostUpdated?.()),this.hasUpdated||(this.hasUpdated=!0,this.firstUpdated(e)),this.updated(e)}_$EM(){this._$AL=new Map,this.isUpdatePending=!1}get updateComplete(){return this.getUpdateComplete()}getUpdateComplete(){return this._$ES}shouldUpdate(e){return!0}update(e){this._$Eq&&=this._$Eq.forEach(e=>this._$ET(e,this[e])),this._$EM()}updated(e){}firstUpdated(e){}};x.elementStyles=[],x.shadowRootOptions={mode:"open"},x[v("elementProperties")]=new Map,x[v("finalized")]=new Map,f?.({ReactiveElement:x}),(g.reactiveElementVersions??=[]).push("2.1.2");const $=globalThis,A=e=>e,k=$.trustedTypes,C=k?k.createPolicy("lit-html",{createHTML:e=>e}):void 0,S="$lit$",E=`lit$${Math.random().toFixed(9).slice(2)}$`,z="?"+E,O=`<${z}>`,M=document,I=()=>M.createComment(""),F=e=>null===e||"object"!=typeof e&&"function"!=typeof e,T=Array.isArray,P="[ \t\n\f\r]",j=/<(?:(!--|\/[^a-zA-Z])|(\/?[a-zA-Z][^>\s]*)|(\/?$))/g,R=/-->/g,N=/>/g,D=RegExp(`>|${P}(?:([^\\s"'>=/]+)(${P}*=${P}*(?:[^ \t\n\f\r"'\`<>=]|("|')|))|$)`,"g"),B=/'/g,K=/"/g,V=/^(?:script|style|textarea|title)$/i,G=e=>(t,...o)=>({_$litType$:e,strings:t,values:o}),q=G(1),U=G(2),L=Symbol.for("lit-noChange"),W=Symbol.for("lit-nothing"),Y=new WeakMap,Q=M.createTreeWalker(M,129);function H(e,t){if(!T(e)||!e.hasOwnProperty("raw"))throw Error("invalid template strings array");return void 0!==C?C.createHTML(t):t}const Z=(e,t)=>{const o=e.length-1,i=[];let s,n=2===t?"<svg>":3===t?"<math>":"",r=j;for(let t=0;t<o;t++){const o=e[t];let a,l,c=-1,d=0;for(;d<o.length&&(r.lastIndex=d,l=r.exec(o),null!==l);)d=r.lastIndex,r===j?"!--"===l[1]?r=R:void 0!==l[1]?r=N:void 0!==l[2]?(V.test(l[2])&&(s=RegExp("</"+l[2],"g")),r=D):void 0!==l[3]&&(r=D):r===D?">"===l[0]?(r=s??j,c=-1):void 0===l[1]?c=-2:(c=r.lastIndex-l[2].length,a=l[1],r=void 0===l[3]?D:'"'===l[3]?K:B):r===K||r===B?r=D:r===R||r===N?r=j:(r=D,s=void 0);const h=r===D&&e[t+1].startsWith("/>")?" ":"";n+=r===j?o+O:c>=0?(i.push(a),o.slice(0,c)+S+o.slice(c)+E+h):o+E+(-2===c?t:h)}return[H(e,n+(e[o]||"<?>")+(2===t?"</svg>":3===t?"</math>":"")),i]};class J{constructor({strings:e,_$litType$:t},o){let i;this.parts=[];let s=0,n=0;const r=e.length-1,a=this.parts,[l,c]=Z(e,t);if(this.el=J.createElement(l,o),Q.currentNode=this.el.content,2===t||3===t){const e=this.el.content.firstChild;e.replaceWith(...e.childNodes)}for(;null!==(i=Q.nextNode())&&a.length<r;){if(1===i.nodeType){if(i.hasAttributes())for(const e of i.getAttributeNames())if(e.endsWith(S)){const t=c[n++],o=i.getAttribute(e).split(E),r=/([.?@])?(.*)/.exec(t);a.push({type:1,index:s,name:r[2],strings:o,ctor:"."===r[1]?ie:"?"===r[1]?se:"@"===r[1]?ne:oe}),i.removeAttribute(e)}else e.startsWith(E)&&(a.push({type:6,index:s}),i.removeAttribute(e));if(V.test(i.tagName)){const e=i.textContent.split(E),t=e.length-1;if(t>0){i.textContent=k?k.emptyScript:"";for(let o=0;o<t;o++)i.append(e[o],I()),Q.nextNode(),a.push({type:2,index:++s});i.append(e[t],I())}}}else if(8===i.nodeType)if(i.data===z)a.push({type:2,index:s});else{let e=-1;for(;-1!==(e=i.data.indexOf(E,e+1));)a.push({type:7,index:s}),e+=E.length-1}s++}}static createElement(e,t){const o=M.createElement("template");return o.innerHTML=e,o}}function X(e,t,o=e,i){if(t===L)return t;let s=void 0!==i?o._$Co?.[i]:o._$Cl;const n=F(t)?void 0:t._$litDirective$;return s?.constructor!==n&&(s?._$AO?.(!1),void 0===n?s=void 0:(s=new n(e),s._$AT(e,o,i)),void 0!==i?(o._$Co??=[])[i]=s:o._$Cl=s),void 0!==s&&(t=X(e,s._$AS(e,t.values),s,i)),t}class ee{constructor(e,t){this._$AV=[],this._$AN=void 0,this._$AD=e,this._$AM=t}get parentNode(){return this._$AM.parentNode}get _$AU(){return this._$AM._$AU}u(e){const{el:{content:t},parts:o}=this._$AD,i=(e?.creationScope??M).importNode(t,!0);Q.currentNode=i;let s=Q.nextNode(),n=0,r=0,a=o[0];for(;void 0!==a;){if(n===a.index){let t;2===a.type?t=new te(s,s.nextSibling,this,e):1===a.type?t=new a.ctor(s,a.name,a.strings,this,e):6===a.type&&(t=new re(s,this,e)),this._$AV.push(t),a=o[++r]}n!==a?.index&&(s=Q.nextNode(),n++)}return Q.currentNode=M,i}p(e){let t=0;for(const o of this._$AV)void 0!==o&&(void 0!==o.strings?(o._$AI(e,o,t),t+=o.strings.length-2):o._$AI(e[t])),t++}}class te{get _$AU(){return this._$AM?._$AU??this._$Cv}constructor(e,t,o,i){this.type=2,this._$AH=W,this._$AN=void 0,this._$AA=e,this._$AB=t,this._$AM=o,this.options=i,this._$Cv=i?.isConnected??!0}get parentNode(){let e=this._$AA.parentNode;const t=this._$AM;return void 0!==t&&11===e?.nodeType&&(e=t.parentNode),e}get startNode(){return this._$AA}get endNode(){return this._$AB}_$AI(e,t=this){e=X(this,e,t),F(e)?e===W||null==e||""===e?(this._$AH!==W&&this._$AR(),this._$AH=W):e!==this._$AH&&e!==L&&this._(e):void 0!==e._$litType$?this.$(e):void 0!==e.nodeType?this.T(e):(e=>T(e)||"function"==typeof e?.[Symbol.iterator])(e)?this.k(e):this._(e)}O(e){return this._$AA.parentNode.insertBefore(e,this._$AB)}T(e){this._$AH!==e&&(this._$AR(),this._$AH=this.O(e))}_(e){this._$AH!==W&&F(this._$AH)?this._$AA.nextSibling.data=e:this.T(M.createTextNode(e)),this._$AH=e}$(e){const{values:t,_$litType$:o}=e,i="number"==typeof o?this._$AC(e):(void 0===o.el&&(o.el=J.createElement(H(o.h,o.h[0]),this.options)),o);if(this._$AH?._$AD===i)this._$AH.p(t);else{const e=new ee(i,this),o=e.u(this.options);e.p(t),this.T(o),this._$AH=e}}_$AC(e){let t=Y.get(e.strings);return void 0===t&&Y.set(e.strings,t=new J(e)),t}k(e){T(this._$AH)||(this._$AH=[],this._$AR());const t=this._$AH;let o,i=0;for(const s of e)i===t.length?t.push(o=new te(this.O(I()),this.O(I()),this,this.options)):o=t[i],o._$AI(s),i++;i<t.length&&(this._$AR(o&&o._$AB.nextSibling,i),t.length=i)}_$AR(e=this._$AA.nextSibling,t){for(this._$AP?.(!1,!0,t);e!==this._$AB;){const t=A(e).nextSibling;A(e).remove(),e=t}}setConnected(e){void 0===this._$AM&&(this._$Cv=e,this._$AP?.(e))}}class oe{get tagName(){return this.element.tagName}get _$AU(){return this._$AM._$AU}constructor(e,t,o,i,s){this.type=1,this._$AH=W,this._$AN=void 0,this.element=e,this.name=t,this._$AM=i,this.options=s,o.length>2||""!==o[0]||""!==o[1]?(this._$AH=Array(o.length-1).fill(new String),this.strings=o):this._$AH=W}_$AI(e,t=this,o,i){const s=this.strings;let n=!1;if(void 0===s)e=X(this,e,t,0),n=!F(e)||e!==this._$AH&&e!==L,n&&(this._$AH=e);else{const i=e;let r,a;for(e=s[0],r=0;r<s.length-1;r++)a=X(this,i[o+r],t,r),a===L&&(a=this._$AH[r]),n||=!F(a)||a!==this._$AH[r],a===W?e=W:e!==W&&(e+=(a??"")+s[r+1]),this._$AH[r]=a}n&&!i&&this.j(e)}j(e){e===W?this.element.removeAttribute(this.name):this.element.setAttribute(this.name,e??"")}}class ie extends oe{constructor(){super(...arguments),this.type=3}j(e){this.element[this.name]=e===W?void 0:e}}class se extends oe{constructor(){super(...arguments),this.type=4}j(e){this.element.toggleAttribute(this.name,!!e&&e!==W)}}class ne extends oe{constructor(e,t,o,i,s){super(e,t,o,i,s),this.type=5}_$AI(e,t=this){if((e=X(this,e,t,0)??W)===L)return;const o=this._$AH,i=e===W&&o!==W||e.capture!==o.capture||e.once!==o.once||e.passive!==o.passive,s=e!==W&&(o===W||i);i&&this.element.removeEventListener(this.name,this,o),s&&this.element.addEventListener(this.name,this,e),this._$AH=e}handleEvent(e){"function"==typeof this._$AH?this._$AH.call(this.options?.host??this.element,e):this._$AH.handleEvent(e)}}class re{constructor(e,t,o){this.element=e,this.type=6,this._$AN=void 0,this._$AM=t,this.options=o}get _$AU(){return this._$AM._$AU}_$AI(e){X(this,e)}}const ae=$.litHtmlPolyfillSupport;ae?.(J,te),($.litHtmlVersions??=[]).push("3.3.2");const le=globalThis;let ce=class extends x{constructor(){super(...arguments),this.renderOptions={host:this},this._$Do=void 0}createRenderRoot(){const e=super.createRenderRoot();return this.renderOptions.renderBefore??=e.firstChild,e}update(e){const t=this.render();this.hasUpdated||(this.renderOptions.isConnected=this.isConnected),super.update(e),this._$Do=((e,t,o)=>{const i=o?.renderBefore??t;let s=i._$litPart$;if(void 0===s){const e=o?.renderBefore??null;i._$litPart$=s=new te(t.insertBefore(I(),e),e,void 0,o??{})}return s._$AI(e),s})(t,this.renderRoot,this.renderOptions)}connectedCallback(){super.connectedCallback(),this._$Do?.setConnected(!0)}disconnectedCallback(){super.disconnectedCallback(),this._$Do?.setConnected(!1)}render(){return L}};ce._$litElement$=!0,ce.finalized=!0,le.litElementHydrateSupport?.({LitElement:ce});const de=le.litElementPolyfillSupport;de?.({LitElement:ce}),(le.litElementVersions??=[]).push("4.2.2");const he=e=>(t,o)=>{void 0!==o?o.addInitializer(()=>{customElements.define(e,t)}):customElements.define(e,t)},ue={attribute:!0,type:String,converter:y,reflect:!1,hasChanged:b},pe=(e=ue,t,o)=>{const{kind:i,metadata:s}=o;let n=globalThis.litPropertyMetadata.get(s);if(void 0===n&&globalThis.litPropertyMetadata.set(s,n=new Map),"setter"===i&&((e=Object.create(e)).wrapped=!0),n.set(o.name,e),"accessor"===i){const{name:i}=o;return{set(o){const s=t.get.call(this);t.set.call(this,o),this.requestUpdate(i,s,e,!0,o)},init(t){return void 0!==t&&this.C(i,void 0,e,t),t}}}if("setter"===i){const{name:i}=o;return function(o){const s=this[i];t.call(this,o),this.requestUpdate(i,s,e,!0,o)}}throw Error("Unsupported decorator location: "+i)};function ge(e){return(t,o)=>"object"==typeof o?pe(e,t,o):((e,t,o)=>{const i=t.hasOwnProperty(o);return t.constructor.createProperty(o,e),i?Object.getOwnPropertyDescriptor(t,o):void 0})(e,t,o)}function me(e){return ge({...e,state:!0,attribute:!1})}function _e(e,t,o){if(!e)return!0;for(const i of o)if(i&&e.states[i]!==t.states[i])return!0;return!1}const fe="2.6.0",ve="adaptive-cover-pro-card",ye="adaptive-cover-pro-card-editor",be="adaptive-cover-pro-sky-compass-card",we="adaptive-cover-pro-sky-compass-card-editor",xe="adaptive-cover-pro-tile-card",$e="adaptive-cover-pro-tile-card-editor",Ae="adaptive_cover_pro",ke=["force","weather","manual","custom_position","motion","cloud","climate","glare_zone","solar","default","floor_clamp"],Ce={force:"Force Override",weather:"Weather Safety",manual:"Manual Override",custom_position:"Custom Position",motion:"Motion Timeout",cloud:"Cloud Suppression",climate:"Climate",glare_zone:"Glare Zone",solar:"Solar Tracking",default:"Default",floor_clamp:"Min Floor"},Se={force:"handler.force",weather:"handler.weather",manual:"handler.manual",custom_position:"handler.custom_position",motion:"handler.motion",cloud:"handler.cloud",climate:"handler.climate",glare_zone:"handler.glare_zone",solar:"handler.solar",default:"handler.default",floor_clamp:"handler.floor_clamp"},Ee={cover_blind:"mdi:blinds-horizontal",cover_awning:"mdi:awning-outline",cover_tilt:"mdi:blinds"},ze={cover_blind:"mdi:blinds-open",cover_awning:"mdi:awning-outline",cover_tilt:"mdi:blinds-open"},Oe={cover_blind:"mdi:blinds-horizontal-closed",cover_awning:"mdi:window-closed-variant",cover_tilt:"mdi:blinds"},Me={manual:"manual",force:"force",weather:"weather",glare_zone:"glare_zone",climate:"climate",cloud:"cloud",custom_position:"custom_position",solar:"solar",motion:"motion"},Ie={auto:{label:"Auto",bg:"rgba(76, 175, 80, 0.18)",fg:"#2e7d32"},manual:{label:"Manual",bg:"rgba(255, 152, 0, 0.22)",fg:"#e65100"},force:{label:"Force",bg:"rgba(244, 67, 54, 0.22)",fg:"#b71c1c"},weather:{label:"Sun protection",bg:"rgba(244, 67, 54, 0.22)",fg:"#b71c1c"},glare_zone:{label:"Glare",bg:"rgba(244, 67, 54, 0.22)",fg:"#b71c1c"},climate:{label:"Climate",bg:"rgba(0, 150, 136, 0.22)",fg:"#00695c"},cloud:{label:"Cloudy",bg:"rgba(33, 150, 243, 0.22)",fg:"#0d47a1"},custom_position:{label:"Custom",bg:"rgba(156, 39, 176, 0.22)",fg:"#6a1b9a"},solar:{label:"Solar tracking",bg:"rgba(76, 175, 80, 0.22)",fg:"#1b5e20"},motion:{label:"Motion",bg:"rgba(255, 235, 59, 0.22)",fg:"#827717"},off:{label:"Off",bg:"rgba(97, 97, 97, 0.28)",fg:"#212121"},off_schedule:{label:"Off-schedule",bg:"rgba(96, 125, 139, 0.22)",fg:"#37474f"}},Fe={auto:"badge.auto",manual:"badge.manual",force:"badge.force",weather:"badge.weather",glare_zone:"badge.glare_zone",climate:"badge.climate",cloud:"badge.cloud",custom_position:"badge.custom_position",solar:"badge.solar",motion:"badge.motion",off:"badge.off",off_schedule:"badge.off_schedule"},Te={auto:"mdi:autorenew",manual:"mdi:hand-back-right",force:"mdi:flash",weather:"mdi:shield-sun",glare_zone:"mdi:weather-sunny-alert",climate:"mdi:thermostat",cloud:"mdi:weather-cloudy",custom_position:"mdi:bookmark",solar:"mdi:white-balance-sunny",motion:"mdi:motion-sensor",off:"mdi:power",off_schedule:"mdi:clock-alert-outline"},Pe={integration_enabled:!0,automatic_control:!0,reset_manual_override:!0},je={"sensor:Cover_Position":"target_position_sensor","sensor:sun_position":"sun_sensor","sensor:Start Sun":"start_sensor","sensor:End Sun":"end_sensor","sensor:control_status":"control_status_sensor","sensor:decision_trace":"decision_trace_sensor","sensor:last_cover_action":"last_action_sensor","sensor:last_skipped_action":"last_skipped_sensor","sensor:manual_override_end_time":"manual_override_end_sensor","sensor:position_verification":"position_verification_sensor","sensor:motion_status":"motion_status_sensor","sensor:climate_status":"climate_status_sensor","sensor:position_forecast":"position_forecast_sensor","binary_sensor:sun_motion":"sun_infront_binary","binary_sensor:manual_override":"manual_override_binary","binary_sensor:position_mismatch":"position_mismatch_binary","binary_sensor:glare_active":"glare_active_binary","switch:Integration Enabled":"integration_enabled_switch","switch:Automatic Control":"automatic_control_switch","switch:Manual Override":"manual_toggle_switch","switch:Climate Mode":"climate_mode_switch","switch:Motion Control":"motion_control_switch","button:Reset Manual Override":"reset_override_button"},Re={en:{handler:{force:"Force Override",weather:"Weather Safety",manual:"Manual Override",custom_position:"Custom Position",motion:"Motion Timeout",cloud:"Cloud Suppression",climate:"Climate",glare_zone:"Glare Zone",solar:"Solar Tracking",default:"Default",floor_clamp:"Min Floor"},badge:{auto:"Auto",manual:"Manual",force:"Force",weather:"Weather safety",glare_zone:"Glare",climate:"Climate",cloud:"Cloudy",custom_position:"Custom",solar:"Solar tracking",motion:"Motion idle",off:"Off",off_schedule:"Off-schedule",floor_suffix:" ↥",safety:"Safety"},forecast:{event:{sunrise:"Sunrise",sunset:"Sunset",fov_enter:"Sun enters window field of view",fov_exit:"Sun leaves window field of view"},hover_hint:"Hover the curve for time + forecast position; hover a colored line for the event it marks.",solar_only_note:"Solar geometry only — does not reflect manual overrides, custom positions, cloud suppression, or weather."},dialog:{configure_integration:"Configure integration",open_device_page:"Open device page",close:"Close",target:"Target",resume_auto:"Resume Auto",hide_advanced:"▼ Hide advanced",show_advanced:"▶ Advanced",custom_positions:"Custom positions",floor_tooltip:"Floor — slot raises position above raw calc",floor:"↥",disable_slot:"Disable slot {slot}",enable_slot:"Enable slot {slot}",on:"On",off:"Off",controls:"Controls",automatic:"Automatic",climate:"Climate",motion:"Motion",toggle_hint:"{label} {state} — tap to toggle",state_on:"on",state_off:"off",todays_forecast:"Today's forecast"},overrides:{title:"Overrides",manual:"Manual",force:"Force",motion:"Motion",active:"Active",off:"Off",ends_in:"ends in {time}",active_count:"{count} active",timeout:"expires in {time}",reset_manual:"Reset Manual"},climate:{title:"Climate",active:"Active: {strategy}",indoor:"Indoor",outdoor:"Outdoor",presence:"Presence",sunny:"Sunny",lux:"Lux",irradiance:"Irradiance",mode_off:"Climate mode off",standby:"Standby",threshold_low:"low",threshold_high:"high",threshold_summer_outside:"summer",reason:{outside_time_window:"Outside the operating time window",thresholds_not_met:"Temperatures within the comfort band — no action needed",other_mode_active:"Another control mode is currently active",readings_unavailable:"Temperature readings unavailable",mode_off:"Climate mode is turned off"}},compass:{placeholder_no_entries:"No Adaptive Cover Pro entries selected.",placeholder_no_sun:"Sun sensor not yet populated.",sun_tooltip:"Sun: {az} az / {el} el",sunrise_tooltip:"Sunrise: {time}",sunset_tooltip:"Sunset: {time}",moon_tooltip:"Moon: {phase} ({pct}%)",sun_path_tooltip:"Sun path (today)",in_fov_check:"✓ in FOV",in_fov:"in FOV",in_fov_tooltip:"Sun is currently within this window’s field of view",none:"—",sun:"Sun",moon:"Moon",sun_up_not_hitting:"Sun (up, not hitting)",sun_below_horizon:"Sun (below horizon)",window_fov:"Window FOV",sun_path:"Sun path",sunrise:"Sunrise",sunset:"Sunset",cover_position:"Cover position",window_normal:"Window normal",stat_sun:"Sun: ",stat_azi:"Azi: ",stat_elev:"Elev: ",stat_window:"Window: ",active_sun_arc:"Active sun arc {from} – {to}{elev}",fov_arc:"FOV {left} left / {right} right{elev}",window_normal_tooltip:"Window normal: {bearing}",cover_position_target:"Target: {pct}%",cover_position_target_awning:"Target (extended): {pct}%",cover_position_actual:"Actual: {pct}%",blind_spot:"Blind spot: {from} – {to}",elev_suffix:" · elev {min}–{max}"},covers:{placeholder:"No covers reported by the integration.",title:"Covers",target:"Target: {pct}",click_to_set:"Click to set position",target_tooltip:"Target {pct}%"},decision:{placeholder:"Decision trace not yet populated.",pipeline:"Pipeline",winner:"Winner: {name}",summary_tooltip:"Why this position?",not_evaluated:"not evaluated",floor_suffix:" floor",outside_schedule:"Outside schedule — automatic control paused",outside_schedule_tooltip:"The configured schedule window is not active, so automatic positioning is paused."},header:{on:"ON",off:"OFF",integration_enabled:"Integration Enabled",auto:"Auto",automatic_control:"Automatic Control"},tile:{motion_pending:"Motion timeout pending",motion_detected:"Motion detected",open:"Open",stop:"Stop",close:"Close",resume_aria:"Resume automatic control",registry_failed:"Registry fetch failed: {error}",loading:"Loading…",entry_not_found:"Adaptive Cover Pro entry {entry} not found."},formatters:{expired:"expired"},elevation:{title:"Sun today",fov_window:"FOV: {from} → {to}",fov_windows:"FOV: {windows}",fov_window_named:"{name}: {windows}",no_fov_today:"Sun does not enter FOV today",placeholder:"Sun elevation chart unavailable.",schedule:"Schedule {from} – {to}",schedule_from:"Schedule from {from}",schedule_until:"Schedule until {to}",schedule_start_tooltip:"Schedule start",schedule_end_tooltip:"Schedule end"},root:{loading_registry:"Loading Adaptive Cover Pro registry…",no_entities_title:"No Adaptive Cover Pro entities found",footer_version:"adaptive-cover-pro-card v{version}",compass_no_match:"No matching Adaptive Cover Pro entities",compass_configured:"Configured entries: {entries}",compass_not_found:"Entries not found: {entries}"},editor:{common:{entry_id:"Adaptive Cover Pro instance",support_alt:"Buy me a coffee",title_optional:"Title (optional)",title_placeholder:"e.g. West-facing windows",north_offset:"Compass north offset (°)",north_offset_hint:'Rotate the compass clockwise so "up" matches your map. Default: 0.',loading_entries:"Loading Adaptive Cover Pro config entries…",load_failed:"Failed to load config entries: {error}",no_entries:"No Adaptive Cover Pro config entries found. Add an instance under",no_entries_path:"Settings → Devices & Services",no_entries_then:", then come back.",entry_id_manual_placeholder:"Enter config entry ID manually",entry_id_fallback_label:"Entry ID",unknown_entry:"(unknown: {entry})",reset:"Reset"},main:{sections:"Sections",sections_hint:"Toggle which parts of the card are shown.",section_sky_label:"Sky compass",section_sky_desc:"Sun vs. window FOV, polar plot",section_elevation_label:"Sun today",section_elevation_desc:"Elevation-vs-time chart with FOV band and current-time cursor",section_decision_label:"Decision strip",section_decision_desc:"All 10 pipeline handlers with the winning row highlighted",section_covers_label:"Cover positions",section_covers_desc:"Per-cover live vs. target bars; click to set position",section_overrides_label:"Overrides panel",section_overrides_desc:"Manual, force, motion tiles + reset button",section_climate_label:"Climate panel",section_climate_desc:"Summer/winter/intermediate strategy; shows standby when climate mode is off or inactive",controls:"Controls",controls_hint:"Render as read-only (visible but not clickable).",integration_pill_label:"Integration ON/OFF pill",integration_pill_desc:"Allow toggling the integration from the card header.",automatic_pill_label:"Automatic Control pill",automatic_pill_desc:"Allow toggling automatic control from the card header.",reset_button_label:"Reset Manual Override button",reset_button_desc:"Allow pressing the reset tile in the overrides panel.",display:"Display",compact_label:"Compact mode",compact_desc:"Tighter spacing between sections.",show_compass_stats_label:"Show compass stats",show_compass_stats_desc:"Azi, Elev, ∠, and Window angle below the sky compass.",show_compass_legend_label:"Show compass legend",show_compass_legend_desc:"Color key below the sky compass.",show_moon_label:"Show moon on compass",show_moon_desc:"Moon position and phase overlay on the sky compass.",hide_inactive_label:"Hide inactive handlers",hide_inactive_desc:"Show only the winner and actively matched pipeline handlers."},tile:{name:"Title override",icon:"Icon override",cover:"Cover entity",layout:"Layout",show_position:"Show position %",show_state:"Show state (Open/Closed)",show_decision_summary:"Show decision summary",show_controls:"Show ↑■▼ controls",show_badge:"Show contextual badge",badge_section:"Badges",badge_auto:"Auto",badge_solar:"Solar tracking",badge_force:"Force override",badge_weather:"Weather safety",badge_manual:"Manual override",badge_custom_position:"Custom position",badge_motion:"Motion",badge_climate:"Climate",badge_glare_zone:"Glare zone",badge_cloud:"Cloud suppression",show_compass:"Show sun compass in dialog",show_elevation_chart:"Show sun-today chart in dialog",show_motion_icon:"Show motion indicator",tap_action:"Tap action",hold_action:"Hold action",double_tap_action:"Double-tap action",cover_blank_hint:"Leave blank to use the first managed cover automatically.",layout_option_one_line:"One line (compact)",layout_option_detailed:"Detailed (title, state, indicators)"},compass:{instances:"Adaptive Cover Pro instances",instances_hint:"Pick one or more. Each selected entry adds an overlay to the compass.",cover_colors:"Cover colors",cover_colors_hint:"Override the default palette color for each overlay.",default_color:"default",display:"Display",toggle_compact_label:"Compact mode",toggle_compact_desc:"Smaller SVG, legend hidden.",toggle_legend_label:"Legend",toggle_legend_desc:"Color swatches + entry labels below compass.",toggle_stats_label:"Stats",toggle_stats_desc:"Sun + per-window numeric rows.",toggle_moon_label:"Moon",toggle_moon_desc:"Render moon position and phase.",toggle_cardinals_label:"Cardinal labels",toggle_cardinals_desc:"N/E/S/W letters around the compass.",toggle_blind_spot_label:"Blind spots",toggle_blind_spot_desc:"Hatched wedges for each window’s blind range.",toggle_sun_path_label:"Sun path",toggle_sun_path_desc:"Today’s sun arc across the sky.",toggle_sunrise_sunset_label:"Sunrise / sunset markers",toggle_sunrise_sunset_desc:"Small dots at rise and set azimuths.",toggle_cover_fill_label:"Cover closure fill",toggle_cover_fill_desc:"Inner wedge showing how closed each cover is.",toggle_window_arrow_label:"Window-normal arrow",toggle_window_arrow_desc:"Line from center toward each window’s azimuth.",toggle_elevation_chart_label:"Sun-today chart",toggle_elevation_chart_desc:"Elevation-vs-time chart below the compass, with FOV band and elevation limits."}}},fr:{handler:{force:"Dérogation forcée",weather:"Sécurité météo",manual:"Dérogation manuelle",custom_position:"Position personnalisée",motion:"Délai d'inactivité du mouvement",cloud:"Désactivation par temps nuageux",climate:"Climatique",glare_zone:"Zone d'éblouissement",solar:"Suivi solaire",default:"Par défaut",floor_clamp:"Plancher"},badge:{auto:"Auto",manual:"Manuel",force:"Forcé",weather:"Sécurité météo",glare_zone:"Éblouissement",climate:"Climatique",cloud:"Nuageux",custom_position:"Personnalisé",solar:"Suivi solaire",motion:"Inactivité",off:"Off",off_schedule:"Hors planning",floor_suffix:" ↥",safety:"Sécurité"},forecast:{event:{sunrise:"Lever du soleil",sunset:"Coucher du soleil",fov_enter:"Le soleil entre dans le champ de vision de la fenêtre",fov_exit:"Le soleil quitte le champ de vision de la fenêtre"},hover_hint:"Survolez la courbe pour voir l'heure et la position prévue ; survolez une ligne colorée pour voir l'événement qu'elle indique.",solar_only_note:"Géométrie solaire uniquement — ne tient pas compte des dérogations manuelles, des positions personnalisées, de la désactivation par temps nuageux ni des conditions météo."},dialog:{configure_integration:"Configurer l'intégration",open_device_page:"Ouvrir la page de l'appareil",close:"Fermer",target:"Cible",resume_auto:"Reprendre l'automatique",hide_advanced:"▼ Masquer les options avancées",show_advanced:"▶ Afficher les options avancées",custom_positions:"Positions personnalisées",floor_tooltip:"Plancher — cette valeur force une position minimale au-dessus du calcul automatique",floor:"↥",disable_slot:"Désactiver le créneau {slot}",enable_slot:"Activer le créneau {slot}",on:"Activé",off:"Désactivé",controls:"Commandes",automatic:"Automatique",climate:"Climatique",motion:"Mouvement",toggle_hint:"{label} {state} — appuyez pour basculer",state_on:"activé",state_off:"désactivé",todays_forecast:"Prévisions du jour"},overrides:{title:"Dérogations",manual:"Manuel",force:"Forcé",motion:"Mouvement",active:"Actif",off:"Désactivé",ends_in:"se termine dans {time}",active_count:"{count} dérogation(s) active(s)",timeout:"expire dans {time}",reset_manual:"Réinitialiser le mode manuel"},climate:{title:"Climatique",active:"Actif : {strategy}",indoor:"Intérieur",outdoor:"Extérieur",presence:"Présence",sunny:"Ensoleillé",lux:"Lux",irradiance:"Irradiance",mode_off:"Mode climatique désactivé",standby:"En veille",threshold_low:"bas",threshold_high:"haut",threshold_summer_outside:"été",reason:{outside_time_window:"En dehors de la plage horaire de fonctionnement",thresholds_not_met:"Températures dans la plage de confort — aucune action requise",other_mode_active:"Un autre mode de contrôle est actuellement actif",readings_unavailable:"Relevés de température indisponibles",mode_off:"Le mode climatique est désactivé"}},compass:{placeholder_no_entries:"Aucune instance Adaptive Cover Pro sélectionnée.",placeholder_no_sun:"Le capteur solaire n'est pas encore renseigné.",sun_tooltip:"Soleil : {az} az / {el} él",sunrise_tooltip:"Lever du soleil : {time}",sunset_tooltip:"Coucher du soleil : {time}",moon_tooltip:"Lune : {phase} ({pct}%)",sun_path_tooltip:"Trajectoire solaire (aujourd'hui)",in_fov_check:"✓ dans le champ de vision",in_fov:"dans le champ de vision",in_fov_tooltip:"Le soleil est actuellement dans le champ de vision de cette fenêtre",none:"—",sun:"Soleil",moon:"Lune",sun_up_not_hitting:"Soleil (levé, ne frappe pas)",sun_below_horizon:"Soleil (sous l’horizon)",window_fov:"Champ de vision",sun_path:"Trajectoire solaire",sunrise:"Lever du soleil",sunset:"Coucher du soleil",cover_position:"Position du store",window_normal:"Axe de la fenêtre",stat_sun:"Soleil : ",stat_azi:"Azi : ",stat_elev:"Élév : ",stat_window:"Fenêtre : ",active_sun_arc:"Arc solaire actif {from} – {to}{elev}",fov_arc:"Champ de vision {left} gauche / {right} droite{elev}",window_normal_tooltip:"Axe de la fenêtre : {bearing}",cover_position_target:"Cible : {pct}%",cover_position_target_awning:"Cible (déployé) : {pct}%",cover_position_actual:"Réel : {pct}%",blind_spot:"Soleil masqué : {from} - {to}",elev_suffix:" · élév {min}–{max}"},covers:{placeholder:"Aucun store signalé par l'intégration.",title:"Stores",target:"Cible : {pct}",click_to_set:"Cliquer pour définir la position",target_tooltip:"Cible {pct}%"},decision:{placeholder:"La trace de décision n'est pas encore renseignée.",pipeline:"Pipeline",winner:"Actif : {name}",summary_tooltip:"Pourquoi cette position ?",not_evaluated:"non évalué",floor_suffix:" plancher",outside_schedule:"Hors planning — contrôle automatique en pause",outside_schedule_tooltip:"La fenêtre de planning configurée n'est pas active, le positionnement automatique est donc en pause."},header:{on:"ON",off:"OFF",integration_enabled:"Intégration activée",auto:"Auto",automatic_control:"Contrôle automatique"},tile:{motion_pending:"Délai de mouvement en cours",motion_detected:"Mouvement détecté",open:"Ouvrir",stop:"Arrêter",close:"Fermer",resume_aria:"Reprendre le contrôle automatique",registry_failed:"Échec de la récupération du registre : {error}",loading:"Chargement…",entry_not_found:"Instance Adaptive Cover Pro {entry} introuvable."},formatters:{expired:"expiré"},elevation:{title:"Soleil aujourd'hui",fov_window:"Champ de vision : {from} → {to}",fov_windows:"Champ de vision : {windows}",fov_window_named:"{name} : {windows}",no_fov_today:"Pas de soleil dans le champ de vision aujourd'hui",placeholder:"Graphique d'élévation solaire indisponible.",schedule:"Programmation {from} – {to}",schedule_from:"Programmation à partir de {from}",schedule_until:"Programmation jusqu'à {to}",schedule_start_tooltip:"Début de programmation",schedule_end_tooltip:"Fin de programmation"},root:{loading_registry:"Chargement du registre Adaptive Cover Pro…",no_entities_title:"Aucune entité Adaptive Cover Pro trouvée",footer_version:"adaptive-cover-pro-card v{version}",compass_no_match:"Aucune entité Adaptive Cover Pro correspondante",compass_configured:"Instances configurées : {entries}",compass_not_found:"Instances introuvables : {entries}"},editor:{common:{entry_id:"Instance Adaptive Cover Pro",support_alt:"Offrez-moi un café",title_optional:"Titre (facultatif)",title_placeholder:"ex. Fenêtres côté ouest",north_offset:"Décalage nord de la boussole (°)",north_offset_hint:"Faites pivoter la boussole dans le sens horaire pour que « haut » corresponde à votre carte. Par défaut : 0.",loading_entries:"Chargement des entrées de configuration Adaptive Cover Pro…",load_failed:"Échec du chargement des entrées de configuration : {error}",no_entries:"Aucune entrée de configuration Adaptive Cover Pro trouvée. Ajoutez une instance sous",no_entries_path:"Paramètres → Appareils et services",no_entries_then:", puis revenez ici.",entry_id_manual_placeholder:"Saisir manuellement l'ID d'entrée de configuration",entry_id_fallback_label:"ID d'entrée",unknown_entry:"(inconnu : {entry})",reset:"Réinitialiser"},main:{sections:"Sections",sections_hint:"Activer ou désactiver les parties de la carte affichées.",section_sky_label:"Boussole céleste",section_sky_desc:"Soleil par rapport au champ de vision de la fenêtre, tracé polaire",section_elevation_label:"Soleil aujourd'hui",section_elevation_desc:"Graphique élévation/temps avec bande FOV et curseur temps réel",section_decision_label:"Bande de décision",section_decision_desc:"Les 10 gestionnaires du pipeline avec la ligne gagnante mise en évidence",section_covers_label:"Positions des stores",section_covers_desc:"Barres position réelle/cible par store ; cliquer pour définir la position",section_overrides_label:"Panneau des dérogations",section_overrides_desc:"Tuiles Manuel, Forcé, Mouvement + bouton de réinitialisation",section_climate_label:"Panneau climatique",section_climate_desc:"Stratégie été/hiver/intermédiaire ; affiche le mode veille si le mode climatique est désactivé ou inactif",controls:"Commandes",controls_hint:"Afficher en lecture seule (visible mais non cliquable).",integration_pill_label:"Bouton ON/OFF de l'intégration",integration_pill_desc:"Permettre de basculer l'intégration depuis l'en-tête de la carte.",automatic_pill_label:"Bouton contrôle automatique",automatic_pill_desc:"Permettre de basculer le contrôle automatique depuis l'en-tête de la carte.",reset_button_label:"Bouton de réinitialisation de la dérogation manuelle",reset_button_desc:"Permettre d'appuyer sur la tuile de réinitialisation dans le panneau des dérogations.",display:"Affichage",compact_label:"Mode compact",compact_desc:"Espacement réduit entre les sections.",show_compass_stats_label:"Afficher les statistiques de la boussole",show_compass_stats_desc:"Azi, Élév, ∠ et angle de fenêtre sous la boussole céleste.",show_compass_legend_label:"Afficher la légende de la boussole",show_compass_legend_desc:"Clé de couleur sous la boussole céleste.",show_moon_label:"Afficher la lune sur la boussole",show_moon_desc:"Position et phase de la lune en superposition sur la boussole céleste.",hide_inactive_label:"Masquer les gestionnaires inactifs",hide_inactive_desc:"Afficher uniquement le gestionnaire sélectionné et les gestionnaires du pipeline actifs."},tile:{name:"Titre personnalisé",icon:"Icône personnalisée",cover:"Entité de store",layout:"Disposition",show_position:"Afficher la position %",show_state:"Afficher l'état (Ouvert/Fermé)",show_decision_summary:"Afficher le résumé de décision",show_controls:"Afficher les commandes ↑■▼",show_badge:"Afficher le badge contextuel",badge_section:"Badges",badge_auto:"Auto",badge_solar:"Suivi solaire",badge_force:"Dérogation forcée",badge_weather:"Sécurité météo",badge_manual:"Dérogation manuelle",badge_custom_position:"Position personnalisée",badge_motion:"Mouvement",badge_climate:"Climatique",badge_glare_zone:"Zone d'éblouissement",badge_cloud:"Suppression nuageuse",show_compass:"Afficher la boussole solaire dans le dialogue",show_elevation_chart:"Afficher le graphique du soleil dans le dialogue",show_motion_icon:"Afficher l'indicateur de mouvement",tap_action:"Action au toucher",hold_action:"Action au maintien",double_tap_action:"Action au double toucher",cover_blank_hint:"Laisser vide pour utiliser automatiquement le premier store géré.",layout_option_one_line:"Une ligne (compact)",layout_option_detailed:"Détaillé (titre, état, indicateurs)"},compass:{instances:"Instances Adaptive Cover Pro",instances_hint:"Sélectionnez une ou plusieurs instances. Chaque instance sélectionnée ajoute une superposition à la boussole.",cover_colors:"Couleurs des stores",cover_colors_hint:"Remplacer la couleur de palette par défaut pour chaque superposition.",default_color:"par défaut",display:"Affichage",toggle_compact_label:"Mode compact",toggle_compact_desc:"SVG plus petit, légende masquée.",toggle_legend_label:"Légende",toggle_legend_desc:"Échantillons de couleur et étiquettes d'instance sous la boussole.",toggle_stats_label:"Statistiques",toggle_stats_desc:"Soleil + lignes numériques par fenêtre.",toggle_moon_label:"Lune",toggle_moon_desc:"Afficher la position et la phase de la lune.",toggle_cardinals_label:"Points cardinaux",toggle_cardinals_desc:"Lettres N/E/S/O autour de la boussole.",toggle_blind_spot_label:"Zones de soleil masqué",toggle_blind_spot_desc:"Secteurs hachurés pour la plage où le soleil est masqué de chaque fenêtre.",toggle_sun_path_label:"Trajectoire solaire",toggle_sun_path_desc:"Arc solaire du jour dans le ciel.",toggle_sunrise_sunset_label:"Repères lever / coucher du soleil",toggle_sunrise_sunset_desc:"Petits points aux azimuts de lever et coucher du soleil.",toggle_cover_fill_label:"Remplissage de fermeture du store",toggle_cover_fill_desc:"Secteur intérieur indiquant le taux de fermeture de chaque store.",toggle_window_arrow_label:"Flèche de normale de fenêtre",toggle_window_arrow_desc:"Ligne du centre vers l'azimut de chaque fenêtre.",toggle_elevation_chart_label:"Graphique du soleil",toggle_elevation_chart_desc:"Graphique élévation/temps sous la boussole, avec bande FOV et limites d'élévation."}}}};function Ne(e,t){const o=t.split(".");let i=e;for(const e of o){if("object"!=typeof i||null===i)return;i=i[e]}return"string"==typeof i?i:void 0}function De(e,t){return t?e.replace(/\{(\w+)\}/g,(e,o)=>Object.prototype.hasOwnProperty.call(t,o)?String(t[o]):e):e}function Be(e,t,o){const i=function(e){const t=(e?.locale?.language??e?.language??"en").toLowerCase().split("-")[0];return t in Re?t:"en"}(t),s=Ne(Re[i],e);if(void 0!==s)return De(s,o);if("en"!==i){const t=Ne(Re.en,e);if(void 0!==t)return De(t,o)}return e}function Ke(){let e=null;return(t,o,i)=>{const s=o.entry_id??"";if(!s)return e=null,null;const n=null!==e&&e.registry===i&&e.entryId===s,r=n?e.base:Ve(s,i);if(!r)return e={registry:i,entryId:s,base:null,devices:null,posState:null,ctrlState:null,result:null},null;const a=t.devices,l=r.entities.target_position_sensor,c=r.entities.control_status_sensor,d=l?t.states[l]:void 0,h=c?t.states[c]:void 0;if(n&&null!==e&&null!==e.result&&e.devices===a&&e.posState===d&&e.ctrlState===h)return e.result;const u=Ge(t,s,r);return e={registry:i,entryId:s,base:r,devices:a,posState:d,ctrlState:h,result:u},u}}function Ve(e,t){const o={},i=`${e}_`;let s,n=!1;for(const r of t){if(r.config_entry_id!==e)continue;if(r.platform!==Ae)continue;if(n=!0,!s&&r.device_id&&(s=r.device_id),!r.unique_id.startsWith(i))continue;const t=r.unique_id.slice(i.length),a=r.entity_id.split(".")[0],l=je[`${a}:${t}`];l&&(o[l]=r.entity_id)}return n&&0!==Object.keys(o).length?{entities:o,deviceId:s}:null}function Ge(e,t,o){const{entities:i,deviceId:s}=o,n=e;let r=t;if(n.devices)for(const e of Object.values(n.devices))if(e.config_entries?.includes(t)){r=e.name_by_user??e.name??t;break}const a=[],l=i.target_position_sensor;if(l){const t=e.states[l]?.attributes?.actual_positions;t&&a.push(...Object.keys(t))}let c="cover_blind";const d=i.control_status_sensor;if(d){const t=e.states[d]?.attributes;t?.cover_type&&(c=t.cover_type)}return{entry_id:t,entry_title:r,cover_type:c,entities:i,managed_covers:a,device_id:s}}function qe(e,t,o){const i=t.entry_id;if(!i)return null;const s=Ve(i,o);return s?Ge(e,i,s):null}async function Ue(e){return(await e.callWS({type:"config_entries/get",domain:Ae})).filter(e=>e.domain===Ae).map(e=>({entry_id:e.entry_id,title:e.title}))}function Le(e,t,o=0){const i=(e-90+o)*Math.PI/180;return{x:t*Math.cos(i),y:t*Math.sin(i)}}function We(e){return 1-Math.max(0,Math.min(90,e))/90}function Ye(e,t,o,i=0,s=0){const n=e=>(e%360+360)%360,r=n(e),a=n(t);let l=a-r;l<0&&(l+=360);const c=l>180?1:0,d=Le(r,o,s),h=Le(a,o,s);if(i<=0)return`M 0 0 L ${d.x} ${d.y} A ${o} ${o} 0 ${c} 1 ${h.x} ${h.y} Z`;const u=Le(a,i,s),p=Le(r,i,s);return[`M ${d.x} ${d.y}`,`A ${o} ${o} 0 ${c} 1 ${h.x} ${h.y}`,`L ${u.x} ${u.y}`,`A ${i} ${i} 0 ${c} 0 ${p.x} ${p.y}`,"Z"].join(" ")}function Qe(e,t,o=0){return Le(e,We(t),o)}function He(e){return(e%360+360)%360}function Ze(e,t,o,i){const s=i??0;let n=-1,r=-1;for(let i=t;i<=o&&i<e.length;i++)e[i].elevation>s&&(-1===n&&(n=i),r=i);return-1===n?null:{wedgeStart:e[n].azimuth,wedgeEnd:e[r].azimuth}}function Je(e,t,o){const i=(e-t)/864e5;return Math.max(0,Math.min(o,i*o))}function Xe(e,t,o){return((e-t)%360+360)%360<=((o-t)%360+360)%360}function et(e,t,o,i){return Xe(o,e,t)||Xe(i,e,t)||Xe(e,o,i)||Xe(t,o,i)}function tt(e,t,o,i){const s="cover_awning"===t?e/100:1-e/100;return Math.min(o*s,i)}async function ot(e){return e.callWS({type:"config/entity_registry/list"})}function it(e,t){let o=null,i=!1;return e.connection.subscribeEvents(e=>t(e.data),"entity_registry_updated").then(e=>{i?e():o=e}).catch(()=>{}),()=>{i=!0,o&&o()}}let st=null,nt=null;function rt(){return st}function at(e,t=!1){if(nt)return nt;if(!t&&st)return Promise.resolve(st);const o=ot(e).then(e=>(st=e,nt=null,e)).catch(e=>{throw nt=null,e});return nt=o,o}function lt(e){return`acp-card:registry:v1:${e}`}const ct={get(e){try{const t=localStorage.getItem(lt(e));if(!t)return null;const o=JSON.parse(t);return 1!==o.schemaVersion?null:o}catch{return null}},set(e,t){try{const o={schemaVersion:1,cardVersion:fe,fetchedAt:Date.now(),entries:t};localStorage.setItem(lt(e),JSON.stringify(o))}catch{}},invalidate(e){try{localStorage.removeItem(lt(e))}catch{}},clear(){try{const e="acp-card:registry:v1:",t=[];for(let o=0;o<localStorage.length;o++){const i=localStorage.key(o);i?.startsWith(e)&&t.push(i)}t.forEach(e=>localStorage.removeItem(e))}catch{}}};function dt(e){return`${e.entity_id}|${e.unique_id}|${e.platform}|${e.config_entry_id??""}`}function ht(e,t,o){return e.filter(e=>e.config_entry_id===t&&void 0===o)}let ut=class extends ce{constructor(){super(...arguments),this.on=!1,this.readonly=!1,this.label="",this.title=""}_handleClick(){this.readonly||this.dispatchEvent(new CustomEvent("pill-click",{bubbles:!0,composed:!0}))}render(){return q`
+function e(e,t,o,s){var i,n=arguments.length,r=n<3?t:null===s?s=Object.getOwnPropertyDescriptor(t,o):s;if("object"==typeof Reflect&&"function"==typeof Reflect.decorate)r=Reflect.decorate(e,t,o,s);else for(var a=e.length-1;a>=0;a--)(i=e[a])&&(r=(n<3?i(r):n>3?i(t,o,r):i(t,o))||r);return n>3&&r&&Object.defineProperty(t,o,r),r}"function"==typeof SuppressedError&&SuppressedError;const t=globalThis,o=t.ShadowRoot&&(void 0===t.ShadyCSS||t.ShadyCSS.nativeShadow)&&"adoptedStyleSheets"in Document.prototype&&"replace"in CSSStyleSheet.prototype,s=Symbol(),i=new WeakMap;let n=class{constructor(e,t,o){if(this._$cssResult$=!0,o!==s)throw Error("CSSResult is not constructable. Use `unsafeCSS` or `css` instead.");this.cssText=e,this.t=t}get styleSheet(){let e=this.o;const t=this.t;if(o&&void 0===e){const o=void 0!==t&&1===t.length;o&&(e=i.get(t)),void 0===e&&((this.o=e=new CSSStyleSheet).replaceSync(this.cssText),o&&i.set(t,e))}return e}toString(){return this.cssText}};const r=(e,...t)=>{const o=1===e.length?e[0]:t.reduce((t,o,s)=>t+(e=>{if(!0===e._$cssResult$)return e.cssText;if("number"==typeof e)return e;throw Error("Value passed to 'css' function must be a 'css' function result: "+e+". Use 'unsafeCSS' to pass non-literal values, but take care to ensure page security.")})(o)+e[s+1],e[0]);return new n(o,e,s)},a=o?e=>e:e=>e instanceof CSSStyleSheet?(e=>{let t="";for(const o of e.cssRules)t+=o.cssText;return(e=>new n("string"==typeof e?e:e+"",void 0,s))(t)})(e):e,{is:l,defineProperty:c,getOwnPropertyDescriptor:d,getOwnPropertyNames:h,getOwnPropertySymbols:u,getPrototypeOf:p}=Object,_=globalThis,m=_.trustedTypes,g=m?m.emptyScript:"",f=_.reactiveElementPolyfillSupport,v=(e,t)=>e,y={toAttribute(e,t){switch(t){case Boolean:e=e?g:null;break;case Object:case Array:e=null==e?e:JSON.stringify(e)}return e},fromAttribute(e,t){let o=e;switch(t){case Boolean:o=null!==e;break;case Number:o=null===e?null:Number(e);break;case Object:case Array:try{o=JSON.parse(e)}catch(e){o=null}}return o}},b=(e,t)=>!l(e,t),w={attribute:!0,type:String,converter:y,reflect:!1,useDefault:!1,hasChanged:b};Symbol.metadata??=Symbol("metadata"),_.litPropertyMetadata??=new WeakMap;let x=class extends HTMLElement{static addInitializer(e){this._$Ei(),(this.l??=[]).push(e)}static get observedAttributes(){return this.finalize(),this._$Eh&&[...this._$Eh.keys()]}static createProperty(e,t=w){if(t.state&&(t.attribute=!1),this._$Ei(),this.prototype.hasOwnProperty(e)&&((t=Object.create(t)).wrapped=!0),this.elementProperties.set(e,t),!t.noAccessor){const o=Symbol(),s=this.getPropertyDescriptor(e,o,t);void 0!==s&&c(this.prototype,e,s)}}static getPropertyDescriptor(e,t,o){const{get:s,set:i}=d(this.prototype,e)??{get(){return this[t]},set(e){this[t]=e}};return{get:s,set(t){const n=s?.call(this);i?.call(this,t),this.requestUpdate(e,n,o)},configurable:!0,enumerable:!0}}static getPropertyOptions(e){return this.elementProperties.get(e)??w}static _$Ei(){if(this.hasOwnProperty(v("elementProperties")))return;const e=p(this);e.finalize(),void 0!==e.l&&(this.l=[...e.l]),this.elementProperties=new Map(e.elementProperties)}static finalize(){if(this.hasOwnProperty(v("finalized")))return;if(this.finalized=!0,this._$Ei(),this.hasOwnProperty(v("properties"))){const e=this.properties,t=[...h(e),...u(e)];for(const o of t)this.createProperty(o,e[o])}const e=this[Symbol.metadata];if(null!==e){const t=litPropertyMetadata.get(e);if(void 0!==t)for(const[e,o]of t)this.elementProperties.set(e,o)}this._$Eh=new Map;for(const[e,t]of this.elementProperties){const o=this._$Eu(e,t);void 0!==o&&this._$Eh.set(o,e)}this.elementStyles=this.finalizeStyles(this.styles)}static finalizeStyles(e){const t=[];if(Array.isArray(e)){const o=new Set(e.flat(1/0).reverse());for(const e of o)t.unshift(a(e))}else void 0!==e&&t.push(a(e));return t}static _$Eu(e,t){const o=t.attribute;return!1===o?void 0:"string"==typeof o?o:"string"==typeof e?e.toLowerCase():void 0}constructor(){super(),this._$Ep=void 0,this.isUpdatePending=!1,this.hasUpdated=!1,this._$Em=null,this._$Ev()}_$Ev(){this._$ES=new Promise(e=>this.enableUpdating=e),this._$AL=new Map,this._$E_(),this.requestUpdate(),this.constructor.l?.forEach(e=>e(this))}addController(e){(this._$EO??=new Set).add(e),void 0!==this.renderRoot&&this.isConnected&&e.hostConnected?.()}removeController(e){this._$EO?.delete(e)}_$E_(){const e=new Map,t=this.constructor.elementProperties;for(const o of t.keys())this.hasOwnProperty(o)&&(e.set(o,this[o]),delete this[o]);e.size>0&&(this._$Ep=e)}createRenderRoot(){const e=this.shadowRoot??this.attachShadow(this.constructor.shadowRootOptions);return((e,s)=>{if(o)e.adoptedStyleSheets=s.map(e=>e instanceof CSSStyleSheet?e:e.styleSheet);else for(const o of s){const s=document.createElement("style"),i=t.litNonce;void 0!==i&&s.setAttribute("nonce",i),s.textContent=o.cssText,e.appendChild(s)}})(e,this.constructor.elementStyles),e}connectedCallback(){this.renderRoot??=this.createRenderRoot(),this.enableUpdating(!0),this._$EO?.forEach(e=>e.hostConnected?.())}enableUpdating(e){}disconnectedCallback(){this._$EO?.forEach(e=>e.hostDisconnected?.())}attributeChangedCallback(e,t,o){this._$AK(e,o)}_$ET(e,t){const o=this.constructor.elementProperties.get(e),s=this.constructor._$Eu(e,o);if(void 0!==s&&!0===o.reflect){const i=(void 0!==o.converter?.toAttribute?o.converter:y).toAttribute(t,o.type);this._$Em=e,null==i?this.removeAttribute(s):this.setAttribute(s,i),this._$Em=null}}_$AK(e,t){const o=this.constructor,s=o._$Eh.get(e);if(void 0!==s&&this._$Em!==s){const e=o.getPropertyOptions(s),i="function"==typeof e.converter?{fromAttribute:e.converter}:void 0!==e.converter?.fromAttribute?e.converter:y;this._$Em=s;const n=i.fromAttribute(t,e.type);this[s]=n??this._$Ej?.get(s)??n,this._$Em=null}}requestUpdate(e,t,o,s=!1,i){if(void 0!==e){const n=this.constructor;if(!1===s&&(i=this[e]),o??=n.getPropertyOptions(e),!((o.hasChanged??b)(i,t)||o.useDefault&&o.reflect&&i===this._$Ej?.get(e)&&!this.hasAttribute(n._$Eu(e,o))))return;this.C(e,t,o)}!1===this.isUpdatePending&&(this._$ES=this._$EP())}C(e,t,{useDefault:o,reflect:s,wrapped:i},n){o&&!(this._$Ej??=new Map).has(e)&&(this._$Ej.set(e,n??t??this[e]),!0!==i||void 0!==n)||(this._$AL.has(e)||(this.hasUpdated||o||(t=void 0),this._$AL.set(e,t)),!0===s&&this._$Em!==e&&(this._$Eq??=new Set).add(e))}async _$EP(){this.isUpdatePending=!0;try{await this._$ES}catch(e){Promise.reject(e)}const e=this.scheduleUpdate();return null!=e&&await e,!this.isUpdatePending}scheduleUpdate(){return this.performUpdate()}performUpdate(){if(!this.isUpdatePending)return;if(!this.hasUpdated){if(this.renderRoot??=this.createRenderRoot(),this._$Ep){for(const[e,t]of this._$Ep)this[e]=t;this._$Ep=void 0}const e=this.constructor.elementProperties;if(e.size>0)for(const[t,o]of e){const{wrapped:e}=o,s=this[t];!0!==e||this._$AL.has(t)||void 0===s||this.C(t,void 0,o,s)}}let e=!1;const t=this._$AL;try{e=this.shouldUpdate(t),e?(this.willUpdate(t),this._$EO?.forEach(e=>e.hostUpdate?.()),this.update(t)):this._$EM()}catch(t){throw e=!1,this._$EM(),t}e&&this._$AE(t)}willUpdate(e){}_$AE(e){this._$EO?.forEach(e=>e.hostUpdated?.()),this.hasUpdated||(this.hasUpdated=!0,this.firstUpdated(e)),this.updated(e)}_$EM(){this._$AL=new Map,this.isUpdatePending=!1}get updateComplete(){return this.getUpdateComplete()}getUpdateComplete(){return this._$ES}shouldUpdate(e){return!0}update(e){this._$Eq&&=this._$Eq.forEach(e=>this._$ET(e,this[e])),this._$EM()}updated(e){}firstUpdated(e){}};x.elementStyles=[],x.shadowRootOptions={mode:"open"},x[v("elementProperties")]=new Map,x[v("finalized")]=new Map,f?.({ReactiveElement:x}),(_.reactiveElementVersions??=[]).push("2.1.2");const $=globalThis,A=e=>e,k=$.trustedTypes,C=k?k.createPolicy("lit-html",{createHTML:e=>e}):void 0,E="$lit$",S=`lit$${Math.random().toFixed(9).slice(2)}$`,z="?"+S,O=`<${z}>`,M=document,I=()=>M.createComment(""),F=e=>null===e||"object"!=typeof e&&"function"!=typeof e,T=Array.isArray,P="[ \t\n\f\r]",j=/<(?:(!--|\/[^a-zA-Z])|(\/?[a-zA-Z][^>\s]*)|(\/?$))/g,R=/-->/g,N=/>/g,D=RegExp(`>|${P}(?:([^\\s"'>=/]+)(${P}*=${P}*(?:[^ \t\n\f\r"'\`<>=]|("|')|))|$)`,"g"),B=/'/g,K=/"/g,V=/^(?:script|style|textarea|title)$/i,G=e=>(t,...o)=>({_$litType$:e,strings:t,values:o}),L=G(1),q=G(2),U=Symbol.for("lit-noChange"),Y=Symbol.for("lit-nothing"),W=new WeakMap,Q=M.createTreeWalker(M,129);function H(e,t){if(!T(e)||!e.hasOwnProperty("raw"))throw Error("invalid template strings array");return void 0!==C?C.createHTML(t):t}const X=(e,t)=>{const o=e.length-1,s=[];let i,n=2===t?"<svg>":3===t?"<math>":"",r=j;for(let t=0;t<o;t++){const o=e[t];let a,l,c=-1,d=0;for(;d<o.length&&(r.lastIndex=d,l=r.exec(o),null!==l);)d=r.lastIndex,r===j?"!--"===l[1]?r=R:void 0!==l[1]?r=N:void 0!==l[2]?(V.test(l[2])&&(i=RegExp("</"+l[2],"g")),r=D):void 0!==l[3]&&(r=D):r===D?">"===l[0]?(r=i??j,c=-1):void 0===l[1]?c=-2:(c=r.lastIndex-l[2].length,a=l[1],r=void 0===l[3]?D:'"'===l[3]?K:B):r===K||r===B?r=D:r===R||r===N?r=j:(r=D,i=void 0);const h=r===D&&e[t+1].startsWith("/>")?" ":"";n+=r===j?o+O:c>=0?(s.push(a),o.slice(0,c)+E+o.slice(c)+S+h):o+S+(-2===c?t:h)}return[H(e,n+(e[o]||"<?>")+(2===t?"</svg>":3===t?"</math>":"")),s]};class Z{constructor({strings:e,_$litType$:t},o){let s;this.parts=[];let i=0,n=0;const r=e.length-1,a=this.parts,[l,c]=X(e,t);if(this.el=Z.createElement(l,o),Q.currentNode=this.el.content,2===t||3===t){const e=this.el.content.firstChild;e.replaceWith(...e.childNodes)}for(;null!==(s=Q.nextNode())&&a.length<r;){if(1===s.nodeType){if(s.hasAttributes())for(const e of s.getAttributeNames())if(e.endsWith(E)){const t=c[n++],o=s.getAttribute(e).split(S),r=/([.?@])?(.*)/.exec(t);a.push({type:1,index:i,name:r[2],strings:o,ctor:"."===r[1]?se:"?"===r[1]?ie:"@"===r[1]?ne:oe}),s.removeAttribute(e)}else e.startsWith(S)&&(a.push({type:6,index:i}),s.removeAttribute(e));if(V.test(s.tagName)){const e=s.textContent.split(S),t=e.length-1;if(t>0){s.textContent=k?k.emptyScript:"";for(let o=0;o<t;o++)s.append(e[o],I()),Q.nextNode(),a.push({type:2,index:++i});s.append(e[t],I())}}}else if(8===s.nodeType)if(s.data===z)a.push({type:2,index:i});else{let e=-1;for(;-1!==(e=s.data.indexOf(S,e+1));)a.push({type:7,index:i}),e+=S.length-1}i++}}static createElement(e,t){const o=M.createElement("template");return o.innerHTML=e,o}}function J(e,t,o=e,s){if(t===U)return t;let i=void 0!==s?o._$Co?.[s]:o._$Cl;const n=F(t)?void 0:t._$litDirective$;return i?.constructor!==n&&(i?._$AO?.(!1),void 0===n?i=void 0:(i=new n(e),i._$AT(e,o,s)),void 0!==s?(o._$Co??=[])[s]=i:o._$Cl=i),void 0!==i&&(t=J(e,i._$AS(e,t.values),i,s)),t}class ee{constructor(e,t){this._$AV=[],this._$AN=void 0,this._$AD=e,this._$AM=t}get parentNode(){return this._$AM.parentNode}get _$AU(){return this._$AM._$AU}u(e){const{el:{content:t},parts:o}=this._$AD,s=(e?.creationScope??M).importNode(t,!0);Q.currentNode=s;let i=Q.nextNode(),n=0,r=0,a=o[0];for(;void 0!==a;){if(n===a.index){let t;2===a.type?t=new te(i,i.nextSibling,this,e):1===a.type?t=new a.ctor(i,a.name,a.strings,this,e):6===a.type&&(t=new re(i,this,e)),this._$AV.push(t),a=o[++r]}n!==a?.index&&(i=Q.nextNode(),n++)}return Q.currentNode=M,s}p(e){let t=0;for(const o of this._$AV)void 0!==o&&(void 0!==o.strings?(o._$AI(e,o,t),t+=o.strings.length-2):o._$AI(e[t])),t++}}class te{get _$AU(){return this._$AM?._$AU??this._$Cv}constructor(e,t,o,s){this.type=2,this._$AH=Y,this._$AN=void 0,this._$AA=e,this._$AB=t,this._$AM=o,this.options=s,this._$Cv=s?.isConnected??!0}get parentNode(){let e=this._$AA.parentNode;const t=this._$AM;return void 0!==t&&11===e?.nodeType&&(e=t.parentNode),e}get startNode(){return this._$AA}get endNode(){return this._$AB}_$AI(e,t=this){e=J(this,e,t),F(e)?e===Y||null==e||""===e?(this._$AH!==Y&&this._$AR(),this._$AH=Y):e!==this._$AH&&e!==U&&this._(e):void 0!==e._$litType$?this.$(e):void 0!==e.nodeType?this.T(e):(e=>T(e)||"function"==typeof e?.[Symbol.iterator])(e)?this.k(e):this._(e)}O(e){return this._$AA.parentNode.insertBefore(e,this._$AB)}T(e){this._$AH!==e&&(this._$AR(),this._$AH=this.O(e))}_(e){this._$AH!==Y&&F(this._$AH)?this._$AA.nextSibling.data=e:this.T(M.createTextNode(e)),this._$AH=e}$(e){const{values:t,_$litType$:o}=e,s="number"==typeof o?this._$AC(e):(void 0===o.el&&(o.el=Z.createElement(H(o.h,o.h[0]),this.options)),o);if(this._$AH?._$AD===s)this._$AH.p(t);else{const e=new ee(s,this),o=e.u(this.options);e.p(t),this.T(o),this._$AH=e}}_$AC(e){let t=W.get(e.strings);return void 0===t&&W.set(e.strings,t=new Z(e)),t}k(e){T(this._$AH)||(this._$AH=[],this._$AR());const t=this._$AH;let o,s=0;for(const i of e)s===t.length?t.push(o=new te(this.O(I()),this.O(I()),this,this.options)):o=t[s],o._$AI(i),s++;s<t.length&&(this._$AR(o&&o._$AB.nextSibling,s),t.length=s)}_$AR(e=this._$AA.nextSibling,t){for(this._$AP?.(!1,!0,t);e!==this._$AB;){const t=A(e).nextSibling;A(e).remove(),e=t}}setConnected(e){void 0===this._$AM&&(this._$Cv=e,this._$AP?.(e))}}class oe{get tagName(){return this.element.tagName}get _$AU(){return this._$AM._$AU}constructor(e,t,o,s,i){this.type=1,this._$AH=Y,this._$AN=void 0,this.element=e,this.name=t,this._$AM=s,this.options=i,o.length>2||""!==o[0]||""!==o[1]?(this._$AH=Array(o.length-1).fill(new String),this.strings=o):this._$AH=Y}_$AI(e,t=this,o,s){const i=this.strings;let n=!1;if(void 0===i)e=J(this,e,t,0),n=!F(e)||e!==this._$AH&&e!==U,n&&(this._$AH=e);else{const s=e;let r,a;for(e=i[0],r=0;r<i.length-1;r++)a=J(this,s[o+r],t,r),a===U&&(a=this._$AH[r]),n||=!F(a)||a!==this._$AH[r],a===Y?e=Y:e!==Y&&(e+=(a??"")+i[r+1]),this._$AH[r]=a}n&&!s&&this.j(e)}j(e){e===Y?this.element.removeAttribute(this.name):this.element.setAttribute(this.name,e??"")}}class se extends oe{constructor(){super(...arguments),this.type=3}j(e){this.element[this.name]=e===Y?void 0:e}}class ie extends oe{constructor(){super(...arguments),this.type=4}j(e){this.element.toggleAttribute(this.name,!!e&&e!==Y)}}class ne extends oe{constructor(e,t,o,s,i){super(e,t,o,s,i),this.type=5}_$AI(e,t=this){if((e=J(this,e,t,0)??Y)===U)return;const o=this._$AH,s=e===Y&&o!==Y||e.capture!==o.capture||e.once!==o.once||e.passive!==o.passive,i=e!==Y&&(o===Y||s);s&&this.element.removeEventListener(this.name,this,o),i&&this.element.addEventListener(this.name,this,e),this._$AH=e}handleEvent(e){"function"==typeof this._$AH?this._$AH.call(this.options?.host??this.element,e):this._$AH.handleEvent(e)}}class re{constructor(e,t,o){this.element=e,this.type=6,this._$AN=void 0,this._$AM=t,this.options=o}get _$AU(){return this._$AM._$AU}_$AI(e){J(this,e)}}const ae=$.litHtmlPolyfillSupport;ae?.(Z,te),($.litHtmlVersions??=[]).push("3.3.2");const le=globalThis;let ce=class extends x{constructor(){super(...arguments),this.renderOptions={host:this},this._$Do=void 0}createRenderRoot(){const e=super.createRenderRoot();return this.renderOptions.renderBefore??=e.firstChild,e}update(e){const t=this.render();this.hasUpdated||(this.renderOptions.isConnected=this.isConnected),super.update(e),this._$Do=((e,t,o)=>{const s=o?.renderBefore??t;let i=s._$litPart$;if(void 0===i){const e=o?.renderBefore??null;s._$litPart$=i=new te(t.insertBefore(I(),e),e,void 0,o??{})}return i._$AI(e),i})(t,this.renderRoot,this.renderOptions)}connectedCallback(){super.connectedCallback(),this._$Do?.setConnected(!0)}disconnectedCallback(){super.disconnectedCallback(),this._$Do?.setConnected(!1)}render(){return U}};ce._$litElement$=!0,ce.finalized=!0,le.litElementHydrateSupport?.({LitElement:ce});const de=le.litElementPolyfillSupport;de?.({LitElement:ce}),(le.litElementVersions??=[]).push("4.2.2");const he=e=>(t,o)=>{void 0!==o?o.addInitializer(()=>{customElements.define(e,t)}):customElements.define(e,t)},ue={attribute:!0,type:String,converter:y,reflect:!1,hasChanged:b},pe=(e=ue,t,o)=>{const{kind:s,metadata:i}=o;let n=globalThis.litPropertyMetadata.get(i);if(void 0===n&&globalThis.litPropertyMetadata.set(i,n=new Map),"setter"===s&&((e=Object.create(e)).wrapped=!0),n.set(o.name,e),"accessor"===s){const{name:s}=o;return{set(o){const i=t.get.call(this);t.set.call(this,o),this.requestUpdate(s,i,e,!0,o)},init(t){return void 0!==t&&this.C(s,void 0,e,t),t}}}if("setter"===s){const{name:s}=o;return function(o){const i=this[s];t.call(this,o),this.requestUpdate(s,i,e,!0,o)}}throw Error("Unsupported decorator location: "+s)};function _e(e){return(t,o)=>"object"==typeof o?pe(e,t,o):((e,t,o)=>{const s=t.hasOwnProperty(o);return t.constructor.createProperty(o,e),s?Object.getOwnPropertyDescriptor(t,o):void 0})(e,t,o)}function me(e){return _e({...e,state:!0,attribute:!1})}function ge(e,t,o){if(!e)return!0;for(const s of o)if(s&&e.states[s]!==t.states[s])return!0;return!1}const fe="2.6.0",ve="adaptive-cover-pro-card",ye="adaptive-cover-pro-card-editor",be="adaptive-cover-pro-sky-compass-card",we="adaptive-cover-pro-sky-compass-card-editor",xe="adaptive-cover-pro-tile-card",$e="adaptive-cover-pro-tile-card-editor",Ae="adaptive_cover_pro",ke=["force","weather","manual","custom_position","motion","cloud","climate","glare_zone","solar","default","floor_clamp"],Ce={force:"Force Override",weather:"Weather Safety",manual:"Manual Override",custom_position:"Custom Position",motion:"Motion Timeout",cloud:"Cloud Suppression",climate:"Climate",glare_zone:"Glare Zone",solar:"Solar Tracking",default:"Default",floor_clamp:"Min Floor"},Ee={force:"handler.force",weather:"handler.weather",manual:"handler.manual",custom_position:"handler.custom_position",motion:"handler.motion",cloud:"handler.cloud",climate:"handler.climate",glare_zone:"handler.glare_zone",solar:"handler.solar",default:"handler.default",floor_clamp:"handler.floor_clamp"},Se={cover_blind:"mdi:blinds-horizontal",cover_awning:"mdi:awning-outline",cover_tilt:"mdi:blinds"},ze={cover_blind:"mdi:blinds-open",cover_awning:"mdi:awning-outline",cover_tilt:"mdi:blinds-open"},Oe={cover_blind:"mdi:blinds-horizontal-closed",cover_awning:"mdi:window-closed-variant",cover_tilt:"mdi:blinds"},Me={manual:"manual",force:"force",weather:"weather",glare_zone:"glare_zone",climate:"climate",cloud:"cloud",custom_position:"custom_position",solar:"solar",motion:"motion"},Ie={auto:{label:"Auto",bg:"rgba(76, 175, 80, 0.18)",fg:"#2e7d32"},manual:{label:"Manual",bg:"rgba(255, 152, 0, 0.22)",fg:"#e65100"},force:{label:"Force",bg:"rgba(244, 67, 54, 0.22)",fg:"#b71c1c"},weather:{label:"Sun protection",bg:"rgba(244, 67, 54, 0.22)",fg:"#b71c1c"},glare_zone:{label:"Glare",bg:"rgba(244, 67, 54, 0.22)",fg:"#b71c1c"},climate:{label:"Climate",bg:"rgba(0, 150, 136, 0.22)",fg:"#00695c"},cloud:{label:"Cloudy",bg:"rgba(33, 150, 243, 0.22)",fg:"#0d47a1"},custom_position:{label:"Custom",bg:"rgba(156, 39, 176, 0.22)",fg:"#6a1b9a"},solar:{label:"Solar tracking",bg:"rgba(76, 175, 80, 0.22)",fg:"#1b5e20"},motion:{label:"Motion",bg:"rgba(255, 235, 59, 0.22)",fg:"#827717"},off:{label:"Off",bg:"rgba(97, 97, 97, 0.28)",fg:"#212121"},off_schedule:{label:"Off-schedule",bg:"rgba(96, 125, 139, 0.22)",fg:"#37474f"}},Fe={auto:"badge.auto",manual:"badge.manual",force:"badge.force",weather:"badge.weather",glare_zone:"badge.glare_zone",climate:"badge.climate",cloud:"badge.cloud",custom_position:"badge.custom_position",solar:"badge.solar",motion:"badge.motion",off:"badge.off",off_schedule:"badge.off_schedule"},Te={auto:"mdi:autorenew",manual:"mdi:hand-back-right",force:"mdi:flash",weather:"mdi:shield-sun",glare_zone:"mdi:weather-sunny-alert",climate:"mdi:thermostat",cloud:"mdi:weather-cloudy",custom_position:"mdi:bookmark",solar:"mdi:white-balance-sunny",motion:"mdi:motion-sensor",off:"mdi:power",off_schedule:"mdi:clock-alert-outline"},Pe={integration_enabled:!0,automatic_control:!0,reset_manual_override:!0},je={"sensor:Cover_Position":"target_position_sensor","sensor:sun_position":"sun_sensor","sensor:Start Sun":"start_sensor","sensor:End Sun":"end_sensor","sensor:control_status":"control_status_sensor","sensor:decision_trace":"decision_trace_sensor","sensor:last_cover_action":"last_action_sensor","sensor:last_skipped_action":"last_skipped_sensor","sensor:manual_override_end_time":"manual_override_end_sensor","sensor:position_verification":"position_verification_sensor","sensor:motion_status":"motion_status_sensor","sensor:climate_status":"climate_status_sensor","sensor:position_forecast":"position_forecast_sensor","binary_sensor:sun_motion":"sun_infront_binary","binary_sensor:manual_override":"manual_override_binary","binary_sensor:position_mismatch":"position_mismatch_binary","binary_sensor:glare_active":"glare_active_binary","switch:Integration Enabled":"integration_enabled_switch","switch:Automatic Control":"automatic_control_switch","switch:Manual Override":"manual_toggle_switch","switch:Climate Mode":"climate_mode_switch","switch:Motion Control":"motion_control_switch","button:Reset Manual Override":"reset_override_button"},Re={en:{handler:{force:"Force Override",weather:"Weather Safety",manual:"Manual Override",custom_position:"Custom Position",motion:"Motion Timeout",cloud:"Cloud Suppression",climate:"Climate",glare_zone:"Glare Zone",solar:"Solar Tracking",default:"Default",floor_clamp:"Min Floor"},badge:{auto:"Auto",manual:"Manual",force:"Force",weather:"Weather safety",glare_zone:"Glare",climate:"Climate",cloud:"Cloudy",custom_position:"Custom",solar:"Solar tracking",motion:"Motion idle",off:"Off",off_schedule:"Off-schedule",floor_suffix:" ↥",safety:"Safety"},forecast:{event:{sunrise:"Sunrise",sunset:"Sunset",fov_enter:"Sun enters window field of view",fov_exit:"Sun leaves window field of view"},hover_hint:"Hover the curve for time + forecast position; hover a colored line for the event it marks.",solar_only_note:"Solar geometry only — does not reflect manual overrides, custom positions, cloud suppression, or weather."},dialog:{configure_integration:"Configure integration",open_device_page:"Open device page",close:"Close",target:"Target",resume_auto:"Resume Auto",hide_advanced:"▼ Hide advanced",show_advanced:"▶ Advanced",custom_positions:"Custom positions",floor_tooltip:"Floor — slot raises position above raw calc",floor:"↥",disable_slot:"Disable slot {slot}",enable_slot:"Enable slot {slot}",on:"On",off:"Off",controls:"Controls",automatic:"Automatic",climate:"Climate",motion:"Motion",toggle_hint:"{label} {state} — tap to toggle",state_on:"on",state_off:"off",todays_forecast:"Today's forecast"},overrides:{title:"Overrides",manual:"Manual",force:"Force",motion:"Motion",active:"Active",off:"Off",ends_in:"ends in {time}",active_count:"{count} active",timeout:"expires in {time}",reset_manual:"Reset Manual"},climate:{title:"Climate",active:"Active: {strategy}",indoor:"Indoor",outdoor:"Outdoor",presence:"Presence",sunny:"Sunny",lux:"Lux",irradiance:"Irradiance",mode_off:"Climate mode off",standby:"Standby",threshold_low:"low",threshold_high:"high",threshold_summer_outside:"summer",reason:{outside_time_window:"Outside the operating time window",thresholds_not_met:"Temperatures within the comfort band — no action needed",other_mode_active:"Another control mode is currently active",readings_unavailable:"Temperature readings unavailable",mode_off:"Climate mode is turned off"}},compass:{placeholder_no_entries:"No Adaptive Cover Pro entries selected.",placeholder_no_sun:"Sun sensor not yet populated.",sun_tooltip:"Sun: {az} az / {el} el",sunrise_tooltip:"Sunrise: {time}",sunset_tooltip:"Sunset: {time}",moon_tooltip:"Moon: {phase} ({pct}%)",sun_path_tooltip:"Sun path (today)",in_fov_check:"✓ in FOV",in_fov:"in FOV",in_fov_tooltip:"Sun is currently within this window’s field of view",none:"—",sun:"Sun",moon:"Moon",sun_up_not_hitting:"Sun (up, not hitting)",sun_below_horizon:"Sun (below horizon)",window_fov:"Window FOV",sun_path:"Sun path",sunrise:"Sunrise",sunset:"Sunset",cover_position:"Cover position",window_normal:"Window normal",stat_sun:"Sun: ",stat_azi:"Azi: ",stat_elev:"Elev: ",stat_window:"Window: ",active_sun_arc:"Active sun arc {from} – {to}{elev}",fov_arc:"FOV {left} left / {right} right{elev}",window_normal_tooltip:"Window normal: {bearing}",cover_position_target:"Target: {pct}%",cover_position_target_awning:"Target (extended): {pct}%",cover_position_actual:"Actual: {pct}%",blind_spot:"Blind spot: {from} – {to}",elev_suffix:" · elev {min}–{max}"},covers:{placeholder:"No covers reported by the integration.",title:"Covers",target:"Target: {pct}",click_to_set:"Click to set position",target_tooltip:"Target {pct}%"},decision:{placeholder:"Decision trace not yet populated.",pipeline:"Pipeline",winner:"Winner: {name}",summary_tooltip:"Why this position?",not_evaluated:"not evaluated",floor_suffix:" floor",outside_schedule:"Outside schedule — automatic control paused",outside_schedule_tooltip:"The configured schedule window is not active, so automatic positioning is paused."},header:{on:"ON",off:"OFF",integration_enabled:"Integration Enabled",auto:"Auto",automatic_control:"Automatic Control"},tile:{motion_pending:"Motion timeout pending",motion_detected:"Motion detected",open:"Open",stop:"Stop",close:"Close",resume_aria:"Resume automatic control",registry_failed:"Registry fetch failed: {error}",loading:"Loading…",entry_not_found:"Adaptive Cover Pro entry {entry} not found."},formatters:{expired:"expired"},elevation:{title:"Sun today",fov_window:"FOV: {from} → {to}",fov_windows:"FOV: {windows}",fov_window_named:"{name}: {windows}",no_fov_today:"Sun does not enter FOV today",placeholder:"Sun elevation chart unavailable.",schedule:"Schedule {from} – {to}",schedule_from:"Schedule from {from}",schedule_until:"Schedule until {to}",schedule_start_tooltip:"Schedule start",schedule_end_tooltip:"Schedule end"},root:{loading_registry:"Loading Adaptive Cover Pro registry…",no_entities_title:"No Adaptive Cover Pro entities found",footer_version:"adaptive-cover-pro-card v{version}",compass_no_match:"No matching Adaptive Cover Pro entities",compass_configured:"Configured entries: {entries}",compass_not_found:"Entries not found: {entries}"},editor:{common:{entry_id:"Adaptive Cover Pro instance",support_alt:"Buy me a coffee",title_optional:"Title (optional)",title_placeholder:"e.g. West-facing windows",north_offset:"Compass north offset (°)",north_offset_hint:'Rotate the compass clockwise so "up" matches your map. Default: 0.',loading_entries:"Loading Adaptive Cover Pro config entries…",load_failed:"Failed to load config entries: {error}",no_entries:"No Adaptive Cover Pro config entries found. Add an instance under",no_entries_path:"Settings → Devices & Services",no_entries_then:", then come back.",entry_id_manual_placeholder:"Enter config entry ID manually",entry_id_fallback_label:"Entry ID",unknown_entry:"(unknown: {entry})",reset:"Reset"},main:{sections:"Sections",sections_hint:"Toggle which parts of the card are shown.",section_sky_label:"Sky compass",section_sky_desc:"Sun vs. window FOV, polar plot",section_elevation_label:"Sun today",section_elevation_desc:"Elevation-vs-time chart with FOV band and current-time cursor",section_decision_label:"Decision strip",section_decision_desc:"All 10 pipeline handlers with the winning row highlighted",section_covers_label:"Cover positions",section_covers_desc:"Per-cover live vs. target bars; click to set position",section_overrides_label:"Overrides panel",section_overrides_desc:"Manual, force, motion tiles + reset button",section_climate_label:"Climate panel",section_climate_desc:"Summer/winter/intermediate strategy; shows standby when climate mode is off or inactive",controls:"Controls",controls_hint:"Render as read-only (visible but not clickable).",integration_pill_label:"Integration ON/OFF pill",integration_pill_desc:"Allow toggling the integration from the card header.",automatic_pill_label:"Automatic Control pill",automatic_pill_desc:"Allow toggling automatic control from the card header.",reset_button_label:"Reset Manual Override button",reset_button_desc:"Allow pressing the reset tile in the overrides panel.",display:"Display",compact_label:"Compact mode",compact_desc:"Tighter spacing between sections.",show_compass_stats_label:"Show compass stats",show_compass_stats_desc:"Azi, Elev, ∠, and Window angle below the sky compass.",show_compass_legend_label:"Show compass legend",show_compass_legend_desc:"Color key below the sky compass.",show_moon_label:"Show moon on compass",show_moon_desc:"Moon position and phase overlay on the sky compass.",hide_inactive_label:"Hide inactive handlers",hide_inactive_desc:"Show only the winner and actively matched pipeline handlers."},tile:{name:"Title override",icon:"Icon override",cover:"Cover entity",layout:"Layout",show_position:"Show position %",show_state:"Show state (Open/Closed)",show_decision_summary:"Show decision summary",show_controls:"Show ↑■▼ controls",show_badge:"Show contextual badge",badge_section:"Badges",badge_auto:"Auto",badge_solar:"Solar tracking",badge_force:"Force override",badge_weather:"Weather safety",badge_manual:"Manual override",badge_custom_position:"Custom position",badge_motion:"Motion",badge_climate:"Climate",badge_glare_zone:"Glare zone",badge_cloud:"Cloud suppression",show_compass:"Show sun compass in dialog",show_elevation_chart:"Show sun-today chart in dialog",show_motion_icon:"Show motion indicator",tap_action:"Tap action",hold_action:"Hold action",double_tap_action:"Double-tap action",cover_blank_hint:"Leave blank to use the first managed cover automatically.",layout_option_one_line:"One line (compact)",layout_option_detailed:"Detailed (title, state, indicators)"},compass:{instances:"Adaptive Cover Pro instances",instances_hint:"Pick one or more. Each selected entry adds an overlay to the compass.",cover_colors:"Cover colors",cover_colors_hint:"Override the default palette color for each overlay.",default_color:"default",display:"Display",toggle_compact_label:"Compact mode",toggle_compact_desc:"Smaller SVG, legend hidden.",toggle_legend_label:"Legend",toggle_legend_desc:"Color swatches + entry labels below compass.",toggle_stats_label:"Stats",toggle_stats_desc:"Sun + per-window numeric rows.",toggle_moon_label:"Moon",toggle_moon_desc:"Render moon position and phase.",toggle_cardinals_label:"Cardinal labels",toggle_cardinals_desc:"N/E/S/W letters around the compass.",toggle_blind_spot_label:"Blind spots",toggle_blind_spot_desc:"Hatched wedges for each window’s blind range.",toggle_sun_path_label:"Sun path",toggle_sun_path_desc:"Today’s sun arc across the sky.",toggle_sunrise_sunset_label:"Sunrise / sunset markers",toggle_sunrise_sunset_desc:"Small dots at rise and set azimuths.",toggle_cover_fill_label:"Cover closure fill",toggle_cover_fill_desc:"Inner wedge showing how closed each cover is.",toggle_window_arrow_label:"Window-normal arrow",toggle_window_arrow_desc:"Line from center toward each window’s azimuth.",toggle_elevation_chart_label:"Sun-today chart",toggle_elevation_chart_desc:"Elevation-vs-time chart below the compass, with FOV band and elevation limits."}}},fr:{handler:{force:"Dérogation forcée",weather:"Sécurité météo",manual:"Dérogation manuelle",custom_position:"Position personnalisée",motion:"Délai d'inactivité du mouvement",cloud:"Désactivation par temps nuageux",climate:"Climatique",glare_zone:"Zone d'éblouissement",solar:"Suivi solaire",default:"Par défaut",floor_clamp:"Plancher"},badge:{auto:"Auto",manual:"Manuel",force:"Forcé",weather:"Sécurité météo",glare_zone:"Éblouissement",climate:"Climatique",cloud:"Nuageux",custom_position:"Personnalisé",solar:"Suivi solaire",motion:"Inactivité",off:"Off",off_schedule:"Hors planning",floor_suffix:" ↥",safety:"Sécurité"},forecast:{event:{sunrise:"Lever du soleil",sunset:"Coucher du soleil",fov_enter:"Le soleil entre dans le champ de vision de la fenêtre",fov_exit:"Le soleil quitte le champ de vision de la fenêtre"},hover_hint:"Survolez la courbe pour voir l'heure et la position prévue ; survolez une ligne colorée pour voir l'événement qu'elle indique.",solar_only_note:"Géométrie solaire uniquement — ne tient pas compte des dérogations manuelles, des positions personnalisées, de la désactivation par temps nuageux ni des conditions météo."},dialog:{configure_integration:"Configurer l'intégration",open_device_page:"Ouvrir la page de l'appareil",close:"Fermer",target:"Cible",resume_auto:"Reprendre l'automatique",hide_advanced:"▼ Masquer les options avancées",show_advanced:"▶ Afficher les options avancées",custom_positions:"Positions personnalisées",floor_tooltip:"Plancher — cette valeur force une position minimale au-dessus du calcul automatique",floor:"↥",disable_slot:"Désactiver le créneau {slot}",enable_slot:"Activer le créneau {slot}",on:"Activé",off:"Désactivé",controls:"Commandes",automatic:"Automatique",climate:"Climatique",motion:"Mouvement",toggle_hint:"{label} {state} — appuyez pour basculer",state_on:"activé",state_off:"désactivé",todays_forecast:"Prévisions du jour"},overrides:{title:"Dérogations",manual:"Manuel",force:"Forcé",motion:"Mouvement",active:"Actif",off:"Désactivé",ends_in:"se termine dans {time}",active_count:"{count} dérogation(s) active(s)",timeout:"expire dans {time}",reset_manual:"Réinitialiser le mode manuel"},climate:{title:"Climatique",active:"Actif : {strategy}",indoor:"Intérieur",outdoor:"Extérieur",presence:"Présence",sunny:"Ensoleillé",lux:"Lux",irradiance:"Irradiance",mode_off:"Mode climatique désactivé",standby:"En veille",threshold_low:"bas",threshold_high:"haut",threshold_summer_outside:"été",reason:{outside_time_window:"En dehors de la plage horaire de fonctionnement",thresholds_not_met:"Températures dans la plage de confort — aucune action requise",other_mode_active:"Un autre mode de contrôle est actuellement actif",readings_unavailable:"Relevés de température indisponibles",mode_off:"Le mode climatique est désactivé"}},compass:{placeholder_no_entries:"Aucune instance Adaptive Cover Pro sélectionnée.",placeholder_no_sun:"Le capteur solaire n'est pas encore renseigné.",sun_tooltip:"Soleil : {az} az / {el} él",sunrise_tooltip:"Lever du soleil : {time}",sunset_tooltip:"Coucher du soleil : {time}",moon_tooltip:"Lune : {phase} ({pct}%)",sun_path_tooltip:"Trajectoire solaire (aujourd'hui)",in_fov_check:"✓ dans le champ de vision",in_fov:"dans le champ de vision",in_fov_tooltip:"Le soleil est actuellement dans le champ de vision de cette fenêtre",none:"—",sun:"Soleil",moon:"Lune",sun_up_not_hitting:"Soleil (levé, ne frappe pas)",sun_below_horizon:"Soleil (sous l’horizon)",window_fov:"Champ de vision",sun_path:"Trajectoire solaire",sunrise:"Lever du soleil",sunset:"Coucher du soleil",cover_position:"Position du store",window_normal:"Axe de la fenêtre",stat_sun:"Soleil : ",stat_azi:"Azi : ",stat_elev:"Élév : ",stat_window:"Fenêtre : ",active_sun_arc:"Arc solaire actif {from} – {to}{elev}",fov_arc:"Champ de vision {left} gauche / {right} droite{elev}",window_normal_tooltip:"Axe de la fenêtre : {bearing}",cover_position_target:"Cible : {pct}%",cover_position_target_awning:"Cible (déployé) : {pct}%",cover_position_actual:"Réel : {pct}%",blind_spot:"Soleil masqué : {from} - {to}",elev_suffix:" · élév {min}–{max}"},covers:{placeholder:"Aucun store signalé par l'intégration.",title:"Stores",target:"Cible : {pct}",click_to_set:"Cliquer pour définir la position",target_tooltip:"Cible {pct}%"},decision:{placeholder:"La trace de décision n'est pas encore renseignée.",pipeline:"Pipeline",winner:"Actif : {name}",summary_tooltip:"Pourquoi cette position ?",not_evaluated:"non évalué",floor_suffix:" plancher",outside_schedule:"Hors planning — contrôle automatique en pause",outside_schedule_tooltip:"La fenêtre de planning configurée n'est pas active, le positionnement automatique est donc en pause."},header:{on:"ON",off:"OFF",integration_enabled:"Intégration activée",auto:"Auto",automatic_control:"Contrôle automatique"},tile:{motion_pending:"Délai de mouvement en cours",motion_detected:"Mouvement détecté",open:"Ouvrir",stop:"Arrêter",close:"Fermer",resume_aria:"Reprendre le contrôle automatique",registry_failed:"Échec de la récupération du registre : {error}",loading:"Chargement…",entry_not_found:"Instance Adaptive Cover Pro {entry} introuvable."},formatters:{expired:"expiré"},elevation:{title:"Soleil aujourd'hui",fov_window:"Champ de vision : {from} → {to}",fov_windows:"Champ de vision : {windows}",fov_window_named:"{name} : {windows}",no_fov_today:"Pas de soleil dans le champ de vision aujourd'hui",placeholder:"Graphique d'élévation solaire indisponible.",schedule:"Programmation {from} – {to}",schedule_from:"Programmation à partir de {from}",schedule_until:"Programmation jusqu'à {to}",schedule_start_tooltip:"Début de programmation",schedule_end_tooltip:"Fin de programmation"},root:{loading_registry:"Chargement du registre Adaptive Cover Pro…",no_entities_title:"Aucune entité Adaptive Cover Pro trouvée",footer_version:"adaptive-cover-pro-card v{version}",compass_no_match:"Aucune entité Adaptive Cover Pro correspondante",compass_configured:"Instances configurées : {entries}",compass_not_found:"Instances introuvables : {entries}"},editor:{common:{entry_id:"Instance Adaptive Cover Pro",support_alt:"Offrez-moi un café",title_optional:"Titre (facultatif)",title_placeholder:"ex. Fenêtres côté ouest",north_offset:"Décalage nord de la boussole (°)",north_offset_hint:"Faites pivoter la boussole dans le sens horaire pour que « haut » corresponde à votre carte. Par défaut : 0.",loading_entries:"Chargement des entrées de configuration Adaptive Cover Pro…",load_failed:"Échec du chargement des entrées de configuration : {error}",no_entries:"Aucune entrée de configuration Adaptive Cover Pro trouvée. Ajoutez une instance sous",no_entries_path:"Paramètres → Appareils et services",no_entries_then:", puis revenez ici.",entry_id_manual_placeholder:"Saisir manuellement l'ID d'entrée de configuration",entry_id_fallback_label:"ID d'entrée",unknown_entry:"(inconnu : {entry})",reset:"Réinitialiser"},main:{sections:"Sections",sections_hint:"Activer ou désactiver les parties de la carte affichées.",section_sky_label:"Boussole céleste",section_sky_desc:"Soleil par rapport au champ de vision de la fenêtre, tracé polaire",section_elevation_label:"Soleil aujourd'hui",section_elevation_desc:"Graphique élévation/temps avec bande FOV et curseur temps réel",section_decision_label:"Bande de décision",section_decision_desc:"Les 10 gestionnaires du pipeline avec la ligne gagnante mise en évidence",section_covers_label:"Positions des stores",section_covers_desc:"Barres position réelle/cible par store ; cliquer pour définir la position",section_overrides_label:"Panneau des dérogations",section_overrides_desc:"Tuiles Manuel, Forcé, Mouvement + bouton de réinitialisation",section_climate_label:"Panneau climatique",section_climate_desc:"Stratégie été/hiver/intermédiaire ; affiche le mode veille si le mode climatique est désactivé ou inactif",controls:"Commandes",controls_hint:"Afficher en lecture seule (visible mais non cliquable).",integration_pill_label:"Bouton ON/OFF de l'intégration",integration_pill_desc:"Permettre de basculer l'intégration depuis l'en-tête de la carte.",automatic_pill_label:"Bouton contrôle automatique",automatic_pill_desc:"Permettre de basculer le contrôle automatique depuis l'en-tête de la carte.",reset_button_label:"Bouton de réinitialisation de la dérogation manuelle",reset_button_desc:"Permettre d'appuyer sur la tuile de réinitialisation dans le panneau des dérogations.",display:"Affichage",compact_label:"Mode compact",compact_desc:"Espacement réduit entre les sections.",show_compass_stats_label:"Afficher les statistiques de la boussole",show_compass_stats_desc:"Azi, Élév, ∠ et angle de fenêtre sous la boussole céleste.",show_compass_legend_label:"Afficher la légende de la boussole",show_compass_legend_desc:"Clé de couleur sous la boussole céleste.",show_moon_label:"Afficher la lune sur la boussole",show_moon_desc:"Position et phase de la lune en superposition sur la boussole céleste.",hide_inactive_label:"Masquer les gestionnaires inactifs",hide_inactive_desc:"Afficher uniquement le gestionnaire sélectionné et les gestionnaires du pipeline actifs."},tile:{name:"Titre personnalisé",icon:"Icône personnalisée",cover:"Entité de store",layout:"Disposition",show_position:"Afficher la position %",show_state:"Afficher l'état (Ouvert/Fermé)",show_decision_summary:"Afficher le résumé de décision",show_controls:"Afficher les commandes ↑■▼",show_badge:"Afficher le badge contextuel",badge_section:"Badges",badge_auto:"Auto",badge_solar:"Suivi solaire",badge_force:"Dérogation forcée",badge_weather:"Sécurité météo",badge_manual:"Dérogation manuelle",badge_custom_position:"Position personnalisée",badge_motion:"Mouvement",badge_climate:"Climatique",badge_glare_zone:"Zone d'éblouissement",badge_cloud:"Suppression nuageuse",show_compass:"Afficher la boussole solaire dans le dialogue",show_elevation_chart:"Afficher le graphique du soleil dans le dialogue",show_motion_icon:"Afficher l'indicateur de mouvement",tap_action:"Action au toucher",hold_action:"Action au maintien",double_tap_action:"Action au double toucher",cover_blank_hint:"Laisser vide pour utiliser automatiquement le premier store géré.",layout_option_one_line:"Une ligne (compact)",layout_option_detailed:"Détaillé (titre, état, indicateurs)"},compass:{instances:"Instances Adaptive Cover Pro",instances_hint:"Sélectionnez une ou plusieurs instances. Chaque instance sélectionnée ajoute une superposition à la boussole.",cover_colors:"Couleurs des stores",cover_colors_hint:"Remplacer la couleur de palette par défaut pour chaque superposition.",default_color:"par défaut",display:"Affichage",toggle_compact_label:"Mode compact",toggle_compact_desc:"SVG plus petit, légende masquée.",toggle_legend_label:"Légende",toggle_legend_desc:"Échantillons de couleur et étiquettes d'instance sous la boussole.",toggle_stats_label:"Statistiques",toggle_stats_desc:"Soleil + lignes numériques par fenêtre.",toggle_moon_label:"Lune",toggle_moon_desc:"Afficher la position et la phase de la lune.",toggle_cardinals_label:"Points cardinaux",toggle_cardinals_desc:"Lettres N/E/S/O autour de la boussole.",toggle_blind_spot_label:"Zones de soleil masqué",toggle_blind_spot_desc:"Secteurs hachurés pour la plage où le soleil est masqué de chaque fenêtre.",toggle_sun_path_label:"Trajectoire solaire",toggle_sun_path_desc:"Arc solaire du jour dans le ciel.",toggle_sunrise_sunset_label:"Repères lever / coucher du soleil",toggle_sunrise_sunset_desc:"Petits points aux azimuts de lever et coucher du soleil.",toggle_cover_fill_label:"Remplissage de fermeture du store",toggle_cover_fill_desc:"Secteur intérieur indiquant le taux de fermeture de chaque store.",toggle_window_arrow_label:"Flèche de normale de fenêtre",toggle_window_arrow_desc:"Ligne du centre vers l'azimut de chaque fenêtre.",toggle_elevation_chart_label:"Graphique du soleil",toggle_elevation_chart_desc:"Graphique élévation/temps sous la boussole, avec bande FOV et limites d'élévation."}}}};function Ne(e,t){const o=t.split(".");let s=e;for(const e of o){if("object"!=typeof s||null===s)return;s=s[e]}return"string"==typeof s?s:void 0}function De(e,t){return t?e.replace(/\{(\w+)\}/g,(e,o)=>Object.prototype.hasOwnProperty.call(t,o)?String(t[o]):e):e}function Be(e,t,o){const s=function(e){const t=(e?.locale?.language??e?.language??"en").toLowerCase().split("-")[0];return t in Re?t:"en"}(t),i=Ne(Re[s],e);if(void 0!==i)return De(i,o);if("en"!==s){const t=Ne(Re.en,e);if(void 0!==t)return De(t,o)}return e}const Ke=e=>(...t)=>({_$litDirective$:e,values:t});class Ve{constructor(e){}get _$AU(){return this._$AM._$AU}_$AT(e,t,o){this._$Ct=e,this._$AM=t,this._$Ci=o}_$AS(e,t){return this.update(e,t)}update(e,t){return this.render(...t)}}const Ge=(e,t)=>{const o=e._$AN;if(void 0===o)return!1;for(const e of o)e._$AO?.(t,!1),Ge(e,t);return!0},Le=e=>{let t,o;do{if(void 0===(t=e._$AM))break;o=t._$AN,o.delete(e),e=t}while(0===o?.size)},qe=e=>{for(let t;t=e._$AM;e=t){let o=t._$AN;if(void 0===o)t._$AN=o=new Set;else if(o.has(e))break;o.add(e),We(t)}};function Ue(e){void 0!==this._$AN?(Le(this),this._$AM=e,qe(this)):this._$AM=e}function Ye(e,t=!1,o=0){const s=this._$AH,i=this._$AN;if(void 0!==i&&0!==i.size)if(t)if(Array.isArray(s))for(let e=o;e<s.length;e++)Ge(s[e],!1),Le(s[e]);else null!=s&&(Ge(s,!1),Le(s));else Ge(this,e)}const We=e=>{2==e.type&&(e._$AP??=Ye,e._$AQ??=Ue)};class Qe extends Ve{constructor(){super(...arguments),this._$AN=void 0}_$AT(e,t,o){super._$AT(e,t,o),qe(this),this.isConnected=e._$AU}_$AO(e,t=!0){e!==this.isConnected&&(this.isConnected=e,e?this.reconnected?.():this.disconnected?.()),t&&(Ge(this,e),Le(this))}setValue(e){if((()=>void 0===this._$Ct.strings)())this._$Ct._$AI(e,this);else{const t=[...this._$Ct._$AH];t[this._$Ci]=e,this._$Ct._$AI(t,this,0)}}disconnected(){}reconnected(){}}const He=[12,16];function Xe(e,t,o=0){const s=(e-90+o)*Math.PI/180;return{x:t*Math.cos(s),y:t*Math.sin(s)}}function Ze(e){return 1-Math.max(0,Math.min(90,e))/90}function Je(e,t,o,s=0,i=0){const n=e=>(e%360+360)%360,r=n(e),a=n(t);let l=a-r;l<0&&(l+=360);const c=l>180?1:0,d=Xe(r,o,i),h=Xe(a,o,i);if(s<=0)return`M 0 0 L ${d.x} ${d.y} A ${o} ${o} 0 ${c} 1 ${h.x} ${h.y} Z`;const u=Xe(a,s,i),p=Xe(r,s,i);return[`M ${d.x} ${d.y}`,`A ${o} ${o} 0 ${c} 1 ${h.x} ${h.y}`,`L ${u.x} ${u.y}`,`A ${s} ${s} 0 ${c} 0 ${p.x} ${p.y}`,"Z"].join(" ")}function et(e,t,o=0){return Xe(e,Ze(t),o)}function tt(e){return(e%360+360)%360}function ot(e,t,o,s){const i=s??0;let n=-1,r=-1;for(let s=t;s<=o&&s<e.length;s++)e[s].elevation>i&&(-1===n&&(n=s),r=s);return-1===n?null:{wedgeStart:e[n].azimuth,wedgeEnd:e[r].azimuth}}function st(e,t,o){const s=(e-t)/864e5;return Math.max(0,Math.min(o,s*o))}function it(e,t,o){return((e-t)%360+360)%360<=((o-t)%360+360)%360}function nt(e,t,o,s){return it(o,e,t)||it(s,e,t)||it(e,o,s)||it(t,o,s)}function rt(e,t,o,s){const i="cover_awning"===t?e/100:1-e/100;return Math.min(o*i,s)}let at=class extends ce{constructor(){super(...arguments),this.text="",this.cursorX=0,this.cursorY=0,this.offset=He,this.visible=!1,this._x=0,this._y=0}connectedCallback(){super.connectedCallback(),this.hasAttribute("role")||this.setAttribute("role","tooltip")}updated(){if(!this.visible)return;this.setAttribute("aria-hidden","false");const e=this.shadowRoot?.querySelector(".bubble"),t=e?.offsetWidth??0,o=e?.offsetHeight??0,s="undefined"!=typeof window?window.innerWidth:0,i="undefined"!=typeof window?window.innerHeight:0,{x:n,y:r}=function(e){const{cursorX:t,cursorY:o,ttW:s,ttH:i,vpW:n,vpH:r}=e,[a,l]=e.offset??He;let c=t+a,d=!1;c+s>n&&(c=t-a-s,d=!0),c<0&&(c=0);let h=o+l;return h+i>r&&(h=o-l-i),h<0&&(h=0),{x:c,y:h,flipped:d}}({cursorX:this.cursorX,cursorY:this.cursorY,ttW:t,ttH:o,vpW:s,vpH:i,offset:this.offset});n!==this._x&&(this._x=n),r!==this._y&&(this._y=r)}render(){return this.visible?L`<div class="bubble" style="transform: translate3d(${this._x}px, ${this._y}px, 0)">
+      ${this.text}
+    </div>`:(this.setAttribute("aria-hidden","true"),Y)}};at.styles=r`
+    :host {
+      position: fixed;
+      top: 0;
+      left: 0;
+      z-index: 100000;
+      pointer-events: none;
+    }
+    :host(:not([visible])) {
+      display: none;
+    }
+    .bubble {
+      position: absolute;
+      top: 0;
+      left: 0;
+      max-width: 280px;
+      padding: 6px 10px;
+      border-radius: 6px;
+      background: var(--acp-tooltip-bg, rgba(40, 40, 40, 0.96));
+      color: var(--acp-tooltip-fg, #fff);
+      font-size: 0.78rem;
+      line-height: 1.35;
+      box-shadow: 0 2px 10px rgba(0, 0, 0, 0.35);
+      white-space: normal;
+      word-break: break-word;
+    }
+  `,e([_e({type:String})],at.prototype,"text",void 0),e([_e({type:Number})],at.prototype,"cursorX",void 0),e([_e({type:Number})],at.prototype,"cursorY",void 0),e([_e({attribute:!1})],at.prototype,"offset",void 0),e([_e({type:Boolean,reflect:!0})],at.prototype,"visible",void 0),e([me()],at.prototype,"_x",void 0),e([me()],at.prototype,"_y",void 0),at=e([he("acp-floating-tooltip")],at);const lt={enabled:!0,offset:He,delay:400};function ct(e){void 0!==e.enabled&&(lt.enabled=e.enabled),void 0!==e.offset&&(lt.offset=e.offset),void 0!==e.delay&&(lt.delay=e.delay)}const dt="acp-floating-tooltip-bubble",ht=new class{constructor(){this._el=null,this._refs=0}get id(){return dt}retain(){this._refs+=1,this._ensure()}release(){this._refs=Math.max(0,this._refs-1)}_ensure(){if("undefined"==typeof document)return null;if(this._el&&this._el.isConnected)return this._el;const e=document.createElement("acp-floating-tooltip");return e.id=dt,document.body.appendChild(e),this._el=e,e}show(e,t,o,s){const i=this._ensure();i&&(i.text=e,i.cursorX=t,i.cursorY=o,i.offset=s,i.visible=!0)}move(e,t){this._el&&this._el.visible&&(this._el.cursorX=e,this._el.cursorY=t)}hide(){this._el&&(this._el.visible=!1)}_reset(){this._el&&this._el.parentNode&&this._el.parentNode.removeChild(this._el),this._el=null,this._refs=0}},ut=Ke(class extends Qe{constructor(e){if(super(e),this._el=null,this._text="",this._offset=He,this._delay=400,this._enabled=!0,this._openTimer=null,this._shown=!1,this._retained=!1,this._lastX=0,this._lastY=0,this._onEnter=e=>this._handleEnter(e),this._onMove=e=>this._handleMove(e),this._onLeave=()=>this._dismiss(),this._onFocus=()=>this._handleFocus(),this._onBlur=()=>this._dismiss(),this._onKey=e=>{"Escape"===e.key&&this._dismiss()},this._onScroll=()=>this._dismiss(),6!==e.type)throw new Error("tooltip() can only be used as an element-part directive")}render(e,t){return Y}update(e,[t,o]){const s=e.element;return this._text=t??"",this._offset=o?.offset??lt.offset,this._delay=o?.delay??lt.delay,this._enabled=o?.enabled??lt.enabled,this._el!==s?(this._teardown(),this._el=s,this._wire()):this._applyAttributes(),this.render(t,o)}_wire(){const e=this._el;e&&(this._applyAttributes(),this._enabled&&(ht.retain(),this._retained=!0,e.addEventListener("pointerenter",this._onEnter),e.addEventListener("pointermove",this._onMove),e.addEventListener("pointerleave",this._onLeave),e.addEventListener("focusin",this._onFocus),e.addEventListener("focusout",this._onBlur),e.addEventListener("keydown",this._onKey),window.addEventListener("scroll",this._onScroll,!0)))}_applyAttributes(){const e=this._el;e&&(this._enabled?(e.removeAttribute("title"),e.setAttribute("data-tooltip",this._text),e.setAttribute("aria-describedby",ht.id)):(e.removeAttribute("data-tooltip"),e.removeAttribute("aria-describedby"),e.removeAttribute("acp-tt-shown"),e.setAttribute("title",this._text)))}_handleEnter(e){this._lastX=e.clientX,this._lastY=e.clientY,this._armOpen()}_handleFocus(){const e=this._el;if(e&&"function"==typeof e.getBoundingClientRect){const t=e.getBoundingClientRect();this._lastX=t.left+t.width/2,this._lastY=t.bottom}this._armOpen()}_armOpen(){null===this._openTimer&&(this._openTimer=setTimeout(()=>{this._openTimer=null,this._open()},this._delay))}_open(){this._el&&(ht.show(this._text,this._lastX,this._lastY,this._offset),this._shown=!0,this._el.setAttribute("acp-tt-shown",""))}_handleMove(e){this._lastX=e.clientX,this._lastY=e.clientY,this._shown&&ht.move(this._lastX,this._lastY)}_dismiss(){null!==this._openTimer&&(clearTimeout(this._openTimer),this._openTimer=null),this._shown&&(ht.hide(),this._shown=!1),this._el?.removeAttribute("acp-tt-shown")}_teardown(){const e=this._el;e&&(this._dismiss(),e.removeEventListener("pointerenter",this._onEnter),e.removeEventListener("pointermove",this._onMove),e.removeEventListener("pointerleave",this._onLeave),e.removeEventListener("focusin",this._onFocus),e.removeEventListener("focusout",this._onBlur),e.removeEventListener("keydown",this._onKey),"undefined"!=typeof window&&window.removeEventListener("scroll",this._onScroll,!0),this._retained&&(ht.release(),this._retained=!1),this._el=null)}disconnected(){this._teardown()}reconnected(){this._wire()}});function pt(){let e=null;return(t,o,s)=>{const i=o.entry_id??"";if(!i)return e=null,null;const n=null!==e&&e.registry===s&&e.entryId===i,r=n?e.base:_t(i,s);if(!r)return e={registry:s,entryId:i,base:null,devices:null,posState:null,ctrlState:null,result:null},null;const a=t.devices,l=r.entities.target_position_sensor,c=r.entities.control_status_sensor,d=l?t.states[l]:void 0,h=c?t.states[c]:void 0;if(n&&null!==e&&null!==e.result&&e.devices===a&&e.posState===d&&e.ctrlState===h)return e.result;const u=mt(t,i,r);return e={registry:s,entryId:i,base:r,devices:a,posState:d,ctrlState:h,result:u},u}}function _t(e,t){const o={},s=`${e}_`;let i,n=!1;for(const r of t){if(r.config_entry_id!==e)continue;if(r.platform!==Ae)continue;if(n=!0,!i&&r.device_id&&(i=r.device_id),!r.unique_id.startsWith(s))continue;const t=r.unique_id.slice(s.length),a=r.entity_id.split(".")[0],l=je[`${a}:${t}`];l&&(o[l]=r.entity_id)}return n&&0!==Object.keys(o).length?{entities:o,deviceId:i}:null}function mt(e,t,o){const{entities:s,deviceId:i}=o,n=e;let r=t;if(n.devices)for(const e of Object.values(n.devices))if(e.config_entries?.includes(t)){r=e.name_by_user??e.name??t;break}const a=[],l=s.target_position_sensor;if(l){const t=e.states[l]?.attributes?.actual_positions;t&&a.push(...Object.keys(t))}let c="cover_blind";const d=s.control_status_sensor;if(d){const t=e.states[d]?.attributes;t?.cover_type&&(c=t.cover_type)}return{entry_id:t,entry_title:r,cover_type:c,entities:s,managed_covers:a,device_id:i}}function gt(e,t,o){const s=t.entry_id;if(!s)return null;const i=_t(s,o);return i?mt(e,s,i):null}async function ft(e){return(await e.callWS({type:"config_entries/get",domain:Ae})).filter(e=>e.domain===Ae).map(e=>({entry_id:e.entry_id,title:e.title}))}async function vt(e){return e.callWS({type:"config/entity_registry/list"})}function yt(e,t){let o=null,s=!1;return e.connection.subscribeEvents(e=>t(e.data),"entity_registry_updated").then(e=>{s?e():o=e}).catch(()=>{}),()=>{s=!0,o&&o()}}let bt=null,wt=null;function xt(){return bt}function $t(e,t=!1){if(wt)return wt;if(!t&&bt)return Promise.resolve(bt);const o=vt(e).then(e=>(bt=e,wt=null,e)).catch(e=>{throw wt=null,e});return wt=o,o}function At(e){return`acp-card:registry:v1:${e}`}const kt={get(e){try{const t=localStorage.getItem(At(e));if(!t)return null;const o=JSON.parse(t);return 1!==o.schemaVersion?null:o}catch{return null}},set(e,t){try{const o={schemaVersion:1,cardVersion:fe,fetchedAt:Date.now(),entries:t};localStorage.setItem(At(e),JSON.stringify(o))}catch{}},invalidate(e){try{localStorage.removeItem(At(e))}catch{}},clear(){try{const e="acp-card:registry:v1:",t=[];for(let o=0;o<localStorage.length;o++){const s=localStorage.key(o);s?.startsWith(e)&&t.push(s)}t.forEach(e=>localStorage.removeItem(e))}catch{}}};function Ct(e){return`${e.entity_id}|${e.unique_id}|${e.platform}|${e.config_entry_id??""}`}function Et(e,t,o){return e.filter(e=>e.config_entry_id===t&&void 0===o)}let St=class extends ce{constructor(){super(...arguments),this.on=!1,this.readonly=!1,this.label="",this.title=""}_handleClick(){this.readonly||this.dispatchEvent(new CustomEvent("pill-click",{bubbles:!0,composed:!0}))}render(){return L`
       <button
         class="pill ${this.on?"on":"off"} ${this.readonly?"readonly":""}"
-        title=${this.title}
-        aria-disabled=${this.readonly?"true":W}
+        ${ut(this.title)}
+        aria-disabled=${this.readonly?"true":Y}
         tabindex=${this.readonly?"-1":"0"}
         @click=${this._handleClick}
       >
         ${this.label}
       </button>
-    `}};ut.styles=r`
+    `}};St.styles=r`
     .pill {
       padding: 2px 10px;
       border-radius: 999px;
@@ -31,54 +59,61 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
     .pill.readonly {
       cursor: default;
       opacity: 0.85;
-      pointer-events: none;
+    }
+    /* Readonly pills aren't clickable, so a help cursor is a useful "hover for
+       more" hint; clickable pills keep their pointer cursor (below). The shown
+       state reverts to default once OUR bubble appears. */
+    .pill.readonly[data-tooltip]:hover {
+      cursor: help;
+    }
+    .pill[data-tooltip][acp-tt-shown] {
+      cursor: default;
     }
     .pill.on.readonly {
       opacity: 0.85;
     }
-  `,e([ge({type:Boolean})],ut.prototype,"on",void 0),e([ge({type:Boolean})],ut.prototype,"readonly",void 0),e([ge({type:String})],ut.prototype,"label",void 0),e([ge({type:String})],ut.prototype,"title",void 0),ut=e([he("acp-header-pill")],ut);class pt{constructor(e){}get _$AU(){return this._$AM._$AU}_$AT(e,t,o){this._$Ct=e,this._$AM=t,this._$Ci=o}_$AS(e,t){return this.update(e,t)}update(e,t){return this.render(...t)}}const gt=(mt=class extends pt{constructor(e){if(super(e),1!==e.type||"class"!==e.name||e.strings?.length>2)throw Error("`classMap()` can only be used in the `class` attribute and must be the only part in the attribute.")}render(e){return" "+Object.keys(e).filter(t=>e[t]).join(" ")+" "}update(e,[t]){if(void 0===this.st){this.st=new Set,void 0!==e.strings&&(this.nt=new Set(e.strings.join(" ").split(/\s/).filter(e=>""!==e)));for(const e in t)t[e]&&!this.nt?.has(e)&&this.st.add(e);return this.render(t)}const o=e.element.classList;for(const e of this.st)e in t||(o.remove(e),this.st.delete(e));for(const e in t){const i=!!t[e];i===this.st.has(e)||this.nt?.has(e)||(i?(o.add(e),this.st.add(e)):(o.remove(e),this.st.delete(e)))}return L}},(...e)=>({_$litDirective$:mt,values:e}));var mt;function _t(e){return e&&e.__esModule&&Object.prototype.hasOwnProperty.call(e,"default")?e.default:e}var ft,vt,yt={exports:{}},bt=(ft||(ft=1,vt=yt,function(){var e=Math.PI,t=Math.sin,o=Math.cos,i=Math.tan,s=Math.asin,n=Math.atan2,r=Math.acos,a=e/180,l=864e5,c=2440588,d=2451545;function h(e){return new Date((e+.5-c)*l)}function u(e){return function(e){return e.valueOf()/l-.5+c}(e)-d}var p=23.4397*a;function g(e,s){return n(t(e)*o(p)-i(s)*t(p),o(e))}function m(e,i){return s(t(i)*o(p)+o(i)*t(p)*t(e))}function _(e,s,r){return n(t(e),o(e)*t(s)-i(r)*o(s))}function f(e,i,n){return s(t(i)*t(n)+o(i)*o(n)*o(e))}function v(e,t){return a*(280.16+360.9856235*e)-t}function y(e){return a*(357.5291+.98560028*e)}function b(o){return o+a*(1.9148*t(o)+.02*t(2*o)+3e-4*t(3*o))+102.9372*a+e}function w(e){var t=b(y(e));return{dec:m(t,0),ra:g(t,0)}}var x={getPosition:function(e,t,o){var i=a*-o,s=a*t,n=u(e),r=w(n),l=v(n,i)-r.ra;return{azimuth:_(l,s,r.dec),altitude:f(l,s,r.dec)}}},$=x.times=[[-.833,"sunrise","sunset"],[-.3,"sunriseEnd","sunsetStart"],[-6,"dawn","dusk"],[-12,"nauticalDawn","nauticalDusk"],[-18,"nightEnd","night"],[6,"goldenHourEnd","goldenHour"]];x.addTime=function(e,t,o){$.push([e,t,o])};var A=9e-4;function k(t,o,i){return A+(t+o)/(2*e)+i}function C(e,o,i){return d+e+.0053*t(o)-.0069*t(2*i)}function S(e,i,s,n,a,l,c){var d=function(e,i,s){return r((t(e)-t(i)*t(s))/(o(i)*o(s)))}(e,s,n);return C(k(d,i,a),l,c)}function E(e){var i=a*(134.963+13.064993*e),s=a*(93.272+13.22935*e),n=a*(218.316+13.176396*e)+6.289*a*t(i),r=5.128*a*t(s),l=385001-20905*o(i);return{ra:g(n,r),dec:m(n,r),dist:l}}function z(e,t){return new Date(e.valueOf()+t*l/24)}x.getTimes=function(t,o,i,s){var n,r,l,c,d,p=a*-i,g=a*o,_=function(e){return-2.076*Math.sqrt(e)/60}(s=s||0),f=function(t,o){return Math.round(t-A-o/(2*e))}(u(t),p),v=k(0,p,f),w=y(v),x=b(w),E=m(x,0),z=C(v,w,x),O={solarNoon:h(z),nadir:h(z-.5)};for(n=0,r=$.length;n<r;n+=1)d=z-((c=S(((l=$[n])[0]+_)*a,p,g,E,f,w,x))-z),O[l[1]]=h(d),O[l[2]]=h(c);return O},x.getMoonPosition=function(e,s,r){var l=a*-r,c=a*s,d=u(e),h=E(d),p=v(d,l)-h.ra,g=f(p,c,h.dec),m=n(t(p),i(c)*o(h.dec)-t(h.dec)*o(p));return g+=function(e){return e<0&&(e=0),2967e-7/Math.tan(e+.00312536/(e+.08901179))}(g),{azimuth:_(p,c,h.dec),altitude:g,distance:h.dist,parallacticAngle:m}},x.getMoonIllumination=function(e){var i=u(e||new Date),s=w(i),a=E(i),l=149598e3,c=r(t(s.dec)*t(a.dec)+o(s.dec)*o(a.dec)*o(s.ra-a.ra)),d=n(l*t(c),a.dist-l*o(c)),h=n(o(s.dec)*t(s.ra-a.ra),t(s.dec)*o(a.dec)-o(s.dec)*t(a.dec)*o(s.ra-a.ra));return{fraction:(1+o(d))/2,phase:.5+.5*d*(h<0?-1:1)/Math.PI,angle:h}},x.getMoonTimes=function(e,t,o,i){var s=new Date(e);i?s.setUTCHours(0,0,0,0):s.setHours(0,0,0,0);for(var n,r,l,c,d,h,u,p,g,m,_,f,v,y=.133*a,b=x.getMoonPosition(s,t,o).altitude-y,w=1;w<=24&&(n=x.getMoonPosition(z(s,w),t,o).altitude-y,p=((d=(b+(r=x.getMoonPosition(z(s,w+1),t,o).altitude-y))/2-n)*(u=-(h=(r-b)/2)/(2*d))+h)*u+n,m=0,(g=h*h-4*d*n)>=0&&(_=u-(v=Math.sqrt(g)/(2*Math.abs(d))),f=u+v,Math.abs(_)<=1&&m++,Math.abs(f)<=1&&m++,_<-1&&(_=f)),1===m?b<0?l=w+_:c=w+_:2===m&&(l=w+(p<0?f:_),c=w+(p<0?_:f)),!l||!c);w+=2)b=r;var $={};return l&&($.rise=z(s,l)),c&&($.set=z(s,c)),l||c||($[p>0?"alwaysUp":"alwaysDown"]=!0),$},vt.exports=x}()),yt.exports),wt=_t(bt);const xt=new Map;function $t(e,t,o,i=10){const s=`${e},${t},${o.getTime()},${i}`,n=xt.get(s);if(n)return xt.delete(s),xt.set(s,n),n;const r=[],a=o.getTime()+864e5;for(let s=o.getTime();s<=a;s+=60*i*1e3){const o=new Date(s),i=wt.getPosition(o,e,t);r.push({t:o,elevation:180*i.altitude/Math.PI,azimuth:((180*i.azimuth/Math.PI+180)%360+360)%360})}if(xt.set(s,r),xt.size>4){const e=xt.keys().next().value;void 0!==e&&xt.delete(e)}return r}function At(e=new Date){const t=new Date(e);return t.setHours(0,0,0,0),t}function kt(e,t=new Date){if(!e)return At(t);const o=new Intl.DateTimeFormat("en-CA",{timeZone:e,year:"numeric",month:"2-digit",day:"2-digit"}).format(t),[i,s,n]=o.split("-").map(Number),r=Date.UTC(i,s-1,n,0,0,0),a=function(e,t){const o=new Intl.DateTimeFormat("en-US",{timeZone:e,year:"numeric",month:"2-digit",day:"2-digit",hour:"2-digit",minute:"2-digit",second:"2-digit",hourCycle:"h23"}).formatToParts(t),i={};for(const e of o)"literal"!==e.type&&(i[e.type]=Number(e.value));return Date.UTC(i.year,i.month-1,i.day,i.hour,i.minute,i.second)-t.getTime()}(e,new Date(r));return new Date(r-a)}function Ct(e,t,o,i){const s=((t-o)%360+360)%360;return((e-s)%360+360)%360<=((((t+i)%360+360)%360-s)%360+360)%360}function St(e,t,o,i){const s=[];let n=-1;for(let r=0;r<e.length;r++){const a=e[r];a.elevation>0&&Ct(a.azimuth,t,o,i)?-1===n&&(n=r):-1!==n&&(s.push({startIdx:n,endIdx:r-1}),n=-1)}return-1!==n&&s.push({startIdx:n,endIdx:e.length-1}),s}function Et(e,t,o=new Date){const i=wt.getMoonPosition(o,e,t),s=wt.getMoonIllumination(o);return{azimuth:((180*i.azimuth/Math.PI+180)%360+360)%360,elevation:180*i.altitude/Math.PI,phase:s.phase,fraction:s.fraction,phaseName:zt(s.phase)}}function zt(e){return e<.0625||e>=.9375?"New Moon":e<.1875?"Waxing Crescent":e<.3125?"First Quarter":e<.4375?"Waxing Gibbous":e<.5625?"Full Moon":e<.6875?"Waning Gibbous":e<.8125?"Last Quarter":"Waning Crescent"}function Ot(e){return null==e||Number.isNaN(e)?"—":`${Math.round(e)}%`}function Mt(e){return null==e||Number.isNaN(e)?"—":`${e.toFixed(1)}°`}function It(e,t){if(!e)return"—";const o=new Date(e);return Number.isNaN(o.getTime())?"—":o.toLocaleTimeString([],{hour:"2-digit",minute:"2-digit",timeZone:t})}function Ft(e,t){if(!e)return"—";const o=new Date(e).getTime();if(Number.isNaN(o))return"—";const i=Math.round((o-Date.now())/1e3);return i<=0?t?Be("formatters.expired",t):"expired":function(e){if(null==e||Number.isNaN(e))return"—";const t=Math.max(0,Math.round(e));if(t<60)return`${t}s`;const o=Math.floor(t/60);return o<60?`${o}m ${t%60}s`:`${Math.floor(o/60)}h ${o%60}m`}(i)}const Tt=new Set(["outside_fov","in_fov_not_valid","hitting"]),Pt={night:"sun night",hitting:"sun valid",in_fov_not_valid:"sun in-fov",outside_fov:"sun up"};function jt(e){return e.belowHorizon?"night":e.sunState&&Tt.has(e.sunState)?e.sunState:e.directSunValid?"hitting":e.inFov?"in_fov_not_valid":"outside_fov"}const Rt=["#1f77b4","#ff7f0e","#2ca02c","#d62728","#9467bd","#17becf","#e377c2"];function Nt(e){const t=Rt.length;return Rt[(e%t+t)%t]}function Dt(e,t){return"string"==typeof e&&e.length>0?{color:e,isOverride:!0}:{color:Nt(t),isOverride:!1}}const Bt=110;let Kt=class extends ce{constructor(){super(...arguments),this.discovered_list=[],this.compact=!1,this.showStats=!0,this.showLegend=!0,this.showMoon=!1,this.showCardinals=!0,this.showBlindSpot=!0,this.showSunPath=!0,this.showSunriseSunset=!0,this.showCoverFill=!0,this.showWindowArrow=!0,this.coverColors=[],this.northOffsetDeg=0,this._hiddenEntries=new Set}shouldUpdate(e){return e.size>1||!e.has("hass")||_e(e.get("hass"),this.hass,this._relevantIds())}_relevantIds(){const e=[];for(const t of this.discovered_list){const o=t.entities;e.push(o.sun_sensor,o.target_position_sensor,o.manual_override_binary,o.sun_infront_binary,o.decision_trace_sensor,o.start_sensor,o.end_sensor)}return e}_toggleEntry(e){const t=new Set(this._hiddenEntries);t.has(e)?t.delete(e):t.add(e),this._hiddenEntries=t}_sunFor(e){const t=e.entities.sun_sensor;if(!t)return null;const o=this.hass.states[t];if(!o)return null;const i=parseFloat(o.state);return Number.isNaN(i)?null:{...o.attributes,window_azimuth:o.attributes.window_azimuth}}_coverPositionFor(e){const t=e.entities.target_position_sensor;if(!t)return null;const o=parseFloat(this.hass.states[t]?.state??"");return Number.isNaN(o)?null:o}_actualPositionFor(e){const t=e.entities.target_position_sensor;if(!t)return null;const o=this.hass.states[t]?.attributes;return o?.actual_positions?function(e){const t=Object.values(e).filter(e=>"number"==typeof e);return 0===t.length?null:t.reduce((e,t)=>e+t,0)/t.length}(o.actual_positions):null}_solarTargetFor(e){const t=e.entities.target_position_sensor;if(!t)return null;const o=this.hass.states[t]?.attributes,i=o?.raw_calculated_position;return"number"==typeof i&&Number.isFinite(i)?i:null}_manualOverrideActive(e){const t=e.entities.manual_override_binary;return!!t&&"on"===this.hass.states[t]?.state}_sunInfrontFor(e){const t=e.entities.sun_infront_binary;return!!t&&"on"===this.hass.states[t]?.state}_sunDotStateFor(e,t){const o=e.entities.decision_trace_sensor?this.hass.states[e.entities.decision_trace_sensor]?.attributes:void 0;return jt({belowHorizon:t.elevation<=0,sunState:o?.sun_state??null,directSunValid:o?.direct_sun_valid??!1,inFov:!0===t.in_fov})}_readActiveAzimuth(e){if(!e)return null;const t=this.hass.states[e];if(!t)return null;if("unavailable"===t.state||"unknown"===t.state)return null;const o=t.attributes.azimuth;return"number"==typeof o&&Number.isFinite(o)?o:null}_buildOverlays(){const e=[];return this.discovered_list.forEach((t,o)=>{const i=this._sunFor(t);if(!i)return;const s=t.entities.sun_sensor,n=parseFloat(this.hass.states[s]?.state??"0"),{color:r,isOverride:a}=Dt(this.coverColors?.[o],o),l=this._coverPositionFor(t),c=function(e,t,o){return e&&null!=t&&Number.isFinite(t)?t===o?null:t:null}(this._manualOverrideActive(t),this._solarTargetFor(t),l);e.push({d:t,sun:i,sunAzi:n,sunInfront:this._sunInfrontFor(t),dotState:this._sunDotStateFor(t,i),coverPos:c??l,actualPos:this._actualPositionFor(t),coverType:t.cover_type,color:r,isOverride:a,index:o})}),e}render(){if(!this.hass)return W;if(!this.discovered_list||0===this.discovered_list.length)return q`<div class="placeholder">${Be("compass.placeholder_no_entries",this.hass)}</div>`;const e=this._buildOverlays();if(0===e.length)return q`<div class="placeholder">${Be("compass.placeholder_no_sun",this.hass)}</div>`;const t=e.filter(e=>!this._hiddenEntries.has(e.d.entry_id)),o=He(this.northOffsetDeg),i=e.length>1,s=e[0],n=s.sunAzi,r=s.sun.elevation,a=Qe(n,r,o),l={night:-1,outside_fov:0,in_fov_not_valid:1,hitting:2},c=r<=0?"night":e.reduce((e,t)=>l[t.dotState]>l[e]?t.dotState:e,"outside_fov"),d=Pt[c],{latitude:h,longitude:u,time_zone:p}=this.hass.config,g=void 0!==h&&void 0!==u?$t(h,u,kt(p)):[],m=this.showMoon&&void 0!==h&&void 0!==u?Et(h,u):null,_=null!==m&&m.elevation>0,f=m?m.phase<.5?-24*m.phase:24*(1-m.phase):0,v=_?Qe(m.azimuth,m.elevation,o):null,y=v?v.x*Bt:0,b=v?v.y*Bt:0,w=this.showSunPath?function(e){const t=[];let o=-1;for(let i=0;i<e.length;i++)e[i].elevation>0?-1===o&&(o=i):-1!==o&&(t.push({startIdx:o,endIdx:i-1}),o=-1);return-1!==o&&t.push({startIdx:o,endIdx:e.length-1}),t}(g).map(e=>g.slice(e.startIdx,e.endIdx+1).map(e=>{const t=Qe(e.azimuth,e.elevation,o);return{x:t.x*Bt,y:t.y*Bt,elev:e.elevation}})):[],x=[122,127,135],$=[245,197,24],A=e=>{const t=Math.sqrt(Math.max(0,Math.min(1,e/90))),o=x.map((e,o)=>Math.round(e+($[o]-e)*t));return`rgb(${o[0]},${o[1]},${o[2]})`},k=this.showSunPath&&this.showSunriseSunset?w.filter(e=>e.length>1).map((e,t)=>{const o=e[0],i=e[e.length-1],s=i.x-o.x,n=i.y-o.y,r=s*s+n*n||1,a=e.filter((t,o)=>o%6==0||o===e.length-1).map(e=>({offset:100*Math.max(0,Math.min(1,((e.x-o.x)*s+(e.y-o.y)*n)/r)),color:A(e.elev)}));return{id:`sun-path-grad-${t}`,x1:o.x,y1:o.y,x2:i.x,y2:i.y,stops:a}}):[],C=e=>this.showSunriseSunset?`url(#sun-path-grad-${e})`:"var(--warning-color, gold)",S=Le(0,124,o),E=Le(90,124,o),z=Le(180,124,o),O=Le(270,124,o),M=Le(0,Bt,o),I=Le(180,Bt,o),F=Le(90,Bt,o),T=Le(270,Bt,o),P=Be("compass.sun_tooltip",this.hass,{az:Mt(n),el:Mt(r)}),j=null!==m?Be("compass.moon_tooltip",this.hass,{phase:m.phaseName,pct:Math.round(100*m.fraction)}):"",R=Be("compass.sun_path_tooltip",this.hass);return q`
+  `,e([_e({type:Boolean})],St.prototype,"on",void 0),e([_e({type:Boolean})],St.prototype,"readonly",void 0),e([_e({type:String})],St.prototype,"label",void 0),e([_e({type:String})],St.prototype,"title",void 0),St=e([he("acp-header-pill")],St);const zt=Ke(class extends Ve{constructor(e){if(super(e),1!==e.type||"class"!==e.name||e.strings?.length>2)throw Error("`classMap()` can only be used in the `class` attribute and must be the only part in the attribute.")}render(e){return" "+Object.keys(e).filter(t=>e[t]).join(" ")+" "}update(e,[t]){if(void 0===this.st){this.st=new Set,void 0!==e.strings&&(this.nt=new Set(e.strings.join(" ").split(/\s/).filter(e=>""!==e)));for(const e in t)t[e]&&!this.nt?.has(e)&&this.st.add(e);return this.render(t)}const o=e.element.classList;for(const e of this.st)e in t||(o.remove(e),this.st.delete(e));for(const e in t){const s=!!t[e];s===this.st.has(e)||this.nt?.has(e)||(s?(o.add(e),this.st.add(e)):(o.remove(e),this.st.delete(e)))}return U}});function Ot(e){return e&&e.__esModule&&Object.prototype.hasOwnProperty.call(e,"default")?e.default:e}var Mt,It,Ft={exports:{}},Tt=(Mt||(Mt=1,It=Ft,function(){var e=Math.PI,t=Math.sin,o=Math.cos,s=Math.tan,i=Math.asin,n=Math.atan2,r=Math.acos,a=e/180,l=864e5,c=2440588,d=2451545;function h(e){return new Date((e+.5-c)*l)}function u(e){return function(e){return e.valueOf()/l-.5+c}(e)-d}var p=23.4397*a;function _(e,i){return n(t(e)*o(p)-s(i)*t(p),o(e))}function m(e,s){return i(t(s)*o(p)+o(s)*t(p)*t(e))}function g(e,i,r){return n(t(e),o(e)*t(i)-s(r)*o(i))}function f(e,s,n){return i(t(s)*t(n)+o(s)*o(n)*o(e))}function v(e,t){return a*(280.16+360.9856235*e)-t}function y(e){return a*(357.5291+.98560028*e)}function b(o){return o+a*(1.9148*t(o)+.02*t(2*o)+3e-4*t(3*o))+102.9372*a+e}function w(e){var t=b(y(e));return{dec:m(t,0),ra:_(t,0)}}var x={getPosition:function(e,t,o){var s=a*-o,i=a*t,n=u(e),r=w(n),l=v(n,s)-r.ra;return{azimuth:g(l,i,r.dec),altitude:f(l,i,r.dec)}}},$=x.times=[[-.833,"sunrise","sunset"],[-.3,"sunriseEnd","sunsetStart"],[-6,"dawn","dusk"],[-12,"nauticalDawn","nauticalDusk"],[-18,"nightEnd","night"],[6,"goldenHourEnd","goldenHour"]];x.addTime=function(e,t,o){$.push([e,t,o])};var A=9e-4;function k(t,o,s){return A+(t+o)/(2*e)+s}function C(e,o,s){return d+e+.0053*t(o)-.0069*t(2*s)}function E(e,s,i,n,a,l,c){var d=function(e,s,i){return r((t(e)-t(s)*t(i))/(o(s)*o(i)))}(e,i,n);return C(k(d,s,a),l,c)}function S(e){var s=a*(134.963+13.064993*e),i=a*(93.272+13.22935*e),n=a*(218.316+13.176396*e)+6.289*a*t(s),r=5.128*a*t(i),l=385001-20905*o(s);return{ra:_(n,r),dec:m(n,r),dist:l}}function z(e,t){return new Date(e.valueOf()+t*l/24)}x.getTimes=function(t,o,s,i){var n,r,l,c,d,p=a*-s,_=a*o,g=function(e){return-2.076*Math.sqrt(e)/60}(i=i||0),f=function(t,o){return Math.round(t-A-o/(2*e))}(u(t),p),v=k(0,p,f),w=y(v),x=b(w),S=m(x,0),z=C(v,w,x),O={solarNoon:h(z),nadir:h(z-.5)};for(n=0,r=$.length;n<r;n+=1)d=z-((c=E(((l=$[n])[0]+g)*a,p,_,S,f,w,x))-z),O[l[1]]=h(d),O[l[2]]=h(c);return O},x.getMoonPosition=function(e,i,r){var l=a*-r,c=a*i,d=u(e),h=S(d),p=v(d,l)-h.ra,_=f(p,c,h.dec),m=n(t(p),s(c)*o(h.dec)-t(h.dec)*o(p));return _+=function(e){return e<0&&(e=0),2967e-7/Math.tan(e+.00312536/(e+.08901179))}(_),{azimuth:g(p,c,h.dec),altitude:_,distance:h.dist,parallacticAngle:m}},x.getMoonIllumination=function(e){var s=u(e||new Date),i=w(s),a=S(s),l=149598e3,c=r(t(i.dec)*t(a.dec)+o(i.dec)*o(a.dec)*o(i.ra-a.ra)),d=n(l*t(c),a.dist-l*o(c)),h=n(o(i.dec)*t(i.ra-a.ra),t(i.dec)*o(a.dec)-o(i.dec)*t(a.dec)*o(i.ra-a.ra));return{fraction:(1+o(d))/2,phase:.5+.5*d*(h<0?-1:1)/Math.PI,angle:h}},x.getMoonTimes=function(e,t,o,s){var i=new Date(e);s?i.setUTCHours(0,0,0,0):i.setHours(0,0,0,0);for(var n,r,l,c,d,h,u,p,_,m,g,f,v,y=.133*a,b=x.getMoonPosition(i,t,o).altitude-y,w=1;w<=24&&(n=x.getMoonPosition(z(i,w),t,o).altitude-y,p=((d=(b+(r=x.getMoonPosition(z(i,w+1),t,o).altitude-y))/2-n)*(u=-(h=(r-b)/2)/(2*d))+h)*u+n,m=0,(_=h*h-4*d*n)>=0&&(g=u-(v=Math.sqrt(_)/(2*Math.abs(d))),f=u+v,Math.abs(g)<=1&&m++,Math.abs(f)<=1&&m++,g<-1&&(g=f)),1===m?b<0?l=w+g:c=w+g:2===m&&(l=w+(p<0?f:g),c=w+(p<0?g:f)),!l||!c);w+=2)b=r;var $={};return l&&($.rise=z(i,l)),c&&($.set=z(i,c)),l||c||($[p>0?"alwaysUp":"alwaysDown"]=!0),$},It.exports=x}()),Ft.exports),Pt=Ot(Tt);const jt=new Map;function Rt(e,t,o,s=10){const i=`${e},${t},${o.getTime()},${s}`,n=jt.get(i);if(n)return jt.delete(i),jt.set(i,n),n;const r=[],a=o.getTime()+864e5;for(let i=o.getTime();i<=a;i+=60*s*1e3){const o=new Date(i),s=Pt.getPosition(o,e,t);r.push({t:o,elevation:180*s.altitude/Math.PI,azimuth:((180*s.azimuth/Math.PI+180)%360+360)%360})}if(jt.set(i,r),jt.size>4){const e=jt.keys().next().value;void 0!==e&&jt.delete(e)}return r}function Nt(e=new Date){const t=new Date(e);return t.setHours(0,0,0,0),t}function Dt(e,t=new Date){if(!e)return Nt(t);const o=new Intl.DateTimeFormat("en-CA",{timeZone:e,year:"numeric",month:"2-digit",day:"2-digit"}).format(t),[s,i,n]=o.split("-").map(Number),r=Date.UTC(s,i-1,n,0,0,0),a=function(e,t){const o=new Intl.DateTimeFormat("en-US",{timeZone:e,year:"numeric",month:"2-digit",day:"2-digit",hour:"2-digit",minute:"2-digit",second:"2-digit",hourCycle:"h23"}).formatToParts(t),s={};for(const e of o)"literal"!==e.type&&(s[e.type]=Number(e.value));return Date.UTC(s.year,s.month-1,s.day,s.hour,s.minute,s.second)-t.getTime()}(e,new Date(r));return new Date(r-a)}function Bt(e,t,o,s){const i=((t-o)%360+360)%360;return((e-i)%360+360)%360<=((((t+s)%360+360)%360-i)%360+360)%360}function Kt(e,t,o,s){const i=[];let n=-1;for(let r=0;r<e.length;r++){const a=e[r];a.elevation>0&&Bt(a.azimuth,t,o,s)?-1===n&&(n=r):-1!==n&&(i.push({startIdx:n,endIdx:r-1}),n=-1)}return-1!==n&&i.push({startIdx:n,endIdx:e.length-1}),i}function Vt(e,t,o=new Date){const s=Pt.getMoonPosition(o,e,t),i=Pt.getMoonIllumination(o);return{azimuth:((180*s.azimuth/Math.PI+180)%360+360)%360,elevation:180*s.altitude/Math.PI,phase:i.phase,fraction:i.fraction,phaseName:Gt(i.phase)}}function Gt(e){return e<.0625||e>=.9375?"New Moon":e<.1875?"Waxing Crescent":e<.3125?"First Quarter":e<.4375?"Waxing Gibbous":e<.5625?"Full Moon":e<.6875?"Waning Gibbous":e<.8125?"Last Quarter":"Waning Crescent"}function Lt(e){return null==e||Number.isNaN(e)?"—":`${Math.round(e)}%`}function qt(e){return null==e||Number.isNaN(e)?"—":`${e.toFixed(1)}°`}function Ut(e,t){if(!e)return"—";const o=new Date(e);return Number.isNaN(o.getTime())?"—":o.toLocaleTimeString([],{hour:"2-digit",minute:"2-digit",timeZone:t})}function Yt(e,t){if(!e)return"—";const o=new Date(e).getTime();if(Number.isNaN(o))return"—";const s=Math.round((o-Date.now())/1e3);return s<=0?t?Be("formatters.expired",t):"expired":function(e){if(null==e||Number.isNaN(e))return"—";const t=Math.max(0,Math.round(e));if(t<60)return`${t}s`;const o=Math.floor(t/60);return o<60?`${o}m ${t%60}s`:`${Math.floor(o/60)}h ${o%60}m`}(s)}const Wt=new Set(["outside_fov","in_fov_not_valid","hitting"]),Qt={night:"sun night",hitting:"sun valid",in_fov_not_valid:"sun in-fov",outside_fov:"sun up"};function Ht(e){return e.belowHorizon?"night":e.sunState&&Wt.has(e.sunState)?e.sunState:e.directSunValid?"hitting":e.inFov?"in_fov_not_valid":"outside_fov"}const Xt=["#1f77b4","#ff7f0e","#2ca02c","#d62728","#9467bd","#17becf","#e377c2"];function Zt(e){const t=Xt.length;return Xt[(e%t+t)%t]}function Jt(e,t){return"string"==typeof e&&e.length>0?{color:e,isOverride:!0}:{color:Zt(t),isOverride:!1}}const eo=110;let to=class extends ce{constructor(){super(...arguments),this.discovered_list=[],this.compact=!1,this.showStats=!0,this.showLegend=!0,this.showMoon=!1,this.showCardinals=!0,this.showBlindSpot=!0,this.showSunPath=!0,this.showSunriseSunset=!0,this.showCoverFill=!0,this.showWindowArrow=!0,this.coverColors=[],this.northOffsetDeg=0,this._hiddenEntries=new Set}shouldUpdate(e){return e.size>1||!e.has("hass")||ge(e.get("hass"),this.hass,this._relevantIds())}_relevantIds(){const e=[];for(const t of this.discovered_list){const o=t.entities;e.push(o.sun_sensor,o.target_position_sensor,o.manual_override_binary,o.sun_infront_binary,o.decision_trace_sensor,o.start_sensor,o.end_sensor)}return e}_toggleEntry(e){const t=new Set(this._hiddenEntries);t.has(e)?t.delete(e):t.add(e),this._hiddenEntries=t}_sunFor(e){const t=e.entities.sun_sensor;if(!t)return null;const o=this.hass.states[t];if(!o)return null;const s=parseFloat(o.state);return Number.isNaN(s)?null:{...o.attributes,window_azimuth:o.attributes.window_azimuth}}_coverPositionFor(e){const t=e.entities.target_position_sensor;if(!t)return null;const o=parseFloat(this.hass.states[t]?.state??"");return Number.isNaN(o)?null:o}_actualPositionFor(e){const t=e.entities.target_position_sensor;if(!t)return null;const o=this.hass.states[t]?.attributes;return o?.actual_positions?function(e){const t=Object.values(e).filter(e=>"number"==typeof e);return 0===t.length?null:t.reduce((e,t)=>e+t,0)/t.length}(o.actual_positions):null}_solarTargetFor(e){const t=e.entities.target_position_sensor;if(!t)return null;const o=this.hass.states[t]?.attributes,s=o?.raw_calculated_position;return"number"==typeof s&&Number.isFinite(s)?s:null}_manualOverrideActive(e){const t=e.entities.manual_override_binary;return!!t&&"on"===this.hass.states[t]?.state}_sunInfrontFor(e){const t=e.entities.sun_infront_binary;return!!t&&"on"===this.hass.states[t]?.state}_sunDotStateFor(e,t){const o=e.entities.decision_trace_sensor?this.hass.states[e.entities.decision_trace_sensor]?.attributes:void 0;return Ht({belowHorizon:t.elevation<=0,sunState:o?.sun_state??null,directSunValid:o?.direct_sun_valid??!1,inFov:!0===t.in_fov})}_readActiveAzimuth(e){if(!e)return null;const t=this.hass.states[e];if(!t)return null;if("unavailable"===t.state||"unknown"===t.state)return null;const o=t.attributes.azimuth;return"number"==typeof o&&Number.isFinite(o)?o:null}_buildOverlays(){const e=[];return this.discovered_list.forEach((t,o)=>{const s=this._sunFor(t);if(!s)return;const i=t.entities.sun_sensor,n=parseFloat(this.hass.states[i]?.state??"0"),{color:r,isOverride:a}=Jt(this.coverColors?.[o],o),l=this._coverPositionFor(t),c=function(e,t,o){return e&&null!=t&&Number.isFinite(t)?t===o?null:t:null}(this._manualOverrideActive(t),this._solarTargetFor(t),l);e.push({d:t,sun:s,sunAzi:n,sunInfront:this._sunInfrontFor(t),dotState:this._sunDotStateFor(t,s),coverPos:c??l,actualPos:this._actualPositionFor(t),coverType:t.cover_type,color:r,isOverride:a,index:o})}),e}render(){if(!this.hass)return Y;if(!this.discovered_list||0===this.discovered_list.length)return L`<div class="placeholder">${Be("compass.placeholder_no_entries",this.hass)}</div>`;const e=this._buildOverlays();if(0===e.length)return L`<div class="placeholder">${Be("compass.placeholder_no_sun",this.hass)}</div>`;const t=e.filter(e=>!this._hiddenEntries.has(e.d.entry_id)),o=tt(this.northOffsetDeg),s=e.length>1,i=e[0],n=i.sunAzi,r=i.sun.elevation,a=et(n,r,o),l={night:-1,outside_fov:0,in_fov_not_valid:1,hitting:2},c=r<=0?"night":e.reduce((e,t)=>l[t.dotState]>l[e]?t.dotState:e,"outside_fov"),d=Qt[c],{latitude:h,longitude:u,time_zone:p}=this.hass.config,_=void 0!==h&&void 0!==u?Rt(h,u,Dt(p)):[],m=this.showMoon&&void 0!==h&&void 0!==u?Vt(h,u):null,g=null!==m&&m.elevation>0,f=m?m.phase<.5?-24*m.phase:24*(1-m.phase):0,v=g?et(m.azimuth,m.elevation,o):null,y=v?v.x*eo:0,b=v?v.y*eo:0,w=this.showSunPath?function(e){const t=[];let o=-1;for(let s=0;s<e.length;s++)e[s].elevation>0?-1===o&&(o=s):-1!==o&&(t.push({startIdx:o,endIdx:s-1}),o=-1);return-1!==o&&t.push({startIdx:o,endIdx:e.length-1}),t}(_).map(e=>_.slice(e.startIdx,e.endIdx+1).map(e=>{const t=et(e.azimuth,e.elevation,o);return{x:t.x*eo,y:t.y*eo,elev:e.elevation}})):[],x=[122,127,135],$=[245,197,24],A=e=>{const t=Math.sqrt(Math.max(0,Math.min(1,e/90))),o=x.map((e,o)=>Math.round(e+($[o]-e)*t));return`rgb(${o[0]},${o[1]},${o[2]})`},k=this.showSunPath&&this.showSunriseSunset?w.filter(e=>e.length>1).map((e,t)=>{const o=e[0],s=e[e.length-1],i=s.x-o.x,n=s.y-o.y,r=i*i+n*n||1,a=e.filter((t,o)=>o%6==0||o===e.length-1).map(e=>({offset:100*Math.max(0,Math.min(1,((e.x-o.x)*i+(e.y-o.y)*n)/r)),color:A(e.elev)}));return{id:`sun-path-grad-${t}`,x1:o.x,y1:o.y,x2:s.x,y2:s.y,stops:a}}):[],C=e=>this.showSunriseSunset?`url(#sun-path-grad-${e})`:"var(--warning-color, gold)",E=Xe(0,124,o),S=Xe(90,124,o),z=Xe(180,124,o),O=Xe(270,124,o),M=Xe(0,eo,o),I=Xe(180,eo,o),F=Xe(90,eo,o),T=Xe(270,eo,o),P=Be("compass.sun_tooltip",this.hass,{az:qt(n),el:qt(r)}),j=null!==m?Be("compass.moon_tooltip",this.hass,{phase:m.phaseName,pct:Math.round(100*m.fraction)}):"",R=Be("compass.sun_path_tooltip",this.hass);return L`
       <div class="compass">
         <svg viewBox="${-140} ${-140} ${280} ${280}">
-          ${U`
+          ${q`
             <defs>
-              ${_?U`
+              ${g?q`
                 <mask id="moon-phase-mask">
                   <circle cx=${y} cy=${b} r=${6} fill="white"></circle>
                   <circle cx=${y+f} cy=${b} r=${6} fill="black"></circle>
                 </mask>
-              `:W}
-              ${k.map(e=>U`
+              `:Y}
+              ${k.map(e=>q`
                 <linearGradient id=${e.id} gradientUnits="userSpaceOnUse"
                   x1=${e.x1} y1=${e.y1} x2=${e.x2} y2=${e.y2}>
-                  ${e.stops.map(e=>U`<stop offset="${e.offset}%" stop-color=${e.color}></stop>`)}
+                  ${e.stops.map(e=>q`<stop offset="${e.offset}%" stop-color=${e.color}></stop>`)}
                 </linearGradient>
               `)}
             </defs>
 
-            <circle class="grid" r=${Bt}></circle>
+            <circle class="grid" r=${eo}></circle>
             <circle class="grid" r=${220/3}></circle>
-            <circle class="grid" r=${Bt/3}></circle>
+            <circle class="grid" r=${eo/3}></circle>
             <line class="grid thin" x1=${M.x} y1=${M.y} x2=${I.x} y2=${I.y}></line>
             <line class="grid thin" x1=${F.x} y1=${F.y} x2=${T.x} y2=${T.y}></line>
 
-            ${t.map(e=>this._renderEntryLayers(e,i,o,g))}
+            ${t.map(e=>this._renderEntryLayers(e,s,o,_))}
 
-            ${this.showSunPath&&w.length?U`<g data-tooltip=${R}><title>${R}</title>${w.filter(e=>e.length>1).flatMap((e,t)=>{const o=e.map(e=>`${e.x},${e.y}`).join(" "),i=U`<polyline class="sun-path-line" points=${o}
-                        style="stroke:${C(t)}"></polyline>`,s=[];for(let t=0;t<e.length;t+=10){const o=e[t],i=e[Math.max(0,t-1)],n=e[Math.min(e.length-1,t+1)],r=180*Math.atan2(n.y-i.y,n.x-i.x)/Math.PI,a=this.showSunriseSunset?A(o.elev):"var(--warning-color, gold)";s.push(U`<path class="sun-path-chevron"
+            ${this.showSunPath&&w.length?q`<g ${ut(R)}>${w.filter(e=>e.length>1).flatMap((e,t)=>{const o=e.map(e=>`${e.x},${e.y}`).join(" "),s=q`<polyline class="sun-path-line" points=${o}
+                        style="stroke:${C(t)}"></polyline>`,i=[];for(let t=0;t<e.length;t+=10){const o=e[t],s=e[Math.max(0,t-1)],n=e[Math.min(e.length-1,t+1)],r=180*Math.atan2(n.y-s.y,n.x-s.x)/Math.PI,a=this.showSunriseSunset?A(o.elev):"var(--warning-color, gold)";i.push(q`<path class="sun-path-chevron"
                           transform=${`translate(${o.x} ${o.y}) rotate(${r})`}
                           d="M -2.4 -3 L 1.8 0 L -2.4 3 L -0.7 0 Z"
-                          style=${`fill:${a}`}></path>`)}return[i,...s]})}</g>`:W}
+                          style=${`fill:${a}`}></path>`)}return[s,...i]})}</g>`:Y}
 
-            ${this.showCardinals?U`
-              <text class="cardinal" x=${S.x} y=${S.y} text-anchor="middle" dominant-baseline="central">N</text>
-              <text class="cardinal" x=${E.x} y=${E.y} text-anchor="middle" dominant-baseline="central">E</text>
+            ${this.showCardinals?q`
+              <text class="cardinal" x=${E.x} y=${E.y} text-anchor="middle" dominant-baseline="central">N</text>
+              <text class="cardinal" x=${S.x} y=${S.y} text-anchor="middle" dominant-baseline="central">E</text>
               <text class="cardinal" x=${z.x} y=${z.y} text-anchor="middle" dominant-baseline="central">S</text>
               <text class="cardinal" x=${O.x} y=${O.y} text-anchor="middle" dominant-baseline="central">W</text>
-            `:W}
+            `:Y}
 
-            ${_?U`
-              <g data-tooltip=${j}>
-                <title>${j}</title>
+            ${g?q`
+              <g ${ut(j)}>
                 <circle class="moon-outline" cx=${y} cy=${b} r=${6}></circle>
                 <image
                   class="moon-img"
@@ -90,66 +125,59 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
                   mask="url(#moon-phase-mask)"
                 ></image>
               </g>
-            `:W}
+            `:Y}
 
-            <g data-tooltip=${P}>
-              <title>${P}</title>
-              <circle class=${d} cx=${a.x*Bt} cy=${a.y*Bt} r="7"></circle>
+            <g ${ut(P)}>
+              <circle class=${d} cx=${a.x*eo} cy=${a.y*eo} r="7"></circle>
             </g>
           `}
         </svg>
-        ${this.showLegend?this._renderLegend(e,i):W}
-        ${this.showStats?this._renderStats(e,i):W}
+        ${this.showLegend?this._renderLegend(e,s):Y}
+        ${this.showStats?this._renderStats(e,s):Y}
       </div>
-    `}_renderEntryLayers(e,t,o=0,i=[]){const s=He(e.sun.window_azimuth),n=He(s-e.sun.fov_left),r=He(s+e.sun.fov_right),a=this._readActiveAzimuth(e.d.entities.start_sensor),l=this._readActiveAzimuth(e.d.entities.end_sensor),c=null!==a&&null!==l;let d,h;if(c)({wedgeStart:d,wedgeEnd:h}=function(e,t,o,i,s){const n=((o-i)%360+360)%360,r=i+s,a=((t-n)%360+360)%360,l=e=>e<=r?e:e-r<360-e?r:0,c=l(((e-n)%360+360)%360),d=l(a);return c===d?{wedgeStart:n,wedgeEnd:((n+r)%360+360)%360}:{wedgeStart:((n+Math.min(c,d))%360+360)%360,wedgeEnd:((n+Math.max(c,d))%360+360)%360}}(He(a),He(l),s,e.sun.fov_left,e.sun.fov_right));else{const t=function(e,t,o,i,s){if(void 0===s)return null;const n=He(t-o),r=o+i,a=e.filter(e=>((e.azimuth-n)%360+360)%360<=r&&e.elevation>s);return 0===a.length?null:{wedgeStart:a[0].azimuth,wedgeEnd:a[a.length-1].azimuth}}(i,s,e.sun.fov_left,e.sun.fov_right,e.sun.min_elevation);d=t?t.wedgeStart:n,h=t?t.wedgeEnd:r}const u=Le(s,Bt,o),{outer:p,inner:g}=(m=e.sun.min_elevation,_=e.sun.max_elevation,f=Bt,void 0!==m&&void 0!==_&&m>_?{outer:f,inner:0}:{outer:void 0!==m?f*We(m):f,inner:void 0!==_?f*We(_):0});var m,_,f;const v=null!==e.coverPos?tt(e.coverPos,e.coverType,Bt,p):null,y=null!==e.actualPos?tt(e.actualPos,e.coverType,Bt,p):null,b=e.sun.blind_spot_range?[He((w=s)-(x=e.sun.blind_spot_range)[1]),He(w-x[0])]:null;var w,x;const $=b?Ye(b[0],b[1],Bt,0,o):null,A=Ye(d,h,p,g,o),k=c&&(d!==n||h!==r),C=k?Ye(n,r,p,g,o):"",S=null!==v&&v>g?Ye(d,h,v,g,o):"",E=null!==y&&y>g?Ye(d,h,y,g,o):"",z=[];for(const t of St(i,s,e.sun.fov_left,e.sun.fov_right)){const s=Ze(i,t.startIdx,t.endIdx,e.sun.min_elevation);s&&!et(s.wedgeStart,s.wedgeEnd,d,h)&&z.push({fov:Ye(s.wedgeStart,s.wedgeEnd,p,g,o),cover:this.showCoverFill&&null!==v&&v>g?Ye(s.wedgeStart,s.wedgeEnd,v,g,o):"",actual:this.showCoverFill&&null!==y&&y>g?Ye(s.wedgeStart,s.wedgeEnd,y,g,o):"",from:s.wedgeStart,to:s.wedgeEnd})}const O=t?`${e.d.entry_title}: `:"",M=void 0!==e.sun.min_elevation||void 0!==e.sun.max_elevation?Be("compass.elev_suffix",this.hass,{min:Mt(e.sun.min_elevation??0),max:Mt(e.sun.max_elevation??90)}):"",I=c?`${O}${Be("compass.active_sun_arc",this.hass,{from:Mt(d),to:Mt(h),elev:M})}`:`${O}${Be("compass.fov_arc",this.hass,{left:Mt(e.sun.fov_left),right:Mt(e.sun.fov_right),elev:M})}`,F=`${O}${Be("compass.window_normal_tooltip",this.hass,{bearing:Mt(s)})}`,T=[];if(null!==e.coverPos){const t="cover_awning"===e.coverType?"compass.cover_position_target_awning":"compass.cover_position_target";T.push(`${O}${Be(t,this.hass,{pct:e.coverPos})}`),null!==e.actualPos&&T.push(Be("compass.cover_position_actual",this.hass,{pct:Math.round(e.actualPos)}))}const P=T.join("\n"),j=b?`${O}${Be("compass.blind_spot",this.hass,{from:Mt(b[0]),to:Mt(b[1])})}`:"",R=t||e.isOverride,N=t||e.isOverride,D=R?`fill: ${e.color}; stroke: ${e.color};`:"",B=N?`fill: ${e.color}; stroke: ${e.color};`:"",K=R?`fill: ${e.color}; stroke: ${e.color};`:"",V=R?`stroke: ${e.color};`:"",G=R?`fill: ${e.color};`:"",q=this.showCoverFill&&""!==S,L=this.showBlindSpot&&!!$,Y=this.showWindowArrow,Q=`M 0 0 L ${u.x} ${u.y}`,H="display: none;",Z=`${O}${Be("compass.fov_arc",this.hass,{left:Mt(e.sun.fov_left),right:Mt(e.sun.fov_right),elev:M})}`;return U`<g class="entry-overlay">
-      ${k?U`<g data-tooltip=${Z}>
-              <title>${Z}</title>
+    `}_renderEntryLayers(e,t,o=0,s=[]){const i=tt(e.sun.window_azimuth),n=tt(i-e.sun.fov_left),r=tt(i+e.sun.fov_right),a=this._readActiveAzimuth(e.d.entities.start_sensor),l=this._readActiveAzimuth(e.d.entities.end_sensor),c=null!==a&&null!==l;let d,h;if(c)({wedgeStart:d,wedgeEnd:h}=function(e,t,o,s,i){const n=((o-s)%360+360)%360,r=s+i,a=((t-n)%360+360)%360,l=e=>e<=r?e:e-r<360-e?r:0,c=l(((e-n)%360+360)%360),d=l(a);return c===d?{wedgeStart:n,wedgeEnd:((n+r)%360+360)%360}:{wedgeStart:((n+Math.min(c,d))%360+360)%360,wedgeEnd:((n+Math.max(c,d))%360+360)%360}}(tt(a),tt(l),i,e.sun.fov_left,e.sun.fov_right));else{const t=function(e,t,o,s,i){if(void 0===i)return null;const n=tt(t-o),r=o+s,a=e.filter(e=>((e.azimuth-n)%360+360)%360<=r&&e.elevation>i);return 0===a.length?null:{wedgeStart:a[0].azimuth,wedgeEnd:a[a.length-1].azimuth}}(s,i,e.sun.fov_left,e.sun.fov_right,e.sun.min_elevation);d=t?t.wedgeStart:n,h=t?t.wedgeEnd:r}const u=Xe(i,eo,o),{outer:p,inner:_}=(m=e.sun.min_elevation,g=e.sun.max_elevation,f=eo,void 0!==m&&void 0!==g&&m>g?{outer:f,inner:0}:{outer:void 0!==m?f*Ze(m):f,inner:void 0!==g?f*Ze(g):0});var m,g,f;const v=null!==e.coverPos?rt(e.coverPos,e.coverType,eo,p):null,y=null!==e.actualPos?rt(e.actualPos,e.coverType,eo,p):null,b=e.sun.blind_spot_range?[tt((w=i)-(x=e.sun.blind_spot_range)[1]),tt(w-x[0])]:null;var w,x;const $=b?Je(b[0],b[1],eo,0,o):null,A=Je(d,h,p,_,o),k=c&&(d!==n||h!==r),C=k?Je(n,r,p,_,o):"",E=null!==v&&v>_?Je(d,h,v,_,o):"",S=null!==y&&y>_?Je(d,h,y,_,o):"",z=[];for(const t of Kt(s,i,e.sun.fov_left,e.sun.fov_right)){const i=ot(s,t.startIdx,t.endIdx,e.sun.min_elevation);i&&!nt(i.wedgeStart,i.wedgeEnd,d,h)&&z.push({fov:Je(i.wedgeStart,i.wedgeEnd,p,_,o),cover:this.showCoverFill&&null!==v&&v>_?Je(i.wedgeStart,i.wedgeEnd,v,_,o):"",actual:this.showCoverFill&&null!==y&&y>_?Je(i.wedgeStart,i.wedgeEnd,y,_,o):"",from:i.wedgeStart,to:i.wedgeEnd})}const O=t?`${e.d.entry_title}: `:"",M=void 0!==e.sun.min_elevation||void 0!==e.sun.max_elevation?Be("compass.elev_suffix",this.hass,{min:qt(e.sun.min_elevation??0),max:qt(e.sun.max_elevation??90)}):"",I=c?`${O}${Be("compass.active_sun_arc",this.hass,{from:qt(d),to:qt(h),elev:M})}`:`${O}${Be("compass.fov_arc",this.hass,{left:qt(e.sun.fov_left),right:qt(e.sun.fov_right),elev:M})}`,F=`${O}${Be("compass.window_normal_tooltip",this.hass,{bearing:qt(i)})}`,T=[];if(null!==e.coverPos){const t="cover_awning"===e.coverType?"compass.cover_position_target_awning":"compass.cover_position_target";T.push(`${O}${Be(t,this.hass,{pct:e.coverPos})}`),null!==e.actualPos&&T.push(Be("compass.cover_position_actual",this.hass,{pct:Math.round(e.actualPos)}))}const P=T.join("\n"),j=b?`${O}${Be("compass.blind_spot",this.hass,{from:qt(b[0]),to:qt(b[1])})}`:"",R=t||e.isOverride,N=t||e.isOverride,D=R?`fill: ${e.color}; stroke: ${e.color};`:"",B=N?`fill: ${e.color}; stroke: ${e.color};`:"",K=R?`fill: ${e.color}; stroke: ${e.color};`:"",V=R?`stroke: ${e.color};`:"",G=R?`fill: ${e.color};`:"",L=this.showCoverFill&&""!==E,U=this.showBlindSpot&&!!$,W=this.showWindowArrow,Q=`M 0 0 L ${u.x} ${u.y}`,H="display: none;",X=`${O}${Be("compass.fov_arc",this.hass,{left:qt(e.sun.fov_left),right:qt(e.sun.fov_right),elev:M})}`;return q`<g class="entry-overlay">
+      ${k?q`<g ${ut(X)}>
               <path class="fov fov-static" style=${D} d=${C}></path>
-            </g>`:W}
-      <g data-tooltip=${I}>
-        <title>${I}</title>
+            </g>`:Y}
+      <g ${ut(I)}>
         <path class="fov" style=${D} d=${A}></path>
       </g>
-      ${z.map(e=>{const t=`${O}${Be("compass.active_sun_arc",this.hass,{from:Mt(e.from),to:Mt(e.to),elev:M})}`;return U`<g data-tooltip=${t}>
-          <title>${t}</title>
+      ${z.map(e=>{const t=`${O}${Be("compass.active_sun_arc",this.hass,{from:qt(e.from),to:qt(e.to),elev:M})}`;return q`<g ${ut(t)}>
           <path class="fov-extra" style=${D} d=${e.fov}></path>
-          ${e.cover?U`<path class="cover-fill-extra" style=${B} d=${e.cover}></path>`:W}
-          ${e.actual?U`<path class="cover-actual-extra" style=${B} d=${e.actual}></path>`:W}
+          ${e.cover?q`<path class="cover-fill-extra" style=${B} d=${e.cover}></path>`:Y}
+          ${e.actual?q`<path class="cover-actual-extra" style=${B} d=${e.actual}></path>`:Y}
         </g>`})}
-      <g class="arrow-group" data-tooltip=${F} style=${Y?"":H}>
-        <title>${F}</title>
+      <g class="arrow-group" style=${W?"":H} ${ut(F)}>
         <path class="window" style=${V} d=${Q}></path>
         <circle class="window-base" style=${G} cx="0" cy="0" r="4"></circle>
       </g>
-      <g class="cover-group" data-tooltip=${P} style=${q?"":H}>
-        <title>${P}</title>
-        <path class="cover-fill" style=${B} d=${S}></path>
-        ${this.showCoverFill&&E?U`<path class="cover-actual" style=${B} d=${E}></path>`:W}
+      <g class="cover-group" style=${L?"":H} ${ut(P)}>
+        <path class="cover-fill" style=${B} d=${E}></path>
+        ${this.showCoverFill&&S?q`<path class="cover-actual" style=${B} d=${S}></path>`:Y}
       </g>
-      <g class="blind-group" data-tooltip=${j} style=${L?"":H}>
-        <title>${j}</title>
+      <g class="blind-group" style=${U?"":H} ${ut(j)}>
         <path class="blind-spot" style=${K} d=${$??""}></path>
       </g>
-    </g>`}_renderLegend(e,t){return t?q`
+    </g>`}_renderLegend(e,t){return t?L`
         <div class="legend">
-          ${e.map(e=>q`
+          ${e.map(e=>L`
               <button
                 type="button"
-                class=${gt({"entry-toggle":!0,hidden:this._hiddenEntries.has(e.d.entry_id)})}
+                class=${zt({"entry-toggle":!0,hidden:this._hiddenEntries.has(e.d.entry_id)})}
                 aria-pressed=${!this._hiddenEntries.has(e.d.entry_id)}
                 @click=${()=>this._toggleEntry(e.d.entry_id)}
               >
                 <span class="swatch entry" style="background: ${e.color}"></span>
                 ${e.d.entry_title}
-                ${e.sunInfront?q`<span class="status valid">${Be("compass.in_fov_check",this.hass)}</span>`:e.sun.in_fov?q`<span class="status in-fov">${Be("compass.in_fov",this.hass)}</span>`:q`<span class="status">${Be("compass.none",this.hass)}</span>`}
+                ${e.sunInfront?L`<span class="status valid">${Be("compass.in_fov_check",this.hass)}</span>`:e.sun.in_fov?L`<span class="status in-fov">${Be("compass.in_fov",this.hass)}</span>`:L`<span class="status">${Be("compass.none",this.hass)}</span>`}
               </button>
             `)}
           <div><span class="dot sun valid"></span> ${Be("compass.sun",this.hass)}</div>
-          ${this.showMoon?q`<div><span class="dot moon-dot"></span> ${Be("compass.moon",this.hass)}</div>`:W}
+          ${this.showMoon?L`<div><span class="dot moon-dot"></span> ${Be("compass.moon",this.hass)}</div>`:Y}
         </div>
-      `:q`<div class="legend">
+      `:L`<div class="legend">
       <div><span class="dot sun valid"></span> ${Be("compass.sun",this.hass)}</div>
-      ${this.showMoon?q`<div><span class="dot moon-dot"></span> ${Be("compass.moon",this.hass)}</div>`:W}
+      ${this.showMoon?L`<div><span class="dot moon-dot"></span> ${Be("compass.moon",this.hass)}</div>`:Y}
       <div>
         <span
           class="swatch fov"
@@ -157,50 +185,52 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
         ></span>
         ${Be("compass.window_fov",this.hass)}
       </div>
-      ${this.showCoverFill?q`<div>
+      ${this.showCoverFill?L`<div>
             <span
               class="swatch cover-fill-swatch"
               style=${e[0]?.isOverride?`background: ${e[0].color}`:""}
             ></span>
             ${Be("compass.cover_position",this.hass)}
-          </div>`:W}
-      ${this.showWindowArrow?q`<div>
+          </div>`:Y}
+      ${this.showWindowArrow?L`<div>
             <span
               class="swatch window-swatch"
               style=${e[0]?.isOverride?`background: ${e[0].color}`:""}
             ></span>
             ${Be("compass.window_normal",this.hass)}
-          </div>`:W}
-    </div>`}_renderStats(e,t){const o=e[0],i=o.sunAzi,s=o.sun.elevation,{latitude:n,longitude:r}=this.hass.config,a=this.showMoon&&void 0!==n&&void 0!==r?Et(n,r):null;return t?q`
+          </div>`:Y}
+    </div>`}_renderStats(e,t){const o=e[0],s=o.sunAzi,i=o.sun.elevation,{latitude:n,longitude:r}=this.hass.config,a=this.showMoon&&void 0!==n&&void 0!==r?Vt(n,r):null;return t?L`
         <div class="stats dim">
           <div class="stats-row">
             <span
-              >${Be("compass.stat_sun",this.hass)}${Mt(i)} /
-              ${Mt(s)}</span
+              >${Be("compass.stat_sun",this.hass)}${qt(s)} /
+              ${qt(i)}</span
             >
-            ${this.showMoon&&a?q`<span>${a.phaseName} ${Math.round(100*a.fraction)}%</span>`:W}
+            ${this.showMoon&&a?L`<span>${a.phaseName} ${Math.round(100*a.fraction)}%</span>`:Y}
           </div>
-          ${e.map(e=>q`
+          ${e.map(e=>L`
               <div class="stats-row entry-row">
                 <span class="swatch entry" style="background: ${e.color}"></span>
                 <span class="entry-name">${e.d.entry_title}</span>
-                <span>∠${Mt(e.sun.gamma)}</span>
-                <span>W ${Mt(He(e.sun.window_azimuth))}</span>
-                ${e.sun.in_fov?q`<span class="status in-fov" title=${Be("compass.in_fov_tooltip",this.hass)}
+                <span>∠${qt(e.sun.gamma)}</span>
+                <span>W ${qt(tt(e.sun.window_azimuth))}</span>
+                ${e.sun.in_fov?L`<span
+                      class="status in-fov"
+                      ${ut(Be("compass.in_fov_tooltip",this.hass))}
                       >✓</span
-                    >`:W}
+                    >`:Y}
               </div>
             `)}
         </div>
-      `:q`<div class="stats dim">
-      <span>${Be("compass.stat_azi",this.hass)}${Mt(i)}</span>
-      <span>${Be("compass.stat_elev",this.hass)}${Mt(s)}</span>
-      <span>∠: ${Mt(o.sun.gamma)}</span>
+      `:L`<div class="stats dim">
+      <span>${Be("compass.stat_azi",this.hass)}${qt(s)}</span>
+      <span>${Be("compass.stat_elev",this.hass)}${qt(i)}</span>
+      <span>∠: ${qt(o.sun.gamma)}</span>
       <span
-        >${Be("compass.stat_window",this.hass)}${Mt(He(o.sun.window_azimuth))}</span
+        >${Be("compass.stat_window",this.hass)}${qt(tt(o.sun.window_azimuth))}</span
       >
-      ${this.showMoon&&a?q`<span>${a.phaseName} ${Math.round(100*a.fraction)}%</span>`:W}
-    </div>`}};function Vt(e){let t=null,o=null;const i=6e4-Date.now()%6e4;return t=setTimeout(()=>{t=null,e(),o=setInterval(e,6e4)},i),()=>{null!==t&&(clearTimeout(t),t=null),null!==o&&(clearInterval(o),o=null)}}Kt.styles=r`
+      ${this.showMoon&&a?L`<span>${a.phaseName} ${Math.round(100*a.fraction)}%</span>`:Y}
+    </div>`}};function oo(e){let t=null,o=null;const s=6e4-Date.now()%6e4;return t=setTimeout(()=>{t=null,e(),o=setInterval(e,6e4)},s),()=>{null!==t&&(clearTimeout(t),t=null),null!==o&&(clearInterval(o),o=null)}}to.styles=r`
     :host {
       display: block;
       width: 100%;
@@ -494,42 +524,48 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
       background: var(--secondary-text-color);
       opacity: 0.6;
     }
-    g[data-tooltip] {
+    /* Floating-tooltip cursor lifecycle: a help cursor hints "there's more
+       here" on hover (SVG groups + the in-FOV status pip), flipping to default
+       the moment OUR bubble appears. */
+    [data-tooltip]:hover {
+      cursor: help;
+    }
+    [data-tooltip][acp-tt-shown] {
       cursor: default;
     }
-  `,e([ge({attribute:!1})],Kt.prototype,"hass",void 0),e([ge({attribute:!1})],Kt.prototype,"discovered_list",void 0),e([ge({type:Boolean,reflect:!0})],Kt.prototype,"compact",void 0),e([ge({attribute:!1})],Kt.prototype,"showStats",void 0),e([ge({attribute:!1})],Kt.prototype,"showLegend",void 0),e([ge({attribute:!1})],Kt.prototype,"showMoon",void 0),e([ge({attribute:!1})],Kt.prototype,"showCardinals",void 0),e([ge({attribute:!1})],Kt.prototype,"showBlindSpot",void 0),e([ge({attribute:!1})],Kt.prototype,"showSunPath",void 0),e([ge({attribute:!1})],Kt.prototype,"showSunriseSunset",void 0),e([ge({attribute:!1})],Kt.prototype,"showCoverFill",void 0),e([ge({attribute:!1})],Kt.prototype,"showWindowArrow",void 0),e([ge({attribute:!1})],Kt.prototype,"coverColors",void 0),e([ge({attribute:!1})],Kt.prototype,"northOffsetDeg",void 0),e([me()],Kt.prototype,"_hiddenEntries",void 0),Kt=e([he("acp-sky-compass")],Kt);const Gt=32,qt=864e5;function Ut(e){if(!e)return null;const t=new Date(e);return Number.isNaN(t.getTime())?null:t}let Lt=class extends ce{constructor(){super(...arguments),this.discoveredList=[],this.coverColors=[],this.compact=!1,this._cancelMinuteTimer=null}connectedCallback(){super.connectedCallback(),this._cancelMinuteTimer=Vt(()=>this.requestUpdate())}disconnectedCallback(){super.disconnectedCallback(),this._cancelMinuteTimer?.(),this._cancelMinuteTimer=null}shouldUpdate(e){if(e.size>1||!e.has("hass"))return!0;const t=e.get("hass"),o=[];for(const e of this.discoveredList){const t=e.entities;o.push(t.sun_sensor,t.decision_trace_sensor,t.control_status_sensor)}return _e(t,this.hass,o)}_sunAttrsFor(e){const t=e.entities.sun_sensor;if(!t)return null;const o=this.hass.states[t];return o?o.attributes:null}_sunDotTraceInputs(){const e=this.discoveredList[0]?.entities.decision_trace_sensor,t=e?this.hass.states[e]?.attributes:void 0;return{sunState:t?.sun_state??null,directSunValid:t?.direct_sun_valid??!1}}_scheduleBounds(){const e=this.discoveredList[0]?.entities.control_status_sensor;if(!e)return null;const t=this.hass.states[e]?.attributes;return t?{start:Ut(t.schedule_start),end:Ut(t.schedule_end)}:null}render(){if(!this.hass||0===this.discoveredList.length)return W;const e=this._sunAttrsFor(this.discoveredList[0]),{latitude:t,longitude:o,time_zone:i}=this.hass.config??{};if(void 0===t||void 0===o||!e)return q`<div class="placeholder">${Be("elevation.placeholder",this.hass)}</div>`;const s=kt(i),n=$t(t,o,s),r=new Date,a=e=>{const t=e.getTime()-s.getTime();return Gt+t/864e5*360},l=e=>138-(e- -10)/100*128,c=n.map(e=>`${a(e.t).toFixed(1)},${l(e.elevation).toFixed(1)}`).join(" "),d=l(0),h=a(r),u=this._interpAt(n,r),p=u?l(u.elevation):null,g=!u||u.elevation<=0,m=this._sunDotTraceInputs(),_=Pt[jt({belowHorizon:g,sunState:m.sunState,directSunValid:m.directSunValid,inFov:!0===e.in_fov})].replace(/^sun /,""),f=e=>138-128*e,v=this.discoveredList.length>1,y=this._scheduleBounds(),b=y?function(e,t,o,i){if(!e&&!t)return{offSchedule:[],bars:[]};const s=e=>(e.getTime()-o)/i,n=e=>Math.max(0,Math.min(1,e)),r=e=>n(e),a=e=>e>1?e-Math.floor(e):n(e),l=e=>e>0&&e<1?[e]:[];if(e&&!t){const t=s(e);return{offSchedule:[{x0:0,x1:r(t)}],bars:l(t)}}if(!e&&t){const e=s(t);return{offSchedule:[{x0:a(e),x1:1}],bars:l(e)}}const c=s(e),d=s(t),h=r(c),u=a(d),p=[...l(c),...l(d)];if(h>u)return{offSchedule:[{x0:u,x1:h}],bars:p};const g=[];return h>0&&g.push({x0:0,x1:h}),u<1&&g.push({x0:u,x1:1}),{offSchedule:g,bars:p}}(y.start,y.end,s.getTime(),qt):{offSchedule:[],bars:[]},w=e=>Gt+360*e,x=b.offSchedule.map(e=>({x:w(e.x0),width:w(e.x1)-w(e.x0)})),$=y?.start&&s?(y.start.getTime()-s.getTime())/qt:null,A=b.bars.map(e=>{const t=null!==$&&Math.abs(e-$)<1e-9?y.start.toISOString():y.end.toISOString(),o=null!==$&&Math.abs(e-$)<1e-9,s=w(e);return{x:s,anchor:s>=391?"end":s<=33?"start":"middle",label:It(t,i),tooltip:Be(o?"elevation.schedule_start_tooltip":"elevation.schedule_end_tooltip",this.hass)}}),k=(()=>{if(!y)return null;const e=y.start?It(y.start.toISOString(),i):null,t=y.end?It(y.end.toISOString(),i):null;return e&&t?Be("elevation.schedule",this.hass,{from:e,to:t}):e?Be("elevation.schedule_from",this.hass,{from:e}):t?Be("elevation.schedule_until",this.hass,{to:t}):null})(),C=this.discoveredList.map((e,t)=>{const o=this._sunAttrsFor(e),{color:s,isOverride:r}=Dt(this.coverColors?.[t],t),l=r;if(!o)return{d:e,runs:[],inPlotBands:[],runBars:[],label:"",color:s,inlineFill:l};const c=St(n,o.window_azimuth,o.fov_left,o.fov_right),d="number"==typeof o.min_elevation,h="number"==typeof o.max_elevation,{loFrac:u,hiFrac:p}=function(e,t){if(void 0!==e&&void 0!==t&&e>t)return{loFrac:0,hiFrac:1};const o=e=>Math.max(0,Math.min(1,(e- -10)/100));return{loFrac:void 0!==e?o(e):0,hiFrac:void 0!==t?o(t):1}}(o.min_elevation,o.max_elevation),g=d||h?f(p):10,m=d||h?f(u):138,_=g,y=Math.max(0,m-g),b=c.map(e=>({x0:a(n[e.startIdx].t),x1:a(n[e.endIdx].t),y:_,height:y})),w=c.map(e=>({x0:a(n[e.startIdx].t),x1:a(n[e.endIdx].t),range:`${It(n[e.startIdx].t.toISOString(),i)} → ${It(n[e.endIdx].t.toISOString(),i)}`})),x=c.map(e=>`${It(n[e.startIdx].t.toISOString(),i)} → ${It(n[e.endIdx].t.toISOString(),i)}`).join(", "),$=[];return v||(d&&$.push(m),h&&$.push(g)),{d:e,runs:c,inPlotBands:b,runBars:w,label:x,color:s,inlineFill:l,limitLines:$}}),S=C.some(e=>e.runs.length>0),E=v?function(e){if(e<=0)return{rows:[],height:0};const t=Array.from({length:e},(e,t)=>({y:0+11*t,height:8}));return{rows:t,height:0+8*e+3*(e-1)+0}}(C.length):{rows:[],height:0},z=138-E.height-3;return q`
+  `,e([_e({attribute:!1})],to.prototype,"hass",void 0),e([_e({attribute:!1})],to.prototype,"discovered_list",void 0),e([_e({type:Boolean,reflect:!0})],to.prototype,"compact",void 0),e([_e({attribute:!1})],to.prototype,"showStats",void 0),e([_e({attribute:!1})],to.prototype,"showLegend",void 0),e([_e({attribute:!1})],to.prototype,"showMoon",void 0),e([_e({attribute:!1})],to.prototype,"showCardinals",void 0),e([_e({attribute:!1})],to.prototype,"showBlindSpot",void 0),e([_e({attribute:!1})],to.prototype,"showSunPath",void 0),e([_e({attribute:!1})],to.prototype,"showSunriseSunset",void 0),e([_e({attribute:!1})],to.prototype,"showCoverFill",void 0),e([_e({attribute:!1})],to.prototype,"showWindowArrow",void 0),e([_e({attribute:!1})],to.prototype,"coverColors",void 0),e([_e({attribute:!1})],to.prototype,"northOffsetDeg",void 0),e([me()],to.prototype,"_hiddenEntries",void 0),to=e([he("acp-sky-compass")],to);const so=32,io=864e5;function no(e){if(!e)return null;const t=new Date(e);return Number.isNaN(t.getTime())?null:t}let ro=class extends ce{constructor(){super(...arguments),this.discoveredList=[],this.coverColors=[],this.compact=!1,this._cancelMinuteTimer=null}connectedCallback(){super.connectedCallback(),this._cancelMinuteTimer=oo(()=>this.requestUpdate())}disconnectedCallback(){super.disconnectedCallback(),this._cancelMinuteTimer?.(),this._cancelMinuteTimer=null}shouldUpdate(e){if(e.size>1||!e.has("hass"))return!0;const t=e.get("hass"),o=[];for(const e of this.discoveredList){const t=e.entities;o.push(t.sun_sensor,t.decision_trace_sensor,t.control_status_sensor)}return ge(t,this.hass,o)}_sunAttrsFor(e){const t=e.entities.sun_sensor;if(!t)return null;const o=this.hass.states[t];return o?o.attributes:null}_sunDotTraceInputs(){const e=this.discoveredList[0]?.entities.decision_trace_sensor,t=e?this.hass.states[e]?.attributes:void 0;return{sunState:t?.sun_state??null,directSunValid:t?.direct_sun_valid??!1}}_scheduleBounds(){const e=this.discoveredList[0]?.entities.control_status_sensor;if(!e)return null;const t=this.hass.states[e]?.attributes;return t?{start:no(t.schedule_start),end:no(t.schedule_end)}:null}render(){if(!this.hass||0===this.discoveredList.length)return Y;const e=this._sunAttrsFor(this.discoveredList[0]),{latitude:t,longitude:o,time_zone:s}=this.hass.config??{};if(void 0===t||void 0===o||!e)return L`<div class="placeholder">${Be("elevation.placeholder",this.hass)}</div>`;const i=Dt(s),n=Rt(t,o,i),r=new Date,a=e=>{const t=e.getTime()-i.getTime();return so+t/864e5*360},l=e=>138-(e- -10)/100*128,c=n.map(e=>`${a(e.t).toFixed(1)},${l(e.elevation).toFixed(1)}`).join(" "),d=l(0),h=a(r),u=this._interpAt(n,r),p=u?l(u.elevation):null,_=!u||u.elevation<=0,m=this._sunDotTraceInputs(),g=Qt[Ht({belowHorizon:_,sunState:m.sunState,directSunValid:m.directSunValid,inFov:!0===e.in_fov})].replace(/^sun /,""),f=e=>138-128*e,v=this.discoveredList.length>1,y=this._scheduleBounds(),b=y?function(e,t,o,s){if(!e&&!t)return{offSchedule:[],bars:[]};const i=e=>(e.getTime()-o)/s,n=e=>Math.max(0,Math.min(1,e)),r=e=>n(e),a=e=>e>1?e-Math.floor(e):n(e),l=e=>e>0&&e<1?[e]:[];if(e&&!t){const t=i(e);return{offSchedule:[{x0:0,x1:r(t)}],bars:l(t)}}if(!e&&t){const e=i(t);return{offSchedule:[{x0:a(e),x1:1}],bars:l(e)}}const c=i(e),d=i(t),h=r(c),u=a(d),p=[...l(c),...l(d)];if(h>u)return{offSchedule:[{x0:u,x1:h}],bars:p};const _=[];return h>0&&_.push({x0:0,x1:h}),u<1&&_.push({x0:u,x1:1}),{offSchedule:_,bars:p}}(y.start,y.end,i.getTime(),io):{offSchedule:[],bars:[]},w=e=>so+360*e,x=b.offSchedule.map(e=>({x:w(e.x0),width:w(e.x1)-w(e.x0)})),$=y?.start&&i?(y.start.getTime()-i.getTime())/io:null,A=b.bars.map(e=>{const t=null!==$&&Math.abs(e-$)<1e-9?y.start.toISOString():y.end.toISOString(),o=null!==$&&Math.abs(e-$)<1e-9,i=w(e);return{x:i,anchor:i>=391?"end":i<=33?"start":"middle",label:Ut(t,s),tooltip:Be(o?"elevation.schedule_start_tooltip":"elevation.schedule_end_tooltip",this.hass)}}),k=(()=>{if(!y)return null;const e=y.start?Ut(y.start.toISOString(),s):null,t=y.end?Ut(y.end.toISOString(),s):null;return e&&t?Be("elevation.schedule",this.hass,{from:e,to:t}):e?Be("elevation.schedule_from",this.hass,{from:e}):t?Be("elevation.schedule_until",this.hass,{to:t}):null})(),C=this.discoveredList.map((e,t)=>{const o=this._sunAttrsFor(e),{color:i,isOverride:r}=Jt(this.coverColors?.[t],t),l=r;if(!o)return{d:e,runs:[],inPlotBands:[],runBars:[],label:"",color:i,inlineFill:l};const c=Kt(n,o.window_azimuth,o.fov_left,o.fov_right),d="number"==typeof o.min_elevation,h="number"==typeof o.max_elevation,{loFrac:u,hiFrac:p}=function(e,t){if(void 0!==e&&void 0!==t&&e>t)return{loFrac:0,hiFrac:1};const o=e=>Math.max(0,Math.min(1,(e- -10)/100));return{loFrac:void 0!==e?o(e):0,hiFrac:void 0!==t?o(t):1}}(o.min_elevation,o.max_elevation),_=d||h?f(p):10,m=d||h?f(u):138,g=_,y=Math.max(0,m-_),b=c.map(e=>({x0:a(n[e.startIdx].t),x1:a(n[e.endIdx].t),y:g,height:y})),w=c.map(e=>({x0:a(n[e.startIdx].t),x1:a(n[e.endIdx].t),range:`${Ut(n[e.startIdx].t.toISOString(),s)} → ${Ut(n[e.endIdx].t.toISOString(),s)}`})),x=c.map(e=>`${Ut(n[e.startIdx].t.toISOString(),s)} → ${Ut(n[e.endIdx].t.toISOString(),s)}`).join(", "),$=[];return v||(d&&$.push(m),h&&$.push(_)),{d:e,runs:c,inPlotBands:b,runBars:w,label:x,color:i,inlineFill:l,limitLines:$}}),E=C.some(e=>e.runs.length>0),S=v?function(e){if(e<=0)return{rows:[],height:0};const t=Array.from({length:e},(e,t)=>({y:0+11*t,height:8}));return{rows:t,height:0+8*e+3*(e-1)+0}}(C.length):{rows:[],height:0},z=138-S.height-3;return L`
       <div class="wrap">
         <div class="head">
           <span class="label">${Be("elevation.title",this.hass)}</span>
           <span class="head-meta">
-            ${v?W:S?q`<span class="dim"
+            ${v?Y:E?L`<span class="dim"
                       >${Be("elevation.fov_windows",this.hass,{windows:C[0].label})}</span
-                    >`:q`<span class="dim">${Be("elevation.no_fov_today",this.hass)}</span>`}
-            ${k?q`<span class="dim schedule">${k}</span>`:W}
+                    >`:L`<span class="dim">${Be("elevation.no_fov_today",this.hass)}</span>`}
+            ${k?L`<span class="dim schedule">${k}</span>`:Y}
           </span>
         </div>
         <svg viewBox="0 0 ${400} ${160}" preserveAspectRatio="none">
-          ${U`
+          ${q`
             <!-- y-axis gridlines -->
-            ${[0,30,60,90].map(e=>U`
-              <line class="grid" x1=${Gt} y1=${l(e)} x2=${392} y2=${l(e)} />
+            ${[0,30,60,90].map(e=>q`
+              <line class="grid" x1=${so} y1=${l(e)} x2=${392} y2=${l(e)} />
               <text class="tick" x=${28} y=${l(e)+3} text-anchor="end">${e}°</text>
             `)}
 
             <!-- horizon -->
-            <line class="horizon" x1=${Gt} y1=${d} x2=${392} y2=${d} />
+            <line class="horizon" x1=${so} y1=${d} x2=${392} y2=${d} />
 
             <!-- elevation limit gridlines (single-window legacy path only) -->
-            ${C.flatMap(e=>(e.limitLines??[]).map(e=>U`<line class="limit-line" x1=${Gt} y1=${e} x2=${392} y2=${e} />`))}
+            ${C.flatMap(e=>(e.limitLines??[]).map(e=>q`<line class="limit-line" x1=${so} y1=${e} x2=${392} y2=${e} />`))}
 
             <!-- In-plot FOV bands: single-window legacy path only. -->
-            ${v?W:C.flatMap(e=>e.inPlotBands.map(t=>U`<rect
+            ${v?Y:C.flatMap(e=>e.inPlotBands.map(t=>q`<rect
                         class="fov-band"
                         x=${t.x0}
                         y=${t.y}
                         width=${t.x1-t.x0}
                         height=${t.height}
-                        style=${e.inlineFill?`fill:${e.color}`:W}
+                        style=${e.inlineFill?`fill:${e.color}`:Y}
                       />`))}
 
             <!-- Per-window FOV ribbon (multi-window only): one row per window,
@@ -537,42 +573,45 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
                  sharing the plot's xAt() time scale. Overlaid as a band anchored
                  to the bottom of the plot; drawn BEFORE the curve so the blue
                  curve stays crisp on top. -->
-            ${E.rows.flatMap((e,t)=>{const o=C[t],i=z+e.y,s=o.runs.length?o.d.entry_title:Be("elevation.fov_window_named",this.hass,{name:o.d.entry_title,windows:Be("elevation.no_fov_today",this.hass)}),n=U`<rect
+            ${S.rows.flatMap((e,t)=>{const o=C[t],s=z+e.y,i=o.runs.length?o.d.entry_title:Be("elevation.fov_window_named",this.hass,{name:o.d.entry_title,windows:Be("elevation.no_fov_today",this.hass)}),n=q`<rect
                 class="ribbon-track"
-                x=${Gt}
-                y=${i}
+                x=${so}
+                y=${s}
                 width=${360}
                 height=${e.height}
                 rx="2"
-              ><title>${s}</title></rect>`,r=o.runBars.map(t=>U`<rect
+                ${ut(i)}
+              ></rect>`,r=o.runBars.map(t=>q`<rect
                   class="ribbon-bar"
                   x=${t.x0}
-                  y=${i}
+                  y=${s}
                   width=${t.x1-t.x0}
                   height=${e.height}
                   rx="2"
                   style=${`fill:${o.color}`}
-                ><title>${Be("elevation.fov_window_named",this.hass,{name:o.d.entry_title,windows:t.range})}</title></rect>`);return[n,...r]})}
+                  ${ut(Be("elevation.fov_window_named",this.hass,{name:o.d.entry_title,windows:t.range}))}
+                ></rect>`);return[n,...r]})}
 
             <!-- Schedule window overlay (issue #128): faint off-schedule gray
                  zone(s) + thin start/end bars with a clock-time tick. Rendered
                  PRE-CURVE so the sun curve and now-line paint on top. The tick
                  label sits slightly higher than the axis ticks (its own class)
                  so it doesn't read as an axis tick. -->
-            ${x.map(e=>U`<rect
+            ${x.map(e=>q`<rect
                 class="off-schedule-zone"
                 x=${e.x}
                 y=${10}
                 width=${e.width}
                 height=${128}
               />`)}
-            ${A.flatMap(e=>[U`<line
+            ${A.flatMap(e=>[q`<line
                 class="schedule-bar"
                 x1=${e.x}
                 y1=${10}
                 x2=${e.x}
                 y2=${138}
-              ><title>${e.tooltip}</title></line>`,U`<text
+                ${ut(e.tooltip)}
+              ></line>`,q`<text
                 class="schedule-tick"
                 x=${e.x}
                 y=${17}
@@ -585,25 +624,24 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
             <!-- current-time cursor + sun dot, drawn last so they sit on top of
                  the curve AND the ribbon bars. A wide transparent hit-line widens
                  the hover target so the thin now-line is easy to tooltip. -->
-            <g class="now-group">
-              <title>${It(r.toISOString(),i)}</title>
+            <g class="now-group" ${ut(Ut(r.toISOString(),s))}>
               <line class="now-hit" x1=${h} y1=${10} x2=${h} y2=${138} />
               <line class="now" x1=${h} y1=${10} x2=${h} y2=${138} />
             </g>
-            ${null!==p?U`<circle class="sun-dot ${_}" cx=${h} cy=${p} r="4" />`:W}
+            ${null!==p?q`<circle class="sun-dot ${g}" cx=${h} cy=${p} r="4" />`:Y}
 
             <!-- x-axis gridlines + time labels at every 6h, drawn last so the
                  axis sits on the topmost layer (nothing paints over the times).
                  Edge labels anchor inward (start at 00:00, end at 24:00) so they
                  don't clip past the viewBox. -->
-            ${[0,6,12,18,24].map(e=>{const t=new Date(s.getTime()+36e5*e),o=0===e?"start":24===e?"end":"middle";return U`
+            ${[0,6,12,18,24].map(e=>{const t=new Date(i.getTime()+36e5*e),o=0===e?"start":24===e?"end":"middle";return q`
                 <line class="grid faint" x1=${a(t)} y1=${10} x2=${a(t)} y2=${138} />
                 <text class="tick" x=${a(t)} y=${152} text-anchor=${o}>${e.toString().padStart(2,"0")}:00</text>
               `})}
           `}
         </svg>
       </div>
-    `}_interpAt(e,t){if(0===e.length)return null;const o=t.getTime();if(o<=e[0].t.getTime())return e[0];if(o>=e[e.length-1].t.getTime())return e[e.length-1];for(let i=1;i<e.length;i++)if(e[i].t.getTime()>=o){const s=e[i-1],n=e[i],r=(o-s.t.getTime())/(n.t.getTime()-s.t.getTime());return{t:t,elevation:s.elevation+(n.elevation-s.elevation)*r,azimuth:s.azimuth+(n.azimuth-s.azimuth)*r}}return e[e.length-1]}};function Wt(e,t){if(!0===e?.custom_position_minimum_mode&&Array.isArray(e.custom_position_slots)&&void 0!==e.custom_position_active_slot){const t=e.custom_position_slots.find(t=>t.slot===e.custom_position_active_slot);if(void 0!==t&&null!==t.position&&void 0!==t.position)return t.position}return t}function Yt(e){if(void 0===e?.custom_position_active_slot||!Array.isArray(e.custom_position_slots))return!1;const t=e.custom_position_slots.find(t=>t.slot===e.custom_position_active_slot);return 100===t?.priority}function Qt(e){const t=e.replace(/Handler$/,"").replace(/([a-z])([A-Z])/g,"$1_$2").toLowerCase();if(/^custom_position_\d+$/.test(t))return"custom_position";switch(t){case"force_override":return"force";case"weather_override":return"weather";case"manual_override":return"manual";case"motion_timeout":return"motion";case"cloud_suppression":return"cloud";default:return t}}function Ht(e,t,o,i=Ce,s="Safety"){const n=new Map;for(const t of e){if(!t.matched)continue;const e=Qt(t.handler);ke.includes(e)&&n.set(e,t)}const r=[...ke].reverse().filter(e=>n.has(e));return 0===r.length?t.reason??"":r.map(e=>function(e,t,o,i,s){const n=i[e]??e,r=t.position,a=null==r?"":` ${Ot(r)}`;if("custom_position"!==e)return`${n}${a}`.trimEnd();return`${o.custom_position_active_slot_name?`${n} · ${o.custom_position_active_slot_name}`:o.custom_position_active_slot?`${n} #${o.custom_position_active_slot}`:n}${a}${!0===o.custom_position_minimum_mode?" floor":""}${Yt(o)?` · ${s}`:""}`}(e,n.get(e),t,i,s)).join(" → ")}Lt.styles=r`
+    `}_interpAt(e,t){if(0===e.length)return null;const o=t.getTime();if(o<=e[0].t.getTime())return e[0];if(o>=e[e.length-1].t.getTime())return e[e.length-1];for(let s=1;s<e.length;s++)if(e[s].t.getTime()>=o){const i=e[s-1],n=e[s],r=(o-i.t.getTime())/(n.t.getTime()-i.t.getTime());return{t:t,elevation:i.elevation+(n.elevation-i.elevation)*r,azimuth:i.azimuth+(n.azimuth-i.azimuth)*r}}return e[e.length-1]}};function ao(e,t){if(!0===e?.custom_position_minimum_mode&&Array.isArray(e.custom_position_slots)&&void 0!==e.custom_position_active_slot){const t=e.custom_position_slots.find(t=>t.slot===e.custom_position_active_slot);if(void 0!==t&&null!==t.position&&void 0!==t.position)return t.position}return t}function lo(e){if(void 0===e?.custom_position_active_slot||!Array.isArray(e.custom_position_slots))return!1;const t=e.custom_position_slots.find(t=>t.slot===e.custom_position_active_slot);return 100===t?.priority}function co(e){const t=e.replace(/Handler$/,"").replace(/([a-z])([A-Z])/g,"$1_$2").toLowerCase();if(/^custom_position_\d+$/.test(t))return"custom_position";switch(t){case"force_override":return"force";case"weather_override":return"weather";case"manual_override":return"manual";case"motion_timeout":return"motion";case"cloud_suppression":return"cloud";default:return t}}function ho(e,t,o,s=Ce,i="Safety"){const n=new Map;for(const t of e){if(!t.matched)continue;const e=co(t.handler);ke.includes(e)&&n.set(e,t)}const r=[...ke].reverse().filter(e=>n.has(e));return 0===r.length?t.reason??"":r.map(e=>function(e,t,o,s,i){const n=s[e]??e,r=t.position,a=null==r?"":` ${Lt(r)}`;if("custom_position"!==e)return`${n}${a}`.trimEnd();return`${o.custom_position_active_slot_name?`${n} · ${o.custom_position_active_slot_name}`:o.custom_position_active_slot?`${n} #${o.custom_position_active_slot}`:n}${a}${!0===o.custom_position_minimum_mode?" floor":""}${lo(o)?` · ${i}`:""}`}(e,n.get(e),t,s,i)).join(" → ")}ro.styles=r`
     :host {
       display: block;
       width: 100%;
@@ -679,10 +717,18 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
       fill-opacity: 0.12;
       pointer-events: none;
     }
+    /* Floating-tooltip cursor lifecycle: help hint on hover, default once OUR
+       bubble is shown. Applies to every tooltip carrier (schedule bar, ribbon
+       track/bar, now-cursor group). */
+    [data-tooltip]:hover {
+      cursor: help;
+    }
+    [data-tooltip][acp-tt-shown] {
+      cursor: default;
+    }
     .schedule-bar {
       stroke: var(--divider-color);
       stroke-width: 1;
-      cursor: default;
     }
     .schedule-tick {
       font-size: 8px;
@@ -691,14 +737,12 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
     .ribbon-track {
       fill: var(--divider-color);
       fill-opacity: 0.25;
-      cursor: default;
     }
     .ribbon-bar {
       /* Fallback only — the ribbon always sets an inline per-window fill. Kept on
          the cover colour for consistency with the FOV band. */
       fill: var(--primary-color);
       fill-opacity: 0.85;
-      cursor: default;
     }
     .curve {
       fill: none;
@@ -715,7 +759,6 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
     .now-hit {
       stroke: transparent;
       stroke-width: 10;
-      cursor: default;
     }
     /* Colour states mirror acp-sky-compass .sun.* so the sun reads the same
        across both visuals. */
@@ -748,37 +791,45 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
       text-align: center;
       padding: 20px;
     }
-  `,e([ge({attribute:!1})],Lt.prototype,"hass",void 0),e([ge({attribute:!1})],Lt.prototype,"discoveredList",void 0),e([ge({attribute:!1})],Lt.prototype,"coverColors",void 0),e([ge({type:Boolean,reflect:!0})],Lt.prototype,"compact",void 0),Lt=e([he("acp-elevation-chart")],Lt);let Zt=class extends ce{constructor(){super(...arguments),this.compact=!1,this.showSummary=!0,this.hideInactive=!1}shouldUpdate(e){return e.size>1||!e.has("hass")||_e(e.get("hass"),this.hass,[this.discovered?.entities.decision_trace_sensor])}_trace(){const e=this.discovered.entities.decision_trace_sensor;if(!e)return null;const t=this.hass.states[e];if(!t)return null;const o=t.attributes;if(!o?.trace)return null;const i=new Map;for(const e of o.trace)i.set(Qt(e.handler),{matched:e.matched,reason:e.reason,position:e.position});const s={};for(const[e,t]of Object.entries(Se))s[e]=Be(t,this.hass);return{winner:t.state,reason:o.reason??"",steps:i,enabledHandlers:o.enabled_handlers,summary:Ht(o.trace,o,t.state,s),inTimeWindow:o.in_time_window}}render(){if(!this.hass||!this.discovered)return W;const e=this._trace();if(!e)return q`<div class="placeholder">${Be("decision.placeholder",this.hass)}</div>`;const t=function(e){if(!e)return new Set;const t=new Set(e);return new Set(ke.filter(e=>!t.has(e)))}(e.enabledHandlers),o=function(e,t,o,i,s=new Set){return e.filter(e=>e===o||!s.has(e)&&(!i||!0===t.get(e)?.matched))}(ke,e.steps,e.winner,this.hideInactive,t);return q`
+  `,e([_e({attribute:!1})],ro.prototype,"hass",void 0),e([_e({attribute:!1})],ro.prototype,"discoveredList",void 0),e([_e({attribute:!1})],ro.prototype,"coverColors",void 0),e([_e({type:Boolean,reflect:!0})],ro.prototype,"compact",void 0),ro=e([he("acp-elevation-chart")],ro);let uo=class extends ce{constructor(){super(...arguments),this.compact=!1,this.showSummary=!0,this.hideInactive=!1}shouldUpdate(e){return e.size>1||!e.has("hass")||ge(e.get("hass"),this.hass,[this.discovered?.entities.decision_trace_sensor])}_trace(){const e=this.discovered.entities.decision_trace_sensor;if(!e)return null;const t=this.hass.states[e];if(!t)return null;const o=t.attributes;if(!o?.trace)return null;const s=new Map;for(const e of o.trace)s.set(co(e.handler),{matched:e.matched,reason:e.reason,position:e.position});const i={};for(const[e,t]of Object.entries(Ee))i[e]=Be(t,this.hass);return{winner:t.state,reason:o.reason??"",steps:s,enabledHandlers:o.enabled_handlers,summary:ho(o.trace,o,t.state,i),inTimeWindow:o.in_time_window}}render(){if(!this.hass||!this.discovered)return Y;const e=this._trace();if(!e)return L`<div class="placeholder">${Be("decision.placeholder",this.hass)}</div>`;const t=function(e){if(!e)return new Set;const t=new Set(e);return new Set(ke.filter(e=>!t.has(e)))}(e.enabledHandlers),o=function(e,t,o,s,i=new Set){return e.filter(e=>e===o||!i.has(e)&&(!s||!0===t.get(e)?.matched))}(ke,e.steps,e.winner,this.hideInactive,t);return L`
       <div class="wrap">
         <div class="head">
           <span class="label">${Be("decision.pipeline",this.hass)}</span>
           <span class="winner">${Be("decision.winner",this.hass,{name:e.winner})}</span>
         </div>
-        ${!1===e.inTimeWindow?q`<div
+        ${!1===e.inTimeWindow?L`<div
               class="off-schedule"
-              title=${Be("decision.outside_schedule_tooltip",this.hass)}
+              ${ut(Be("decision.outside_schedule_tooltip",this.hass))}
             >
               ${Be("decision.outside_schedule",this.hass)}
-            </div>`:W}
-        ${this.showSummary&&e.summary?q`<div class="summary" title=${Be("decision.summary_tooltip",this.hass)}>
+            </div>`:Y}
+        ${this.showSummary&&e.summary?L`<div class="summary" ${ut(Be("decision.summary_tooltip",this.hass))}>
               ${e.summary}
-            </div>`:W}
+            </div>`:Y}
         <div class="rows">
           ${o.map(t=>this._row(t,e.steps.get(t),e.winner===t))}
         </div>
         <div class="reason dim">${e.reason}</div>
       </div>
-    `}_row(e,t,o){const i=t?.matched??!1,s=t?.reason??Be("decision.not_evaluated",this.hass),n=t?.position;return q`
-      <div class="row ${o?"winner":i?"match":"skip"}">
-        <span class="name">${Be(Se[e],this.hass)}</span>
-        <span class="dots" aria-hidden="true">${i?"████":"────"}</span>
-        <span class="pos">${null!=n?Ot(n):""}</span>
-        <span class="reason-inline dim">${s}</span>
-        ${o?q`<span class="badge">✓</span>`:W}
+    `}_row(e,t,o){const s=t?.matched??!1,i=t?.reason??Be("decision.not_evaluated",this.hass),n=t?.position;return L`
+      <div class="row ${o?"winner":s?"match":"skip"}">
+        <span class="name">${Be(Ee[e],this.hass)}</span>
+        <span class="dots" aria-hidden="true">${s?"████":"────"}</span>
+        <span class="pos">${null!=n?Lt(n):""}</span>
+        <span class="reason-inline dim">${i}</span>
+        ${o?L`<span class="badge">✓</span>`:Y}
       </div>
-    `}};var Jt,Xt;Zt.styles=r`
+    `}};var po,_o;uo.styles=r`
     :host {
       display: block;
+    }
+    /* Floating-tooltip cursor lifecycle: a help cursor hints "there's more
+       here" on hover, flipping to default the moment OUR bubble appears. */
+    [data-tooltip]:hover {
+      cursor: help;
+    }
+    [data-tooltip][acp-tt-shown] {
+      cursor: default;
     }
     .wrap {
       display: flex;
@@ -867,7 +918,6 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
       line-height: 1.3;
       padding: 2px 4px 4px;
       color: var(--primary-text-color);
-      cursor: default;
     }
     :host([compact]) .summary {
       font-size: 0.75rem;
@@ -880,7 +930,6 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
       border-radius: 4px;
       border-left: 3px solid var(--secondary-text-color);
       background: rgba(127, 127, 127, 0.08);
-      cursor: default;
     }
     :host([compact]) .off-schedule {
       font-size: 0.72rem;
@@ -894,23 +943,23 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
       padding: 16px;
       text-align: center;
     }
-  `,e([ge({attribute:!1})],Zt.prototype,"hass",void 0),e([ge({attribute:!1})],Zt.prototype,"discovered",void 0),e([ge({type:Boolean,reflect:!0})],Zt.prototype,"compact",void 0),e([ge({type:Boolean,reflect:!0,attribute:"show-summary"})],Zt.prototype,"showSummary",void 0),e([ge({type:Boolean,reflect:!0,attribute:"hide-inactive"})],Zt.prototype,"hideInactive",void 0),Zt=e([he("acp-decision-strip")],Zt),function(e){e.language="language",e.system="system",e.comma_decimal="comma_decimal",e.decimal_comma="decimal_comma",e.space_comma="space_comma",e.none="none"}(Jt||(Jt={})),function(e){e.language="language",e.system="system",e.am_pm="12",e.twenty_four="24"}(Xt||(Xt={}));const eo=["closed","locked","off"],to=(e,t,o,i)=>{i=i||{},o=null==o?{}:o;const s=new Event(t,{bubbles:void 0===i.bubbles||i.bubbles,cancelable:Boolean(i.cancelable),composed:void 0===i.composed||i.composed});return s.detail=o,e.dispatchEvent(s),s},oo=e=>{to(window,"haptic",e)};function io(e){return void 0!==e&&"none"!==e.action}function so(e,t,o){return e.filter(e=>"off"===e||("solar"===e?function(e){return e.solarMatched&&!e.cloudIsWinner}(o)&&!1!==t?.solar:!1!==t?.[e]))}function no(e){return!!e&&e.some(e=>e.matched&&"solar"===Qt(e.handler))}function ro(e){return"cloud"===Qt(e)}function ao(e){if(!1===e.integrationEnabled)return"off";const t=Qt(e.winner);return e.manualActive&&"force"!==t&&"custom_position"!==t?"manual":Me[t]??"auto"}function lo(e,t){return{solarMatched:no(e),cloudIsWinner:ro(t)}}let co=class extends ce{constructor(){super(...arguments),this.winner="default",this.compact=!1,this.integrationEnabled=!0,this.manualActive=!1,this.safetyActive=!1,this.resumable=!1}render(){const e=this._kind(),t="custom_position"===e&&this.safetyActive,o=t?Ie.force:Ie[e],i=this.hass?Be(Fe[e],this.hass):Ie[e].label,s=t?this.hass?Be("badge.safety",this.hass):"Safety":this._label(e,i),n=t?Te.force:Te[e],r=q`${n?q`<ha-icon class="badge-icon" icon=${n}></ha-icon>`:W}${s}${this.resumable?q`<ha-icon class="resume-icon" icon="mdi:restore"></ha-icon>`:W}`;if(this.resumable){const t=this.hass?Be("tile.resume_aria",this.hass):"Resume automatic control";return q`<button
+  `,e([_e({attribute:!1})],uo.prototype,"hass",void 0),e([_e({attribute:!1})],uo.prototype,"discovered",void 0),e([_e({type:Boolean,reflect:!0})],uo.prototype,"compact",void 0),e([_e({type:Boolean,reflect:!0,attribute:"show-summary"})],uo.prototype,"showSummary",void 0),e([_e({type:Boolean,reflect:!0,attribute:"hide-inactive"})],uo.prototype,"hideInactive",void 0),uo=e([he("acp-decision-strip")],uo),function(e){e.language="language",e.system="system",e.comma_decimal="comma_decimal",e.decimal_comma="decimal_comma",e.space_comma="space_comma",e.none="none"}(po||(po={})),function(e){e.language="language",e.system="system",e.am_pm="12",e.twenty_four="24"}(_o||(_o={}));const mo=["closed","locked","off"],go=(e,t,o,s)=>{s=s||{},o=null==o?{}:o;const i=new Event(t,{bubbles:void 0===s.bubbles||s.bubbles,cancelable:Boolean(s.cancelable),composed:void 0===s.composed||s.composed});return i.detail=o,e.dispatchEvent(i),i},fo=e=>{go(window,"haptic",e)};function vo(e){return void 0!==e&&"none"!==e.action}function yo(e,t,o){return e.filter(e=>"off"===e||("solar"===e?function(e){return e.solarMatched&&!e.cloudIsWinner}(o)&&!1!==t?.solar:!1!==t?.[e]))}function bo(e){return!!e&&e.some(e=>e.matched&&"solar"===co(e.handler))}function wo(e){return"cloud"===co(e)}function xo(e){if(!1===e.integrationEnabled)return"off";const t=co(e.winner);return e.manualActive&&"force"!==t&&"custom_position"!==t?"manual":Me[t]??"auto"}function $o(e,t){return{solarMatched:bo(e),cloudIsWinner:wo(t)}}let Ao=class extends ce{constructor(){super(...arguments),this.winner="default",this.compact=!1,this.integrationEnabled=!0,this.manualActive=!1,this.safetyActive=!1,this.resumable=!1}render(){const e=this._kind(),t="custom_position"===e&&this.safetyActive,o=t?Ie.force:Ie[e],s=this.hass?Be(Fe[e],this.hass):Ie[e].label,i=t?this.hass?Be("badge.safety",this.hass):"Safety":this._label(e,s),n=t?Te.force:Te[e],r=L`${n?L`<ha-icon class="badge-icon" icon=${n}></ha-icon>`:Y}${i}${this.resumable?L`<ha-icon class="resume-icon" icon="mdi:restore"></ha-icon>`:Y}`;if(this.resumable){const t=this.hass?Be("tile.resume_aria",this.hass):"Resume automatic control";return L`<button
         class="badge kind-${e} resumable"
         style="background:${o.bg};color:${o.fg};"
         part="badge"
         type="button"
-        title=${t}
+        ${ut(t)}
         aria-label=${t}
         @click=${this._onResumeClick}
         @pointerdown=${this._stop}
       >
         ${r}
-      </button>`}return q`<span
+      </button>`}return L`<span
       class="badge kind-${e}"
       style="background:${o.bg};color:${o.fg};"
       part="badge"
       >${r}</span
-    >`}_stop(e){e.stopPropagation()}_onResumeClick(e){e.stopPropagation(),this.dispatchEvent(new CustomEvent("acp-resume",{bubbles:!0,composed:!0}))}_kind(){return this.kindOverride??ao({winner:this.winner,integrationEnabled:this.integrationEnabled,manualActive:this.manualActive})}_label(e,t){return"manual"===e?this.manualEndIso?It(this.manualEndIso):t:"custom_position"===e?`${this.slotName?this.slotName:void 0!==this.slotNumber?`${t} #${this.slotNumber}`:t}${void 0!==this.pct&&null!==this.pct?` · ${Math.round(this.pct)}%`:""}${!0===this.minimumMode?this.hass?Be("badge.floor_suffix",this.hass):" ↥":""}`:t}};co.styles=r`
+    >`}_stop(e){e.stopPropagation()}_onResumeClick(e){e.stopPropagation(),this.dispatchEvent(new CustomEvent("acp-resume",{bubbles:!0,composed:!0}))}_kind(){return this.kindOverride??xo({winner:this.winner,integrationEnabled:this.integrationEnabled,manualActive:this.manualActive})}_label(e,t){return"manual"===e?this.manualEndIso?Ut(this.manualEndIso):t:"custom_position"===e?`${this.slotName?this.slotName:void 0!==this.slotNumber?`${t} #${this.slotNumber}`:t}${void 0!==this.pct&&null!==this.pct?` · ${Math.round(this.pct)}%`:""}${!0===this.minimumMode?this.hass?Be("badge.floor_suffix",this.hass):" ↥":""}`:t}};Ao.styles=r`
     :host {
       display: inline-flex;
     }
@@ -957,7 +1006,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
     :host([compact]) .badge-icon {
       --mdc-icon-size: 12px;
     }
-  `,e([ge({attribute:!1})],co.prototype,"hass",void 0),e([ge()],co.prototype,"winner",void 0),e([ge({attribute:"manual-end-iso"})],co.prototype,"manualEndIso",void 0),e([ge({type:Number,attribute:"slot-number"})],co.prototype,"slotNumber",void 0),e([ge({attribute:"slot-name"})],co.prototype,"slotName",void 0),e([ge({type:Number})],co.prototype,"pct",void 0),e([ge({type:Boolean,attribute:"minimum-mode"})],co.prototype,"minimumMode",void 0),e([ge({type:Boolean,reflect:!0})],co.prototype,"compact",void 0),e([ge({type:Boolean,attribute:"integration-enabled"})],co.prototype,"integrationEnabled",void 0),e([ge({type:Boolean,attribute:"manual-active"})],co.prototype,"manualActive",void 0),e([ge({type:Boolean,attribute:"safety-active"})],co.prototype,"safetyActive",void 0),e([ge({attribute:"kind-override"})],co.prototype,"kindOverride",void 0),e([ge({type:Boolean,reflect:!0})],co.prototype,"resumable",void 0),co=e([he("acp-tile-badge")],co);let ho=class extends ce{constructor(){super(...arguments),this.compact=!1,this.resetEnabled=!0,this._tick=null}disconnectedCallback(){super.disconnectedCallback(),this._syncTimer(!1)}shouldUpdate(e){if(e.size>1||!e.has("hass"))return!0;const t=e.get("hass"),o=this.discovered?.entities;return _e(t,this.hass,[o?.manual_override_binary,o?.manual_override_end_sensor,o?.motion_status_sensor,o?.reset_override_button])}updated(){if(!this.hass||!this.discovered)return void this._syncTimer(!1);const e=!this.compact&&(null!==this._manualEndIso()||null!=this._motionStatus()?.endIso);this._syncTimer(e)}_syncTimer(e){e&&null===this._tick?this._tick=setInterval(()=>this.requestUpdate(),1e3):e||null===this._tick||(clearInterval(this._tick),this._tick=null)}_manualActive(){const e=this.discovered.entities.manual_override_binary;return!!e&&"on"===this.hass.states[e]?.state}_manualEndIso(){const e=this.discovered.entities.manual_override_end_sensor;if(!e)return null;const t=this.hass.states[e];return t&&"unknown"!==t.state&&"unavailable"!==t.state?t.state:null}_motionStatus(){const e=this.discovered.entities.motion_status_sensor;if(!e)return null;const t=this.hass.states[e];if(!t)return null;const o=t.attributes.motion_timeout_end_time;return{state:t.state,endIso:o??null}}_resetManual(){const e=this.discovered.entities.reset_override_button;e&&this.hass.callService("button","press",{entity_id:e})}_motionStateLabel(e,t){if(e){const t=this.hass.states[e],o=this.hass.formatEntityState;if(t&&"function"==typeof o){const e=o(t);if(e)return e}}return t.replace(/_/g," ")}render(){if(!this.hass||!this.discovered)return W;const e=this._manualActive(),t=this._manualEndIso(),o=this._motionStatus(),i=this.discovered.entities.motion_status_sensor,s=this.discovered.entities.reset_override_button,n=Be("overrides.reset_manual",this.hass);return q`
+  `,e([_e({attribute:!1})],Ao.prototype,"hass",void 0),e([_e()],Ao.prototype,"winner",void 0),e([_e({attribute:"manual-end-iso"})],Ao.prototype,"manualEndIso",void 0),e([_e({type:Number,attribute:"slot-number"})],Ao.prototype,"slotNumber",void 0),e([_e({attribute:"slot-name"})],Ao.prototype,"slotName",void 0),e([_e({type:Number})],Ao.prototype,"pct",void 0),e([_e({type:Boolean,attribute:"minimum-mode"})],Ao.prototype,"minimumMode",void 0),e([_e({type:Boolean,reflect:!0})],Ao.prototype,"compact",void 0),e([_e({type:Boolean,attribute:"integration-enabled"})],Ao.prototype,"integrationEnabled",void 0),e([_e({type:Boolean,attribute:"manual-active"})],Ao.prototype,"manualActive",void 0),e([_e({type:Boolean,attribute:"safety-active"})],Ao.prototype,"safetyActive",void 0),e([_e({attribute:"kind-override"})],Ao.prototype,"kindOverride",void 0),e([_e({type:Boolean,reflect:!0})],Ao.prototype,"resumable",void 0),Ao=e([he("acp-tile-badge")],Ao);let ko=class extends ce{constructor(){super(...arguments),this.compact=!1,this.resetEnabled=!0,this._tick=null}disconnectedCallback(){super.disconnectedCallback(),this._syncTimer(!1)}shouldUpdate(e){if(e.size>1||!e.has("hass"))return!0;const t=e.get("hass"),o=this.discovered?.entities;return ge(t,this.hass,[o?.manual_override_binary,o?.manual_override_end_sensor,o?.motion_status_sensor,o?.reset_override_button])}updated(){if(!this.hass||!this.discovered)return void this._syncTimer(!1);const e=!this.compact&&(null!==this._manualEndIso()||null!=this._motionStatus()?.endIso);this._syncTimer(e)}_syncTimer(e){e&&null===this._tick?this._tick=setInterval(()=>this.requestUpdate(),1e3):e||null===this._tick||(clearInterval(this._tick),this._tick=null)}_manualActive(){const e=this.discovered.entities.manual_override_binary;return!!e&&"on"===this.hass.states[e]?.state}_manualEndIso(){const e=this.discovered.entities.manual_override_end_sensor;if(!e)return null;const t=this.hass.states[e];return t&&"unknown"!==t.state&&"unavailable"!==t.state?t.state:null}_motionStatus(){const e=this.discovered.entities.motion_status_sensor;if(!e)return null;const t=this.hass.states[e];if(!t)return null;const o=t.attributes.motion_timeout_end_time;return{state:t.state,endIso:o??null}}_resetManual(){const e=this.discovered.entities.reset_override_button;e&&this.hass.callService("button","press",{entity_id:e})}_motionStateLabel(e,t){if(e){const t=this.hass.states[e],o=this.hass.formatEntityState;if(t&&"function"==typeof o){const e=o(t);if(e)return e}}return t.replace(/_/g," ")}render(){if(!this.hass||!this.discovered)return Y;const e=this._manualActive(),t=this._manualEndIso(),o=this._motionStatus(),s=this.discovered.entities.motion_status_sensor,i=this.discovered.entities.reset_override_button,n=Be("overrides.reset_manual",this.hass);return L`
       <div class="wrap">
         <div class="label dim">${Be("overrides.title",this.hass)}</div>
         <div class="grid">
@@ -966,28 +1015,28 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
             <div class="tile-value">
               ${Be(e?"overrides.active":"overrides.off",this.hass)}
             </div>
-            ${t?q`<div class="tile-sub dim">
-                  ${Be("overrides.ends_in",this.hass,{time:Ft(t,this.hass)})}
-                </div>`:W}
+            ${t?L`<div class="tile-sub dim">
+                  ${Be("overrides.ends_in",this.hass,{time:Yt(t,this.hass)})}
+                </div>`:Y}
           </div>
 
-          ${o?q`<div class="tile ${"motion_detected"===o.state?"active":""}">
+          ${o?L`<div class="tile ${"motion_detected"===o.state?"active":""}">
                 <div class="tile-label">${Be("overrides.motion",this.hass)}</div>
-                <div class="tile-value">${this._motionStateLabel(i,o.state)}</div>
-                ${o.endIso?q`<div class="tile-sub dim">
-                      ${Be("overrides.timeout",this.hass,{time:Ft(o.endIso,this.hass)})}
-                    </div>`:W}
-              </div>`:W}
-          ${s?this.resetEnabled?q`<button class="tile action" @click=${this._resetManual}>
+                <div class="tile-value">${this._motionStateLabel(s,o.state)}</div>
+                ${o.endIso?L`<div class="tile-sub dim">
+                      ${Be("overrides.timeout",this.hass,{time:Yt(o.endIso,this.hass)})}
+                    </div>`:Y}
+              </div>`:Y}
+          ${i?this.resetEnabled?L`<button class="tile action" @click=${this._resetManual}>
                   <ha-icon icon="mdi:restore"></ha-icon>
                   <div class="tile-value">${n}</div>
-                </button>`:q`<button class="tile action readonly" aria-disabled="true" tabindex="-1">
+                </button>`:L`<button class="tile action readonly" aria-disabled="true" tabindex="-1">
                   <ha-icon icon="mdi:restore"></ha-icon>
                   <div class="tile-value">${n}</div>
-                </button>`:W}
+                </button>`:Y}
         </div>
       </div>
-    `}};ho.styles=r`
+    `}};ko.styles=r`
     :host {
       display: block;
     }
@@ -1071,50 +1120,50 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
     ha-icon {
       --mdc-icon-size: 18px;
     }
-  `,e([ge({attribute:!1})],ho.prototype,"hass",void 0),e([ge({attribute:!1})],ho.prototype,"discovered",void 0),e([ge({type:Boolean,reflect:!0})],ho.prototype,"compact",void 0),e([ge({type:Boolean,attribute:"reset-enabled"})],ho.prototype,"resetEnabled",void 0),ho=e([he("acp-overrides-panel")],ho);const uo=new Set(["mode_off","active"]),po={summer_mode:"mdi:weather-sunny",winter_mode:"mdi:snowflake",intermediate:"mdi:weather-partly-cloudy"};let go=class extends ce{constructor(){super(...arguments),this.compact=!1}shouldUpdate(e){if(e.size>1||!e.has("hass"))return!0;const t=e.get("hass"),o=this.discovered?.entities;return _e(t,this.hass,[o?.climate_status_sensor,o?.climate_mode_switch])}render(){if(!this.hass||!this.discovered)return W;const e=this.discovered.entities.climate_status_sensor;if(!e)return W;const t=this.hass.states[e];if(!t||"unavailable"===t.state)return W;if("unknown"===t.state||""===t.state){const e=this.discovered.entities.climate_mode_switch,o=!!e&&"off"===this.hass.states[e]?.state,i=Be(o?"climate.mode_off":"climate.standby",this.hass),s=o?"mdi:power-off":"mdi:thermostat",n=t.attributes?.inactive_reason,r=n&&!uo.has(n)?Be(`climate.reason.${n}`,this.hass):void 0;return q`
+  `,e([_e({attribute:!1})],ko.prototype,"hass",void 0),e([_e({attribute:!1})],ko.prototype,"discovered",void 0),e([_e({type:Boolean,reflect:!0})],ko.prototype,"compact",void 0),e([_e({type:Boolean,attribute:"reset-enabled"})],ko.prototype,"resetEnabled",void 0),ko=e([he("acp-overrides-panel")],ko);const Co=new Set(["mode_off","active"]),Eo={summer_mode:"mdi:weather-sunny",winter_mode:"mdi:snowflake",intermediate:"mdi:weather-partly-cloudy"};let So=class extends ce{constructor(){super(...arguments),this.compact=!1}shouldUpdate(e){if(e.size>1||!e.has("hass"))return!0;const t=e.get("hass"),o=this.discovered?.entities;return ge(t,this.hass,[o?.climate_status_sensor,o?.climate_mode_switch])}render(){if(!this.hass||!this.discovered)return Y;const e=this.discovered.entities.climate_status_sensor;if(!e)return Y;const t=this.hass.states[e];if(!t||"unavailable"===t.state)return Y;if("unknown"===t.state||""===t.state){const e=this.discovered.entities.climate_mode_switch,o=!!e&&"off"===this.hass.states[e]?.state,s=Be(o?"climate.mode_off":"climate.standby",this.hass),i=o?"mdi:power-off":"mdi:thermostat",n=t.attributes?.inactive_reason,r=n&&!Co.has(n)?Be(`climate.reason.${n}`,this.hass):void 0;return L`
         <div class="wrap">
           <div class="head">
             <span class="label">${Be("climate.title",this.hass)}</span>
           </div>
           <div class="strategy standby">
-            <ha-icon icon=${s}></ha-icon>
-            <span class="strategy-name dim">${i}</span>
+            <ha-icon icon=${i}></ha-icon>
+            <span class="strategy-name dim">${s}</span>
           </div>
-          ${r?q`<div class="standby-reason dim">${r}</div>`:W}
+          ${r?L`<div class="standby-reason dim">${r}</div>`:Y}
         </div>
-      `}const o=t.state,i=t.attributes??{},s=po[o]??"mdi:thermostat",n=i.temperature_unit??"°",r=this.hass.formatEntityState,a="function"==typeof r?r(t)??o:o,l=void 0!==i.active_temperature?`${i.active_temperature.toFixed(1)}${n}`:"—",c=!0===i.temp_switch,d=(e,t)=>null==t||Number.isNaN(t)?null:`${Be(e,this.hass)} ${t.toFixed(1)}${n}`,h=c?null:[d("climate.threshold_low",i.temp_low),d("climate.threshold_high",i.temp_high)].filter(e=>null!==e).join(" ")||null,u=[...c?[d("climate.threshold_low",i.temp_low),d("climate.threshold_high",i.temp_high)]:[],d("climate.threshold_summer_outside",i.temp_summer_outside)].filter(e=>null!==e).join(" ")||null,p=[void 0!==i.indoor_temperature?{label:Be("climate.indoor",this.hass),value:i.indoor_temperature,unit:n,threshold:h}:null,void 0!==i.outdoor_temperature?{label:Be("climate.outdoor",this.hass),value:i.outdoor_temperature,unit:n,threshold:u}:null].filter(e=>null!==e),g=[{label:Be("climate.presence",this.hass),value:i.is_presence,icon:"mdi:account-check"},{label:Be("climate.sunny",this.hass),value:i.is_sunny,icon:"mdi:white-balance-sunny"},{label:Be("climate.lux",this.hass),value:i.lux_active,icon:"mdi:brightness-7"},{label:Be("climate.irradiance",this.hass),value:i.irradiance_active,icon:"mdi:solar-power"}].filter(e=>void 0!==e.value);return q`
+      `}const o=t.state,s=t.attributes??{},i=Eo[o]??"mdi:thermostat",n=s.temperature_unit??"°",r=this.hass.formatEntityState,a="function"==typeof r?r(t)??o:o,l=void 0!==s.active_temperature?`${s.active_temperature.toFixed(1)}${n}`:"—",c=!0===s.temp_switch,d=(e,t)=>null==t||Number.isNaN(t)?null:`${Be(e,this.hass)} ${t.toFixed(1)}${n}`,h=c?null:[d("climate.threshold_low",s.temp_low),d("climate.threshold_high",s.temp_high)].filter(e=>null!==e).join(" ")||null,u=[...c?[d("climate.threshold_low",s.temp_low),d("climate.threshold_high",s.temp_high)]:[],d("climate.threshold_summer_outside",s.temp_summer_outside)].filter(e=>null!==e).join(" ")||null,p=[void 0!==s.indoor_temperature?{label:Be("climate.indoor",this.hass),value:s.indoor_temperature,unit:n,threshold:h}:null,void 0!==s.outdoor_temperature?{label:Be("climate.outdoor",this.hass),value:s.outdoor_temperature,unit:n,threshold:u}:null].filter(e=>null!==e),_=[{label:Be("climate.presence",this.hass),value:s.is_presence,icon:"mdi:account-check"},{label:Be("climate.sunny",this.hass),value:s.is_sunny,icon:"mdi:white-balance-sunny"},{label:Be("climate.lux",this.hass),value:s.lux_active,icon:"mdi:brightness-7"},{label:Be("climate.irradiance",this.hass),value:s.irradiance_active,icon:"mdi:solar-power"}].filter(e=>void 0!==e.value);return L`
       <div class="wrap">
         <div class="head">
           <span class="label">${Be("climate.title",this.hass)}</span>
           <span class="dim">${Be("climate.active",this.hass,{strategy:l})}</span>
         </div>
         <div class="strategy">
-          <ha-icon icon=${s}></ha-icon>
+          <ha-icon icon=${i}></ha-icon>
           <span class="strategy-name">${a}</span>
         </div>
-        ${p.length?q`
+        ${p.length?L`
               <div class="temps">
-                ${p.map(e=>q`
+                ${p.map(e=>L`
                     <div class="temp">
                       <span class="temp-label dim">${e.label}</span>
                       <span class="temp-value">${e.value.toFixed(1)}${e.unit}</span>
-                      ${e.threshold?q`<span class="temp-threshold dim">${e.threshold}</span>`:W}
+                      ${e.threshold?L`<span class="temp-threshold dim">${e.threshold}</span>`:Y}
                     </div>
                   `)}
               </div>
-            `:W}
-        ${g.length?q`
+            `:Y}
+        ${_.length?L`
               <div class="conditions">
-                ${g.map(e=>q`
-                    <div class="chip ${e.value?"on":"off"}" title=${e.label}>
+                ${_.map(e=>L`
+                    <div class="chip ${e.value?"on":"off"}" ${ut(e.label)}>
                       <ha-icon icon=${e.icon}></ha-icon>
                       <span>${e.label}</span>
                     </div>
                   `)}
               </div>
-            `:W}
+            `:Y}
       </div>
-    `}};go.styles=r`
+    `}};So.styles=r`
     :host {
       display: block;
     }
@@ -1201,6 +1250,11 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
       border-radius: 999px;
       font-size: 0.72rem;
       background: var(--secondary-background-color, rgba(0, 0, 0, 0.04));
+    }
+    [data-tooltip]:hover {
+      cursor: help;
+    }
+    [data-tooltip][acp-tt-shown] {
       cursor: default;
     }
     .chip.on {
@@ -1216,36 +1270,36 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
     .dim {
       color: var(--secondary-text-color);
     }
-  `,e([ge({attribute:!1})],go.prototype,"hass",void 0),e([ge({attribute:!1})],go.prototype,"discovered",void 0),e([ge({type:Boolean,reflect:!0})],go.prototype,"compact",void 0),go=e([he("acp-climate-panel")],go);let mo=class extends ce{constructor(){super(...arguments),this.compact=!1,this.coverColor=null}shouldUpdate(e){if(e.size>1||!e.has("hass"))return!0;const t=e.get("hass"),o=this.discovered?.entities;return _e(t,this.hass,[o?.target_position_sensor,o?.position_mismatch_binary])}_target(){const e=this.discovered.entities.target_position_sensor;if(!e)return{target:null,covers:{}};const t=this.hass.states[e];if(!t)return{target:null,covers:{}};const o=parseFloat(t.state),i=t.attributes;return{target:Number.isNaN(o)?null:o,covers:i?.actual_positions??{}}}_mismatched(){const e=this.discovered.entities.position_mismatch_binary;if(!e)return new Set;const t=this.hass.states[e];if("on"!==t?.state)return new Set;const o=t.attributes.entities;return o?new Set(Object.entries(o).filter(([,e])=>e.mismatch).map(([e])=>e)):new Set}_setPosition(e,t){this.hass.callService(Ae,"set_position",{position:t},{entity_id:e})}render(){if(!this.hass||!this.discovered)return W;const{target:e,covers:t}=this._target(),o=this._mismatched(),i=Object.entries(t);return 0===i.length?q`<div class="placeholder">${Be("covers.placeholder",this.hass)}</div>`:q`
-      <div class="wrap" style=${this.coverColor?`--acp-cover-color:${this.coverColor}`:W}>
+  `,e([_e({attribute:!1})],So.prototype,"hass",void 0),e([_e({attribute:!1})],So.prototype,"discovered",void 0),e([_e({type:Boolean,reflect:!0})],So.prototype,"compact",void 0),So=e([he("acp-climate-panel")],So);let zo=class extends ce{constructor(){super(...arguments),this.compact=!1,this.coverColor=null}shouldUpdate(e){if(e.size>1||!e.has("hass"))return!0;const t=e.get("hass"),o=this.discovered?.entities;return ge(t,this.hass,[o?.target_position_sensor,o?.position_mismatch_binary])}_target(){const e=this.discovered.entities.target_position_sensor;if(!e)return{target:null,covers:{}};const t=this.hass.states[e];if(!t)return{target:null,covers:{}};const o=parseFloat(t.state),s=t.attributes;return{target:Number.isNaN(o)?null:o,covers:s?.actual_positions??{}}}_mismatched(){const e=this.discovered.entities.position_mismatch_binary;if(!e)return new Set;const t=this.hass.states[e];if("on"!==t?.state)return new Set;const o=t.attributes.entities;return o?new Set(Object.entries(o).filter(([,e])=>e.mismatch).map(([e])=>e)):new Set}_setPosition(e,t){this.hass.callService(Ae,"set_position",{position:t},{entity_id:e})}render(){if(!this.hass||!this.discovered)return Y;const{target:e,covers:t}=this._target(),o=this._mismatched(),s=Object.entries(t);return 0===s.length?L`<div class="placeholder">${Be("covers.placeholder",this.hass)}</div>`:L`
+      <div class="wrap" style=${this.coverColor?`--acp-cover-color:${this.coverColor}`:Y}>
         <div class="head">
           <span class="label">${Be("covers.title",this.hass)}</span>
           <span class="target"
-            >${Be("covers.target",this.hass,{pct:Ot(e)})}</span
+            >${Be("covers.target",this.hass,{pct:Lt(e)})}</span
           >
         </div>
-        ${i.map(([t,i])=>this._bar(t,i,e,o.has(t)))}
+        ${s.map(([t,s])=>this._bar(t,s,e,o.has(t)))}
       </div>
-    `}_bar(e,t,o,i){const s=this.hass.states[e]?.attributes?.friendly_name??e,n=t??0,r=o??0;return q`
-      <div class="cover ${i?"mismatch":""}">
-        <div class="name" title=${e}>${s}</div>
-        <div class="num">${Ot(t)}</div>
+    `}_bar(e,t,o,s){const i=this.hass.states[e]?.attributes?.friendly_name??e,n=t??0,r=o??0;return L`
+      <div class="cover ${s?"mismatch":""}">
+        <div class="name" ${ut(e)}>${i}</div>
+        <div class="num">${Lt(t)}</div>
         <div
           class="track"
           @click=${t=>this._handleTrackClick(t,e)}
-          title=${Be("covers.click_to_set",this.hass)}
+          ${ut(Be("covers.click_to_set",this.hass))}
         >
           <div class="fill" style="width:${n}%"></div>
           <div class="fill-closed" style="width:${100-n}%"></div>
-          ${null!==o?q`<div
+          ${null!==o?L`<div
                 class="marker"
                 style="left:${r}%"
-                title=${Be("covers.target_tooltip",this.hass,{pct:r})}
-              ></div>`:W}
+                ${ut(Be("covers.target_tooltip",this.hass,{pct:r}))}
+              ></div>`:Y}
         </div>
-        ${i?q`<ha-icon class="warn" icon="mdi:alert-circle-outline"></ha-icon>`:W}
+        ${s?L`<ha-icon class="warn" icon="mdi:alert-circle-outline"></ha-icon>`:Y}
       </div>
-    `}_handleTrackClick(e,t){const o=e.currentTarget.getBoundingClientRect(),i=Math.round((e.clientX-o.left)/o.width*100),s=Math.max(0,Math.min(100,i));this._setPosition(t,s)}};var _o;mo.styles=r`
+    `}_handleTrackClick(e,t){const o=e.currentTarget.getBoundingClientRect(),s=Math.round((e.clientX-o.left)/o.width*100),i=Math.max(0,Math.min(100,s));this._setPosition(t,i)}};var Oo;zo.styles=r`
     :host {
       display: block;
     }
@@ -1278,6 +1332,14 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
+    }
+    /* The cover name hints with a help cursor; the track is clickable and keeps
+       its pointer cursor (it is excluded from the help rule below). Both revert
+       to their natural cursor once OUR bubble is shown. */
+    .name[data-tooltip]:hover {
+      cursor: help;
+    }
+    .name[data-tooltip][acp-tt-shown] {
       cursor: default;
     }
     .track {
@@ -1342,15 +1404,14 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
       text-align: center;
       padding: 16px;
     }
-  `,e([ge({attribute:!1})],mo.prototype,"hass",void 0),e([ge({attribute:!1})],mo.prototype,"discovered",void 0),e([ge({type:Boolean,reflect:!0})],mo.prototype,"compact",void 0),e([ge({attribute:!1})],mo.prototype,"coverColor",void 0),mo=e([he("acp-cover-bar")],mo);const fo=864e5;let vo=_o=class extends ce{constructor(){super(...arguments),this.samples=[],this.events=[],this.now=Date.now(),this._hoverIdx=null,this._onPointerMove=e=>{const t=e.currentTarget.getBoundingClientRect();if(t.width<=0)return;const o=(e.clientX-t.left)/t.width,i=Math.max(0,Math.min(1,o))*_o.VIEW_W;this._hoverIdx=this._nearestSampleIdx(i)},this._onPointerLeave=()=>{this._hoverIdx=null}}render(){if(!this.samples||0===this.samples.length)return W;const{VIEW_W:e,VIEW_H:t,TOP_PAD:o,EVENT_HIT_W:i}=_o,s=t-o,n=At(new Date(this.now)).getTime(),r=t=>Je(t,n,e),a=this.samples.map(e=>{const t=Date.parse(e.t);return{t:t,x:r(t),y:o+(1-yo(e.position)/100)*s,sample:e,inDay:!Number.isNaN(t)&&t>=n&&t<=n+fo}}),l=a.filter(e=>e.inDay).map(e=>`${e.x.toFixed(1)},${e.y.toFixed(1)}`).join(" "),c=(this.events??[]).map(e=>{const s=Date.parse(e.t);if(Number.isNaN(s)||s<n||s>n+fo)return null;const a=r(s),l=`evt-${e.kind}`,c=function(e,t){const o=`forecast.event.${e.kind}`,i=Be(o,t),s=i===o?e.label??e.kind:i,n=It(e.t);return"—"===n?s:`${s} — ${n}`}(e,this.hass);return U`<g class="event-group" data-tooltip=${c}>
-          <title>${c}</title>
+  `,e([_e({attribute:!1})],zo.prototype,"hass",void 0),e([_e({attribute:!1})],zo.prototype,"discovered",void 0),e([_e({type:Boolean,reflect:!0})],zo.prototype,"compact",void 0),e([_e({attribute:!1})],zo.prototype,"coverColor",void 0),zo=e([he("acp-cover-bar")],zo);const Mo=864e5;let Io=Oo=class extends ce{constructor(){super(...arguments),this.samples=[],this.events=[],this.now=Date.now(),this._hoverIdx=null,this._onPointerMove=e=>{const t=e.currentTarget.getBoundingClientRect();if(t.width<=0)return;const o=(e.clientX-t.left)/t.width,s=Math.max(0,Math.min(1,o))*Oo.VIEW_W;this._hoverIdx=this._nearestSampleIdx(s)},this._onPointerLeave=()=>{this._hoverIdx=null}}render(){if(!this.samples||0===this.samples.length)return Y;const{VIEW_W:e,VIEW_H:t,TOP_PAD:o,EVENT_HIT_W:s}=Oo,i=t-o,n=Nt(new Date(this.now)).getTime(),r=t=>st(t,n,e),a=this.samples.map(e=>{const t=Date.parse(e.t);return{t:t,x:r(t),y:o+(1-Fo(e.position)/100)*i,sample:e,inDay:!Number.isNaN(t)&&t>=n&&t<=n+Mo}}),l=a.filter(e=>e.inDay).map(e=>`${e.x.toFixed(1)},${e.y.toFixed(1)}`).join(" "),c=(this.events??[]).map(e=>{const i=Date.parse(e.t);if(Number.isNaN(i)||i<n||i>n+Mo)return null;const a=r(i),l=`evt-${e.kind}`,c=function(e,t){const o=`forecast.event.${e.kind}`,s=Be(o,t),i=s===o?e.label??e.kind:s,n=Ut(e.t);return"—"===n?i:`${i} — ${n}`}(e,this.hass);return q`<g class="event-group" ${ut(c)}>
           <line
             class="event-hit"
             x1=${a.toFixed(1)}
             x2=${a.toFixed(1)}
             y1=${o}
             y2=${t}
-            stroke-width=${i}
+            stroke-width=${s}
           ></line>
           <line
             class="event-marker ${l}"
@@ -1359,17 +1420,17 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
             y1=${o}
             y2=${t}
           ></line>
-        </g>`}).filter(e=>null!==e),d=null!==this._hoverIdx&&this._hoverIdx>=0&&this._hoverIdx<a.length?a[this._hoverIdx]:null,h=d?U`<g class="hover-guide" pointer-events="none">
+        </g>`}).filter(e=>null!==e),d=null!==this._hoverIdx&&this._hoverIdx>=0&&this._hoverIdx<a.length?a[this._hoverIdx]:null,h=d?q`<g class="hover-guide" pointer-events="none">
           <line class="hover-line"
             x1=${d.x.toFixed(1)} x2=${d.x.toFixed(1)}
             y1=${o} y2=${t}></line>
           <circle class="hover-dot" cx=${d.x.toFixed(1)} cy=${d.y.toFixed(1)} r="3"></circle>
-        </g>`:W,u=d?q`<div class="hover-label" style=${`left: ${(d.x/e*100).toFixed(2)}%`}>
-          ${function(e){const t=It(e.t),o=`${Math.round(yo(e.position))}%`;return e.handler?`${t} · ${o} · ${e.handler}`:`${t} · ${o}`}(d.sample)}
-        </div>`:W,p=[0,6,12,18,24].map(e=>{const i=r(n+36e5*e);return U`
-        <line class="grid faint" x1=${i} y1=${o} x2=${i} y2=${t-.5} />
-        <text class="axis-label tick-time" x=${i} y=${t-3} text-anchor="middle">${e.toString().padStart(2,"0")}:00</text>
-      `}),g=this.now,m=r(g),_=g>=n&&g<=n+fo?U`<line class="now" x1=${m.toFixed(1)} y1=${o} x2=${m.toFixed(1)} y2=${t-.5}></line>`:W;return q`
+        </g>`:Y,u=d?L`<div class="hover-label" style=${`left: ${(d.x/e*100).toFixed(2)}%`}>
+          ${function(e){const t=Ut(e.t),o=`${Math.round(Fo(e.position))}%`;return e.handler?`${t} · ${o} · ${e.handler}`:`${t} · ${o}`}(d.sample)}
+        </div>`:Y,p=[0,6,12,18,24].map(e=>{const s=r(n+36e5*e);return q`
+        <line class="grid faint" x1=${s} y1=${o} x2=${s} y2=${t-.5} />
+        <text class="axis-label tick-time" x=${s} y=${t-3} text-anchor="middle">${e.toString().padStart(2,"0")}:00</text>
+      `}),_=this.now,m=r(_),g=_>=n&&_<=n+Mo?q`<line class="now" x1=${m.toFixed(1)} y1=${o} x2=${m.toFixed(1)} y2=${t-.5}></line>`:Y;return L`
       <div class="wrap">
         <svg
           viewBox="0 0 ${e} ${t}"
@@ -1378,16 +1439,15 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
           @pointermove=${this._onPointerMove}
           @pointerleave=${this._onPointerLeave}
         >
-          <title>${Be("forecast.hover_hint",this.hass)}</title>
           <line class="baseline" x1="0" y1=${t-.5} x2=${e} y2=${t-.5}></line>
           <text class="axis-label" x="4" y=${o+8} text-anchor="start">100%</text>
           ${p}
           <polyline class="curve" points=${l} fill="none"></polyline>
-          ${c} ${h} ${_}
+          ${c} ${h} ${g}
         </svg>
         ${u}
       </div>
-    `}_nearestSampleIdx(e){const t=At(new Date(this.now)).getTime();let o=-1,i=Number.POSITIVE_INFINITY;for(let s=0;s<this.samples.length;s++){const n=Date.parse(this.samples[s].t);if(Number.isNaN(n)||n<t||n>t+fo)continue;const r=Je(n,t,_o.VIEW_W),a=Math.abs(r-e);a<i&&(i=a,o=s)}return o>=0?o:null}};function yo(e){return Number.isNaN(e)||e<0?0:e>100?100:e}vo.VIEW_W=600,vo.VIEW_H=80,vo.TOP_PAD=10,vo.EVENT_HIT_W=12,vo.styles=r`
+    `}_nearestSampleIdx(e){const t=Nt(new Date(this.now)).getTime();let o=-1,s=Number.POSITIVE_INFINITY;for(let i=0;i<this.samples.length;i++){const n=Date.parse(this.samples[i].t);if(Number.isNaN(n)||n<t||n>t+Mo)continue;const r=st(n,t,Oo.VIEW_W),a=Math.abs(r-e);a<s&&(s=a,o=i)}return o>=0?o:null}};function Fo(e){return Number.isNaN(e)||e<0?0:e>100?100:e}Io.VIEW_W=600,Io.VIEW_H=80,Io.TOP_PAD=10,Io.EVENT_HIT_W=12,Io.styles=r`
     :host {
       display: block;
     }
@@ -1410,7 +1470,12 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
       stroke-width: 1.5;
       vector-effect: non-scaling-stroke;
     }
-    .event-group {
+    /* Floating-tooltip cursor lifecycle: a help cursor hints at the event
+       marker on hover, flipping to default once OUR bubble appears. */
+    [data-tooltip]:hover {
+      cursor: help;
+    }
+    [data-tooltip][acp-tt-shown] {
       cursor: default;
     }
     .event-hit {
@@ -1480,25 +1545,25 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
       stroke: var(--accent-color, crimson);
       stroke-width: 1.25;
     }
-  `,e([ge({attribute:!1})],vo.prototype,"hass",void 0),e([ge({attribute:!1})],vo.prototype,"samples",void 0),e([ge({attribute:!1})],vo.prototype,"events",void 0),e([ge({attribute:!1})],vo.prototype,"now",void 0),e([me()],vo.prototype,"_hoverIdx",void 0),vo=_o=e([he("acp-forecast-strip")],vo);let bo=class extends ce{constructor(){super(...arguments),this.open=!1,this.advancedOpen=!1,this.showCompass=!0,this.showElevationChart=!0,this._cancelMinuteTimer=null,this._listSource=null,this._list=[],this._onResume=()=>{const e=this.discovered.entities.reset_override_button;e&&this.hass.callService("button","press",{entity_id:e})},this._toggleAdvanced=()=>{this.advancedOpen=!this.advancedOpen},this._openDevicePage=()=>{const e=this.discovered.device_id;e&&this._navigate(`/config/devices/device/${e}`)},this._openIntegrationPage=()=>{this._navigate(`/config/integrations/integration/${Ae}`)},this._onBackdrop=e=>{e.target===e.currentTarget&&this._emitClose()},this._emitClose=()=>{this.dispatchEvent(new CustomEvent("acp-dialog-close",{bubbles:!0,composed:!0}))},this._stop=e=>{e.stopPropagation()}}updated(){this._syncMinuteTimer(this.open)}disconnectedCallback(){super.disconnectedCallback(),this._syncMinuteTimer(!1)}_syncMinuteTimer(e){e&&null===this._cancelMinuteTimer?this._cancelMinuteTimer=Vt(()=>this.requestUpdate()):e||null===this._cancelMinuteTimer||(this._cancelMinuteTimer(),this._cancelMinuteTimer=null)}get _discoveredList(){return this.discovered!==this._listSource&&(this._listSource=this.discovered,this._list=this.discovered?[this.discovered]:[]),this._list}_buildHandlerLabels(){const e={};for(const[t,o]of Object.entries(Se))e[t]=Be(o,this.hass);return e}render(){if(!this.open||!this.hass||!this.discovered)return W;const e=this._winner(),t=this._traceAttrs(),o=this._matchedHandlers(t,e),i=Yt(t),s=t?Ht(t.trace??[],t,0,this._buildHandlerLabels(),Be("badge.safety",this.hass)):"",n=this._target(),r=this._shouldShowResume(e),a=this._switchOn("integration_enabled_switch"),l=this._switchOn("automatic_control_switch"),c=Be("dialog.configure_integration",this.hass),d=Be("dialog.open_device_page",this.hass),h=Be("dialog.close",this.hass);return q`
+  `,e([_e({attribute:!1})],Io.prototype,"hass",void 0),e([_e({attribute:!1})],Io.prototype,"samples",void 0),e([_e({attribute:!1})],Io.prototype,"events",void 0),e([_e({attribute:!1})],Io.prototype,"now",void 0),e([me()],Io.prototype,"_hoverIdx",void 0),Io=Oo=e([he("acp-forecast-strip")],Io);let To=class extends ce{constructor(){super(...arguments),this.open=!1,this.advancedOpen=!1,this.showCompass=!0,this.showElevationChart=!0,this._cancelMinuteTimer=null,this._listSource=null,this._list=[],this._onResume=()=>{const e=this.discovered.entities.reset_override_button;e&&this.hass.callService("button","press",{entity_id:e})},this._toggleAdvanced=()=>{this.advancedOpen=!this.advancedOpen},this._openDevicePage=()=>{const e=this.discovered.device_id;e&&this._navigate(`/config/devices/device/${e}`)},this._openIntegrationPage=()=>{this._navigate(`/config/integrations/integration/${Ae}`)},this._onBackdrop=e=>{e.target===e.currentTarget&&this._emitClose()},this._emitClose=()=>{this.dispatchEvent(new CustomEvent("acp-dialog-close",{bubbles:!0,composed:!0}))},this._stop=e=>{e.stopPropagation()}}updated(){this._syncMinuteTimer(this.open)}disconnectedCallback(){super.disconnectedCallback(),this._syncMinuteTimer(!1)}_syncMinuteTimer(e){e&&null===this._cancelMinuteTimer?this._cancelMinuteTimer=oo(()=>this.requestUpdate()):e||null===this._cancelMinuteTimer||(this._cancelMinuteTimer(),this._cancelMinuteTimer=null)}get _discoveredList(){return this.discovered!==this._listSource&&(this._listSource=this.discovered,this._list=this.discovered?[this.discovered]:[]),this._list}_buildHandlerLabels(){const e={};for(const[t,o]of Object.entries(Ee))e[t]=Be(o,this.hass);return e}render(){if(!this.open||!this.hass||!this.discovered)return Y;const e=this._winner(),t=this._traceAttrs(),o=this._matchedHandlers(t,e),s=lo(t),i=t?ho(t.trace??[],t,0,this._buildHandlerLabels(),Be("badge.safety",this.hass)):"",n=this._target(),r=this._shouldShowResume(e),a=this._switchOn("integration_enabled_switch"),l=this._switchOn("automatic_control_switch"),c=Be("dialog.configure_integration",this.hass),d=Be("dialog.open_device_page",this.hass),h=Be("dialog.close",this.hass);return L`
       <div class="backdrop" data-open @click=${this._onBackdrop}>
         <div class="dialog" @click=${this._stop} role="dialog" aria-modal="true">
           <div class="header">
             <ha-icon
               class="cover-icon"
-              icon=${Ee[this.discovered.cover_type]??"mdi:window-shutter"}
+              icon=${Se[this.discovered.cover_type]??"mdi:window-shutter"}
             ></ha-icon>
             <div class="title">${this.discovered.entry_title}</div>
             <div class="badges">
-              ${a?l?o.map(e=>q`<acp-tile-badge
+              ${a?l?o.map(e=>L`<acp-tile-badge
                           .hass=${this.hass}
                           .winner=${e}
                           .slotNumber=${"custom_position"===e?t?.custom_position_active_slot:void 0}
                           .slotName=${"custom_position"===e?t?.custom_position_active_slot_name:void 0}
-                          .pct=${"custom_position"===e?Wt(t,n)??void 0:void 0}
+                          .pct=${"custom_position"===e?ao(t,n)??void 0:void 0}
                           .minimumMode=${"custom_position"===e?t?.custom_position_minimum_mode:void 0}
-                          .safetyActive=${"custom_position"===e&&i}
-                        ></acp-tile-badge>`):W:q`<acp-tile-badge
+                          .safetyActive=${"custom_position"===e&&s}
+                        ></acp-tile-badge>`):Y:L`<acp-tile-badge
                     .hass=${this.hass}
                     .integrationEnabled=${!1}
                   ></acp-tile-badge>`}
@@ -1507,47 +1572,47 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
               class="icon-btn options-link"
               type="button"
               aria-label=${c}
-              title=${c}
+              ${ut(c)}
               @click=${this._openIntegrationPage}
             >
               <ha-icon icon="mdi:tune-variant"></ha-icon>
             </button>
-            ${this.discovered.device_id?q`<button
+            ${this.discovered.device_id?L`<button
                   class="icon-btn device-link"
                   type="button"
                   aria-label=${d}
-                  title=${d}
+                  ${ut(d)}
                   @click=${this._openDevicePage}
                 >
                   <ha-icon icon="mdi:cog"></ha-icon>
-                </button>`:W}
+                </button>`:Y}
             <button class="close" type="button" aria-label=${h} @click=${this._emitClose}>
               ✕
             </button>
           </div>
 
-          ${s?q`<div class="summary">${s}</div>`:W}
+          ${i?L`<div class="summary">${i}</div>`:Y}
 
           <div class="position-block">
             <div class="position-label">${Be("dialog.target",this.hass)}</div>
-            <div class="position-value">${Ot(n)}</div>
-            ${this._mismatchActive()?q`<ha-icon class="warn" icon="mdi:alert-circle-outline"></ha-icon>`:W}
+            <div class="position-value">${Lt(n)}</div>
+            ${this._mismatchActive()?L`<ha-icon class="warn" icon="mdi:alert-circle-outline"></ha-icon>`:Y}
           </div>
 
           <acp-cover-bar .hass=${this.hass} .discovered=${this.discovered}></acp-cover-bar>
 
           ${this._renderForecastStrip()} ${this._renderControls()}
-          ${r?q`<div class="actions">
+          ${r?L`<div class="actions">
                 <button class="resume" type="button" @click=${this._onResume}>
                   ${Be("dialog.resume_auto",this.hass)}
                 </button>
-              </div>`:W}
+              </div>`:Y}
 
           <button class="advanced-toggle" type="button" @click=${this._toggleAdvanced}>
             ${this.advancedOpen?Be("dialog.hide_advanced",this.hass):Be("dialog.show_advanced",this.hass)}
           </button>
-          ${this.advancedOpen?q`<div class="advanced">
-                ${this.showCompass?q`<div class="advanced-compass">
+          ${this.advancedOpen?L`<div class="advanced">
+                ${this.showCompass?L`<div class="advanced-compass">
                       <acp-sky-compass
                         .hass=${this.hass}
                         .discovered_list=${this._discoveredList}
@@ -1555,12 +1620,12 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
                         .showLegend=${!1}
                         .showStats=${!0}
                       ></acp-sky-compass>
-                    </div>`:W}
-                ${this.showElevationChart?q`<acp-elevation-chart
+                    </div>`:Y}
+                ${this.showElevationChart?L`<acp-elevation-chart
                       .hass=${this.hass}
                       .discoveredList=${this._discoveredList}
                       ?compact=${!0}
-                    ></acp-elevation-chart>`:W}
+                    ></acp-elevation-chart>`:Y}
                 ${this._renderSlots(t?.custom_position_slots)}
                 <acp-decision-strip
                   .hass=${this.hass}
@@ -1574,27 +1639,27 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
                   .hass=${this.hass}
                   .discovered=${this.discovered}
                 ></acp-climate-panel>
-              </div>`:W}
+              </div>`:Y}
         </div>
       </div>
-    `}_winner(){const e=this.discovered.entities.decision_trace_sensor;return e?this.hass.states[e]?.state??"default":"default"}_traceAttrs(){const e=this.discovered.entities.decision_trace_sensor;if(e)return this.hass.states[e]?.attributes}_matchedHandlers(e,t){if(!e?.trace)return[];const o=new Set;for(const t of e.trace){if(!t.matched)continue;const e=Qt(t.handler);ke.includes(e)&&o.add(e)}const i=ke.filter(e=>o.has(e)).map(e=>Me[e]).filter(e=>void 0!==e),s=lo(e.trace,t);return so(i,this.badges,s)}_target(){const e=this.discovered.entities.target_position_sensor;if(!e)return null;const t=this.hass.states[e];if(!t)return null;const o=parseFloat(t.state);return Number.isNaN(o)?null:o}_mismatchActive(){const e=this.discovered.entities.position_mismatch_binary;return!!e&&"on"===this.hass.states[e]?.state}_manualOverrideOn(){const e=this.discovered.entities.manual_override_binary;return!!e&&"on"===this.hass.states[e]?.state}_switchOn(e){const t=this.discovered.entities[e];return!t||"off"!==this.hass.states[t]?.state}_shouldShowResume(e){return!(!this.discovered.entities.reset_override_button||!this._manualOverrideOn()&&"custom_position"!==Qt(e))}_renderSlots(e){if(!e)return W;const t=e.filter(e=>null!==e.sensor);return 0===t.length?W:q`<div class="slots-section">
+    `}_winner(){const e=this.discovered.entities.decision_trace_sensor;return e?this.hass.states[e]?.state??"default":"default"}_traceAttrs(){const e=this.discovered.entities.decision_trace_sensor;if(e)return this.hass.states[e]?.attributes}_matchedHandlers(e,t){if(!e?.trace)return[];const o=new Set;for(const t of e.trace){if(!t.matched)continue;const e=co(t.handler);ke.includes(e)&&o.add(e)}const s=ke.filter(e=>o.has(e)).map(e=>Me[e]).filter(e=>void 0!==e),i=$o(e.trace,t);return yo(s,this.badges,i)}_target(){const e=this.discovered.entities.target_position_sensor;if(!e)return null;const t=this.hass.states[e];if(!t)return null;const o=parseFloat(t.state);return Number.isNaN(o)?null:o}_mismatchActive(){const e=this.discovered.entities.position_mismatch_binary;return!!e&&"on"===this.hass.states[e]?.state}_manualOverrideOn(){const e=this.discovered.entities.manual_override_binary;return!!e&&"on"===this.hass.states[e]?.state}_switchOn(e){const t=this.discovered.entities[e];return!t||"off"!==this.hass.states[t]?.state}_shouldShowResume(e){return!(!this.discovered.entities.reset_override_button||!this._manualOverrideOn()&&"custom_position"!==co(e))}_renderSlots(e){if(!e)return Y;const t=e.filter(e=>null!==e.sensor);return 0===t.length?Y:L`<div class="slots-section">
       <div class="slots-label">${Be("dialog.custom_positions",this.hass)}</div>
       ${t.map(e=>this._renderSlotRow(e))}
-    </div>`}_renderSlotRow(e){const t=e.sensor_name??`#${e.slot}`,o=e.sensors?.length??0,i=!0===e.template?q`<span
+    </div>`}_renderSlotRow(e){const t=e.sensor_name??`#${e.slot}`,o=e.sensors?.length??0,s=!0===e.template?L`<span
             class="slot-template"
-            title=${"Template"+(o>0?` · ${o} sensors${e.template_mode?` (${e.template_mode})`:""}`:"")}
+            ${ut("Template"+(o>0?` · ${o} sensors${e.template_mode?` (${e.template_mode})`:""}`:""))}
           >
             <ha-icon icon="mdi:code-braces"></ha-icon>
-          </span>`:W;return q`<div class="slot-row" data-slot=${e.slot}>
+          </span>`:Y;return L`<div class="slot-row" data-slot=${e.slot}>
       <span class="slot-label">${t}</span>
-      ${i}
-      <span class="slot-position">${Ot(e.position)}</span>
-      ${!0===e.min_mode?q`<span
+      ${s}
+      <span class="slot-position">${Lt(e.position)}</span>
+      ${!0===e.min_mode?L`<span
             class="slot-min-mode${null!=e.priority&&e.priority>80?"":" is-bypassable"}"
-            title=${Be("dialog.floor_tooltip",this.hass)}
+            ${ut(Be("dialog.floor_tooltip",this.hass))}
           >
             ${Be("dialog.floor",this.hass)}
-          </span>`:W}
+          </span>`:Y}
       <button
         class="slot-toggle ${e.enabled?"on":"off"}"
         type="button"
@@ -1603,28 +1668,28 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
       >
         ${e.enabled?Be("dialog.on",this.hass):Be("dialog.off",this.hass)}
       </button>
-    </div>`}_renderControls(){const e=[{role:"automatic_control_switch",label:Be("dialog.automatic",this.hass)},{role:"climate_mode_switch",label:Be("dialog.climate",this.hass)},{role:"motion_control_switch",label:Be("dialog.motion",this.hass)}].filter(e=>!!this.discovered.entities[e.role]);return 0===e.length?W:q`<div class="controls-block">
+    </div>`}_renderControls(){const e=[{role:"automatic_control_switch",label:Be("dialog.automatic",this.hass)},{role:"climate_mode_switch",label:Be("dialog.climate",this.hass)},{role:"motion_control_switch",label:Be("dialog.motion",this.hass)}].filter(e=>!!this.discovered.entities[e.role]);return 0===e.length?Y:L`<div class="controls-block">
       <div class="controls-label">${Be("dialog.controls",this.hass)}</div>
       <div class="controls-row">${e.map(e=>this._renderSwitchChip(e.role,e.label))}</div>
-    </div>`}_renderSwitchChip(e,t){const o=this.discovered.entities[e],i="on"===this.hass.states[o]?.state,s=Be(i?"dialog.state_on":"dialog.state_off",this.hass),n=Be(i?"dialog.on":"dialog.off",this.hass);return q`<button
-      class="ctrl-toggle ${i?"on":"off"}"
+    </div>`}_renderSwitchChip(e,t){const o=this.discovered.entities[e],s="on"===this.hass.states[o]?.state,i=Be(s?"dialog.state_on":"dialog.state_off",this.hass),n=Be(s?"dialog.on":"dialog.off",this.hass);return L`<button
+      class="ctrl-toggle ${s?"on":"off"}"
       type="button"
-      aria-pressed=${i}
-      aria-label=${Be("dialog.toggle_hint",this.hass,{label:t,state:s})}
-      @click=${()=>this._toggleSwitch(o,i)}
+      aria-pressed=${s}
+      aria-label=${Be("dialog.toggle_hint",this.hass,{label:t,state:i})}
+      @click=${()=>this._toggleSwitch(o,s)}
     >
       <span class="ctrl-label">${t}</span>
       <span class="ctrl-state">${n}</span>
-    </button>`}_toggleSwitch(e,t){this.hass.callService("switch",t?"turn_off":"turn_on",{entity_id:e})}_renderForecastStrip(){const e=this.discovered.entities.position_forecast_sensor;if(!e)return W;const t=this.hass.states[e]?.attributes,o=t?.forecast??[],i=t?.events??[];return 0===o.length?W:q`<div class="forecast-block">
+    </button>`}_toggleSwitch(e,t){this.hass.callService("switch",t?"turn_off":"turn_on",{entity_id:e})}_renderForecastStrip(){const e=this.discovered.entities.position_forecast_sensor;if(!e)return Y;const t=this.hass.states[e]?.attributes,o=t?.forecast??[],s=t?.events??[];return 0===o.length?Y:L`<div class="forecast-block">
       <div class="forecast-label">${Be("dialog.todays_forecast",this.hass)}</div>
       <acp-forecast-strip
         .hass=${this.hass}
         .samples=${o}
-        .events=${i}
+        .events=${s}
         .now=${Date.now()}
       ></acp-forecast-strip>
       <div class="forecast-note">${Be("forecast.solar_only_note",this.hass)}</div>
-    </div>`}_toggleSlot(e){const t=this.discovered.managed_covers[0];t&&this.hass.callService(Ae,"set_custom_position",{entity_id:t,slot:e.slot,enabled:!e.enabled})}_navigate(e){history.pushState(null,"",e),window.dispatchEvent(new CustomEvent("location-changed",{detail:{replace:!1}})),this._emitClose()}};function wo(e){return q`
+    </div>`}_toggleSlot(e){const t=this.discovered.managed_covers[0];t&&this.hass.callService(Ae,"set_custom_position",{entity_id:t,slot:e.slot,enabled:!e.enabled})}_navigate(e){history.pushState(null,"",e),window.dispatchEvent(new CustomEvent("location-changed",{detail:{replace:!1}})),this._emitClose()}};function Po(e){return L`
     <div
       class="editor-footer"
       style="display:flex;align-items:center;justify-content:space-between;gap:8px;"
@@ -1636,7 +1701,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
         ${Be("root.footer_version",e,{version:fe})}
       </span>
     </div>
-  `}bo.styles=r`
+  `}To.styles=r`
     :host {
       display: contents;
     }
@@ -1799,6 +1864,16 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
       display: inline-flex;
       align-items: center;
       color: var(--secondary-text-color);
+    }
+    /* Floating-tooltip cursor lifecycle for the informational chips (the
+       clickable .icon-btn buttons keep their pointer cursor — they are excluded
+       from this rule). Help hint on hover, default once OUR bubble appears. */
+    .slot-template[data-tooltip]:hover,
+    .slot-min-mode[data-tooltip]:hover {
+      cursor: help;
+    }
+    .slot-template[data-tooltip][acp-tt-shown],
+    .slot-min-mode[data-tooltip][acp-tt-shown] {
       cursor: default;
     }
     .slot-template ha-icon {
@@ -1810,7 +1885,6 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
       border-radius: 999px;
       background: rgba(156, 39, 176, 0.22);
       color: #6a1b9a;
-      cursor: default;
     }
     /* Priority axis: floor whose priority ≤ manual-override is bypassable by a
        manual ↓ → subdued. Per-slot rows have no clamping notion, so no fill/outline. */
@@ -1898,7 +1972,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
     .ctrl-toggle:hover {
       background: rgba(var(--rgb-primary-color, 33, 150, 243), 0.08);
     }
-  `,e([ge({attribute:!1})],bo.prototype,"hass",void 0),e([ge({attribute:!1})],bo.prototype,"discovered",void 0),e([ge({type:Boolean,reflect:!0})],bo.prototype,"open",void 0),e([ge({type:Boolean})],bo.prototype,"advancedOpen",void 0),e([ge({type:Boolean})],bo.prototype,"showCompass",void 0),e([ge({type:Boolean})],bo.prototype,"showElevationChart",void 0),e([ge({attribute:!1})],bo.prototype,"badges",void 0),bo=e([he("acp-more-info-dialog")],bo);const xo=["auto","solar","force","weather","manual","custom_position","motion","climate","glare_zone","cloud"],$o={show_position:!0,show_state:!0,show_decision_summary:!1,show_controls:!0,show_badge:!0,show_compass:!0,show_elevation_chart:!0,show_motion_icon:!0,layout:"detailed",badge_auto:!0,badge_solar:!0,badge_force:!0,badge_weather:!0,badge_manual:!0,badge_custom_position:!0,badge_motion:!0,badge_climate:!0,badge_glare_zone:!0,badge_cloud:!0},Ao={entry_id:"editor.common.entry_id",name:"editor.tile.name",icon:"editor.tile.icon",cover:"editor.tile.cover",layout:"editor.tile.layout",show_position:"editor.tile.show_position",show_state:"editor.tile.show_state",show_decision_summary:"editor.tile.show_decision_summary",show_controls:"editor.tile.show_controls",show_badge:"editor.tile.show_badge",badge_section:"editor.tile.badge_section",badge_auto:"editor.tile.badge_auto",badge_solar:"editor.tile.badge_solar",badge_force:"editor.tile.badge_force",badge_weather:"editor.tile.badge_weather",badge_manual:"editor.tile.badge_manual",badge_custom_position:"editor.tile.badge_custom_position",badge_motion:"editor.tile.badge_motion",badge_climate:"editor.tile.badge_climate",badge_glare_zone:"editor.tile.badge_glare_zone",badge_cloud:"editor.tile.badge_cloud",show_compass:"editor.tile.show_compass",show_elevation_chart:"editor.tile.show_elevation_chart",show_motion_icon:"editor.tile.show_motion_icon",tap_action:"editor.tile.tap_action",hold_action:"editor.tile.hold_action",double_tap_action:"editor.tile.double_tap_action"};let ko=class extends ce{constructor(){super(...arguments),this._entries=null,this._entriesError=null,this._registry=null,this._managedCovers=[],this._entriesFetchInFlight=!1,this._registryFetchInFlight=!1,this._unsubRegistry=null,this._computeLabel=e=>{const t=Ao[e.name];return t?Be(t,this.hass):e.name},this._valueChanged=e=>{e.stopPropagation();const t={...e.detail.value};for(const[e,o]of Object.entries($o))e.startsWith("badge_")?t[e]===o&&delete t[e]:this._config&&Object.prototype.hasOwnProperty.call(this._config,e)||t[e]!==o||delete t[e];const o={};for(const e of xo){const i=`badge_${e}`;!1===t[i]&&(o[e]=!1),delete t[i]}const i={...this._config??{type:"",entry_id:""},...t};Object.keys(o).length>0?i.badges=o:delete i.badges,this._emit(i)}}setConfig(e){this._config={...e}}disconnectedCallback(){super.disconnectedCallback(),this._unsubRegistry&&(this._unsubRegistry(),this._unsubRegistry=null)}updated(e){e.has("hass")&&this.hass&&(this._ensureEntries(),this._ensureRegistry()),e.has("_registry")&&null!==this._registry&&this._maybePrefillCover()}_ensureEntries(){this._entries||this._entriesFetchInFlight||(this._entriesFetchInFlight=!0,Ue(this.hass).then(e=>{this._entries=e,this._entriesError=null,this._config?.entry_id||1!==e.length||this._emit({...this._config??{type:"",entry_id:""},entry_id:e[0].entry_id}),this._maybePrefillCover()}).catch(e=>{this._entriesError=e?.message??"failed to load config entries"}).finally(()=>{this._entriesFetchInFlight=!1}))}_ensureRegistry(){null!==this._registry||this._registryFetchInFlight||(this._registryFetchInFlight=!0,ot(this.hass).then(e=>{this._registry=e,this._maybePrefillCover()}).catch(()=>{this._registry=[]}).finally(()=>{this._registryFetchInFlight=!1})),this._unsubRegistry||(this._unsubRegistry=it(this.hass,()=>{this._registryFetchInFlight=!0,ot(this.hass).then(e=>{this._registry=e}).catch(()=>{}).finally(()=>{this._registryFetchInFlight=!1})}))}_emit(e){this._config=e,this.dispatchEvent(new CustomEvent("config-changed",{detail:{config:e},bubbles:!0,composed:!0}))}_maybePrefillCover(){if(!this._config?.entry_id||this._config?.cover||!this._registry||!this.hass)return;const e=qe(this.hass,{type:this._config.type,entry_id:this._config.entry_id},this._registry);this._managedCovers=e?.managed_covers??[],1===e?.managed_covers.length&&this._emit({...this._config,cover:e.managed_covers[0]})}render(){if(!this._config)return W;if(this._entriesError&&!this._entries)return q`
+  `,e([_e({attribute:!1})],To.prototype,"hass",void 0),e([_e({attribute:!1})],To.prototype,"discovered",void 0),e([_e({type:Boolean,reflect:!0})],To.prototype,"open",void 0),e([_e({type:Boolean})],To.prototype,"advancedOpen",void 0),e([_e({type:Boolean})],To.prototype,"showCompass",void 0),e([_e({type:Boolean})],To.prototype,"showElevationChart",void 0),e([_e({attribute:!1})],To.prototype,"badges",void 0),To=e([he("acp-more-info-dialog")],To);const jo=["auto","solar","force","weather","manual","custom_position","motion","climate","glare_zone","cloud"],Ro={show_position:!0,show_state:!0,show_decision_summary:!1,show_controls:!0,show_badge:!0,show_compass:!0,show_elevation_chart:!0,show_motion_icon:!0,layout:"detailed",badge_auto:!0,badge_solar:!0,badge_force:!0,badge_weather:!0,badge_manual:!0,badge_custom_position:!0,badge_motion:!0,badge_climate:!0,badge_glare_zone:!0,badge_cloud:!0},No={entry_id:"editor.common.entry_id",name:"editor.tile.name",icon:"editor.tile.icon",cover:"editor.tile.cover",layout:"editor.tile.layout",show_position:"editor.tile.show_position",show_state:"editor.tile.show_state",show_decision_summary:"editor.tile.show_decision_summary",show_controls:"editor.tile.show_controls",show_badge:"editor.tile.show_badge",badge_section:"editor.tile.badge_section",badge_auto:"editor.tile.badge_auto",badge_solar:"editor.tile.badge_solar",badge_force:"editor.tile.badge_force",badge_weather:"editor.tile.badge_weather",badge_manual:"editor.tile.badge_manual",badge_custom_position:"editor.tile.badge_custom_position",badge_motion:"editor.tile.badge_motion",badge_climate:"editor.tile.badge_climate",badge_glare_zone:"editor.tile.badge_glare_zone",badge_cloud:"editor.tile.badge_cloud",show_compass:"editor.tile.show_compass",show_elevation_chart:"editor.tile.show_elevation_chart",show_motion_icon:"editor.tile.show_motion_icon",tap_action:"editor.tile.tap_action",hold_action:"editor.tile.hold_action",double_tap_action:"editor.tile.double_tap_action"};let Do=class extends ce{constructor(){super(...arguments),this._entries=null,this._entriesError=null,this._registry=null,this._managedCovers=[],this._entriesFetchInFlight=!1,this._registryFetchInFlight=!1,this._unsubRegistry=null,this._computeLabel=e=>{const t=No[e.name];return t?Be(t,this.hass):e.name},this._valueChanged=e=>{e.stopPropagation();const t={...e.detail.value};for(const[e,o]of Object.entries(Ro))e.startsWith("badge_")?t[e]===o&&delete t[e]:this._config&&Object.prototype.hasOwnProperty.call(this._config,e)||t[e]!==o||delete t[e];const o={};for(const e of jo){const s=`badge_${e}`;!1===t[s]&&(o[e]=!1),delete t[s]}const s={...this._config??{type:"",entry_id:""},...t};Object.keys(o).length>0?s.badges=o:delete s.badges,this._emit(s)}}setConfig(e){this._config={...e}}disconnectedCallback(){super.disconnectedCallback(),this._unsubRegistry&&(this._unsubRegistry(),this._unsubRegistry=null)}updated(e){e.has("hass")&&this.hass&&(this._ensureEntries(),this._ensureRegistry()),e.has("_registry")&&null!==this._registry&&this._maybePrefillCover()}_ensureEntries(){this._entries||this._entriesFetchInFlight||(this._entriesFetchInFlight=!0,ft(this.hass).then(e=>{this._entries=e,this._entriesError=null,this._config?.entry_id||1!==e.length||this._emit({...this._config??{type:"",entry_id:""},entry_id:e[0].entry_id}),this._maybePrefillCover()}).catch(e=>{this._entriesError=e?.message??"failed to load config entries"}).finally(()=>{this._entriesFetchInFlight=!1}))}_ensureRegistry(){null!==this._registry||this._registryFetchInFlight||(this._registryFetchInFlight=!0,vt(this.hass).then(e=>{this._registry=e,this._maybePrefillCover()}).catch(()=>{this._registry=[]}).finally(()=>{this._registryFetchInFlight=!1})),this._unsubRegistry||(this._unsubRegistry=yt(this.hass,()=>{this._registryFetchInFlight=!0,vt(this.hass).then(e=>{this._registry=e}).catch(()=>{}).finally(()=>{this._registryFetchInFlight=!1})}))}_emit(e){this._config=e,this.dispatchEvent(new CustomEvent("config-changed",{detail:{config:e},bubbles:!0,composed:!0}))}_maybePrefillCover(){if(!this._config?.entry_id||this._config?.cover||!this._registry||!this.hass)return;const e=gt(this.hass,{type:this._config.type,entry_id:this._config.entry_id},this._registry);this._managedCovers=e?.managed_covers??[],1===e?.managed_covers.length&&this._emit({...this._config,cover:e.managed_covers[0]})}render(){if(!this._config)return Y;if(this._entriesError&&!this._entries)return L`
         <div class="form">
           <div class="error">
             ${Be("editor.common.load_failed",this.hass,{error:this._entriesError})}
@@ -1914,21 +1988,21 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
             placeholder=${Be("editor.common.entry_id_manual_placeholder",this.hass)}
             @change=${e=>this._emit({...this._config??{type:"",entry_id:""},entry_id:e.target.value})}
           />
-          ${wo(this.hass)}
+          ${Po(this.hass)}
         </div>
-      `;const e=this._schema(),{badges:t,...o}=this._config,i={};for(const e of xo)t&&!1===t[e]&&(i[`badge_${e}`]=!1);const s={...$o,...o,...i};return q`
+      `;const e=this._schema(),{badges:t,...o}=this._config,s={};for(const e of jo)t&&!1===t[e]&&(s[`badge_${e}`]=!1);const i={...Ro,...o,...s};return L`
       <div class="form">
         <ha-form
           .hass=${this.hass}
-          .data=${s}
+          .data=${i}
           .schema=${e}
           .computeLabel=${this._computeLabel}
           @value-changed=${this._valueChanged}
         ></ha-form>
-        ${this._managedCovers.length>1&&!this._config?.cover?q`<div class="hint">${Be("editor.tile.cover_blank_hint",this.hass)}</div>`:W}
-        ${wo(this.hass)}
+        ${this._managedCovers.length>1&&!this._config?.cover?L`<div class="hint">${Be("editor.tile.cover_blank_hint",this.hass)}</div>`:Y}
+        ${Po(this.hass)}
       </div>
-    `}_schema(){const e=this._entries?.map(e=>({value:e.entry_id,label:e.title}))??[],t=[{value:"one-line",label:Be("editor.tile.layout_option_one_line",this.hass)},{value:"detailed",label:Be("editor.tile.layout_option_detailed",this.hass)}];let o={entity:{domain:"cover"}};if(this._registry&&this._config?.entry_id){const e=qe(this.hass,{type:this._config.type,entry_id:this._config.entry_id},this._registry);e&&e.managed_covers.length>0&&(o={entity:{domain:"cover",include_entities:e.managed_covers}})}return[{name:"entry_id",required:!0,selector:{select:{options:e,mode:"dropdown"}}},{name:"name",selector:{text:{}}},{name:"icon",selector:{icon:{}}},{name:"cover",selector:o},{name:"layout",selector:{select:{mode:"list",options:t}}},{name:"show_position",selector:{boolean:{}}},{name:"show_state",selector:{boolean:{}}},{name:"show_decision_summary",selector:{boolean:{}}},{name:"show_controls",selector:{boolean:{}}},{name:"show_badge",selector:{boolean:{}}},{type:"expandable",name:"",title:Be("editor.tile.badge_section",this.hass),icon:"mdi:label-multiple-outline",schema:[{type:"grid",name:"",schema:xo.map(e=>({name:`badge_${e}`,selector:{boolean:{}}}))}]},{name:"show_motion_icon",selector:{boolean:{}}},{name:"show_compass",selector:{boolean:{}}},{name:"show_elevation_chart",selector:{boolean:{}}},{name:"tap_action",selector:{ui_action:{}}},{name:"hold_action",selector:{ui_action:{}}},{name:"double_tap_action",selector:{ui_action:{}}}]}};ko.styles=r`
+    `}_schema(){const e=this._entries?.map(e=>({value:e.entry_id,label:e.title}))??[],t=[{value:"one-line",label:Be("editor.tile.layout_option_one_line",this.hass)},{value:"detailed",label:Be("editor.tile.layout_option_detailed",this.hass)}];let o={entity:{domain:"cover"}};if(this._registry&&this._config?.entry_id){const e=gt(this.hass,{type:this._config.type,entry_id:this._config.entry_id},this._registry);e&&e.managed_covers.length>0&&(o={entity:{domain:"cover",include_entities:e.managed_covers}})}return[{name:"entry_id",required:!0,selector:{select:{options:e,mode:"dropdown"}}},{name:"name",selector:{text:{}}},{name:"icon",selector:{icon:{}}},{name:"cover",selector:o},{name:"layout",selector:{select:{mode:"list",options:t}}},{name:"show_position",selector:{boolean:{}}},{name:"show_state",selector:{boolean:{}}},{name:"show_decision_summary",selector:{boolean:{}}},{name:"show_controls",selector:{boolean:{}}},{name:"show_badge",selector:{boolean:{}}},{type:"expandable",name:"",title:Be("editor.tile.badge_section",this.hass),icon:"mdi:label-multiple-outline",schema:[{type:"grid",name:"",schema:jo.map(e=>({name:`badge_${e}`,selector:{boolean:{}}}))}]},{name:"show_motion_icon",selector:{boolean:{}}},{name:"show_compass",selector:{boolean:{}}},{name:"show_elevation_chart",selector:{boolean:{}}},{name:"tap_action",selector:{ui_action:{}}},{name:"hold_action",selector:{ui_action:{}}},{name:"double_tap_action",selector:{ui_action:{}}}]}};Do.styles=r`
     :host {
       display: block;
     }
@@ -1969,13 +2043,13 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
     .dim {
       color: var(--secondary-text-color);
     }
-  `,e([ge({attribute:!1})],ko.prototype,"hass",void 0),e([me()],ko.prototype,"_config",void 0),e([me()],ko.prototype,"_entries",void 0),e([me()],ko.prototype,"_entriesError",void 0),e([me()],ko.prototype,"_registry",void 0),e([me()],ko.prototype,"_managedCovers",void 0),ko=e([he($e)],ko);let Co=class extends ce{constructor(){super(...arguments),this._registry=null,this._registryError=null,this._dialogOpen=!1,this._unsubRegistry=null,this._fetchInFlight=!1,this._memo=Ke(),this._discovered=null,this._fetchGen=0,this._closeDialog=()=>{this._dialogOpen=!1},this._holdTimer=null,this._pendingTapTimer=null,this._holdFired=!1,this._onPointerDown=()=>{this._holdFired=!1,null!=this._holdTimer&&clearTimeout(this._holdTimer),io(this._config?.hold_action)&&(this._holdTimer=setTimeout(()=>{this._holdFired=!0,this._holdTimer=null,this._fireAction("hold")},500))},this._onPointerUp=()=>{null!=this._holdTimer&&(clearTimeout(this._holdTimer),this._holdTimer=null)},this._onPointerCancel=()=>{null!=this._holdTimer&&(clearTimeout(this._holdTimer),this._holdTimer=null)},this._onClick=()=>{if(!this._holdFired)return io(this._config?.double_tap_action)?null!=this._pendingTapTimer?(clearTimeout(this._pendingTapTimer),this._pendingTapTimer=null,void this._fireAction("double_tap")):void(this._pendingTapTimer=setTimeout(()=>{this._pendingTapTimer=null,this._fireAction("tap")},250)):void this._fireAction("tap");this._holdFired=!1}}setConfig(e){if(!e||"string"!=typeof e.entry_id||0===e.entry_id.length)throw new Error(`${xe}: \`entry_id\` is required and must be a non-empty string`);let t={...e};if("string"==typeof t.tap_action&&(t={...t,tap_action:"none"===t.tap_action?{action:"none"}:void 0}),this._config=t,null===this._registry){const e=ct.get(t.entry_id);e&&(this._registry=e.entries)}}getCardSize(){return 1}getGridOptions(){return{columns:"full",rows:"auto",min_columns:3,min_rows:"one-line"!==this._config?.layout?2:1}}static async getStubConfig(e){let t="";try{const o=await Ue(e);t=o[0]?.entry_id??""}catch{}return{type:`custom:${xe}`,entry_id:t}}static async getConfigElement(){return document.createElement($e)}connectedCallback(){if(super.connectedCallback(),null===this._registry){const e=rt();e&&(this._registry=e)}this.hass&&this._ensureRegistry()}disconnectedCallback(){super.disconnectedCallback(),this._unsubRegistry&&(this._unsubRegistry(),this._unsubRegistry=null)}updated(e){e.has("hass")&&this.hass&&this._ensureRegistry()}shouldUpdate(e){return e.size>1||!e.has("hass")||(!this._discovered||_e(e.get("hass"),this.hass,Object.values(this._discovered.entities)))}willUpdate(e){this._config&&this.hass&&null!==this._registry&&(e.has("hass")||e.has("_registry")||e.has("_config"))&&(this._discovered=this._memo(this.hass,{type:this._config.type,entry_id:this._config.entry_id},this._registry))}_ensureRegistry(){this._fetchRegistry(),this._unsubRegistry||(this._unsubRegistry=it(this.hass,()=>{this._fetchRegistry(!0)}))}_fetchRegistry(e=!1){if(this._fetchInFlight)return;this._fetchInFlight=!0;const t=++this._fetchGen;at(this.hass,e).then(e=>{t===this._fetchGen&&e!==this._registry&&(this._registry=e,this._registryError=null,this._config&&ct.set(this._config.entry_id,ht(e,this._config.entry_id)))}).catch(e=>{t===this._fetchGen&&(this._registryError=e?.message??"entity registry fetch failed")}).finally(()=>{t===this._fetchGen&&(this._fetchInFlight=!1)})}render(){if(!this._config||!this.hass)return W;if(null===this._registry)return q`<ha-card>
+  `,e([_e({attribute:!1})],Do.prototype,"hass",void 0),e([me()],Do.prototype,"_config",void 0),e([me()],Do.prototype,"_entries",void 0),e([me()],Do.prototype,"_entriesError",void 0),e([me()],Do.prototype,"_registry",void 0),e([me()],Do.prototype,"_managedCovers",void 0),Do=e([he($e)],Do);let Bo=class extends ce{constructor(){super(...arguments),this._registry=null,this._registryError=null,this._dialogOpen=!1,this._unsubRegistry=null,this._fetchInFlight=!1,this._memo=pt(),this._discovered=null,this._fetchGen=0,this._closeDialog=()=>{this._dialogOpen=!1},this._holdTimer=null,this._pendingTapTimer=null,this._holdFired=!1,this._onPointerDown=()=>{this._holdFired=!1,null!=this._holdTimer&&clearTimeout(this._holdTimer),vo(this._config?.hold_action)&&(this._holdTimer=setTimeout(()=>{this._holdFired=!0,this._holdTimer=null,this._fireAction("hold")},500))},this._onPointerUp=()=>{null!=this._holdTimer&&(clearTimeout(this._holdTimer),this._holdTimer=null)},this._onPointerCancel=()=>{null!=this._holdTimer&&(clearTimeout(this._holdTimer),this._holdTimer=null)},this._onClick=()=>{if(!this._holdFired)return vo(this._config?.double_tap_action)?null!=this._pendingTapTimer?(clearTimeout(this._pendingTapTimer),this._pendingTapTimer=null,void this._fireAction("double_tap")):void(this._pendingTapTimer=setTimeout(()=>{this._pendingTapTimer=null,this._fireAction("tap")},250)):void this._fireAction("tap");this._holdFired=!1}}setConfig(e){if(!e||"string"!=typeof e.entry_id||0===e.entry_id.length)throw new Error(`${xe}: \`entry_id\` is required and must be a non-empty string`);let t={...e};if("string"==typeof t.tap_action&&(t={...t,tap_action:"none"===t.tap_action?{action:"none"}:void 0}),this._config=t,t.tooltips&&ct(t.tooltips),null===this._registry){const e=kt.get(t.entry_id);e&&(this._registry=e.entries)}}getCardSize(){return 1}getGridOptions(){return{columns:"full",rows:"auto",min_columns:3,min_rows:"one-line"!==this._config?.layout?2:1}}static async getStubConfig(e){let t="";try{const o=await ft(e);t=o[0]?.entry_id??""}catch{}return{type:`custom:${xe}`,entry_id:t}}static async getConfigElement(){return document.createElement($e)}connectedCallback(){if(super.connectedCallback(),null===this._registry){const e=xt();e&&(this._registry=e)}this.hass&&this._ensureRegistry()}disconnectedCallback(){super.disconnectedCallback(),this._unsubRegistry&&(this._unsubRegistry(),this._unsubRegistry=null)}updated(e){e.has("hass")&&this.hass&&this._ensureRegistry()}shouldUpdate(e){return e.size>1||!e.has("hass")||(!this._discovered||ge(e.get("hass"),this.hass,Object.values(this._discovered.entities)))}willUpdate(e){this._config&&this.hass&&null!==this._registry&&(e.has("hass")||e.has("_registry")||e.has("_config"))&&(this._discovered=this._memo(this.hass,{type:this._config.type,entry_id:this._config.entry_id},this._registry))}_ensureRegistry(){this._fetchRegistry(),this._unsubRegistry||(this._unsubRegistry=yt(this.hass,()=>{this._fetchRegistry(!0)}))}_fetchRegistry(e=!1){if(this._fetchInFlight)return;this._fetchInFlight=!0;const t=++this._fetchGen;$t(this.hass,e).then(e=>{t===this._fetchGen&&e!==this._registry&&(this._registry=e,this._registryError=null,this._config&&kt.set(this._config.entry_id,Et(e,this._config.entry_id)))}).catch(e=>{t===this._fetchGen&&(this._registryError=e?.message??"entity registry fetch failed")}).finally(()=>{t===this._fetchGen&&(this._fetchInFlight=!1)})}render(){if(!this._config||!this.hass)return Y;if(null===this._registry)return L`<ha-card>
         <div class="empty">
           <p class="dim">
             ${this._registryError?Be("tile.registry_failed",this.hass,{error:this._registryError}):Be("tile.loading",this.hass)}
           </p>
         </div>
-      </ha-card>`;const e=this._discovered;return e?q`
+      </ha-card>`;const e=this._discovered;return e?L`
       <ha-card>${this._renderTile(e)}</ha-card>
       <acp-more-info-dialog
         .hass=${this.hass}
@@ -1986,36 +2060,36 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
         .badges=${this._config.badges}
         @acp-dialog-close=${this._closeDialog}
       ></acp-more-info-dialog>
-    `:q`<ha-card>
+    `:L`<ha-card>
         <div class="empty">
           <p class="dim">
             ${Be("tile.entry_not_found",this.hass,{entry:this._config.entry_id})}
           </p>
         </div>
-      </ha-card>`}_buildHandlerLabels(){const e={};for(const[t,o]of Object.entries(Se))e[t]=Be(o,this.hass);return e}_renderTile(e){const t=this._config,o=t.name??e.entry_title,i=this._resolvedCover(e),s=t.icon??function(e,t){if(null!==t&&!Number.isNaN(t)){if(t>=95)return ze[e]??"mdi:window-shutter-open";if(t<=5)return Oe[e]??"mdi:window-shutter"}return Ee[e]??"mdi:window-shutter"}(e.cover_type,this._liveCoverPosition(i)),n=!1!==t.show_position,r=!1!==t.show_state,a=!1!==t.show_controls,l=!1!==t.show_badge,c=!1!==t.show_motion_icon?this._motionActiveState(e):null,d=Be("timeout_pending"===c?"tile.motion_pending":"tile.motion_detected",this.hass),h="one-line"!==t.layout,u=this._currentPosition(e),p=this._liveCoverPosition(i)??u,g=this._winner(e),m=this._traceAttrs(e),_=this._manualEndIso(e),f=this._isFullyInert(t),v=Yt(m),y=!0===t.show_decision_summary&&m?Ht(m.trace??[],m,0,this._buildHandlerLabels(),Be("badge.safety",this.hass)):"",b=!!y&&h,w=this._switchOn(e,"integration_enabled_switch"),x=this._switchOn(e,"automatic_control_switch"),$=this._manualOverrideOn(e),A=function(e){const t=function(e){const t=ao(e);return"motion"!==t?t:!1===e.badges?.motion||e.showMotionIcon?!1===e.badges?.auto?null:"auto":t}(e);return!1===e.inTimeWindow&&!1!==e.badges?.off_schedule&&"off"!==t&&"manual"!==t&&"force"!==t?"off_schedule":t}({winner:g,integrationEnabled:w,manualActive:$,badges:t.badges,showMotionIcon:!1!==t.show_motion_icon,inTimeWindow:m?.in_time_window}),k=lo(m?.trace,g),C=null!==A&&so([A],t.badges,k).length>0,S=l&&C&&!(!1===x&&!0===w),E=function(e){if(!e.integrationEnabled)return!1;if(!e.automaticControl)return!1;if(e.manualActive)return!1;const t=Qt(e.winner);return"force"!==t&&("custom_position"!==t||!e.bypassAutoControl&&!0!==e.safetyActive)}({winner:g,integrationEnabled:w,automaticControl:x,manualActive:$,bypassAutoControl:!0===m?.bypass_auto_control,safetyActive:v}),z=h&&l&&!1!==t.badges?.auto&&E,O=!(z&&"auto"===A),M=r?function(e,t){if(!e||!t)return null;const o=e.states[t];if(!o?.state||"unknown"===o.state||"unavailable"===o.state)return null;if("function"==typeof e.formatEntityState){const t=e.formatEntityState(o);if(t)return t}if("function"==typeof e.localize){const t=e.localize(`component.cover.entity_component._.state.${o.state}`);if(t)return t}return o.state.charAt(0).toUpperCase()+o.state.slice(1)}(this.hass,i):null,I=[M,n&&null!==p?Ot(p):null].filter(e=>!!e),F=!!M,T=function(e,t,o){if(!Array.isArray(e?.custom_position_slots))return null;const i=e.custom_position_slots.filter(e=>!0===e.min_mode&&!0===e.enabled&&null!==e.sensor&&null!==e.position&&"on"===t[e.sensor]?.state);if(0===i.length)return null;const s=i.reduce((e,t)=>(t.position??0)>(e.position??0)?t:e),n=s.position,r=s.priority??null;return{slot:s.slot,position:n,label:s.sensor_name??`#${s.slot}`,clamping:null!==o&&n>o,sensorOn:!0,priority:r,resistsManual:null!=r&&r>80}}(m,this.hass.states,u),P=Qt(g),j=!!T&&!("custom_position"===P&&!0===m?.custom_position_minimum_mode)&&w,R=$&&!!e.entities.reset_override_button,N=I.length>0?q`<div class="position">${I.join(" · ")}</div>`:W,D=j?q`<span
+      </ha-card>`}_buildHandlerLabels(){const e={};for(const[t,o]of Object.entries(Ee))e[t]=Be(o,this.hass);return e}_renderTile(e){const t=this._config,o=t.name??e.entry_title,s=this._resolvedCover(e),i=t.icon??function(e,t){if(null!==t&&!Number.isNaN(t)){if(t>=95)return ze[e]??"mdi:window-shutter-open";if(t<=5)return Oe[e]??"mdi:window-shutter"}return Se[e]??"mdi:window-shutter"}(e.cover_type,this._liveCoverPosition(s)),n=!1!==t.show_position,r=!1!==t.show_state,a=!1!==t.show_controls,l=!1!==t.show_badge,c=!1!==t.show_motion_icon?this._motionActiveState(e):null,d=Be("timeout_pending"===c?"tile.motion_pending":"tile.motion_detected",this.hass),h="one-line"!==t.layout,u=this._currentPosition(e),p=this._liveCoverPosition(s)??u,_=this._winner(e),m=this._traceAttrs(e),g=this._manualEndIso(e),f=this._isFullyInert(t),v=lo(m),y=!0===t.show_decision_summary&&m?ho(m.trace??[],m,0,this._buildHandlerLabels(),Be("badge.safety",this.hass)):"",b=!!y&&h,w=this._switchOn(e,"integration_enabled_switch"),x=this._switchOn(e,"automatic_control_switch"),$=this._manualOverrideOn(e),A=function(e){const t=function(e){const t=xo(e);return"motion"!==t?t:!1===e.badges?.motion||e.showMotionIcon?!1===e.badges?.auto?null:"auto":t}(e);return!1===e.inTimeWindow&&!1!==e.badges?.off_schedule&&"off"!==t&&"manual"!==t&&"force"!==t?"off_schedule":t}({winner:_,integrationEnabled:w,manualActive:$,badges:t.badges,showMotionIcon:!1!==t.show_motion_icon,inTimeWindow:m?.in_time_window}),k=$o(m?.trace,_),C=null!==A&&yo([A],t.badges,k).length>0,E=l&&C&&!(!1===x&&!0===w),S=function(e){if(!e.integrationEnabled)return!1;if(!e.automaticControl)return!1;if(e.manualActive)return!1;const t=co(e.winner);return"force"!==t&&("custom_position"!==t||!e.bypassAutoControl&&!0!==e.safetyActive)}({winner:_,integrationEnabled:w,automaticControl:x,manualActive:$,bypassAutoControl:!0===m?.bypass_auto_control,safetyActive:v}),z=h&&l&&!1!==t.badges?.auto&&S,O=!(z&&"auto"===A),M=r?function(e,t){if(!e||!t)return null;const o=e.states[t];if(!o?.state||"unknown"===o.state||"unavailable"===o.state)return null;if("function"==typeof e.formatEntityState){const t=e.formatEntityState(o);if(t)return t}if("function"==typeof e.localize){const t=e.localize(`component.cover.entity_component._.state.${o.state}`);if(t)return t}return o.state.charAt(0).toUpperCase()+o.state.slice(1)}(this.hass,s):null,I=[M,n&&null!==p?Lt(p):null].filter(e=>!!e),F=!!M,T=function(e,t,o){if(!Array.isArray(e?.custom_position_slots))return null;const s=e.custom_position_slots.filter(e=>!0===e.min_mode&&!0===e.enabled&&null!==e.sensor&&null!==e.position&&"on"===t[e.sensor]?.state);if(0===s.length)return null;const i=s.reduce((e,t)=>(t.position??0)>(e.position??0)?t:e),n=i.position,r=i.priority??null;return{slot:i.slot,position:n,label:i.sensor_name??`#${i.slot}`,clamping:null!==o&&n>o,sensorOn:!0,priority:r,resistsManual:null!=r&&r>80}}(m,this.hass.states,u),P=co(_),j=!!T&&!("custom_position"===P&&!0===m?.custom_position_minimum_mode)&&w,R=$&&!!e.entities.reset_override_button,N=I.length>0?L`<div class="position">${I.join(" · ")}</div>`:Y,D=j?L`<span
           class=${`acp-floor-chip${T.clamping?"":" is-armed"}${T.resistsManual?" resists-manual":" is-bypassable"}`}
-          title=${Be("dialog.floor_tooltip",this.hass)}
-          >${Be("dialog.floor",this.hass)} ${Ot(T.position)}</span
-        >`:W,B=S?q`<acp-tile-badge
+          ${ut(Be("dialog.floor_tooltip",this.hass))}
+          >${Be("dialog.floor",this.hass)} ${Lt(T.position)}</span
+        >`:Y,B=E?L`<acp-tile-badge
           .hass=${this.hass}
-          .winner=${g}
+          .winner=${_}
           .kindOverride=${A??void 0}
           .integrationEnabled=${w}
           .slotNumber=${m?.custom_position_active_slot}
           .slotName=${m?.custom_position_active_slot_name}
-          .pct=${Wt(m,u)??void 0}
+          .pct=${ao(m,u)??void 0}
           .minimumMode=${m?.custom_position_minimum_mode}
           .safetyActive=${v}
-          .manualEndIso=${_}
+          .manualEndIso=${g}
           .manualActive=${$}
           .resumable=${R}
           @acp-resume=${()=>this._resume(e)}
-        ></acp-tile-badge>`:W,K=z?q`<acp-tile-badge
+        ></acp-tile-badge>`:Y,K=z?L`<acp-tile-badge
           .hass=${this.hass}
-          .winner=${g}
+          .winner=${_}
           .kindOverride=${"auto"}
           .integrationEnabled=${w}
-        ></acp-tile-badge>`:W;return q`
+        ></acp-tile-badge>`:Y;return L`
       <div
         class=${`tile-body${h?" detailed":""}${b?" has-summary":""}${F?" has-state-label":""}${j?" has-floor-chip":""}`}
         role=${f?"group":"button"}
@@ -2027,29 +2101,29 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
         @click=${this._onClick}
       >
         <div class="cover-icon-wrap">
-          <ha-icon class="cover-icon" icon=${s}></ha-icon>
-          ${c?q`<ha-icon
+          <ha-icon class="cover-icon" icon=${i}></ha-icon>
+          ${c?L`<ha-icon
                 class="motion-overlay ${c}"
                 icon="mdi:motion-sensor"
-                title=${d}
-              ></ha-icon>`:W}
+                ${ut(d)}
+              ></ha-icon>`:Y}
         </div>
         <div class="label">
-          <div class="title" title=${e.entry_title}>${o}</div>
-          ${y&&!h?q`<div class="summary">${y}</div>`:W}
-          ${b?q`<div class="summary inline-summary" title=${y}>${y}</div>`:W}
+          <div class="title" ${ut(e.entry_title)}>${o}</div>
+          ${y&&!h?L`<div class="summary">${y}</div>`:Y}
+          ${b?L`<div class="summary inline-summary" ${ut(y)}>${y}</div>`:Y}
         </div>
-        ${h&&z?q`<div class="auto-line">${K}</div>`:W}
-        ${h?q`<div class="detail-line">
-              ${N}${D}${O?B:W}
-            </div>`:q`${N}${D}`}
-        ${a?q`<div class="controls" @click=${this._stop} @pointerdown=${this._stop}>
+        ${h&&z?L`<div class="auto-line">${K}</div>`:Y}
+        ${h?L`<div class="detail-line">
+              ${N}${D}${O?B:Y}
+            </div>`:L`${N}${D}`}
+        ${a?L`<div class="controls" @click=${this._stop} @pointerdown=${this._stop}>
               <button
                 class="up"
                 type="button"
                 aria-label=${Be("tile.open",this.hass)}
-                ?disabled=${!i}
-                @click=${()=>this._setCoverPosition(i,100)}
+                ?disabled=${!s}
+                @click=${()=>this._setCoverPosition(s,100)}
               >
                 <ha-icon icon="mdi:arrow-up"></ha-icon>
               </button>
@@ -2057,8 +2131,8 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
                 class="stop"
                 type="button"
                 aria-label=${Be("tile.stop",this.hass)}
-                ?disabled=${!i}
-                @click=${()=>this._stopCover(i)}
+                ?disabled=${!s}
+                @click=${()=>this._stopCover(s)}
               >
                 <ha-icon icon="mdi:stop"></ha-icon>
               </button>
@@ -2066,15 +2140,15 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
                 class="down"
                 type="button"
                 aria-label=${Be("tile.close",this.hass)}
-                ?disabled=${!i}
-                @click=${()=>this._setCoverPosition(i,0)}
+                ?disabled=${!s}
+                @click=${()=>this._setCoverPosition(s,0)}
               >
                 <ha-icon icon="mdi:arrow-down"></ha-icon>
               </button>
-            </div>`:W}
-        ${h?W:B}
+            </div>`:Y}
+        ${h?Y:B}
       </div>
-    `}_resolvedCover(e){return this._config?.cover?this._config.cover:e.managed_covers[0]}_currentPosition(e){const t=e.entities.target_position_sensor;if(!t)return null;const o=this.hass.states[t];if(!o)return null;const i=parseFloat(o.state);return Number.isNaN(i)?null:i}_liveCoverPosition(e){if(!e)return null;const t=this.hass.states[e]?.attributes?.current_position;return"number"!=typeof t||Number.isNaN(t)?null:t}_winner(e){const t=e.entities.decision_trace_sensor;return t?this.hass.states[t]?.state??"default":"default"}_traceAttrs(e){const t=e.entities.decision_trace_sensor;if(t)return this.hass.states[t]?.attributes}_motionActiveState(e){const t=e.entities.motion_status_sensor;if(!t)return null;const o=this.hass.states[t]?.state;return"motion_detected"===o||"timeout_pending"===o?o:null}_manualOverrideOn(e){const t=e.entities.manual_override_binary;return!!t&&"on"===this.hass.states[t]?.state}_switchOn(e,t){const o=e.entities[t];return!o||"off"!==this.hass.states[o]?.state}_manualEndIso(e){if(!this._manualOverrideOn(e))return;const t=e.entities.manual_override_end_sensor;return t?this.hass.states[t]?.state:void 0}_setCoverPosition(e,t){e&&this.hass.callService(Ae,"set_position",{position:t},{entity_id:e})}_stopCover(e){e&&this.hass.callService(Ae,"stop",{},{entity_id:e})}_resume(e){const t=e.entities.reset_override_button;t&&this.hass.callService("button","press",{entity_id:t})}_tapActionConfig(){const e=this._config?.tap_action;if("string"!=typeof e)return e}_isFullyInert(e){return!!(e=>!!e&&"none"===e.action)(this._tapActionConfig())&&!io(e.hold_action)&&!io(e.double_tap_action)}_fireAction(e){if(!this._config||!this.hass)return;const t=this._tapActionConfig();if("tap"===e&&void 0===t)return this._dialogOpen=!0,void this.dispatchEvent(new CustomEvent("acp-tile-tap",{bubbles:!0,composed:!0}));const o=this._resolvedCoverFromState();((e,t,o,i)=>{let s;"double_tap"===i&&o.double_tap_action?s=o.double_tap_action:"hold"===i&&o.hold_action?s=o.hold_action:"tap"===i&&o.tap_action&&(s=o.tap_action),((e,t,o,i)=>{if(i||(i={action:"more-info"}),!i.confirmation||i.confirmation.exemptions&&i.confirmation.exemptions.some(e=>e.user===t.user.id)||(oo("warning"),confirm(i.confirmation.text||`Are you sure you want to ${i.action}?`)))switch(i.action){case"more-info":(o.entity||o.camera_image)&&to(e,"hass-more-info",{entityId:o.entity?o.entity:o.camera_image});break;case"navigate":i.navigation_path&&((e,t,o=!1)=>{o?history.replaceState(null,"",t):history.pushState(null,"",t),to(window,"location-changed",{replace:o})})(0,i.navigation_path);break;case"url":i.url_path&&window.open(i.url_path);break;case"toggle":o.entity&&(((e,t)=>{((e,t,o=!0)=>{const i=function(e){return e.substr(0,e.indexOf("."))}(t),s="group"===i?"homeassistant":i;let n;switch(i){case"lock":n=o?"unlock":"lock";break;case"cover":n=o?"open_cover":"close_cover";break;default:n=o?"turn_on":"turn_off"}e.callService(s,n,{entity_id:t})})(e,t,eo.includes(e.states[t].state))})(t,o.entity),oo("success"));break;case"call-service":{if(!i.service)return void oo("failure");const[e,o]=i.service.split(".",2);t.callService(e,o,i.service_data,i.target),oo("success");break}case"fire-dom-event":to(e,"ll-custom",i)}})(e,t,o,s)})(this,this.hass,{entity:o,tap_action:t,hold_action:this._config.hold_action,double_tap_action:this._config.double_tap_action},e)}_resolvedCoverFromState(){if(this._config?.cover)return this._config.cover;if(null===this._registry)return;const e=this._discovered??this._memo(this.hass,{type:this._config.type,entry_id:this._config.entry_id},this._registry);return e?.managed_covers[0]}_stop(e){e.stopPropagation()}};Co.styles=r`
+    `}_resolvedCover(e){return this._config?.cover?this._config.cover:e.managed_covers[0]}_currentPosition(e){const t=e.entities.target_position_sensor;if(!t)return null;const o=this.hass.states[t];if(!o)return null;const s=parseFloat(o.state);return Number.isNaN(s)?null:s}_liveCoverPosition(e){if(!e)return null;const t=this.hass.states[e]?.attributes?.current_position;return"number"!=typeof t||Number.isNaN(t)?null:t}_winner(e){const t=e.entities.decision_trace_sensor;return t?this.hass.states[t]?.state??"default":"default"}_traceAttrs(e){const t=e.entities.decision_trace_sensor;if(t)return this.hass.states[t]?.attributes}_motionActiveState(e){const t=e.entities.motion_status_sensor;if(!t)return null;const o=this.hass.states[t]?.state;return"motion_detected"===o||"timeout_pending"===o?o:null}_manualOverrideOn(e){const t=e.entities.manual_override_binary;return!!t&&"on"===this.hass.states[t]?.state}_switchOn(e,t){const o=e.entities[t];return!o||"off"!==this.hass.states[o]?.state}_manualEndIso(e){if(!this._manualOverrideOn(e))return;const t=e.entities.manual_override_end_sensor;return t?this.hass.states[t]?.state:void 0}_setCoverPosition(e,t){e&&this.hass.callService(Ae,"set_position",{position:t},{entity_id:e})}_stopCover(e){e&&this.hass.callService(Ae,"stop",{},{entity_id:e})}_resume(e){const t=e.entities.reset_override_button;t&&this.hass.callService("button","press",{entity_id:t})}_tapActionConfig(){const e=this._config?.tap_action;if("string"!=typeof e)return e}_isFullyInert(e){return!!(e=>!!e&&"none"===e.action)(this._tapActionConfig())&&!vo(e.hold_action)&&!vo(e.double_tap_action)}_fireAction(e){if(!this._config||!this.hass)return;const t=this._tapActionConfig();if("tap"===e&&void 0===t)return this._dialogOpen=!0,void this.dispatchEvent(new CustomEvent("acp-tile-tap",{bubbles:!0,composed:!0}));const o=this._resolvedCoverFromState();((e,t,o,s)=>{let i;"double_tap"===s&&o.double_tap_action?i=o.double_tap_action:"hold"===s&&o.hold_action?i=o.hold_action:"tap"===s&&o.tap_action&&(i=o.tap_action),((e,t,o,s)=>{if(s||(s={action:"more-info"}),!s.confirmation||s.confirmation.exemptions&&s.confirmation.exemptions.some(e=>e.user===t.user.id)||(fo("warning"),confirm(s.confirmation.text||`Are you sure you want to ${s.action}?`)))switch(s.action){case"more-info":(o.entity||o.camera_image)&&go(e,"hass-more-info",{entityId:o.entity?o.entity:o.camera_image});break;case"navigate":s.navigation_path&&((e,t,o=!1)=>{o?history.replaceState(null,"",t):history.pushState(null,"",t),go(window,"location-changed",{replace:o})})(0,s.navigation_path);break;case"url":s.url_path&&window.open(s.url_path);break;case"toggle":o.entity&&(((e,t)=>{((e,t,o=!0)=>{const s=function(e){return e.substr(0,e.indexOf("."))}(t),i="group"===s?"homeassistant":s;let n;switch(s){case"lock":n=o?"unlock":"lock";break;case"cover":n=o?"open_cover":"close_cover";break;default:n=o?"turn_on":"turn_off"}e.callService(i,n,{entity_id:t})})(e,t,mo.includes(e.states[t].state))})(t,o.entity),fo("success"));break;case"call-service":{if(!s.service)return void fo("failure");const[e,o]=s.service.split(".",2);t.callService(e,o,s.service_data,s.target),fo("success");break}case"fire-dom-event":go(e,"ll-custom",s)}})(e,t,o,i)})(this,this.hass,{entity:o,tap_action:t,hold_action:this._config.hold_action,double_tap_action:this._config.double_tap_action},e)}_resolvedCoverFromState(){if(this._config?.cover)return this._config.cover;if(null===this._registry)return;const e=this._discovered??this._memo(this.hass,{type:this._config.type,entry_id:this._config.entry_id},this._registry);return e?.managed_covers[0]}_stop(e){e.stopPropagation()}};Bo.styles=r`
     :host {
       display: block;
       height: 100%;
@@ -2311,6 +2385,14 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
       border: 1px solid transparent;
       white-space: nowrap;
       align-self: center;
+    }
+    /* Floating-tooltip cursor lifecycle for the tooltip carriers inside the
+       tile (floor chip, title, inline summary, motion overlay). Help hint on
+       hover, default once OUR bubble appears. */
+    [data-tooltip]:hover {
+      cursor: help;
+    }
+    [data-tooltip][acp-tt-shown] {
       cursor: default;
     }
     /* Clamping axis: not-clamping → hollow/outline (transparent fill + purple border). */
@@ -2451,7 +2533,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
       color: var(--secondary-text-color);
       margin: 0;
     }
-  `,e([ge({attribute:!1})],Co.prototype,"hass",void 0),e([me()],Co.prototype,"_config",void 0),e([me()],Co.prototype,"_registry",void 0),e([me()],Co.prototype,"_registryError",void 0),e([me()],Co.prototype,"_dialogOpen",void 0),Co=e([he(xe)],Co),window.customCards=window.customCards||[],window.customCards.some(e=>e.type===xe)||window.customCards.push({type:xe,name:"Adaptive Cover Pro — Tile",description:"Compact chip-style tile for one Adaptive Cover Pro instance: icon, name, position, ↑■↓, contextual badge.",preview:!0,documentationURL:"https://github.com/jrhubott/adaptive-cover-pro/wiki/Lovelace-Card"});const So=[{key:"sky",labelKey:"editor.main.section_sky_label",descKey:"editor.main.section_sky_desc"},{key:"elevation",labelKey:"editor.main.section_elevation_label",descKey:"editor.main.section_elevation_desc"},{key:"decision",labelKey:"editor.main.section_decision_label",descKey:"editor.main.section_decision_desc"},{key:"covers",labelKey:"editor.main.section_covers_label",descKey:"editor.main.section_covers_desc"},{key:"overrides",labelKey:"editor.main.section_overrides_label",descKey:"editor.main.section_overrides_desc"},{key:"climate",labelKey:"editor.main.section_climate_label",descKey:"editor.main.section_climate_desc"}],Eo=So.map(e=>e.key);let zo=class extends ce{constructor(){super(...arguments),this._entries=null,this._entriesError=null,this._fetchInFlight=!1}setConfig(e){this._config=e}updated(e){e.has("hass")&&this.hass&&!this._entries&&!this._fetchInFlight&&(this._fetchInFlight=!0,Ue(this.hass).then(e=>{this._entries=e,this._entriesError=null,this._config?.entry_id||1!==e.length||this._emit({...this._config??{type:"",entry_id:""},entry_id:e[0].entry_id})}).catch(e=>{this._entriesError=e?.message??"failed to load config entries"}).finally(()=>{this._fetchInFlight=!1}))}get _currentSections(){return this._config?.show_sections??Eo}_emit(e){this._config=e,this.dispatchEvent(new CustomEvent("config-changed",{detail:{config:e},bubbles:!0,composed:!0}))}_onEntryChange(e){const t=e.target.value;this._emit({...this._config??{type:"",entry_id:""},entry_id:t})}_onSectionToggle(e,t){const o=new Set(this._currentSections);t?o.add(e):o.delete(e);const i=So.map(e=>e.key).filter(e=>o.has(e));this._emit({...this._config??{type:"",entry_id:""},show_sections:i})}_onCompactToggle(e){this._emit({...this._config??{type:"",entry_id:""},compact:e})}_onCompassStatsToggle(e){this._emit({...this._config??{type:"",entry_id:""},show_compass_stats:e})}_onCompassLegendToggle(e){this._emit({...this._config??{type:"",entry_id:""},show_compass_legend:e})}_onMoonToggle(e){this._emit({...this._config??{type:"",entry_id:""},show_moon:e})}_onHideInactiveToggle(e){this._emit({...this._config??{type:"",entry_id:""},hide_inactive_handlers:e})}_onNorthOffsetChange(e){const t=parseFloat(e.target.value),o=Number.isFinite(t)?t:0;this._emit({...this._config??{type:"",entry_id:""},north_offset:o})}_onControlToggle(e,t){const o=this._config??{type:"",entry_id:""};this._emit({...o,controls:{...o.controls,[e]:t}})}_onCoverColorChange(e){const t=this._config??{type:"",entry_id:""};this._emit({...t,cover_colors:[e]})}_onCoverColorReset(){const e={...this._config??{type:"",entry_id:""}};delete e.cover_colors,this._emit(e)}render(){if(!this._config)return W;const e=new Set(this._currentSections);return q`
+  `,e([_e({attribute:!1})],Bo.prototype,"hass",void 0),e([me()],Bo.prototype,"_config",void 0),e([me()],Bo.prototype,"_registry",void 0),e([me()],Bo.prototype,"_registryError",void 0),e([me()],Bo.prototype,"_dialogOpen",void 0),Bo=e([he(xe)],Bo),window.customCards=window.customCards||[],window.customCards.some(e=>e.type===xe)||window.customCards.push({type:xe,name:"Adaptive Cover Pro — Tile",description:"Compact chip-style tile for one Adaptive Cover Pro instance: icon, name, position, ↑■↓, contextual badge.",preview:!0,documentationURL:"https://github.com/jrhubott/adaptive-cover-pro/wiki/Lovelace-Card"});const Ko=[{key:"sky",labelKey:"editor.main.section_sky_label",descKey:"editor.main.section_sky_desc"},{key:"elevation",labelKey:"editor.main.section_elevation_label",descKey:"editor.main.section_elevation_desc"},{key:"decision",labelKey:"editor.main.section_decision_label",descKey:"editor.main.section_decision_desc"},{key:"covers",labelKey:"editor.main.section_covers_label",descKey:"editor.main.section_covers_desc"},{key:"overrides",labelKey:"editor.main.section_overrides_label",descKey:"editor.main.section_overrides_desc"},{key:"climate",labelKey:"editor.main.section_climate_label",descKey:"editor.main.section_climate_desc"}],Vo=Ko.map(e=>e.key);let Go=class extends ce{constructor(){super(...arguments),this._entries=null,this._entriesError=null,this._fetchInFlight=!1}setConfig(e){this._config=e}updated(e){e.has("hass")&&this.hass&&!this._entries&&!this._fetchInFlight&&(this._fetchInFlight=!0,ft(this.hass).then(e=>{this._entries=e,this._entriesError=null,this._config?.entry_id||1!==e.length||this._emit({...this._config??{type:"",entry_id:""},entry_id:e[0].entry_id})}).catch(e=>{this._entriesError=e?.message??"failed to load config entries"}).finally(()=>{this._fetchInFlight=!1}))}get _currentSections(){return this._config?.show_sections??Vo}_emit(e){this._config=e,this.dispatchEvent(new CustomEvent("config-changed",{detail:{config:e},bubbles:!0,composed:!0}))}_onEntryChange(e){const t=e.target.value;this._emit({...this._config??{type:"",entry_id:""},entry_id:t})}_onSectionToggle(e,t){const o=new Set(this._currentSections);t?o.add(e):o.delete(e);const s=Ko.map(e=>e.key).filter(e=>o.has(e));this._emit({...this._config??{type:"",entry_id:""},show_sections:s})}_onCompactToggle(e){this._emit({...this._config??{type:"",entry_id:""},compact:e})}_onCompassStatsToggle(e){this._emit({...this._config??{type:"",entry_id:""},show_compass_stats:e})}_onCompassLegendToggle(e){this._emit({...this._config??{type:"",entry_id:""},show_compass_legend:e})}_onMoonToggle(e){this._emit({...this._config??{type:"",entry_id:""},show_moon:e})}_onHideInactiveToggle(e){this._emit({...this._config??{type:"",entry_id:""},hide_inactive_handlers:e})}_onNorthOffsetChange(e){const t=parseFloat(e.target.value),o=Number.isFinite(t)?t:0;this._emit({...this._config??{type:"",entry_id:""},north_offset:o})}_onControlToggle(e,t){const o=this._config??{type:"",entry_id:""};this._emit({...o,controls:{...o.controls,[e]:t}})}_onCoverColorChange(e){const t=this._config??{type:"",entry_id:""};this._emit({...t,cover_colors:[e]})}_onCoverColorReset(){const e={...this._config??{type:"",entry_id:""}};delete e.cover_colors,this._emit(e)}render(){if(!this._config)return Y;const e=new Set(this._currentSections);return L`
       <div class="form">
         <div class="section">
           <label class="field-label">${Be("editor.common.entry_id",this.hass)}</label>
@@ -2461,7 +2543,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
         <div class="section">
           <label class="field-label">${Be("editor.main.sections",this.hass)}</label>
           <div class="hint">${Be("editor.main.sections_hint",this.hass)}</div>
-          ${So.map(t=>q`
+          ${Ko.map(t=>L`
               <label class="toggle-row">
                 <input
                   type="checkbox"
@@ -2516,11 +2598,11 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
           </label>
         </div>
 
-        ${this._config.entry_id?q`
+        ${this._config.entry_id?L`
               <div class="section">
                 <label class="field-label">${Be("editor.compass.cover_colors",this.hass)}</label>
                 <div class="hint">${Be("editor.compass.cover_colors_hint",this.hass)}</div>
-                ${(()=>{const e=this._config.cover_colors?.[0]??null,t=e??Nt(0);return q`
+                ${(()=>{const e=this._config.cover_colors?.[0]??null,t=e??Zt(0);return L`
                     <div class="color-row">
                       <input
                         type="color"
@@ -2543,7 +2625,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
                     </div>
                   `})()}
               </div>
-            `:W}
+            `:Y}
 
         <div class="section">
           <label class="field-label">${Be("editor.main.display",this.hass)}</label>
@@ -2624,9 +2706,9 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
             @change=${this._onNorthOffsetChange}
           />
         </div>
-        ${wo(this.hass)}
+        ${Po(this.hass)}
       </div>
-    `}_renderEntryPicker(){return this._entriesError?q`
+    `}_renderEntryPicker(){return this._entriesError?L`
         <div class="error">
           ${Be("editor.common.load_failed",this.hass,{error:this._entriesError})}
         </div>
@@ -2637,23 +2719,23 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
           @change=${this._onEntryChange}
           class="text-input"
         />
-      `:this._entries?0===this._entries.length?q`
+      `:this._entries?0===this._entries.length?L`
         <div class="error">
           ${Be("editor.common.no_entries",this.hass)}
           <code>${Be("editor.common.no_entries_path",this.hass)}</code>${Be("editor.common.no_entries_then",this.hass)}
         </div>
-      `:q`
+      `:L`
       <select class="select" .value=${this._config?.entry_id??""} @change=${this._onEntryChange}>
-        ${this._config?.entry_id&&!this._entries.some(e=>e.entry_id===this._config.entry_id)?q`<option value=${this._config.entry_id}>
+        ${this._config?.entry_id&&!this._entries.some(e=>e.entry_id===this._config.entry_id)?L`<option value=${this._config.entry_id}>
               ${Be("editor.common.unknown_entry",this.hass,{entry:this._config.entry_id})}
-            </option>`:W}
-        ${this._entries.map(e=>q`
+            </option>`:Y}
+        ${this._entries.map(e=>L`
             <option value=${e.entry_id} ?selected=${e.entry_id===this._config?.entry_id}>
               ${e.title}
             </option>
           `)}
       </select>
-    `:q`<div class="hint">${Be("editor.common.loading_entries",this.hass)}</div>`}};zo.styles=r`
+    `:L`<div class="hint">${Be("editor.common.loading_entries",this.hass)}</div>`}};Go.styles=r`
     :host {
       display: block;
     }
@@ -2768,7 +2850,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
     .dim {
       color: var(--secondary-text-color);
     }
-  `,e([ge({attribute:!1})],zo.prototype,"hass",void 0),e([me()],zo.prototype,"_config",void 0),e([me()],zo.prototype,"_entries",void 0),e([me()],zo.prototype,"_entriesError",void 0),zo=e([he(ye)],zo);const Oo=[{key:"compact",labelKey:"editor.compass.toggle_compact_label",descKey:"editor.compass.toggle_compact_desc",defaultOn:!1},{key:"show_legend",labelKey:"editor.compass.toggle_legend_label",descKey:"editor.compass.toggle_legend_desc",defaultOn:!0},{key:"show_stats",labelKey:"editor.compass.toggle_stats_label",descKey:"editor.compass.toggle_stats_desc",defaultOn:!0},{key:"show_moon",labelKey:"editor.compass.toggle_moon_label",descKey:"editor.compass.toggle_moon_desc",defaultOn:!1},{key:"show_cardinals",labelKey:"editor.compass.toggle_cardinals_label",descKey:"editor.compass.toggle_cardinals_desc",defaultOn:!0},{key:"show_blind_spot",labelKey:"editor.compass.toggle_blind_spot_label",descKey:"editor.compass.toggle_blind_spot_desc",defaultOn:!0},{key:"show_sun_path",labelKey:"editor.compass.toggle_sun_path_label",descKey:"editor.compass.toggle_sun_path_desc",defaultOn:!0},{key:"show_sunrise_sunset",labelKey:"editor.compass.toggle_sunrise_sunset_label",descKey:"editor.compass.toggle_sunrise_sunset_desc",defaultOn:!0},{key:"show_cover_fill",labelKey:"editor.compass.toggle_cover_fill_label",descKey:"editor.compass.toggle_cover_fill_desc",defaultOn:!0},{key:"show_window_arrow",labelKey:"editor.compass.toggle_window_arrow_label",descKey:"editor.compass.toggle_window_arrow_desc",defaultOn:!0},{key:"show_elevation_chart",labelKey:"editor.compass.toggle_elevation_chart_label",descKey:"editor.compass.toggle_elevation_chart_desc",defaultOn:!0}];let Mo=class extends ce{constructor(){super(...arguments),this._entries=null,this._entriesError=null,this._fetchInFlight=!1}setConfig(e){this._config=e}updated(e){e.has("hass")&&this.hass&&!this._entries&&!this._fetchInFlight&&(this._fetchInFlight=!0,Ue(this.hass).then(e=>{this._entries=e,this._entriesError=null}).catch(e=>{this._entriesError=e?.message??"failed to load config entries"}).finally(()=>{this._fetchInFlight=!1}))}_emit(e){this._config=e,this.dispatchEvent(new CustomEvent("config-changed",{detail:{config:e},bubbles:!0,composed:!0}))}_baseConfig(){return this._config??{type:`custom:${be}`,entry_ids:[]}}_trimColors(e){let t=-1;for(let o=0;o<e.length;o++)e[o]&&(t=o);if(!(t<0))return e.slice(0,t+1)}_emitWithColors(e,t,o){const i=this._trimColors(t),{cover_colors:s,...n}=e,r=i?{...n,...o,cover_colors:i}:{...n,...o};this._emit(r)}_onCoverColorChange(e,t){const o=this._baseConfig(),i=[...o.cover_colors??[]];for(;i.length<=e;)i.push(null);i[e]=t,this._emitWithColors(o,i)}_onCoverColorReset(e){const t=this._baseConfig(),o=[...t.cover_colors??[]];e<o.length&&(o[e]=null),this._emitWithColors(t,o)}_onEntryToggle(e,t){const o=this._baseConfig(),i=new Set(o.entry_ids);t?i.add(e):i.delete(e);const s=(this._entries??[]).map(e=>e.entry_id).filter(e=>i.has(e)),n=o.cover_colors??[],r=s.map(e=>{const t=o.entry_ids.indexOf(e);return t>=0?n[t]??null:null});this._emitWithColors(o,r,{entry_ids:s})}_onToggle(e,t){this._emit({...this._baseConfig(),[e]:t})}_onNorthOffsetChange(e){const t=parseFloat(e.target.value),o=Number.isFinite(t)?t:0;this._emit({...this._baseConfig(),north_offset:o})}_onTitleChange(e){const t=e.target.value,o=this._baseConfig();if(t)this._emit({...o,title:t});else{const{title:e,...t}=o;this._emit(t)}}render(){if(!this._config)return W;const e=new Set(this._config.entry_ids);return q`
+  `,e([_e({attribute:!1})],Go.prototype,"hass",void 0),e([me()],Go.prototype,"_config",void 0),e([me()],Go.prototype,"_entries",void 0),e([me()],Go.prototype,"_entriesError",void 0),Go=e([he(ye)],Go);const Lo=[{key:"compact",labelKey:"editor.compass.toggle_compact_label",descKey:"editor.compass.toggle_compact_desc",defaultOn:!1},{key:"show_legend",labelKey:"editor.compass.toggle_legend_label",descKey:"editor.compass.toggle_legend_desc",defaultOn:!0},{key:"show_stats",labelKey:"editor.compass.toggle_stats_label",descKey:"editor.compass.toggle_stats_desc",defaultOn:!0},{key:"show_moon",labelKey:"editor.compass.toggle_moon_label",descKey:"editor.compass.toggle_moon_desc",defaultOn:!1},{key:"show_cardinals",labelKey:"editor.compass.toggle_cardinals_label",descKey:"editor.compass.toggle_cardinals_desc",defaultOn:!0},{key:"show_blind_spot",labelKey:"editor.compass.toggle_blind_spot_label",descKey:"editor.compass.toggle_blind_spot_desc",defaultOn:!0},{key:"show_sun_path",labelKey:"editor.compass.toggle_sun_path_label",descKey:"editor.compass.toggle_sun_path_desc",defaultOn:!0},{key:"show_sunrise_sunset",labelKey:"editor.compass.toggle_sunrise_sunset_label",descKey:"editor.compass.toggle_sunrise_sunset_desc",defaultOn:!0},{key:"show_cover_fill",labelKey:"editor.compass.toggle_cover_fill_label",descKey:"editor.compass.toggle_cover_fill_desc",defaultOn:!0},{key:"show_window_arrow",labelKey:"editor.compass.toggle_window_arrow_label",descKey:"editor.compass.toggle_window_arrow_desc",defaultOn:!0},{key:"show_elevation_chart",labelKey:"editor.compass.toggle_elevation_chart_label",descKey:"editor.compass.toggle_elevation_chart_desc",defaultOn:!0}];let qo=class extends ce{constructor(){super(...arguments),this._entries=null,this._entriesError=null,this._fetchInFlight=!1}setConfig(e){this._config=e}updated(e){e.has("hass")&&this.hass&&!this._entries&&!this._fetchInFlight&&(this._fetchInFlight=!0,ft(this.hass).then(e=>{this._entries=e,this._entriesError=null}).catch(e=>{this._entriesError=e?.message??"failed to load config entries"}).finally(()=>{this._fetchInFlight=!1}))}_emit(e){this._config=e,this.dispatchEvent(new CustomEvent("config-changed",{detail:{config:e},bubbles:!0,composed:!0}))}_baseConfig(){return this._config??{type:`custom:${be}`,entry_ids:[]}}_trimColors(e){let t=-1;for(let o=0;o<e.length;o++)e[o]&&(t=o);if(!(t<0))return e.slice(0,t+1)}_emitWithColors(e,t,o){const s=this._trimColors(t),{cover_colors:i,...n}=e,r=s?{...n,...o,cover_colors:s}:{...n,...o};this._emit(r)}_onCoverColorChange(e,t){const o=this._baseConfig(),s=[...o.cover_colors??[]];for(;s.length<=e;)s.push(null);s[e]=t,this._emitWithColors(o,s)}_onCoverColorReset(e){const t=this._baseConfig(),o=[...t.cover_colors??[]];e<o.length&&(o[e]=null),this._emitWithColors(t,o)}_onEntryToggle(e,t){const o=this._baseConfig(),s=new Set(o.entry_ids);t?s.add(e):s.delete(e);const i=(this._entries??[]).map(e=>e.entry_id).filter(e=>s.has(e)),n=o.cover_colors??[],r=i.map(e=>{const t=o.entry_ids.indexOf(e);return t>=0?n[t]??null:null});this._emitWithColors(o,r,{entry_ids:i})}_onToggle(e,t){this._emit({...this._baseConfig(),[e]:t})}_onNorthOffsetChange(e){const t=parseFloat(e.target.value),o=Number.isFinite(t)?t:0;this._emit({...this._baseConfig(),north_offset:o})}_onTitleChange(e){const t=e.target.value,o=this._baseConfig();if(t)this._emit({...o,title:t});else{const{title:e,...t}=o;this._emit(t)}}render(){if(!this._config)return Y;const e=new Set(this._config.entry_ids);return L`
       <div class="form">
         <div class="section">
           <label class="field-label">${Be("editor.compass.instances",this.hass)}</label>
@@ -2787,19 +2869,19 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
           />
         </div>
 
-        ${this._config.entry_ids.length>0?q`
+        ${this._config.entry_ids.length>0?L`
               <div class="section">
                 <label class="field-label">${Be("editor.compass.cover_colors",this.hass)}</label>
                 <div class="hint">${Be("editor.compass.cover_colors_hint",this.hass)}</div>
-                ${this._config.entry_ids.map((e,t)=>{const o=this._config.cover_colors?.[t]??null,i=o??Nt(t),s=this._entries?.find(t=>t.entry_id===e);return q`
+                ${this._config.entry_ids.map((e,t)=>{const o=this._config.cover_colors?.[t]??null,s=o??Zt(t),i=this._entries?.find(t=>t.entry_id===e);return L`
                     <div class="color-row">
                       <input
                         type="color"
-                        .value=${i}
+                        .value=${s}
                         @change=${e=>this._onCoverColorChange(t,e.target.value)}
                       />
                       <span class="toggle-text">
-                        <span class="toggle-label">${s?.title??e}</span>
+                        <span class="toggle-label">${i?.title??e}</span>
                         <span class="toggle-desc"
                           >${o||Be("editor.compass.default_color",this.hass)}</span
                         >
@@ -2815,11 +2897,11 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
                     </div>
                   `})}
               </div>
-            `:W}
+            `:Y}
 
         <div class="section">
           <label class="field-label">${Be("editor.compass.display",this.hass)}</label>
-          ${Oo.map(e=>q`
+          ${Lo.map(e=>L`
               <label class="toggle-row">
                 <input
                   type="checkbox"
@@ -2846,18 +2928,18 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
             @change=${this._onNorthOffsetChange}
           />
         </div>
-        ${wo(this.hass)}
+        ${Po(this.hass)}
       </div>
-    `}_renderEntryPicker(e){return this._entriesError?q`<div class="error">
+    `}_renderEntryPicker(e){return this._entriesError?L`<div class="error">
         ${Be("editor.common.load_failed",this.hass,{error:this._entriesError})}
-      </div>`:this._entries?0===this._entries.length?q`
+      </div>`:this._entries?0===this._entries.length?L`
         <div class="error">
           ${Be("editor.common.no_entries",this.hass)}
           <code>${Be("editor.common.no_entries_path",this.hass)}</code>${Be("editor.common.no_entries_then",this.hass)}
         </div>
-      `:q`
+      `:L`
       <div class="entry-list">
-        ${this._entries.map(t=>q`
+        ${this._entries.map(t=>L`
             <label class="toggle-row">
               <input
                 type="checkbox"
@@ -2871,7 +2953,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
             </label>
           `)}
       </div>
-    `:q`<div class="hint">${Be("editor.common.loading_entries",this.hass)}</div>`}};Mo.styles=r`
+    `:L`<div class="hint">${Be("editor.common.loading_entries",this.hass)}</div>`}};qo.styles=r`
     :host {
       display: block;
     }
@@ -2988,22 +3070,22 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
     .dim {
       color: var(--secondary-text-color);
     }
-  `,e([ge({attribute:!1})],Mo.prototype,"hass",void 0),e([me()],Mo.prototype,"_config",void 0),e([me()],Mo.prototype,"_entries",void 0),e([me()],Mo.prototype,"_entriesError",void 0),Mo=e([he(we)],Mo);let Io=class extends ce{constructor(){super(...arguments),this._registry=null,this._registryError=null,this._unsubRegistry=null,this._fetchInFlight=!1,this._listMemo=function(){const e=new Map;let t=[],o=[],i={list:[],missing:[]};return(s,n,r,a)=>{const l=n.map(t=>{let o=e.get(t);return o||(o=Ke(),e.set(t,o)),o(s,{type:a,entry_id:t},r)});if(e.size>n.length)for(const t of e.keys())n.includes(t)||e.delete(t);const c=t.length===n.length&&t.every((e,t)=>e===n[t])&&o.length===l.length&&o.every((e,t)=>e===l[t]);if(c)return i;t=n.slice(),o=l;const d=[],h=[];return n.forEach((e,t)=>{const o=l[t];o?d.push(o):h.push(e)}),i={list:d,missing:h},i}}(),this._discoveredResult={list:[],missing:[]}}setConfig(e){if(!e||!Array.isArray(e.entry_ids)||0===e.entry_ids.length)throw new Error("adaptive-cover-pro-sky-compass-card: `entry_ids` must be a non-empty array");if(e.entry_ids.some(e=>"string"!=typeof e||0===e.length))throw new Error("adaptive-cover-pro-sky-compass-card: every `entry_ids` entry must be a non-empty string");if(this._config={...e,entry_ids:[...e.entry_ids]},null===this._registry){const e=this._config.entry_ids.map(e=>ct.get(e)?.entries);e.every(e=>void 0!==e)&&(this._registry=e.flat())}}getCardSize(){return 4}getGridOptions(){return{columns:12,rows:"auto",min_columns:6,max_columns:12}}static async getConfigElement(){return document.createElement(we)}static async getStubConfig(e){let t=[];try{const o=await Ue(e);o[0]&&(t=[o[0].entry_id])}catch{}return{type:`custom:${be}`,entry_ids:t}}connectedCallback(){if(super.connectedCallback(),null===this._registry){const e=rt();e&&(this._registry=e)}this.hass&&this._ensureRegistry()}disconnectedCallback(){super.disconnectedCallback(),this._unsubRegistry&&(this._unsubRegistry(),this._unsubRegistry=null)}updated(e){e.has("hass")&&this.hass&&this._ensureRegistry()}shouldUpdate(e){if(e.size>1||!e.has("hass"))return!0;const t=[];for(const e of this._discoveredResult.list)t.push(...Object.values(e.entities));return 0===t.length||_e(e.get("hass"),this.hass,t)}willUpdate(e){this._config&&this.hass&&null!==this._registry&&(e.has("hass")||e.has("_registry")||e.has("_config"))&&(this._discoveredResult=this._listMemo(this.hass,this._config.entry_ids,this._registry,this._config.type))}_ensureRegistry(){this._fetchRegistry(),this._unsubRegistry||(this._unsubRegistry=it(this.hass,()=>{this._fetchRegistry(!0)}))}_fetchRegistry(e=!1){this._fetchInFlight||(this._fetchInFlight=!0,at(this.hass,e).then(e=>{if(e!==this._registry&&(this._registry=e,this._registryError=null,this._config))for(const t of this._config.entry_ids)ct.set(t,ht(e,t))}).catch(e=>{this._registryError=e?.message??"entity registry fetch failed"}).finally(()=>{this._fetchInFlight=!1}))}render(){if(!this._config||!this.hass)return W;if(null===this._registry)return q`<ha-card>
+  `,e([_e({attribute:!1})],qo.prototype,"hass",void 0),e([me()],qo.prototype,"_config",void 0),e([me()],qo.prototype,"_entries",void 0),e([me()],qo.prototype,"_entriesError",void 0),qo=e([he(we)],qo);let Uo=class extends ce{constructor(){super(...arguments),this._registry=null,this._registryError=null,this._unsubRegistry=null,this._fetchInFlight=!1,this._listMemo=function(){const e=new Map;let t=[],o=[],s={list:[],missing:[]};return(i,n,r,a)=>{const l=n.map(t=>{let o=e.get(t);return o||(o=pt(),e.set(t,o)),o(i,{type:a,entry_id:t},r)});if(e.size>n.length)for(const t of e.keys())n.includes(t)||e.delete(t);const c=t.length===n.length&&t.every((e,t)=>e===n[t])&&o.length===l.length&&o.every((e,t)=>e===l[t]);if(c)return s;t=n.slice(),o=l;const d=[],h=[];return n.forEach((e,t)=>{const o=l[t];o?d.push(o):h.push(e)}),s={list:d,missing:h},s}}(),this._discoveredResult={list:[],missing:[]}}setConfig(e){if(!e||!Array.isArray(e.entry_ids)||0===e.entry_ids.length)throw new Error("adaptive-cover-pro-sky-compass-card: `entry_ids` must be a non-empty array");if(e.entry_ids.some(e=>"string"!=typeof e||0===e.length))throw new Error("adaptive-cover-pro-sky-compass-card: every `entry_ids` entry must be a non-empty string");if(this._config={...e,entry_ids:[...e.entry_ids]},e.tooltips&&ct(e.tooltips),null===this._registry){const e=this._config.entry_ids.map(e=>kt.get(e)?.entries);e.every(e=>void 0!==e)&&(this._registry=e.flat())}}getCardSize(){return 4}getGridOptions(){return{columns:12,rows:"auto",min_columns:6,max_columns:12}}static async getConfigElement(){return document.createElement(we)}static async getStubConfig(e){let t=[];try{const o=await ft(e);o[0]&&(t=[o[0].entry_id])}catch{}return{type:`custom:${be}`,entry_ids:t}}connectedCallback(){if(super.connectedCallback(),null===this._registry){const e=xt();e&&(this._registry=e)}this.hass&&this._ensureRegistry()}disconnectedCallback(){super.disconnectedCallback(),this._unsubRegistry&&(this._unsubRegistry(),this._unsubRegistry=null)}updated(e){e.has("hass")&&this.hass&&this._ensureRegistry()}shouldUpdate(e){if(e.size>1||!e.has("hass"))return!0;const t=[];for(const e of this._discoveredResult.list)t.push(...Object.values(e.entities));return 0===t.length||ge(e.get("hass"),this.hass,t)}willUpdate(e){this._config&&this.hass&&null!==this._registry&&(e.has("hass")||e.has("_registry")||e.has("_config"))&&(this._discoveredResult=this._listMemo(this.hass,this._config.entry_ids,this._registry,this._config.type))}_ensureRegistry(){this._fetchRegistry(),this._unsubRegistry||(this._unsubRegistry=yt(this.hass,()=>{this._fetchRegistry(!0)}))}_fetchRegistry(e=!1){this._fetchInFlight||(this._fetchInFlight=!0,$t(this.hass,e).then(e=>{if(e!==this._registry&&(this._registry=e,this._registryError=null,this._config))for(const t of this._config.entry_ids)kt.set(t,Et(e,t))}).catch(e=>{this._registryError=e?.message??"entity registry fetch failed"}).finally(()=>{this._fetchInFlight=!1}))}render(){if(!this._config||!this.hass)return Y;if(null===this._registry)return L`<ha-card>
         <div class="empty">
           <p class="dim">
             ${this._registryError?Be("tile.registry_failed",this.hass,{error:this._registryError}):Be("root.loading_registry",this.hass)}
           </p>
         </div>
-      </ha-card>`;const{list:e,missing:t}=this._discoveredResult;if(0===e.length)return q`<ha-card>
+      </ha-card>`;const{list:e,missing:t}=this._discoveredResult;if(0===e.length)return L`<ha-card>
         <div class="empty">
           <p><strong>${Be("root.compass_no_match",this.hass)}</strong></p>
           <p class="dim">
             ${Be("root.compass_configured",this.hass,{entries:this._config.entry_ids.join(", ")})}
           </p>
         </div>
-      </ha-card>`;const o=this._config;return q`
+      </ha-card>`;const o=this._config;return L`
       <ha-card>
-        ${o.title?q`<div class="card-header">${o.title}</div>`:W}
+        ${o.title?L`<div class="card-header">${o.title}</div>`:Y}
         <acp-sky-compass
           .hass=${this.hass}
           .discovered_list=${e}
@@ -3018,19 +3100,19 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
           .showCoverFill=${o.show_cover_fill??!0}
           .showWindowArrow=${o.show_window_arrow??!0}
           .coverColors=${o.cover_colors??[]}
-          .northOffsetDeg=${He(o.north_offset??0)}
+          .northOffsetDeg=${tt(o.north_offset??0)}
         ></acp-sky-compass>
-        ${!1!==o.show_elevation_chart?q`<acp-elevation-chart
+        ${!1!==o.show_elevation_chart?L`<acp-elevation-chart
               .hass=${this.hass}
               .discoveredList=${e}
               .coverColors=${o.cover_colors??[]}
               ?compact=${!!o.compact}
-            ></acp-elevation-chart>`:W}
-        ${t.length>0?q`<div class="warn dim">
+            ></acp-elevation-chart>`:Y}
+        ${t.length>0?L`<div class="warn dim">
               ${Be("root.compass_not_found",this.hass,{entries:t.join(", ")})}
-            </div>`:W}
+            </div>`:Y}
       </ha-card>
-    `}};Io.styles=r`
+    `}};Uo.styles=r`
     :host {
       display: block;
     }
@@ -3057,33 +3139,33 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
       font-size: 0.78rem;
       text-align: center;
     }
-  `,e([ge({attribute:!1})],Io.prototype,"hass",void 0),e([me()],Io.prototype,"_config",void 0),e([me()],Io.prototype,"_registry",void 0),e([me()],Io.prototype,"_registryError",void 0),Io=e([he(be)],Io),window.customCards=window.customCards||[],window.customCards.some(e=>e.type===be)||window.customCards.push({type:be,name:"Adaptive Cover Pro — Sky Compass",description:"Polar sun-vs-FOV plot; overlay one or more Adaptive Cover Pro entries on a single compass.",preview:!0,documentationURL:"https://github.com/jrhubott/adaptive-cover-pro/wiki/Lovelace-Card"});const Fo=["sky","elevation","decision","covers","overrides","climate"];let To=class extends ce{constructor(){super(...arguments),this._registry=null,this._registryError=null,this._discovered=null,this._discoveredList=[],this._discoveredListSource=null,this._unsubRegistry=null,this._fetchInFlight=!1,this._memo=Ke(),this._debounceTimer=null,this._debounceFirstAt=null,this._DEBOUNCE_DELAY=500,this._DEBOUNCE_MAX=2e3}setConfig(e){if(!e?.entry_id)throw new Error("adaptive-cover-pro-card: `entry_id` is required");if(this._config={...e},null===this._registry){const t=ct.get(e.entry_id);t&&(this._registry=t.entries)}}getCardSize(){return 6}getGridOptions(){return{columns:12,rows:"auto",min_columns:6,max_columns:12}}static async getConfigElement(){return document.createElement(ye)}static async getStubConfig(e){let t="";try{const o=await Ue(e);t=o[0]?.entry_id??""}catch{}return{type:`custom:${ve}`,entry_id:t}}connectedCallback(){if(super.connectedCallback(),null===this._registry){const e=rt();e&&(this._registry=e)}this.hass&&this._ensureRegistry()}disconnectedCallback(){super.disconnectedCallback(),this._unsubRegistry&&(this._unsubRegistry(),this._unsubRegistry=null),null!==this._debounceTimer&&(clearTimeout(this._debounceTimer),this._debounceTimer=null,this._debounceFirstAt=null)}updated(e){e.has("hass")&&this.hass&&this._ensureRegistry()}shouldUpdate(e){return e.size>1||!e.has("hass")||(!this._discovered||_e(e.get("hass"),this.hass,Object.values(this._discovered.entities)))}willUpdate(e){null!==this._registry&&this._config&&this.hass&&(e.has("hass")||e.has("_registry")||e.has("_config"))&&(this._discovered=this._memo(this.hass,this._config,this._registry)),this._discovered!==this._discoveredListSource&&(this._discoveredListSource=this._discovered,this._discoveredList=this._discovered?[this._discovered]:[])}_ensureRegistry(){this._fetchRegistry(),this._unsubRegistry||(this._unsubRegistry=it(this.hass,e=>{const t=new Set(ht(this._registry??[],this._config?.entry_id??"").map(e=>e.entity_id));(function(e,t){return"create"===e.action||t.has(e.entity_id)})(e,t)&&this._scheduleRefetch()}))}_fetchRegistry(e=!1){this._fetchInFlight||(this._fetchInFlight=!0,at(this.hass,e).then(e=>{if(e===this._registry)return;const t=this._config?.entry_id;if(t){const o=ht(e,t);(null===this._registry||function(e,t){if(e.length!==t.length)return!0;const o=new Map(e.map(e=>[e.entity_id,dt(e)]));for(const e of t)if(o.get(e.entity_id)!==dt(e))return!0;return!1}(ht(this._registry,t),o))&&(this._registry=e,ct.set(t,o))}else this._registry=e;this._registryError=null}).catch(e=>{this._registryError=e?.message??"entity registry fetch failed"}).finally(()=>{this._fetchInFlight=!1}))}_scheduleRefetch(){const e=Date.now();null===this._debounceFirstAt&&(this._debounceFirstAt=e);const t=e-this._debounceFirstAt,o=this._DEBOUNCE_MAX-t,i=Math.min(this._DEBOUNCE_DELAY,o);if(null!==this._debounceTimer&&clearTimeout(this._debounceTimer),i<=0)return this._debounceFirstAt=null,void this._fetchRegistry(!0);this._debounceTimer=setTimeout(()=>{this._debounceTimer=null,this._debounceFirstAt=null,this._fetchRegistry(!0)},i)}get _sections(){return this._config?.show_sections??Fo}_renderHeader(e,t){const o=Ee[e.cover_type]??"mdi:window-shutter",i=e.entities.integration_enabled_switch,s=e.entities.automatic_control_switch,n=!i||"on"===this.hass.states[i]?.state,r=!s||"on"===this.hass.states[s]?.state;return q`
+  `,e([_e({attribute:!1})],Uo.prototype,"hass",void 0),e([me()],Uo.prototype,"_config",void 0),e([me()],Uo.prototype,"_registry",void 0),e([me()],Uo.prototype,"_registryError",void 0),Uo=e([he(be)],Uo),window.customCards=window.customCards||[],window.customCards.some(e=>e.type===be)||window.customCards.push({type:be,name:"Adaptive Cover Pro — Sky Compass",description:"Polar sun-vs-FOV plot; overlay one or more Adaptive Cover Pro entries on a single compass.",preview:!0,documentationURL:"https://github.com/jrhubott/adaptive-cover-pro/wiki/Lovelace-Card"});const Yo=["sky","elevation","decision","covers","overrides","climate"];let Wo=class extends ce{constructor(){super(...arguments),this._registry=null,this._registryError=null,this._discovered=null,this._discoveredList=[],this._discoveredListSource=null,this._unsubRegistry=null,this._fetchInFlight=!1,this._memo=pt(),this._debounceTimer=null,this._debounceFirstAt=null,this._DEBOUNCE_DELAY=500,this._DEBOUNCE_MAX=2e3}setConfig(e){if(!e?.entry_id)throw new Error("adaptive-cover-pro-card: `entry_id` is required");if(this._config={...e},e.tooltips&&ct(e.tooltips),null===this._registry){const t=kt.get(e.entry_id);t&&(this._registry=t.entries)}}getCardSize(){return 6}getGridOptions(){return{columns:12,rows:"auto",min_columns:6,max_columns:12}}static async getConfigElement(){return document.createElement(ye)}static async getStubConfig(e){let t="";try{const o=await ft(e);t=o[0]?.entry_id??""}catch{}return{type:`custom:${ve}`,entry_id:t}}connectedCallback(){if(super.connectedCallback(),null===this._registry){const e=xt();e&&(this._registry=e)}this.hass&&this._ensureRegistry()}disconnectedCallback(){super.disconnectedCallback(),this._unsubRegistry&&(this._unsubRegistry(),this._unsubRegistry=null),null!==this._debounceTimer&&(clearTimeout(this._debounceTimer),this._debounceTimer=null,this._debounceFirstAt=null)}updated(e){e.has("hass")&&this.hass&&this._ensureRegistry()}shouldUpdate(e){return e.size>1||!e.has("hass")||(!this._discovered||ge(e.get("hass"),this.hass,Object.values(this._discovered.entities)))}willUpdate(e){null!==this._registry&&this._config&&this.hass&&(e.has("hass")||e.has("_registry")||e.has("_config"))&&(this._discovered=this._memo(this.hass,this._config,this._registry)),this._discovered!==this._discoveredListSource&&(this._discoveredListSource=this._discovered,this._discoveredList=this._discovered?[this._discovered]:[])}_ensureRegistry(){this._fetchRegistry(),this._unsubRegistry||(this._unsubRegistry=yt(this.hass,e=>{const t=new Set(Et(this._registry??[],this._config?.entry_id??"").map(e=>e.entity_id));(function(e,t){return"create"===e.action||t.has(e.entity_id)})(e,t)&&this._scheduleRefetch()}))}_fetchRegistry(e=!1){this._fetchInFlight||(this._fetchInFlight=!0,$t(this.hass,e).then(e=>{if(e===this._registry)return;const t=this._config?.entry_id;if(t){const o=Et(e,t);(null===this._registry||function(e,t){if(e.length!==t.length)return!0;const o=new Map(e.map(e=>[e.entity_id,Ct(e)]));for(const e of t)if(o.get(e.entity_id)!==Ct(e))return!0;return!1}(Et(this._registry,t),o))&&(this._registry=e,kt.set(t,o))}else this._registry=e;this._registryError=null}).catch(e=>{this._registryError=e?.message??"entity registry fetch failed"}).finally(()=>{this._fetchInFlight=!1}))}_scheduleRefetch(){const e=Date.now();null===this._debounceFirstAt&&(this._debounceFirstAt=e);const t=e-this._debounceFirstAt,o=this._DEBOUNCE_MAX-t,s=Math.min(this._DEBOUNCE_DELAY,o);if(null!==this._debounceTimer&&clearTimeout(this._debounceTimer),s<=0)return this._debounceFirstAt=null,void this._fetchRegistry(!0);this._debounceTimer=setTimeout(()=>{this._debounceTimer=null,this._debounceFirstAt=null,this._fetchRegistry(!0)},s)}get _sections(){return this._config?.show_sections??Yo}_renderHeader(e,t){const o=Se[e.cover_type]??"mdi:window-shutter",s=e.entities.integration_enabled_switch,i=e.entities.automatic_control_switch,n=!s||"on"===this.hass.states[s]?.state,r=!i||"on"===this.hass.states[i]?.state;return L`
       <div class="header">
         <ha-icon .icon=${o}></ha-icon>
         <span class="title">${e.entry_title}</span>
         <span class="spacer"></span>
-        ${i?q`<acp-header-pill
+        ${s?L`<acp-header-pill
               .on=${n}
               .readonly=${!t.integration_enabled}
               .label=${Be(n?"header.on":"header.off",this.hass)}
               title=${Be("header.integration_enabled",this.hass)}
-              @pill-click=${()=>this._toggle(i)}
-            ></acp-header-pill>`:W}
-        ${s?q`<acp-header-pill
+              @pill-click=${()=>this._toggle(s)}
+            ></acp-header-pill>`:Y}
+        ${i?L`<acp-header-pill
               .on=${r}
               .readonly=${!t.automatic_control}
               .label=${Be("header.auto",this.hass)}
               title=${Be("header.automatic_control",this.hass)}
-              @pill-click=${()=>this._toggle(s)}
-            ></acp-header-pill>`:W}
+              @pill-click=${()=>this._toggle(i)}
+            ></acp-header-pill>`:Y}
       </div>
-    `}_toggle(e){const t=e.split(".")[0];this.hass.callService(t,"toggle",{entity_id:e})}_renderLoading(){return q`
+    `}_toggle(e){const t=e.split(".")[0];this.hass.callService(t,"toggle",{entity_id:e})}_renderLoading(){return L`
       <ha-card>
         <div class="empty">
           <p class="dim">${Be("root.loading_registry",this.hass)}</p>
         </div>
       </ha-card>
-    `}_renderEmpty(e){const t=this._config.entry_id,o=this._registry?.length??0,i=this._registry?.filter(e=>e.config_entry_id===t&&"adaptive_cover_pro"===e.platform).length;return q`
+    `}_renderEmpty(e){const t=this._config.entry_id,o=this._registry?.length??0,s=this._registry?.filter(e=>e.config_entry_id===t&&"adaptive_cover_pro"===e.platform).length;return L`
       <ha-card>
         <div class="empty">
           <p><strong>${Be("root.no_entities_title",this.hass)}</strong></p>
@@ -3091,8 +3173,8 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
           <ul class="diag">
             <li>Reason: <code>${e}</code></li>
             <li>Registry entries loaded: <code>${o}</code></li>
-            <li>ACP entities matching entry_id: <code>${i??"—"}</code></li>
-            ${this._registryError?q`<li>Registry fetch error: <code>${this._registryError}</code></li>`:W}
+            <li>ACP entities matching entry_id: <code>${s??"—"}</code></li>
+            ${this._registryError?L`<li>Registry fetch error: <code>${this._registryError}</code></li>`:Y}
           </ul>
           <p class="dim">
             If the count is 0, the <code>entry_id</code> is wrong. Find it at
@@ -3101,11 +3183,11 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
           </p>
         </div>
       </ha-card>
-    `}render(){if(!this._config||!this.hass)return W;if(null===this._registry)return this._registryError?this._renderEmpty("registry fetch failed"):this._renderLoading();const e=this._discovered;if(!e)return this._renderEmpty("no matching entities after unique_id lookup");const t=(o=this._config,{...Pe,...o?.controls});var o;const i=this._sections;return q`
+    `}render(){if(!this._config||!this.hass)return Y;if(null===this._registry)return this._registryError?this._renderEmpty("registry fetch failed"):this._renderLoading();const e=this._discovered;if(!e)return this._renderEmpty("no matching entities after unique_id lookup");const t=(o=this._config,{...Pe,...o?.controls});var o;const s=this._sections;return L`
       <ha-card>
         ${this._renderHeader(e,t)}
         <div class="body ${this._config.compact?"compact":""}">
-          ${i.includes("sky")?q`<acp-sky-compass
+          ${s.includes("sky")?L`<acp-sky-compass
                 .hass=${this.hass}
                 .discovered_list=${this._discoveredList}
                 ?compact=${!!this._config.compact}
@@ -3113,41 +3195,41 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
                 .showLegend=${this._config.show_compass_legend??!0}
                 .showMoon=${this._config.show_moon??!1}
                 .coverColors=${this._config.cover_colors??[]}
-                .northOffsetDeg=${He(this._config.north_offset??0)}
-              ></acp-sky-compass>`:W}
-          ${i.includes("elevation")?q`<acp-elevation-chart
+                .northOffsetDeg=${tt(this._config.north_offset??0)}
+              ></acp-sky-compass>`:Y}
+          ${s.includes("elevation")?L`<acp-elevation-chart
                 .hass=${this.hass}
                 .discoveredList=${this._discoveredList}
                 ?compact=${!!this._config.compact}
                 .coverColors=${this._config.cover_colors??[]}
-              ></acp-elevation-chart>`:W}
-          ${i.includes("decision")?q`<acp-decision-strip
+              ></acp-elevation-chart>`:Y}
+          ${s.includes("decision")?L`<acp-decision-strip
                 .hass=${this.hass}
                 .discovered=${e}
                 ?compact=${!!this._config.compact}
                 ?hide-inactive=${!!this._config.hide_inactive_handlers||!!this._config.compact}
                 ?show-summary=${!1!==this._config.show_decision_summary}
-              ></acp-decision-strip>`:W}
-          ${i.includes("covers")?q`<acp-cover-bar
+              ></acp-decision-strip>`:Y}
+          ${s.includes("covers")?L`<acp-cover-bar
                 .hass=${this.hass}
                 .discovered=${e}
                 ?compact=${!!this._config.compact}
                 .coverColor=${this._config.cover_colors?.[0]??null}
-              ></acp-cover-bar>`:W}
-          ${i.includes("overrides")?q`<acp-overrides-panel
+              ></acp-cover-bar>`:Y}
+          ${s.includes("overrides")?L`<acp-overrides-panel
                 .hass=${this.hass}
                 .discovered=${e}
                 ?compact=${!!this._config.compact}
                 .resetEnabled=${t.reset_manual_override}
-              ></acp-overrides-panel>`:W}
-          ${i.includes("climate")?q`<acp-climate-panel
+              ></acp-overrides-panel>`:Y}
+          ${s.includes("climate")?L`<acp-climate-panel
                 .hass=${this.hass}
                 .discovered=${e}
                 ?compact=${!!this._config.compact}
-              ></acp-climate-panel>`:W}
+              ></acp-climate-panel>`:Y}
         </div>
       </ha-card>
-    `}};To.styles=r`
+    `}};Wo.styles=r`
     :host {
       display: block;
     }
@@ -3201,4 +3283,4 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
     .dim {
       color: var(--secondary-text-color);
     }
-  `,e([ge({attribute:!1})],To.prototype,"hass",void 0),e([me()],To.prototype,"_config",void 0),e([me()],To.prototype,"_registry",void 0),e([me()],To.prototype,"_registryError",void 0),e([me()],To.prototype,"_discovered",void 0),To=e([he(ve)],To),window.customCards=window.customCards||[],window.customCards.push({type:ve,name:"Adaptive Cover Pro",description:"Visualize sun/window geometry, the pipeline decision trace, and live cover positions with inline controls.",preview:!0,documentationURL:"https://github.com/jrhubott/adaptive-cover-pro-card"}),console.info(`%c adaptive-cover-pro-card %c v${fe} `,"color: white; background: #3f51b5; font-weight: 700;","color: #3f51b5; background: white; font-weight: 700;");export{To as AdaptiveCoverProCard};
+  `,e([_e({attribute:!1})],Wo.prototype,"hass",void 0),e([me()],Wo.prototype,"_config",void 0),e([me()],Wo.prototype,"_registry",void 0),e([me()],Wo.prototype,"_registryError",void 0),e([me()],Wo.prototype,"_discovered",void 0),Wo=e([he(ve)],Wo),window.customCards=window.customCards||[],window.customCards.push({type:ve,name:"Adaptive Cover Pro",description:"Visualize sun/window geometry, the pipeline decision trace, and live cover positions with inline controls.",preview:!0,documentationURL:"https://github.com/jrhubott/adaptive-cover-pro-card"}),console.info(`%c adaptive-cover-pro-card %c v${fe} `,"color: white; background: #3f51b5; font-weight: 700;","color: #3f51b5; background: white; font-weight: 700;");export{Wo as AdaptiveCoverProCard};

--- a/dist/adaptive-cover-pro-card.js
+++ b/dist/adaptive-cover-pro-card.js
@@ -16,6 +16,7 @@ function e(e,t,o,s){var i,n=arguments.length,r=n<3?t:null===s?s=Object.getOwnPro
       position: absolute;
       top: 0;
       left: 0;
+      width: max-content;
       max-width: 280px;
       padding: 6px 10px;
       border-radius: 6px;

--- a/harness/src/card-stage.ts
+++ b/harness/src/card-stage.ts
@@ -210,6 +210,17 @@ export class AcpHarnessCardStage extends LitElement {
       show_decision_summary: r.show_decision_summary,
       cover_colors: [this.config.entries[0].color],
       north_offset: r.north_offset,
+      tooltips: this._tooltipsConfig(),
+    };
+  }
+
+  /** Map the harness tooltips options onto the card's `tooltips` config.
+   *  `floating` → enabled; `native` → disabled (native browser tooltips). */
+  private _tooltipsConfig(): Record<string, unknown> {
+    const tt = this.config.tooltips;
+    return {
+      enabled: tt.mode === 'floating',
+      offset: tt.offset,
     };
   }
 
@@ -232,6 +243,7 @@ export class AcpHarnessCardStage extends LitElement {
       show_elevation_chart: c.show_elevation_chart,
       cover_colors: this.config.entries.map((e) => e.color),
       north_offset: c.north_offset,
+      tooltips: this._tooltipsConfig(),
     };
   }
 
@@ -255,6 +267,7 @@ export class AcpHarnessCardStage extends LitElement {
       show_elevation_chart: t.show_elevation_chart,
       show_motion_icon: t.show_motion_icon,
       layout: t.layout,
+      tooltips: this._tooltipsConfig(),
     };
   }
 

--- a/harness/src/control-panel.ts
+++ b/harness/src/control-panel.ts
@@ -10,6 +10,7 @@ import type {
   HarnessEntry,
   ManagedCoverCfg,
   MotionStatusValue,
+  TooltipMode,
 } from './types';
 
 /**
@@ -101,6 +102,60 @@ export class AcpHarnessControlPanel extends LitElement {
           <option value="dark" ?selected=${this.config.theme === 'dark'}>Dark</option>
         </select>
       </label>
+      <label class="row">
+        <span>Tooltips</span>
+        <select
+          @change=${(e: Event) =>
+            this._emit({
+              ...this.config,
+              tooltips: {
+                ...this.config.tooltips,
+                mode: (e.target as HTMLSelectElement).value as TooltipMode,
+              },
+            })}
+        >
+          <option value="floating" ?selected=${this.config.tooltips.mode === 'floating'}>
+            Floating (card-owned)
+          </option>
+          <option value="native" ?selected=${this.config.tooltips.mode === 'native'}>
+            Native (browser title)
+          </option>
+        </select>
+      </label>
+      ${this.config.tooltips.mode === 'floating'
+        ? html`
+            ${this._numberSlider(
+              'Tooltip offset → right',
+              this.config.tooltips.offset[0],
+              0,
+              48,
+              1,
+              (v) =>
+                this._emit({
+                  ...this.config,
+                  tooltips: {
+                    ...this.config.tooltips,
+                    offset: [v, this.config.tooltips.offset[1]],
+                  },
+                }),
+            )}
+            ${this._numberSlider(
+              'Tooltip offset ↓ down',
+              this.config.tooltips.offset[1],
+              0,
+              48,
+              1,
+              (v) =>
+                this._emit({
+                  ...this.config,
+                  tooltips: {
+                    ...this.config.tooltips,
+                    offset: [this.config.tooltips.offset[0], v],
+                  },
+                }),
+            )}
+          `
+        : ''}
       <button class="ghost" @click=${this._onReset}>Reset to preset</button>
     `;
   }

--- a/harness/src/scenarios.ts
+++ b/harness/src/scenarios.ts
@@ -164,8 +164,13 @@ function baseConfig(date: string, time: number, lat = 47.6, lon = -122.3): Harne
     root: defaultRoot(),
     compass: defaultCompass(),
     tile: defaultTile(),
+    tooltips: defaultTooltips(),
     stageHeight: 0,
   };
+}
+
+export function defaultTooltips(): HarnessConfig['tooltips'] {
+  return { mode: 'floating', offset: [12, 16] };
 }
 
 export interface Scenario {
@@ -935,6 +940,23 @@ export const SCENARIOS: Scenario[] = [
       return c;
     },
   },
+  {
+    id: 'floating-tooltip',
+    label: 'Floating tooltip (#134)',
+    description:
+      'Card-owned floating tooltip enabled (down-and-right of the cursor, help cursor on hover that flips to default once the bubble shows). Hover the decision summary, the off-schedule banner, the compass FOV/sun groups, or the cover names. Switch the Tooltips control to "native" to compare with native browser tooltips.',
+    build: () => {
+      const c = baseConfig('2026-06-21', 13 * 60);
+      c.scenario = 'floating-tooltip';
+      // Off-schedule banner + a manual override make several tooltip carriers
+      // appear at once (summary, banner, badge, compass groups, cover names).
+      c.entries[0].flags.in_time_window = false;
+      c.entries[0].flags.schedule_start_minutes = 9 * 60;
+      c.entries[0].flags.schedule_end_minutes = 11 * 60;
+      c.tooltips = { mode: 'floating', offset: [12, 16] };
+      return c;
+    },
+  },
 ];
 
 export function findScenario(id: string): Scenario | undefined {
@@ -960,5 +982,6 @@ export function normalizeConfig(cfg: HarnessConfig): HarnessConfig {
       badges: { ...defaultBadges(), ...(cfg.tile?.badges ?? {}) },
       tileWidth: cfg.tile?.tileWidth ?? 0,
     },
+    tooltips: { ...defaultTooltips(), ...(cfg.tooltips ?? {}) },
   };
 }

--- a/harness/src/types.ts
+++ b/harness/src/types.ts
@@ -14,6 +14,17 @@ export type ClimateInactiveReason =
   | 'readings_unavailable';
 export type DecisionMode = 'derived' | 'scripted';
 
+/** Floating-tooltip behavior mirror of the card's `tooltips` config. `mode`
+ *  maps to the card's `tooltips.enabled`: `floating` → true, `native` → false.
+ *  `off` also sets enabled false (native tooltips are the off-state). */
+export type TooltipMode = 'floating' | 'native';
+
+export interface TooltipsOptions {
+  mode: TooltipMode;
+  /** [right, down] cursor offset in px (mirrors `tooltips.offset`). */
+  offset: [number, number];
+}
+
 export interface CustomPositionSlotCfg {
   slot: 1 | 2 | 3 | 4 | 5;
   enabled: boolean;
@@ -200,6 +211,8 @@ export interface HarnessConfig {
   root: RootCardOptions;
   compass: SkyCompassCardOptions;
   tile: TileCardOptions;
+  /** Floating-tooltip behavior, threaded into all three card configs. */
+  tooltips: TooltipsOptions;
   /** Fixed stage height in px for the Sky Compass card, mimicking HA's
    *  fixed grid-row height in a Sections dashboard. 0 = grow freely (the
    *  harness default). A positive value caps the compass card-host and clips

--- a/src/adaptive-cover-pro-card.ts
+++ b/src/adaptive-cover-pro-card.ts
@@ -12,6 +12,7 @@ import {
   resolveControlFlags,
 } from './const';
 import { t } from './lib/i18n';
+import { setTooltipDefaults } from './lib/tooltip';
 import { createDiscoveryMemo } from './lib/entity-discovery';
 import { fetchAcpConfigEntries } from './lib/config-entries';
 import { normalizeAzimuth } from './lib/geometry';
@@ -69,6 +70,7 @@ export class AdaptiveCoverProCard extends LitElement {
       throw new Error('adaptive-cover-pro-card: `entry_id` is required');
     }
     this._config = { ...config };
+    if (config.tooltips) setTooltipDefaults(config.tooltips);
     // Warm-start: synchronously hydrate registry from cache so first render skips loading state.
     if (this._registry === null) {
       const cached = registryCache.get(config.entry_id);

--- a/src/adaptive-cover-pro-sky-compass-card.ts
+++ b/src/adaptive-cover-pro-sky-compass-card.ts
@@ -13,6 +13,7 @@ import { loadEntityRegistry, getCachedRegistry } from './lib/registry-store';
 import { registryCache } from './lib/registry-cache';
 import { filterAcp } from './lib/registry-diff';
 import type { SkyCompassCardConfig } from './types';
+import { setTooltipDefaults } from './lib/tooltip';
 
 import './components/sky-compass';
 import './components/elevation-chart';
@@ -44,6 +45,7 @@ export class AdaptiveCoverProSkyCompassCard extends LitElement {
       );
     }
     this._config = { ...config, entry_ids: [...config.entry_ids] };
+    if (config.tooltips) setTooltipDefaults(config.tooltips);
     // Warm-start from the persisted ACP slices so a reload skips the Loading state — but
     // only when every configured entry is cached, otherwise the missing ones would flash a
     // false "not found" until the shared fetch revalidates.

--- a/src/adaptive-cover-pro-tile-card.ts
+++ b/src/adaptive-cover-pro-tile-card.ts
@@ -41,6 +41,7 @@ import {
 } from './lib/badge-visibility';
 import { formatCoverState, formatPercent } from './lib/formatters';
 import { t } from './lib/i18n';
+import { tooltip, setTooltipDefaults } from './lib/tooltip';
 
 import './components/tile-badge';
 import './components/more-info-dialog';
@@ -80,6 +81,7 @@ export class AdaptiveCoverProTileCard extends LitElement {
       };
     }
     this._config = next;
+    if (next.tooltips) setTooltipDefaults(next.tooltips);
     // Warm-start synchronously from the persisted ACP slice so a reload skips the Loading
     // state; the shared fetch below revalidates. Discovery filters the registry anyway, so
     // holding just the slice is fine.
@@ -357,7 +359,7 @@ export class AdaptiveCoverProTileCard extends LitElement {
           class=${`acp-floor-chip${activeFloor!.clamping ? '' : ' is-armed'}${
             activeFloor!.resistsManual ? ' resists-manual' : ' is-bypassable'
           }`}
-          title=${t('dialog.floor_tooltip', this.hass)}
+          ${tooltip(t('dialog.floor_tooltip', this.hass))}
           >${t('dialog.floor', this.hass)} ${formatPercent(activeFloor!.position)}</span
         >`
       : nothing;
@@ -406,15 +408,15 @@ export class AdaptiveCoverProTileCard extends LitElement {
             ? html`<ha-icon
                 class="motion-overlay ${motionState}"
                 icon="mdi:motion-sensor"
-                title=${motionTitle}
+                ${tooltip(motionTitle)}
               ></ha-icon>`
             : nothing}
         </div>
         <div class="label">
-          <div class="title" title=${discovered.entry_title}>${title}</div>
+          <div class="title" ${tooltip(discovered.entry_title)}>${title}</div>
           ${summary && !detailed ? html`<div class="summary">${summary}</div>` : nothing}
           ${hasBottomSummary
-            ? html`<div class="summary inline-summary" title=${summary}>${summary}</div>`
+            ? html`<div class="summary inline-summary" ${tooltip(summary)}>${summary}</div>`
             : nothing}
         </div>
         ${detailed && showAutoBadge ? html`<div class="auto-line">${autoBadgeTpl}</div>` : nothing}
@@ -880,6 +882,14 @@ export class AdaptiveCoverProTileCard extends LitElement {
       border: 1px solid transparent;
       white-space: nowrap;
       align-self: center;
+    }
+    /* Floating-tooltip cursor lifecycle for the tooltip carriers inside the
+       tile (floor chip, title, inline summary, motion overlay). Help hint on
+       hover, default once OUR bubble appears. */
+    [data-tooltip]:hover {
+      cursor: help;
+    }
+    [data-tooltip][acp-tt-shown] {
       cursor: default;
     }
     /* Clamping axis: not-clamping → hollow/outline (transparent fill + purple border). */

--- a/src/adaptive-cover-pro-tile-card.ts
+++ b/src/adaptive-cover-pro-tile-card.ts
@@ -413,7 +413,7 @@ export class AdaptiveCoverProTileCard extends LitElement {
             : nothing}
         </div>
         <div class="label">
-          <div class="title" ${tooltip(discovered.entry_title)}>${title}</div>
+          <div class="title">${title}</div>
           ${summary && !detailed ? html`<div class="summary">${summary}</div>` : nothing}
           ${hasBottomSummary
             ? html`<div class="summary inline-summary" ${tooltip(summary)}>${summary}</div>`

--- a/src/components/climate-panel.ts
+++ b/src/components/climate-panel.ts
@@ -5,6 +5,7 @@ import type { HomeAssistant } from 'custom-card-helpers';
 import { entityStateChanged } from '../lib/hass-change';
 import type { DiscoveredEntities } from '../types';
 import { t } from '../lib/i18n';
+import { tooltip } from '../lib/tooltip';
 
 interface ClimateAttrs {
   active_temperature?: number;
@@ -204,7 +205,7 @@ export class ClimatePanel extends LitElement {
               <div class="conditions">
                 ${conditions.map(
                   (c) => html`
-                    <div class="chip ${c.value ? 'on' : 'off'}" title=${c.label}>
+                    <div class="chip ${c.value ? 'on' : 'off'}" ${tooltip(c.label)}>
                       <ha-icon icon=${c.icon}></ha-icon>
                       <span>${c.label}</span>
                     </div>
@@ -304,6 +305,11 @@ export class ClimatePanel extends LitElement {
       border-radius: 999px;
       font-size: 0.72rem;
       background: var(--secondary-background-color, rgba(0, 0, 0, 0.04));
+    }
+    [data-tooltip]:hover {
+      cursor: help;
+    }
+    [data-tooltip][acp-tt-shown] {
       cursor: default;
     }
     .chip.on {

--- a/src/components/cover-bar.ts
+++ b/src/components/cover-bar.ts
@@ -7,6 +7,7 @@ import type { CoverPositionAttributes, DiscoveredEntities } from '../types';
 import { formatPercent } from '../lib/formatters';
 import { INTEGRATION_DOMAIN } from '../const';
 import { t } from '../lib/i18n';
+import { tooltip } from '../lib/tooltip';
 
 @customElement('acp-cover-bar')
 export class CoverBar extends LitElement {
@@ -101,12 +102,12 @@ export class CoverBar extends LitElement {
     const targetPct = target ?? 0;
     return html`
       <div class="cover ${mismatch ? 'mismatch' : ''}">
-        <div class="name" title=${entityId}>${friendly}</div>
+        <div class="name" ${tooltip(entityId)}>${friendly}</div>
         <div class="num">${formatPercent(actual)}</div>
         <div
           class="track"
           @click=${(e: MouseEvent) => this._handleTrackClick(e, entityId)}
-          title=${t('covers.click_to_set', this.hass)}
+          ${tooltip(t('covers.click_to_set', this.hass))}
         >
           <div class="fill" style="width:${actualPct}%"></div>
           <div class="fill-closed" style="width:${100 - actualPct}%"></div>
@@ -114,7 +115,7 @@ export class CoverBar extends LitElement {
             ? html`<div
                 class="marker"
                 style="left:${targetPct}%"
-                title=${t('covers.target_tooltip', this.hass, { pct: targetPct })}
+                ${tooltip(t('covers.target_tooltip', this.hass, { pct: targetPct }))}
               ></div>`
             : nothing}
         </div>
@@ -166,6 +167,14 @@ export class CoverBar extends LitElement {
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
+    }
+    /* The cover name hints with a help cursor; the track is clickable and keeps
+       its pointer cursor (it is excluded from the help rule below). Both revert
+       to their natural cursor once OUR bubble is shown. */
+    .name[data-tooltip]:hover {
+      cursor: help;
+    }
+    .name[data-tooltip][acp-tt-shown] {
       cursor: default;
     }
     .track {

--- a/src/components/decision-strip.ts
+++ b/src/components/decision-strip.ts
@@ -8,6 +8,7 @@ import type { DecisionTraceAttributes, DiscoveredEntities } from '../types';
 import { formatPercent } from '../lib/formatters';
 import { buildDecisionSentence, normalizeHandler } from '../lib/decision-summary';
 import { t } from '../lib/i18n';
+import { tooltip } from '../lib/tooltip';
 
 @customElement('acp-decision-strip')
 export class DecisionStrip extends LitElement {
@@ -84,13 +85,13 @@ export class DecisionStrip extends LitElement {
         ${trace.inTimeWindow === false
           ? html`<div
               class="off-schedule"
-              title=${t('decision.outside_schedule_tooltip', this.hass)}
+              ${tooltip(t('decision.outside_schedule_tooltip', this.hass))}
             >
               ${t('decision.outside_schedule', this.hass)}
             </div>`
           : nothing}
         ${this.showSummary && trace.summary
-          ? html`<div class="summary" title=${t('decision.summary_tooltip', this.hass)}>
+          ? html`<div class="summary" ${tooltip(t('decision.summary_tooltip', this.hass))}>
               ${trace.summary}
             </div>`
           : nothing}
@@ -120,6 +121,14 @@ export class DecisionStrip extends LitElement {
   public static styles = css`
     :host {
       display: block;
+    }
+    /* Floating-tooltip cursor lifecycle: a help cursor hints "there's more
+       here" on hover, flipping to default the moment OUR bubble appears. */
+    [data-tooltip]:hover {
+      cursor: help;
+    }
+    [data-tooltip][acp-tt-shown] {
+      cursor: default;
     }
     .wrap {
       display: flex;
@@ -208,7 +217,6 @@ export class DecisionStrip extends LitElement {
       line-height: 1.3;
       padding: 2px 4px 4px;
       color: var(--primary-text-color);
-      cursor: default;
     }
     :host([compact]) .summary {
       font-size: 0.75rem;
@@ -221,7 +229,6 @@ export class DecisionStrip extends LitElement {
       border-radius: 4px;
       border-left: 3px solid var(--secondary-text-color);
       background: rgba(127, 127, 127, 0.08);
-      cursor: default;
     }
     :host([compact]) .off-schedule {
       font-size: 0.72rem;

--- a/src/components/elevation-chart.ts
+++ b/src/components/elevation-chart.ts
@@ -12,6 +12,7 @@ import { sunDotState, SUN_DOT_CLASS } from '../lib/sun-dot-state';
 import { resolveCoverColor } from '../lib/palette';
 import { formatClock } from '../lib/formatters';
 import { t } from '../lib/i18n';
+import { tooltip } from '../lib/tooltip';
 
 const VIEWBOX_W = 400;
 const VIEWBOX_H = 160;
@@ -379,7 +380,8 @@ export class ElevationChart extends LitElement {
                 width=${VIEWBOX_W - PAD_L - PAD_R}
                 height=${row.height}
                 rx="2"
-              ><title>${trackTitle}</title></rect>`;
+                ${tooltip(trackTitle)}
+              ></rect>`;
               const bars = w.runBars.map(
                 (b) => svg`<rect
                   class="ribbon-bar"
@@ -389,10 +391,13 @@ export class ElevationChart extends LitElement {
                   height=${row.height}
                   rx="2"
                   style=${`fill:${w.color}`}
-                ><title>${t('elevation.fov_window_named', this.hass, {
-                  name: w.d.entry_title,
-                  windows: b.range,
-                })}</title></rect>`,
+                  ${tooltip(
+                    t('elevation.fov_window_named', this.hass, {
+                      name: w.d.entry_title,
+                      windows: b.range,
+                    }),
+                  )}
+                ></rect>`,
               );
               return [track, ...bars];
             })}
@@ -418,7 +423,8 @@ export class ElevationChart extends LitElement {
                 y1=${PAD_T}
                 x2=${b.x}
                 y2=${VIEWBOX_H - PAD_B}
-              ><title>${b.tooltip}</title></line>`,
+                ${tooltip(b.tooltip)}
+              ></line>`,
               svg`<text
                 class="schedule-tick"
                 x=${b.x}
@@ -433,8 +439,7 @@ export class ElevationChart extends LitElement {
             <!-- current-time cursor + sun dot, drawn last so they sit on top of
                  the curve AND the ribbon bars. A wide transparent hit-line widens
                  the hover target so the thin now-line is easy to tooltip. -->
-            <g class="now-group">
-              <title>${formatClock(now.toISOString(), time_zone)}</title>
+            <g class="now-group" ${tooltip(formatClock(now.toISOString(), time_zone))}>
               <line class="now-hit" x1=${nowX} y1=${PAD_T} x2=${nowX} y2=${nowY2} />
               <line class="now" x1=${nowX} y1=${PAD_T} x2=${nowX} y2=${nowY2} />
             </g>
@@ -558,10 +563,18 @@ export class ElevationChart extends LitElement {
       fill-opacity: 0.12;
       pointer-events: none;
     }
+    /* Floating-tooltip cursor lifecycle: help hint on hover, default once OUR
+       bubble is shown. Applies to every tooltip carrier (schedule bar, ribbon
+       track/bar, now-cursor group). */
+    [data-tooltip]:hover {
+      cursor: help;
+    }
+    [data-tooltip][acp-tt-shown] {
+      cursor: default;
+    }
     .schedule-bar {
       stroke: var(--divider-color);
       stroke-width: 1;
-      cursor: default;
     }
     .schedule-tick {
       font-size: 8px;
@@ -570,14 +583,12 @@ export class ElevationChart extends LitElement {
     .ribbon-track {
       fill: var(--divider-color);
       fill-opacity: 0.25;
-      cursor: default;
     }
     .ribbon-bar {
       /* Fallback only — the ribbon always sets an inline per-window fill. Kept on
          the cover colour for consistency with the FOV band. */
       fill: var(--primary-color);
       fill-opacity: 0.85;
-      cursor: default;
     }
     .curve {
       fill: none;
@@ -594,7 +605,6 @@ export class ElevationChart extends LitElement {
     .now-hit {
       stroke: transparent;
       stroke-width: 10;
-      cursor: default;
     }
     /* Colour states mirror acp-sky-compass .sun.* so the sun reads the same
        across both visuals. */

--- a/src/components/floating-tooltip.ts
+++ b/src/components/floating-tooltip.ts
@@ -1,0 +1,105 @@
+import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+
+import { placeTooltip, DEFAULT_TOOLTIP_OFFSET } from '../lib/geometry';
+
+/**
+ * `<acp-floating-tooltip>` — the card-owned tooltip bubble.
+ *
+ * A single instance is appended to `document.body` by the FloatingTooltip
+ * singleton (see `lib/tooltip.ts`) and repositioned/retexted as the pointer
+ * moves between anchored elements. It renders a `position: fixed`, high
+ * `z-index`, `pointer-events: none` bubble so it floats above the dashboard
+ * without ever intercepting input.
+ *
+ * Positioning math lives in `geometry.placeTooltip`; this element only measures
+ * its own bubble and applies the resulting transform.
+ */
+@customElement('acp-floating-tooltip')
+export class FloatingTooltipElement extends LitElement {
+  /** The tooltip text. */
+  @property({ type: String }) public text = '';
+  /** Pointer (or anchor) X in viewport coordinates. */
+  @property({ type: Number }) public cursorX = 0;
+  /** Pointer (or anchor) Y in viewport coordinates. */
+  @property({ type: Number }) public cursorY = 0;
+  /** [right, down] offset from the cursor. */
+  @property({ attribute: false }) public offset: readonly [number, number] = DEFAULT_TOOLTIP_OFFSET;
+  /** Whether the bubble is currently shown. Reflected so CSS + tests can key off it. */
+  @property({ type: Boolean, reflect: true }) public visible = false;
+
+  @state() private _x = 0;
+  @state() private _y = 0;
+
+  public connectedCallback(): void {
+    super.connectedCallback();
+    if (!this.hasAttribute('role')) this.setAttribute('role', 'tooltip');
+  }
+
+  protected updated(): void {
+    if (!this.visible) return;
+    this.setAttribute('aria-hidden', 'false');
+    // Measure the rendered bubble, then re-place. happy-dom returns 0-sized
+    // rects, so the math degrades to the cursor+offset origin in tests.
+    const bubble = this.shadowRoot?.querySelector('.bubble') as HTMLElement | null;
+    const w = bubble?.offsetWidth ?? 0;
+    const h = bubble?.offsetHeight ?? 0;
+    const vpW = typeof window !== 'undefined' ? window.innerWidth : 0;
+    const vpH = typeof window !== 'undefined' ? window.innerHeight : 0;
+    const { x, y } = placeTooltip({
+      cursorX: this.cursorX,
+      cursorY: this.cursorY,
+      ttW: w,
+      ttH: h,
+      vpW,
+      vpH,
+      offset: this.offset,
+    });
+    if (x !== this._x) this._x = x;
+    if (y !== this._y) this._y = y;
+  }
+
+  protected render(): TemplateResult | typeof nothing {
+    if (!this.visible) {
+      this.setAttribute('aria-hidden', 'true');
+      return nothing;
+    }
+    return html`<div class="bubble" style="transform: translate3d(${this._x}px, ${this._y}px, 0)">
+      ${this.text}
+    </div>`;
+  }
+
+  public static styles = css`
+    :host {
+      position: fixed;
+      top: 0;
+      left: 0;
+      z-index: 100000;
+      pointer-events: none;
+    }
+    :host(:not([visible])) {
+      display: none;
+    }
+    .bubble {
+      position: absolute;
+      top: 0;
+      left: 0;
+      max-width: 280px;
+      padding: 6px 10px;
+      border-radius: 6px;
+      background: var(--acp-tooltip-bg, rgba(40, 40, 40, 0.96));
+      color: var(--acp-tooltip-fg, #fff);
+      font-size: 0.78rem;
+      line-height: 1.35;
+      box-shadow: 0 2px 10px rgba(0, 0, 0, 0.35);
+      white-space: normal;
+      word-break: break-word;
+    }
+  `;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'acp-floating-tooltip': FloatingTooltipElement;
+  }
+}

--- a/src/components/floating-tooltip.ts
+++ b/src/components/floating-tooltip.ts
@@ -84,6 +84,7 @@ export class FloatingTooltipElement extends LitElement {
       position: absolute;
       top: 0;
       left: 0;
+      width: max-content;
       max-width: 280px;
       padding: 6px 10px;
       border-radius: 6px;

--- a/src/components/forecast-strip.ts
+++ b/src/components/forecast-strip.ts
@@ -7,6 +7,7 @@ import { formatClock } from '../lib/formatters';
 import { t } from '../lib/i18n';
 import { dayFractionX } from '../lib/geometry';
 import { startOfDay } from '../lib/sun-model';
+import { tooltip } from '../lib/tooltip';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
@@ -20,8 +21,9 @@ const DAY_MS = 24 * 60 * 60 * 1000;
  * (00:00→24:00) so it aligns with the elevation chart.
  *
  * Hover affordances:
- *   - Vertical event markers get a wide invisible hit area + cursor:help and
- *     a richer `<title>` (kind meaning + local time).
+ *   - Vertical event markers get a wide invisible hit area and a card-owned
+ *     floating tooltip (kind meaning + local time) via the `tooltip()`
+ *     directive, with a help→default cursor handoff.
  *   - The curve shows a follow-along label with the nearest sample's time,
  *     position %, and handler (solar/default/...).
  */
@@ -78,9 +80,8 @@ export class ForecastStrip extends LitElement {
           return null;
         const x = xAt(eventTime);
         const colorClass = `evt-${e.kind}`;
-        const tooltip = describeEvent(e, this.hass);
-        return svg`<g class="event-group" data-tooltip=${tooltip}>
-          <title>${tooltip}</title>
+        const ttText = describeEvent(e, this.hass);
+        return svg`<g class="event-group" ${tooltip(ttText)}>
           <line
             class="event-hit"
             x1=${x.toFixed(1)}
@@ -146,7 +147,6 @@ export class ForecastStrip extends LitElement {
           @pointermove=${this._onPointerMove}
           @pointerleave=${this._onPointerLeave}
         >
-          <title>${t('forecast.hover_hint', this.hass)}</title>
           <line class="baseline" x1="0" y1=${VIEW_H - 0.5} x2=${VIEW_W} y2=${VIEW_H - 0.5}></line>
           <text class="axis-label" x="4" y=${TOP_PAD + 8} text-anchor="start">100%</text>
           ${ticks}
@@ -212,7 +212,12 @@ export class ForecastStrip extends LitElement {
       stroke-width: 1.5;
       vector-effect: non-scaling-stroke;
     }
-    .event-group {
+    /* Floating-tooltip cursor lifecycle: a help cursor hints at the event
+       marker on hover, flipping to default once OUR bubble appears. */
+    [data-tooltip]:hover {
+      cursor: help;
+    }
+    [data-tooltip][acp-tt-shown] {
       cursor: default;
     }
     .event-hit {

--- a/src/components/header-pill.ts
+++ b/src/components/header-pill.ts
@@ -1,6 +1,8 @@
 import { LitElement, html, css, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
+import { tooltip } from '../lib/tooltip';
+
 @customElement('acp-header-pill')
 export class AcpHeaderPill extends LitElement {
   @property({ type: Boolean }) public on = false;
@@ -17,7 +19,7 @@ export class AcpHeaderPill extends LitElement {
     return html`
       <button
         class="pill ${this.on ? 'on' : 'off'} ${this.readonly ? 'readonly' : ''}"
-        title=${this.title}
+        ${tooltip(this.title)}
         aria-disabled=${this.readonly ? 'true' : nothing}
         tabindex=${this.readonly ? '-1' : '0'}
         @click=${this._handleClick}
@@ -49,7 +51,15 @@ export class AcpHeaderPill extends LitElement {
     .pill.readonly {
       cursor: default;
       opacity: 0.85;
-      pointer-events: none;
+    }
+    /* Readonly pills aren't clickable, so a help cursor is a useful "hover for
+       more" hint; clickable pills keep their pointer cursor (below). The shown
+       state reverts to default once OUR bubble appears. */
+    .pill.readonly[data-tooltip]:hover {
+      cursor: help;
+    }
+    .pill[data-tooltip][acp-tt-shown] {
+      cursor: default;
     }
     .pill.on.readonly {
       opacity: 0.85;

--- a/src/components/more-info-dialog.ts
+++ b/src/components/more-info-dialog.ts
@@ -32,6 +32,7 @@ import type {
 } from '../types';
 import { formatPercent } from '../lib/formatters';
 import { t } from '../lib/i18n';
+import { tooltip } from '../lib/tooltip';
 
 import './tile-badge';
 import './decision-strip';
@@ -175,7 +176,7 @@ export class MoreInfoDialog extends LitElement {
               class="icon-btn options-link"
               type="button"
               aria-label=${configureLabel}
-              title=${configureLabel}
+              ${tooltip(configureLabel)}
               @click=${this._openIntegrationPage}
             >
               <ha-icon icon="mdi:tune-variant"></ha-icon>
@@ -185,7 +186,7 @@ export class MoreInfoDialog extends LitElement {
                   class="icon-btn device-link"
                   type="button"
                   aria-label=${deviceLabel}
-                  title=${deviceLabel}
+                  ${tooltip(deviceLabel)}
                   @click=${this._openDevicePage}
                 >
                   <ha-icon icon="mdi:cog"></ha-icon>
@@ -355,11 +356,13 @@ export class MoreInfoDialog extends LitElement {
       slot.template === true
         ? html`<span
             class="slot-template"
-            title=${`Template${
-              sensorCount > 0
-                ? ` · ${sensorCount} sensors${slot.template_mode ? ` (${slot.template_mode})` : ''}`
-                : ''
-            }`}
+            ${tooltip(
+              `Template${
+                sensorCount > 0
+                  ? ` · ${sensorCount} sensors${slot.template_mode ? ` (${slot.template_mode})` : ''}`
+                  : ''
+              }`,
+            )}
           >
             <ha-icon icon="mdi:code-braces"></ha-icon>
           </span>`
@@ -373,7 +376,7 @@ export class MoreInfoDialog extends LitElement {
             class="slot-min-mode${slot.priority != null && slot.priority > MANUAL_OVERRIDE_PRIORITY
               ? ''
               : ' is-bypassable'}"
-            title=${t('dialog.floor_tooltip', this.hass)}
+            ${tooltip(t('dialog.floor_tooltip', this.hass))}
           >
             ${t('dialog.floor', this.hass)}
           </span>`
@@ -655,6 +658,16 @@ export class MoreInfoDialog extends LitElement {
       display: inline-flex;
       align-items: center;
       color: var(--secondary-text-color);
+    }
+    /* Floating-tooltip cursor lifecycle for the informational chips (the
+       clickable .icon-btn buttons keep their pointer cursor — they are excluded
+       from this rule). Help hint on hover, default once OUR bubble appears. */
+    .slot-template[data-tooltip]:hover,
+    .slot-min-mode[data-tooltip]:hover {
+      cursor: help;
+    }
+    .slot-template[data-tooltip][acp-tt-shown],
+    .slot-min-mode[data-tooltip][acp-tt-shown] {
       cursor: default;
     }
     .slot-template ha-icon {
@@ -666,7 +679,6 @@ export class MoreInfoDialog extends LitElement {
       border-radius: 999px;
       background: rgba(156, 39, 176, 0.22);
       color: #6a1b9a;
-      cursor: default;
     }
     /* Priority axis: floor whose priority ≤ manual-override is bypassable by a
        manual ↓ → subdued. Per-slot rows have no clamping notion, so no fill/outline. */

--- a/src/components/sky-compass.ts
+++ b/src/components/sky-compass.ts
@@ -34,6 +34,7 @@ import { sunDotState, SUN_DOT_CLASS, type SunDotState } from '../lib/sun-dot-sta
 import { resolveCoverColor } from '../lib/palette';
 import { MOON_IMAGE } from '../lib/moon-image';
 import { t } from '../lib/i18n';
+import { tooltip } from '../lib/tooltip';
 
 // viewBox must have ~30 px of padding beyond OUTER_R so cardinal labels
 // (positioned at OUTER_R + 6..14) don't clip when rendered with
@@ -407,7 +408,7 @@ export class SkyCompass extends LitElement {
 
             ${
               this.showSunPath && sunPathRuns.length
-                ? svg`<g data-tooltip=${ttSunPath}><title>${ttSunPath}</title>${sunPathRuns
+                ? svg`<g ${tooltip(ttSunPath)}>${sunPathRuns
                     .filter((pts) => pts.length > 1)
                     .flatMap((pts, i) => {
                       const ptsStr = pts.map((p) => `${p.x},${p.y}`).join(' ');
@@ -453,8 +454,7 @@ export class SkyCompass extends LitElement {
             ${
               moonAboveHorizon
                 ? svg`
-              <g data-tooltip=${ttMoon}>
-                <title>${ttMoon}</title>
+              <g ${tooltip(ttMoon)}>
                 <circle class="moon-outline" cx=${moonX} cy=${moonY} r=${MOON_R}></circle>
                 <image
                   class="moon-img"
@@ -470,8 +470,7 @@ export class SkyCompass extends LitElement {
                 : nothing
             }
 
-            <g data-tooltip=${ttSun}>
-              <title>${ttSun}</title>
+            <g ${tooltip(ttSun)}>
               <circle class=${sunDotClass} cx=${sunPt.x * OUTER_R} cy=${sunPt.y * OUTER_R} r="7"></circle>
             </g>
           `}
@@ -665,14 +664,12 @@ export class SkyCompass extends LitElement {
     return svg`<g class="entry-overlay">
       ${
         showStaticUnderlay
-          ? svg`<g data-tooltip=${ttFovStatic}>
-              <title>${ttFovStatic}</title>
+          ? svg`<g ${tooltip(ttFovStatic)}>
               <path class="fov fov-static" style=${fovStyle} d=${fovStaticPath}></path>
             </g>`
           : nothing
       }
-      <g data-tooltip=${ttFov}>
-        <title>${ttFov}</title>
+      <g ${tooltip(ttFov)}>
         <path class="fov" style=${fovStyle} d=${fovPath}></path>
       </g>
       ${extraWedges.map((w) => {
@@ -681,20 +678,17 @@ export class SkyCompass extends LitElement {
           to: formatDegrees(w.to),
           elev: elevSuffix,
         })}`;
-        return svg`<g data-tooltip=${ttExtra}>
-          <title>${ttExtra}</title>
+        return svg`<g ${tooltip(ttExtra)}>
           <path class="fov-extra" style=${fovStyle} d=${w.fov}></path>
           ${w.cover ? svg`<path class="cover-fill-extra" style=${coverStyle} d=${w.cover}></path>` : nothing}
           ${w.actual ? svg`<path class="cover-actual-extra" style=${coverStyle} d=${w.actual}></path>` : nothing}
         </g>`;
       })}
-      <g class="arrow-group" data-tooltip=${ttWindow} style=${showArrow ? '' : hideStyle}>
-        <title>${ttWindow}</title>
+      <g class="arrow-group" style=${showArrow ? '' : hideStyle} ${tooltip(ttWindow)}>
         <path class="window" style=${arrowStyle} d=${arrowPath}></path>
         <circle class="window-base" style=${arrowBaseStyle} cx="0" cy="0" r="4"></circle>
       </g>
-      <g class="cover-group" data-tooltip=${ttCoverFill} style=${showCover ? '' : hideStyle}>
-        <title>${ttCoverFill}</title>
+      <g class="cover-group" style=${showCover ? '' : hideStyle} ${tooltip(ttCoverFill)}>
         <path class="cover-fill" style=${coverStyle} d=${coverPath}></path>
         ${
           this.showCoverFill && actualPath
@@ -702,8 +696,7 @@ export class SkyCompass extends LitElement {
             : nothing
         }
       </g>
-      <g class="blind-group" data-tooltip=${ttBlindSpot} style=${showBlind ? '' : hideStyle}>
-        <title>${ttBlindSpot}</title>
+      <g class="blind-group" style=${showBlind ? '' : hideStyle} ${tooltip(ttBlindSpot)}>
         <path class="blind-spot" style=${blindStyle} d=${blindSpot ?? ''}></path>
       </g>
     </g>`;
@@ -807,7 +800,9 @@ export class SkyCompass extends LitElement {
                 <span>∠${formatDegrees(o.sun.gamma)}</span>
                 <span>W ${formatDegrees(normalizeAzimuth(o.sun.window_azimuth))}</span>
                 ${o.sun.in_fov
-                  ? html`<span class="status in-fov" title=${t('compass.in_fov_tooltip', this.hass)}
+                  ? html`<span
+                      class="status in-fov"
+                      ${tooltip(t('compass.in_fov_tooltip', this.hass))}
                       >✓</span
                     >`
                   : nothing}
@@ -1126,7 +1121,13 @@ export class SkyCompass extends LitElement {
       background: var(--secondary-text-color);
       opacity: 0.6;
     }
-    g[data-tooltip] {
+    /* Floating-tooltip cursor lifecycle: a help cursor hints "there's more
+       here" on hover (SVG groups + the in-FOV status pip), flipping to default
+       the moment OUR bubble appears. */
+    [data-tooltip]:hover {
+      cursor: help;
+    }
+    [data-tooltip][acp-tt-shown] {
       cursor: default;
     }
   `;

--- a/src/components/tile-badge.ts
+++ b/src/components/tile-badge.ts
@@ -6,6 +6,7 @@ import { BADGE_I18N_KEYS, BADGE_ICONS, BADGE_TOKENS, type BadgeKind } from '../c
 import { winnerBadgeKind } from '../lib/badge-visibility';
 import { formatClock } from '../lib/formatters';
 import { t } from '../lib/i18n';
+import { tooltip } from '../lib/tooltip';
 
 /**
  * Compact contextual badge for the tile card.
@@ -92,7 +93,7 @@ export class TileBadge extends LitElement {
         style="background:${tokens.bg};color:${tokens.fg};"
         part="badge"
         type="button"
-        title=${hint}
+        ${tooltip(hint)}
         aria-label=${hint}
         @click=${this._onResumeClick}
         @pointerdown=${this._stop}

--- a/src/lib/geometry.ts
+++ b/src/lib/geometry.ts
@@ -18,6 +18,57 @@ export function degToRad(deg: number): number {
   return (deg * Math.PI) / 180;
 }
 
+/** Default down-and-right offset (px) for the floating tooltip: [right, down]. */
+export const DEFAULT_TOOLTIP_OFFSET: readonly [number, number] = [12, 16];
+
+export interface PlaceTooltipArgs {
+  /** Pointer (or anchor) X in viewport coordinates. */
+  cursorX: number;
+  /** Pointer (or anchor) Y in viewport coordinates. */
+  cursorY: number;
+  /** Measured tooltip bubble width (px). */
+  ttW: number;
+  /** Measured tooltip bubble height (px). */
+  ttH: number;
+  /** Viewport width (px). */
+  vpW: number;
+  /** Viewport height (px). */
+  vpH: number;
+  /** [right, down] offset from the cursor; defaults to DEFAULT_TOOLTIP_OFFSET. */
+  offset?: readonly [number, number];
+}
+
+/**
+ * Position a floating tooltip down-and-right of the cursor, flipping to the
+ * opposite side of either axis when the preferred placement would overflow the
+ * viewport, and finally clamping both coordinates to be non-negative.
+ *
+ * Pure: takes the cursor position, the measured bubble size, the viewport size,
+ * and an offset; returns the top-left {x, y} of the bubble plus `flipped` (true
+ * when the X axis was flipped to the left of the cursor). All math lives here so
+ * the component and tests share one implementation.
+ */
+export function placeTooltip(args: PlaceTooltipArgs): { x: number; y: number; flipped: boolean } {
+  const { cursorX, cursorY, ttW, ttH, vpW, vpH } = args;
+  const [offsetX, offsetY] = args.offset ?? DEFAULT_TOOLTIP_OFFSET;
+
+  let x = cursorX + offsetX;
+  let flipped = false;
+  if (x + ttW > vpW) {
+    x = cursorX - offsetX - ttW;
+    flipped = true;
+  }
+  if (x < 0) x = 0;
+
+  let y = cursorY + offsetY;
+  if (y + ttH > vpH) {
+    y = cursorY - offsetY - ttH;
+  }
+  if (y < 0) y = 0;
+
+  return { x, y, flipped };
+}
+
 /** Azimuth (degrees, 0=N clockwise) + radius (0..1) → Cartesian point on a unit circle with +y down.
  *  northOffsetDeg rotates the whole compass clockwise by that many degrees (0 = North at top). */
 export function azimuthToCartesian(azimuthDeg: number, radius: number, northOffsetDeg = 0): Point {

--- a/src/lib/tooltip.ts
+++ b/src/lib/tooltip.ts
@@ -1,0 +1,290 @@
+import { nothing, type ElementPart } from 'lit';
+import { directive, AsyncDirective, PartType, type PartInfo } from 'lit/async-directive.js';
+
+import { DEFAULT_TOOLTIP_OFFSET } from './geometry';
+// Side-effect import: registers the `<acp-floating-tooltip>` custom element so
+// the singleton manager can create it on demand.
+import '../components/floating-tooltip';
+import type { FloatingTooltipElement } from '../components/floating-tooltip';
+
+/**
+ * Card-owned floating tooltip.
+ *
+ * `tooltip(text, opts?)` is a Lit `AsyncDirective` applied to an element. While
+ * floating tooltips are enabled it:
+ *   - mirrors `text` onto `data-tooltip` and wires `aria-describedby` to the
+ *     shared bubble's stable id (a11y),
+ *   - installs pointer/focus/keyboard listeners that arm an open-delay timer,
+ *     show the singleton bubble down-and-right of the cursor, follow the pointer,
+ *     and dismiss on leave / blur / Escape / scroll,
+ *   - drives a help→default cursor handoff via the `acp-tt-shown` attribute
+ *     (CSS keys `cursor: help` on hover, `cursor: default` once OUR bubble shows).
+ *
+ * When disabled it degrades to a plain native `title=` (today's behavior) and
+ * sets no `data-tooltip`/`aria-describedby`/listeners.
+ *
+ * All positioning math lives in `geometry.placeTooltip`; all rendering lives in
+ * `<acp-floating-tooltip>`. This module owns only lifecycle + listeners.
+ */
+
+export interface TooltipOptions {
+  /** Master switch. Default true. */
+  enabled?: boolean;
+  /** [right, down] cursor offset. Default [12, 16]. */
+  offset?: readonly [number, number];
+  /** Open delay in ms before the bubble appears. Default 400. */
+  delay?: number;
+}
+
+interface ResolvedTooltipDefaults {
+  enabled: boolean;
+  offset: readonly [number, number];
+  delay: number;
+}
+
+const moduleDefaults: ResolvedTooltipDefaults = {
+  enabled: true,
+  offset: DEFAULT_TOOLTIP_OFFSET,
+  delay: 400,
+};
+
+/** Thread per-card config into the directive's module-level defaults. */
+export function setTooltipDefaults(opts: TooltipOptions): void {
+  if (opts.enabled !== undefined) moduleDefaults.enabled = opts.enabled;
+  if (opts.offset !== undefined) moduleDefaults.offset = opts.offset;
+  if (opts.delay !== undefined) moduleDefaults.delay = opts.delay;
+}
+
+const BUBBLE_ID = 'acp-floating-tooltip-bubble';
+
+/**
+ * Ref-counted manager for the single `<acp-floating-tooltip>` appended to
+ * `document.body`. Lazily mounts on first show/connect and tracks how many live
+ * directives reference it so it can stay mounted while any anchor is active.
+ */
+class FloatingTooltipManager {
+  private _el: FloatingTooltipElement | null = null;
+  private _refs = 0;
+
+  public get id(): string {
+    return BUBBLE_ID;
+  }
+
+  public retain(): void {
+    this._refs += 1;
+    // Mount eagerly on first reference so the single bubble exists in the DOM
+    // (with its stable id for aria-describedby) before any hover.
+    this._ensure();
+  }
+
+  public release(): void {
+    this._refs = Math.max(0, this._refs - 1);
+  }
+
+  private _ensure(): FloatingTooltipElement | null {
+    if (typeof document === 'undefined') return null;
+    if (this._el && this._el.isConnected) return this._el;
+    // Importing the element module registers the custom element.
+    const el = document.createElement('acp-floating-tooltip') as FloatingTooltipElement;
+    el.id = BUBBLE_ID;
+    document.body.appendChild(el);
+    this._el = el;
+    return el;
+  }
+
+  public show(text: string, x: number, y: number, offset: readonly [number, number]): void {
+    const el = this._ensure();
+    if (!el) return;
+    el.text = text;
+    el.cursorX = x;
+    el.cursorY = y;
+    el.offset = offset;
+    el.visible = true;
+  }
+
+  public move(x: number, y: number): void {
+    if (!this._el || !this._el.visible) return;
+    this._el.cursorX = x;
+    this._el.cursorY = y;
+  }
+
+  public hide(): void {
+    if (this._el) this._el.visible = false;
+  }
+
+  /** Test-only: tear the singleton down so each test starts clean. */
+  public _reset(): void {
+    if (this._el && this._el.parentNode) this._el.parentNode.removeChild(this._el);
+    this._el = null;
+    this._refs = 0;
+  }
+}
+
+const manager = new FloatingTooltipManager();
+
+/** Test-only helper to reset the shared singleton between cases. */
+export function _resetTooltipSingleton(): void {
+  manager._reset();
+}
+
+class TooltipDirective extends AsyncDirective {
+  private _el: Element | null = null;
+  private _text = '';
+  private _offset: readonly [number, number] = DEFAULT_TOOLTIP_OFFSET;
+  private _delay = 400;
+  private _enabled = true;
+  private _openTimer: ReturnType<typeof setTimeout> | null = null;
+  private _shown = false;
+  private _retained = false;
+  private _lastX = 0;
+  private _lastY = 0;
+
+  // Bound listeners (stable references for add/removeEventListener).
+  private _onEnter = (e: Event): void => this._handleEnter(e as PointerEvent);
+  private _onMove = (e: Event): void => this._handleMove(e as PointerEvent);
+  private _onLeave = (): void => this._dismiss();
+  private _onFocus = (): void => this._handleFocus();
+  private _onBlur = (): void => this._dismiss();
+  private _onKey = (e: Event): void => {
+    if ((e as KeyboardEvent).key === 'Escape') this._dismiss();
+  };
+  private _onScroll = (): void => this._dismiss();
+
+  constructor(partInfo: PartInfo) {
+    super(partInfo);
+    if (partInfo.type !== PartType.ELEMENT) {
+      throw new Error('tooltip() can only be used as an element-part directive');
+    }
+  }
+
+  public render(_text: string, _opts?: TooltipOptions): typeof nothing {
+    return nothing;
+  }
+
+  public override update(part: ElementPart, [text, opts]: [string, TooltipOptions?]): unknown {
+    const el = part.element;
+    this._text = text ?? '';
+    this._offset = opts?.offset ?? moduleDefaults.offset;
+    this._delay = opts?.delay ?? moduleDefaults.delay;
+    this._enabled = opts?.enabled ?? moduleDefaults.enabled;
+
+    if (this._el !== el) {
+      this._teardown();
+      this._el = el;
+      this._wire();
+    } else {
+      this._applyAttributes();
+    }
+    return this.render(text, opts);
+  }
+
+  private _wire(): void {
+    const el = this._el;
+    if (!el) return;
+    this._applyAttributes();
+    if (!this._enabled) return;
+    manager.retain();
+    this._retained = true;
+    el.addEventListener('pointerenter', this._onEnter);
+    el.addEventListener('pointermove', this._onMove);
+    el.addEventListener('pointerleave', this._onLeave);
+    el.addEventListener('focusin', this._onFocus);
+    el.addEventListener('focusout', this._onBlur);
+    el.addEventListener('keydown', this._onKey);
+    window.addEventListener('scroll', this._onScroll, true);
+  }
+
+  private _applyAttributes(): void {
+    const el = this._el;
+    if (!el) return;
+    if (this._enabled) {
+      el.removeAttribute('title');
+      el.setAttribute('data-tooltip', this._text);
+      el.setAttribute('aria-describedby', manager.id);
+    } else {
+      el.removeAttribute('data-tooltip');
+      el.removeAttribute('aria-describedby');
+      el.removeAttribute('acp-tt-shown');
+      el.setAttribute('title', this._text);
+    }
+  }
+
+  private _handleEnter(e: PointerEvent): void {
+    this._lastX = e.clientX;
+    this._lastY = e.clientY;
+    this._armOpen();
+  }
+
+  private _handleFocus(): void {
+    const el = this._el as HTMLElement | null;
+    if (el && typeof el.getBoundingClientRect === 'function') {
+      const r = el.getBoundingClientRect();
+      this._lastX = r.left + r.width / 2;
+      this._lastY = r.bottom;
+    }
+    this._armOpen();
+  }
+
+  private _armOpen(): void {
+    if (this._openTimer !== null) return;
+    this._openTimer = setTimeout(() => {
+      this._openTimer = null;
+      this._open();
+    }, this._delay);
+  }
+
+  private _open(): void {
+    if (!this._el) return;
+    manager.show(this._text, this._lastX, this._lastY, this._offset);
+    this._shown = true;
+    this._el.setAttribute('acp-tt-shown', '');
+  }
+
+  private _handleMove(e: PointerEvent): void {
+    this._lastX = e.clientX;
+    this._lastY = e.clientY;
+    if (this._shown) manager.move(this._lastX, this._lastY);
+  }
+
+  private _dismiss(): void {
+    if (this._openTimer !== null) {
+      clearTimeout(this._openTimer);
+      this._openTimer = null;
+    }
+    if (this._shown) {
+      manager.hide();
+      this._shown = false;
+    }
+    this._el?.removeAttribute('acp-tt-shown');
+  }
+
+  private _teardown(): void {
+    const el = this._el;
+    if (!el) return;
+    this._dismiss();
+    el.removeEventListener('pointerenter', this._onEnter);
+    el.removeEventListener('pointermove', this._onMove);
+    el.removeEventListener('pointerleave', this._onLeave);
+    el.removeEventListener('focusin', this._onFocus);
+    el.removeEventListener('focusout', this._onBlur);
+    el.removeEventListener('keydown', this._onKey);
+    if (typeof window !== 'undefined') {
+      window.removeEventListener('scroll', this._onScroll, true);
+    }
+    if (this._retained) {
+      manager.release();
+      this._retained = false;
+    }
+    this._el = null;
+  }
+
+  public override disconnected(): void {
+    this._teardown();
+  }
+
+  public override reconnected(): void {
+    this._wire();
+  }
+}
+
+export const tooltip = directive(TooltipDirective);

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,17 @@ export type { HomeAssistant };
 
 export type CardSection = 'sky' | 'elevation' | 'decision' | 'covers' | 'overrides' | 'climate';
 
+/**
+ * Card-owned floating-tooltip configuration. When `enabled === false` the card
+ * falls back to native browser `title=` tooltips. `offset` is the [right, down]
+ * pixel offset of the bubble from the cursor; `delay` is the open delay (ms).
+ */
+export interface TooltipsConfig {
+  enabled?: boolean;
+  offset?: [number, number];
+  delay?: number;
+}
+
 export interface AdaptiveCoverProCardConfig extends LovelaceCardConfig {
   type: string;
   entry_id: string;
@@ -26,6 +37,9 @@ export interface AdaptiveCoverProCardConfig extends LovelaceCardConfig {
     automatic_control?: boolean;
     reset_manual_override?: boolean;
   };
+  /** Card-owned floating tooltip behavior. Defaults: enabled, offset [12,16],
+   *  delay 400ms. Set `enabled: false` to use native browser tooltips. */
+  tooltips?: TooltipsConfig;
 }
 
 export interface AdaptiveCoverProTileCardConfig extends LovelaceCardConfig {
@@ -89,6 +103,9 @@ export interface AdaptiveCoverProTileCardConfig extends LovelaceCardConfig {
   hold_action?: ActionConfig;
   /** Double-tap action. Standard HA `ActionConfig`. */
   double_tap_action?: ActionConfig;
+  /** Card-owned floating tooltip behavior. Defaults: enabled, offset [12,16],
+   *  delay 400ms. Set `enabled: false` to use native browser tooltips. */
+  tooltips?: TooltipsConfig;
 }
 
 export interface SkyCompassCardConfig extends LovelaceCardConfig {
@@ -111,6 +128,9 @@ export interface SkyCompassCardConfig extends LovelaceCardConfig {
   show_elevation_chart?: boolean;
   cover_colors?: (string | null)[];
   north_offset?: number;
+  /** Card-owned floating tooltip behavior. Defaults: enabled, offset [12,16],
+   *  delay 400ms. Set `enabled: false` to use native browser tooltips. */
+  tooltips?: TooltipsConfig;
 }
 
 export interface DiscoveredEntities {

--- a/tests/components.test.ts
+++ b/tests/components.test.ts
@@ -126,7 +126,9 @@ describe('acp-decision-strip', () => {
     const banner = el.shadowRoot!.querySelector('.off-schedule');
     expect(banner).toBeTruthy();
     expect(banner!.textContent).toContain('Outside schedule');
-    expect(banner!.getAttribute('title')).toContain('schedule window is not active');
+    // Floating tooltip: text now lives on data-tooltip (no native title=).
+    expect(banner!.getAttribute('data-tooltip')).toContain('schedule window is not active');
+    expect(banner!.hasAttribute('title')).toBe(false);
   });
 
   it('hides the off-schedule banner when in_time_window is true', async () => {

--- a/tests/elevation-chart.test.ts
+++ b/tests/elevation-chart.test.ts
@@ -251,7 +251,7 @@ describe('acp-elevation-chart: multi-window ribbon', () => {
     expect(el.shadowRoot!.querySelectorAll('rect.ribbon-track').length).toBe(2);
   });
 
-  it('gives each ribbon bar a <title> tooltip with the window name and FOV time range', async () => {
+  it('gives each ribbon bar a data-tooltip with the window name and FOV time range', async () => {
     const el = await mount({
       hass: twoWindowHass(),
       discoveredList: [discoveredSouth, discoveredWest],
@@ -259,7 +259,7 @@ describe('acp-elevation-chart: multi-window ribbon', () => {
     });
     const bars = el.shadowRoot!.querySelectorAll('rect.ribbon-bar');
     expect(bars.length).toBeGreaterThan(0);
-    const titles = Array.from(bars).map((b) => b.querySelector('title')?.textContent ?? '');
+    const titles = Array.from(bars).map((b) => b.getAttribute('data-tooltip') ?? '');
     // Every bar carries a tooltip; at least one names a window with a → range.
     expect(titles.every((tx) => tx.length > 0)).toBe(true);
     expect(titles.some((tx) => tx.includes('Living Room') && tx.includes('→'))).toBe(true);
@@ -273,7 +273,7 @@ describe('acp-elevation-chart: multi-window ribbon', () => {
       coverColors: ['#ff7043', '#7e57c2'],
     });
     const trackTitles = Array.from(el.shadowRoot!.querySelectorAll('rect.ribbon-track')).map(
-      (r) => r.querySelector('title')?.textContent ?? '',
+      (r) => r.getAttribute('data-tooltip') ?? '',
     );
     expect(trackTitles.some((tx) => tx.includes('Living Room'))).toBe(true);
     expect(trackTitles.some((tx) => tx.includes('Office'))).toBe(true);

--- a/tests/floating-tooltip.test.ts
+++ b/tests/floating-tooltip.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import '../src/components/floating-tooltip';
+import { FloatingTooltipElement } from '../src/components/floating-tooltip';
+import type { CSSResult } from 'lit';
+
+interface TTLike extends HTMLElement {
+  updateComplete: Promise<boolean>;
+  text: string;
+  cursorX: number;
+  cursorY: number;
+  visible: boolean;
+}
+
+function make(): TTLike {
+  const el = document.createElement('acp-floating-tooltip') as TTLike;
+  document.body.appendChild(el);
+  return el;
+}
+
+describe('acp-floating-tooltip element', () => {
+  it('exposes role=tooltip on the host for a11y', async () => {
+    const el = make();
+    await el.updateComplete;
+    expect(el.getAttribute('role')).toBe('tooltip');
+  });
+
+  it('is hidden (aria-hidden) until visible is set', async () => {
+    const el = make();
+    await el.updateComplete;
+    expect(el.hasAttribute('visible')).toBe(false);
+    el.visible = true;
+    await el.updateComplete;
+    expect(el.hasAttribute('visible')).toBe(true);
+  });
+
+  it('renders the supplied text', async () => {
+    const el = make();
+    el.text = 'Hello tooltip';
+    el.visible = true;
+    await el.updateComplete;
+    expect(el.shadowRoot!.textContent).toContain('Hello tooltip');
+  });
+
+  it('positions itself with fixed positioning at the placed coordinates', async () => {
+    const el = make();
+    el.text = 'x';
+    el.cursorX = 100;
+    el.cursorY = 200;
+    el.visible = true;
+    await el.updateComplete;
+    const bubble = el.shadowRoot!.querySelector('.bubble') as HTMLElement;
+    expect(bubble).toBeTruthy();
+    // transform is a translate3d to the placed origin (down-right of cursor).
+    expect(bubble.style.transform).toContain('translate');
+  });
+
+  it('uses pointer-events:none and a high z-index so it never blocks input', () => {
+    const styles = (FloatingTooltipElement as unknown as { styles: CSSResult }).styles.cssText;
+    expect(styles).toContain('pointer-events: none');
+    expect(styles).toMatch(/z-index:\s*\d{4,}/);
+    expect(styles).toContain('position: fixed');
+  });
+});

--- a/tests/more-info-dialog.test.ts
+++ b/tests/more-info-dialog.test.ts
@@ -417,8 +417,8 @@ describe('acp-more-info-dialog: slot management', () => {
     const chips = el.shadowRoot!.querySelectorAll('.slot-row .slot-template');
     expect(chips.length).toBe(1);
     // The chip's tooltip surfaces the sensor count and combine mode.
-    expect(chips[0].getAttribute('title')).toContain('2 sensors');
-    expect(chips[0].getAttribute('title')).toContain('or');
+    expect(chips[0].getAttribute('data-tooltip')).toContain('2 sensors');
+    expect(chips[0].getAttribute('data-tooltip')).toContain('or');
   });
 
   it('floor pill is the ↥ glyph', async () => {

--- a/tests/sky-compass.test.ts
+++ b/tests/sky-compass.test.ts
@@ -403,7 +403,7 @@ describe('acp-sky-compass (multi-entry overlay)', () => {
     expect(ticks.length).toBe(2);
     ticks.forEach((tick) => {
       expect(tick.textContent?.trim()).toBe('✓');
-      const title = tick.getAttribute('title') ?? '';
+      const title = tick.getAttribute('data-tooltip') ?? '';
       expect(title).toContain('field of view');
     });
   });
@@ -585,9 +585,9 @@ describe('acp-sky-compass blind spot bearing conversion', () => {
       { sensorId: 'sensor.sun_pos_entry1', windowAzimuth: 180, blindSpot: [10, 30] },
     ]);
     const el = await mountCompass([d], hass);
-    const title = el.shadowRoot!.querySelector('g.blind-group > title');
-    expect(title?.textContent ?? '').toContain('150');
-    expect(title?.textContent ?? '').toContain('170');
+    const title = el.shadowRoot!.querySelector('g.blind-group')?.getAttribute('data-tooltip') ?? '';
+    expect(title).toContain('150');
+    expect(title).toContain('170');
   });
 });
 
@@ -882,7 +882,7 @@ describe('acp-sky-compass FOV elevation limits', () => {
     const hass = makeHass([{ sensorId, windowAzimuth: 180, minElevation: 10, maxElevation: 60 }]);
     const el = await mountCompass([d()], hass);
     const fovGroup = el.shadowRoot!.querySelector('path.fov')?.parentElement;
-    const titleText = fovGroup?.querySelector('title')?.textContent ?? '';
+    const titleText = fovGroup?.getAttribute('data-tooltip') ?? '';
     expect(titleText).toContain('10');
     expect(titleText).toContain('60');
   });
@@ -891,7 +891,7 @@ describe('acp-sky-compass FOV elevation limits', () => {
     const hass = makeHass([{ sensorId, windowAzimuth: 180 }]);
     const el = await mountCompass([d()], hass);
     const fovGroup = el.shadowRoot!.querySelector('path.fov')?.parentElement;
-    const titleText = fovGroup?.querySelector('title')?.textContent ?? '';
+    const titleText = fovGroup?.getAttribute('data-tooltip') ?? '';
     expect(titleText).not.toContain('elev');
   });
 });
@@ -1024,8 +1024,9 @@ describe('acp-sky-compass cover-fill polarity by cover_type', () => {
       },
     ]);
     const elAwning = await mountCompass([discAwning], hassAwning);
-    const awningTitle = elAwning.shadowRoot!.querySelector('g.cover-group > title');
-    expect(awningTitle?.textContent ?? '').toContain('Target (extended): 75%');
+    const awningTitle =
+      elAwning.shadowRoot!.querySelector('g.cover-group')?.getAttribute('data-tooltip') ?? '';
+    expect(awningTitle).toContain('Target (extended): 75%');
 
     const targetBlind = 'sensor.target_pos_blind7';
     const discBlind = makeDiscovered('blind7', 'Blind', {
@@ -1041,9 +1042,10 @@ describe('acp-sky-compass cover-fill polarity by cover_type', () => {
       },
     ]);
     const elBlind = await mountCompass([discBlind], hassBlind);
-    const blindTitle = elBlind.shadowRoot!.querySelector('g.cover-group > title');
-    expect(blindTitle?.textContent ?? '').toContain('Target: 75%');
-    expect(blindTitle?.textContent ?? '').not.toContain('extended');
+    const blindTitle =
+      elBlind.shadowRoot!.querySelector('g.cover-group')?.getAttribute('data-tooltip') ?? '';
+    expect(blindTitle).toContain('Target: 75%');
+    expect(blindTitle).not.toContain('extended');
   });
 });
 
@@ -1063,7 +1065,7 @@ describe('acp-sky-compass cover tooltip target + actual lines (#132)', () => {
       },
     ]);
     const el = await mountCompass([disc], hass);
-    const tt = el.shadowRoot!.querySelector('g.cover-group > title')?.textContent ?? '';
+    const tt = el.shadowRoot!.querySelector('g.cover-group')?.getAttribute('data-tooltip') ?? '';
     expect(tt).toContain('Target: 30%');
     expect(tt).toContain('Actual: 80%');
   });
@@ -1072,7 +1074,7 @@ describe('acp-sky-compass cover tooltip target + actual lines (#132)', () => {
     const disc = makeDiscovered('tt', 'Kitchen', { targetSensorId });
     const hass = makeHass([{ sensorId, windowAzimuth: 180, coverPos: 30, targetSensorId }]);
     const el = await mountCompass([disc], hass);
-    const tt = el.shadowRoot!.querySelector('g.cover-group > title')?.textContent ?? '';
+    const tt = el.shadowRoot!.querySelector('g.cover-group')?.getAttribute('data-tooltip') ?? '';
     expect(tt).toContain('Target: 30%');
     expect(tt).not.toContain('Actual');
   });
@@ -1233,7 +1235,7 @@ describe('acp-sky-compass manual-override divergence (#132 Problem A)', () => {
       },
     ]);
     const el = await mountCompass([disc()], hass);
-    const tt = el.shadowRoot!.querySelector('g.cover-group > title')?.textContent ?? '';
+    const tt = el.shadowRoot!.querySelector('g.cover-group')?.getAttribute('data-tooltip') ?? '';
     // Target line = solar would-be (20%); Actual line = held (80%).
     expect(tt).toContain('Target: 20%');
     expect(tt).toContain('Actual: 80%');
@@ -1513,7 +1515,7 @@ describe('acp-sky-compass active sun arc (start/end sensor azimuths)', () => {
     ]);
     const el = await mountCompass([d], hass);
     const fovGroup = el.shadowRoot!.querySelector('path.fov:not(.fov-static)')?.parentElement;
-    const titleText = fovGroup?.querySelector('title')?.textContent ?? '';
+    const titleText = fovGroup?.getAttribute('data-tooltip') ?? '';
     expect(titleText).toContain('Active sun arc');
     expect(titleText).toMatch(/150/);
     expect(titleText).toMatch(/210/);
@@ -1707,17 +1709,21 @@ describe('acp-sky-compass (multiple FOV crossings)', () => {
     // there is still exactly one primary active-arc wedge (plus its static underlay)
     expect(el.shadowRoot!.querySelectorAll('path.fov:not(.fov-static)').length).toBe(1);
     // each extra crossing reuses the active-sun-arc tooltip
-    const titleText = extras[0].parentElement?.querySelector('title')?.textContent ?? '';
+    const titleText = extras[0].parentElement?.getAttribute('data-tooltip') ?? '';
     expect(titleText).toContain('Active sun arc');
   });
 });
 
-describe('acp-sky-compass tooltip cursor', () => {
-  // Regression guard: tooltip carriers must use cursor: default, not cursor: help
-  // (issue #134 — the question-mark cursor confuses users).
+describe('acp-sky-compass tooltip cursor lifecycle', () => {
+  // Issue #134 follow-up: the help cursor is a brief discovery hint on hover,
+  // flipping to default the moment OUR floating tooltip appears (acp-tt-shown).
   const cssText = (SkyCompass as unknown as { styles: { cssText: string } }).styles.cssText;
 
-  it('g[data-tooltip] uses cursor: default, not cursor: help', () => {
-    expect(cssText).not.toContain('cursor: help');
+  it('hover shows a help cursor on tooltip carriers', () => {
+    expect(cssText).toMatch(/\[data-tooltip\]:hover\s*{\s*cursor:\s*help/);
+  });
+
+  it('the shown state reverts the cursor to default', () => {
+    expect(cssText).toMatch(/\[data-tooltip\]\[acp-tt-shown\]\s*{\s*cursor:\s*default/);
   });
 });

--- a/tests/tile-card.test.ts
+++ b/tests/tile-card.test.ts
@@ -1048,14 +1048,14 @@ describe('adaptive-cover-pro-tile-card motion indicator', () => {
     const el = await mountWithMotion({ type: TYPE, entry_id: ENTRY }, 'motion_detected');
     const overlay = el.shadowRoot!.querySelector('.motion-overlay');
     expect(overlay).toBeTruthy();
-    expect(overlay!.getAttribute('title')).toBe('Motion detected');
+    expect(overlay!.getAttribute('data-tooltip')).toBe('Motion detected');
   });
 
   it('renders the overlay when motion_status is timeout_pending', async () => {
     const el = await mountWithMotion({ type: TYPE, entry_id: ENTRY }, 'timeout_pending');
     const overlay = el.shadowRoot!.querySelector('.motion-overlay');
     expect(overlay).toBeTruthy();
-    expect(overlay!.getAttribute('title')).toBe('Motion timeout pending');
+    expect(overlay!.getAttribute('data-tooltip')).toBe('Motion timeout pending');
   });
 
   it('hides the overlay when motion_status is no_motion', async () => {

--- a/tests/tooltip-config.test.ts
+++ b/tests/tooltip-config.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { setTooltipDefaults, _resetTooltipSingleton } from '../src/lib/tooltip';
+import { tooltip } from '../src/lib/tooltip';
+import { html, render } from 'lit';
+import '../src/adaptive-cover-pro-tile-card';
+import type { AdaptiveCoverProTileCardConfig } from '../src/types';
+
+beforeEach(() => {
+  setTooltipDefaults({ enabled: true, offset: [12, 16], delay: 400 });
+  _resetTooltipSingleton();
+  document.body.innerHTML = '';
+});
+
+function anchorWithTooltip(): HTMLElement {
+  const host = document.createElement('div');
+  document.body.appendChild(host);
+  render(html`<span class="anchor" ${tooltip('Hi')}>x</span>`, host);
+  return host.querySelector('.anchor') as HTMLElement;
+}
+
+describe('tile-card setConfig threads tooltips config into the directive defaults', () => {
+  it('disabling tooltips via config makes the directive emit a native title', async () => {
+    const card = document.createElement('adaptive-cover-pro-tile-card') as HTMLElement & {
+      setConfig: (c: AdaptiveCoverProTileCardConfig) => void;
+    };
+    card.setConfig({
+      type: 'custom:adaptive-cover-pro-tile-card',
+      entry_id: 'entry1',
+      tooltips: { enabled: false },
+    });
+    const el = anchorWithTooltip();
+    expect(el.getAttribute('title')).toBe('Hi');
+    expect(el.hasAttribute('data-tooltip')).toBe(false);
+  });
+
+  it('enabling tooltips (default) makes the directive emit data-tooltip', async () => {
+    const card = document.createElement('adaptive-cover-pro-tile-card') as HTMLElement & {
+      setConfig: (c: AdaptiveCoverProTileCardConfig) => void;
+    };
+    card.setConfig({
+      type: 'custom:adaptive-cover-pro-tile-card',
+      entry_id: 'entry1',
+      tooltips: { enabled: true },
+    });
+    const el = anchorWithTooltip();
+    expect(el.getAttribute('data-tooltip')).toBe('Hi');
+    expect(el.hasAttribute('title')).toBe(false);
+  });
+});

--- a/tests/tooltip-directive.test.ts
+++ b/tests/tooltip-directive.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { html, render } from 'lit';
+import { tooltip, setTooltipDefaults, _resetTooltipSingleton } from '../src/lib/tooltip';
+
+beforeEach(() => {
+  setTooltipDefaults({ enabled: true, offset: [12, 16], delay: 400 });
+  _resetTooltipSingleton();
+  document.body.innerHTML = '';
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+function renderTip(text: string, opts?: Parameters<typeof tooltip>[1]): HTMLElement {
+  const host = document.createElement('div');
+  document.body.appendChild(host);
+  render(html`<span class="anchor" ${tooltip(text, opts)}>label</span>`, host);
+  return host.querySelector('.anchor') as HTMLElement;
+}
+
+describe('tooltip directive — a11y + data wiring', () => {
+  it('sets data-tooltip to the text when floating is enabled', () => {
+    const el = renderTip('Hello');
+    expect(el.getAttribute('data-tooltip')).toBe('Hello');
+  });
+
+  it('sets aria-describedby to the singleton bubble id', () => {
+    const el = renderTip('Hello');
+    expect(el.getAttribute('aria-describedby')).toBeTruthy();
+  });
+
+  it('does NOT set a native title when floating is enabled (avoids double tooltip)', () => {
+    const el = renderTip('Hello');
+    expect(el.hasAttribute('title')).toBe(false);
+  });
+
+  it('degrades to a native title= and no data-tooltip when disabled', () => {
+    setTooltipDefaults({ enabled: false });
+    const el = renderTip('Hello');
+    expect(el.getAttribute('title')).toBe('Hello');
+    expect(el.hasAttribute('data-tooltip')).toBe(false);
+    expect(el.hasAttribute('aria-describedby')).toBe(false);
+  });
+});
+
+describe('tooltip directive — cursor lifecycle + open delay', () => {
+  it('does not show the bubble before the open delay elapses', () => {
+    vi.useFakeTimers();
+    const el = renderTip('Hello');
+    el.dispatchEvent(new PointerEvent('pointerenter', { clientX: 50, clientY: 60 }));
+    expect(el.hasAttribute('acp-tt-shown')).toBe(false);
+    vi.advanceTimersByTime(399);
+    expect(el.hasAttribute('acp-tt-shown')).toBe(false);
+  });
+
+  it('flips to shown (acp-tt-shown) after the delay, and the bubble becomes visible', () => {
+    vi.useFakeTimers();
+    const el = renderTip('Hello');
+    el.dispatchEvent(new PointerEvent('pointerenter', { clientX: 50, clientY: 60 }));
+    vi.advanceTimersByTime(400);
+    expect(el.hasAttribute('acp-tt-shown')).toBe(true);
+    const bubble = document.querySelector('acp-floating-tooltip') as HTMLElement & {
+      visible: boolean;
+    };
+    expect(bubble).toBeTruthy();
+    expect(bubble.visible).toBe(true);
+  });
+
+  it('clears the open timer and never shows when the pointer leaves first', () => {
+    vi.useFakeTimers();
+    const el = renderTip('Hello');
+    el.dispatchEvent(new PointerEvent('pointerenter', { clientX: 50, clientY: 60 }));
+    vi.advanceTimersByTime(200);
+    el.dispatchEvent(new PointerEvent('pointerleave'));
+    vi.advanceTimersByTime(400);
+    expect(el.hasAttribute('acp-tt-shown')).toBe(false);
+  });
+
+  it('hides and clears acp-tt-shown on pointerleave', () => {
+    vi.useFakeTimers();
+    const el = renderTip('Hello');
+    el.dispatchEvent(new PointerEvent('pointerenter', { clientX: 50, clientY: 60 }));
+    vi.advanceTimersByTime(400);
+    expect(el.hasAttribute('acp-tt-shown')).toBe(true);
+    el.dispatchEvent(new PointerEvent('pointerleave'));
+    expect(el.hasAttribute('acp-tt-shown')).toBe(false);
+    const bubble = document.querySelector('acp-floating-tooltip') as HTMLElement & {
+      visible: boolean;
+    };
+    expect(bubble.visible).toBe(false);
+  });
+
+  it('hides on Escape keydown', () => {
+    vi.useFakeTimers();
+    const el = renderTip('Hello');
+    el.dispatchEvent(new PointerEvent('pointerenter', { clientX: 50, clientY: 60 }));
+    vi.advanceTimersByTime(400);
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    expect(el.hasAttribute('acp-tt-shown')).toBe(false);
+  });
+
+  it('shows on focusin using the element bounding rect', () => {
+    vi.useFakeTimers();
+    const el = renderTip('Hello');
+    el.dispatchEvent(new FocusEvent('focusin'));
+    vi.advanceTimersByTime(400);
+    expect(el.hasAttribute('acp-tt-shown')).toBe(true);
+  });
+});
+
+describe('tooltip singleton — ref-counting + single mount', () => {
+  it('mounts exactly one bubble element to document.body across many anchors', () => {
+    renderTip('A');
+    renderTip('B');
+    renderTip('C');
+    const bubbles = document.querySelectorAll('acp-floating-tooltip');
+    expect(bubbles.length).toBe(1);
+  });
+});

--- a/tests/tooltip-placement.test.ts
+++ b/tests/tooltip-placement.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { placeTooltip } from '../src/lib/geometry';
+
+describe('placeTooltip — down-and-right with viewport clamping', () => {
+  const vp = { vpW: 1000, vpH: 800 };
+  const tt = { ttW: 120, ttH: 40 };
+  const offset: [number, number] = [12, 16];
+
+  it('places the bubble down-and-right of the cursor by default', () => {
+    const r = placeTooltip({ cursorX: 100, cursorY: 200, ...tt, ...vp, offset });
+    expect(r).toEqual({ x: 112, y: 216, flipped: false });
+  });
+
+  it('flips X to the left when the bubble would overflow the right edge', () => {
+    // cursorX near right edge: 100 + 12 + 120 = 232 fits at x=950? No: 950+12+120=1082 > 1000
+    const r = placeTooltip({ cursorX: 950, cursorY: 200, ...tt, ...vp, offset });
+    // flipped X = cursorX - offsetX - ttW = 950 - 12 - 120 = 818
+    expect(r.x).toBe(818);
+    expect(r.flipped).toBe(true);
+  });
+
+  it('flips Y upward when the bubble would overflow the bottom edge', () => {
+    const r = placeTooltip({ cursorX: 100, cursorY: 790, ...tt, ...vp, offset });
+    // flipped Y = cursorY - offsetY - ttH = 790 - 16 - 40 = 734
+    expect(r.y).toBe(734);
+  });
+
+  it('clamps X to >= 0 when a leftward flip would still go negative', () => {
+    const r = placeTooltip({
+      cursorX: 5,
+      cursorY: 200,
+      ttW: 120,
+      ttH: 40,
+      vpW: 100,
+      vpH: 800,
+      offset,
+    });
+    // down-right overflows (5+12+120=137 > 100); flip left = 5-12-120 = -127 -> clamp 0
+    expect(r.x).toBe(0);
+    expect(r.flipped).toBe(true);
+  });
+
+  it('clamps Y to >= 0 when an upward flip would still go negative', () => {
+    const r = placeTooltip({
+      cursorX: 100,
+      cursorY: 5,
+      ttW: 120,
+      ttH: 40,
+      vpW: 1000,
+      vpH: 30,
+      offset,
+    });
+    // down (5+16+40=61 > 30); flip up = 5-16-40 = -51 -> clamp 0
+    expect(r.y).toBe(0);
+  });
+
+  it('uses a default offset of [12, 16] when offset is omitted', () => {
+    const r = placeTooltip({ cursorX: 100, cursorY: 200, ttW: 120, ttH: 40, vpW: 1000, vpH: 800 });
+    expect(r).toEqual({ x: 112, y: 216, flipped: false });
+  });
+});


### PR DESCRIPTION
## Summary
Replaces the card's native browser tooltips (`title=` / SVG `<title>`) with a card-owned custom floating tooltip. It is offset down-and-right of the cursor with viewport-edge clamping, and adds a help-cursor lifecycle: `cursor: help` appears on hover as a discovery hint, then flips to `default` the moment the tooltip becomes visible. A new `tooltips: { enabled, offset, delay }` config option controls it (default on; `enabled: false` restores native `title`). Built as a Lit `AsyncDirective` + a single ref-counted `<acp-floating-tooltip>` overlay on `document.body`; positioning math lives in `geometry.ts`. Accessibility preserved via `role="tooltip"`, `aria-describedby`, and focus triggers. Harness mirrored with a new `floating-tooltip` scenario and a tooltips toggle.

## Testing
- ✅ `npm run test` — 865 passing (up from 840; 4 new test files)
- ✅ `npx tsc --noEmit` clean
- ✅ `./scripts/lint` clean
- ✅ `npm run build` — `dist/` rebuilt and current

## Related Issues
Refs #134