### PR TITLE
fix: show_decision_summary: false now hides the summary in the main card

### DIFF
--- a/dist/adaptive-cover-pro-card.js
+++ b/dist/adaptive-cover-pro-card.js
@@ -3599,7 +3599,7 @@ function e(e,t,s,i){var o,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
                 .discovered=${e}
                 ?compact=${!!this._config.compact}
                 ?hide-inactive=${!!this._config.hide_inactive_handlers||!!this._config.compact}
-                ?show-summary=${!1!==this._config.show_decision_summary}
+                .showSummary=${!1!==this._config.show_decision_summary}
               ></acp-decision-strip>`:W}
           ${i.includes("covers")?L`<acp-cover-bar
                 .hass=${this.hass}

--- a/src/adaptive-cover-pro-card.ts
+++ b/src/adaptive-cover-pro-card.ts
@@ -370,7 +370,7 @@ export class AdaptiveCoverProCard extends LitElement {
                 .discovered=${discovered}
                 ?compact=${!!this._config.compact}
                 ?hide-inactive=${!!this._config.hide_inactive_handlers || !!this._config.compact}
-                ?show-summary=${this._config.show_decision_summary !== false}
+                .showSummary=${this._config.show_decision_summary !== false}
               ></acp-decision-strip>`
             : nothing}
           ${sections.includes('covers')

--- a/tests/main-card.test.ts
+++ b/tests/main-card.test.ts
@@ -154,6 +154,35 @@ describe('AdaptiveCoverProCard.getGridOptions', () => {
   });
 });
 
+describe('main card show_decision_summary config (issue #173)', () => {
+  it('sets showSummary to false on the strip when show_decision_summary: false', async () => {
+    const el = await mountWithRegistry({
+      type: 'custom:adaptive-cover-pro-card',
+      entry_id: ENTRY,
+      show_decision_summary: false,
+    });
+    interface StripEl extends HTMLElement {
+      showSummary?: boolean;
+    }
+    const strip = el.shadowRoot!.querySelector('acp-decision-strip') as StripEl;
+    expect(strip).toBeTruthy();
+    expect(strip.showSummary).toBe(false);
+  });
+
+  it('keeps showSummary true when show_decision_summary is omitted', async () => {
+    const el = await mountWithRegistry({
+      type: 'custom:adaptive-cover-pro-card',
+      entry_id: ENTRY,
+    });
+    interface StripEl extends HTMLElement {
+      showSummary?: boolean;
+    }
+    const strip = el.shadowRoot!.querySelector('acp-decision-strip') as StripEl;
+    expect(strip).toBeTruthy();
+    expect(strip.showSummary).toBe(true);
+  });
+});
+
 describe('header layout — long entry title', () => {
   it('renders the header with a title span', async () => {
     const el = await mountWithRegistry({


### PR DESCRIPTION
## Summary
`show_decision_summary: false` was a no-op on the main card. The decision section bound the strip's `show-summary` via a boolean *attribute* (`?show-summary=`), but `acp-decision-strip.showSummary` is `reflect: true` defaulting to `true` — on mount the child reflected `true` back onto the attribute and the property never flipped, so the summary always rendered. Fixed by binding the property directly (`.showSummary=`), matching the standalone Decision Strip card. One-line change in the `decision` section; `compact`/`hide-inactive` are unaffected (their defaults are `false`).

## Testing
- ✅ `npm run test` — 971 passing (+2 regression tests; was 969)
- ✅ `npm run lint` clean · `npm run build` regenerated `dist/`

## Related Issues
Refs #173