### PR TITLE
fix: gray climate panel when climate isn't the pipeline winner (#168)

### DIFF
--- a/dist/adaptive-cover-pro-card.js
+++ b/dist/adaptive-cover-pro-card.js
@@ -1336,30 +1336,19 @@ function e(e,t,i,s){var o,n=arguments.length,r=n<3?t:null===s?s=Object.getOwnPro
     ha-icon {
       --mdc-icon-size: 18px;
     }
-  `,e([_e({attribute:!1})],Ki.prototype,"hass",void 0),e([_e({attribute:!1})],Ki.prototype,"discovered",void 0),e([_e({type:Boolean,reflect:!0})],Ki.prototype,"compact",void 0),e([_e({type:Boolean,attribute:"reset-enabled"})],Ki.prototype,"resetEnabled",void 0),Ki=e([he("acp-overrides-panel")],Ki);const Gi=new Set(["mode_off","active"]),Vi={summer_mode:"mdi:weather-sunny",winter_mode:"mdi:snowflake",intermediate:"mdi:weather-partly-cloudy"};let Li=class extends ce{constructor(){super(...arguments),this.compact=!1}shouldUpdate(e){if(e.size>1||!e.has("hass"))return!0;const t=e.get("hass"),i=this.discovered?.entities;return me(t,this.hass,[i?.climate_status_sensor,i?.climate_mode_switch])}render(){if(!this.hass||!this.discovered)return q;const e=this.discovered.entities.climate_status_sensor;if(!e)return q;const t=this.hass.states[e];if(!t||"unavailable"===t.state)return q;if("unknown"===t.state||""===t.state){const e=this.discovered.entities.climate_mode_switch,i=!!e&&"off"===this.hass.states[e]?.state,s=Le(i?"climate.mode_off":"climate.standby",this.hass),o=i?"mdi:power-off":"mdi:thermostat",n=t.attributes?.inactive_reason,r=n&&!Gi.has(n)?Le(`climate.reason.${n}`,this.hass):void 0;return L`
-        <div class="wrap">
-          <div class="head">
-            <span class="label">${Le("climate.title",this.hass)}</span>
-          </div>
-          <div class="strategy standby">
-            <ha-icon icon=${o}></ha-icon>
-            <span class="strategy-name dim">${s}</span>
-          </div>
-          ${r?L`<div class="standby-reason dim">${r}</div>`:q}
-        </div>
-      `}const i=t.state,s=t.attributes??{},o=Vi[i]??"mdi:thermostat",n=s.temperature_unit??"°",r=this.hass.formatEntityState,a="function"==typeof r?r(t)??i:i,l=void 0!==s.active_temperature?`${s.active_temperature.toFixed(1)}${n}`:"—",c=!0===s.temp_switch,d=(e,t)=>null==t||Number.isNaN(t)?null:`${Le(e,this.hass)} ${t.toFixed(1)}${n}`,h=c?null:[d("climate.threshold_low",s.temp_low),d("climate.threshold_high",s.temp_high)].filter(e=>null!==e).join(" ")||null,u=[...c?[d("climate.threshold_low",s.temp_low),d("climate.threshold_high",s.temp_high)]:[],d("climate.threshold_summer_outside",s.temp_summer_outside)].filter(e=>null!==e).join(" ")||null,p=[void 0!==s.indoor_temperature?{label:Le("climate.indoor",this.hass),value:s.indoor_temperature,unit:n,threshold:h}:null,void 0!==s.outdoor_temperature?{label:Le("climate.outdoor",this.hass),value:s.outdoor_temperature,unit:n,threshold:u}:null].filter(e=>null!==e),_=[{label:Le("climate.presence",this.hass),value:s.is_presence,icon:"mdi:account-check"},{label:Le("climate.sunny",this.hass),value:s.is_sunny,icon:"mdi:white-balance-sunny"},{label:Le("climate.lux",this.hass),value:s.lux_active,icon:"mdi:brightness-7"},{label:Le("climate.irradiance",this.hass),value:s.irradiance_active,icon:"mdi:solar-power"}].filter(e=>void 0!==e.value);return L`
+  `,e([_e({attribute:!1})],Ki.prototype,"hass",void 0),e([_e({attribute:!1})],Ki.prototype,"discovered",void 0),e([_e({type:Boolean,reflect:!0})],Ki.prototype,"compact",void 0),e([_e({type:Boolean,attribute:"reset-enabled"})],Ki.prototype,"resetEnabled",void 0),Ki=e([he("acp-overrides-panel")],Ki);const Gi=new Set(["mode_off","active"]),Vi={summer_mode:"mdi:weather-sunny",winter_mode:"mdi:snowflake",intermediate:"mdi:weather-partly-cloudy"};let Li=class extends ce{constructor(){super(...arguments),this.compact=!1}shouldUpdate(e){if(e.size>1||!e.has("hass"))return!0;const t=e.get("hass"),i=this.discovered?.entities;return me(t,this.hass,[i?.climate_status_sensor,i?.climate_mode_switch])}render(){if(!this.hass||!this.discovered)return q;const e=this.discovered.entities.climate_status_sensor;if(!e)return q;const t=this.hass.states[e];if(!t||"unavailable"===t.state)return q;if("unknown"===t.state||""===t.state){const e=this.discovered.entities.climate_mode_switch,i=!!e&&"off"===this.hass.states[e]?.state,s=Le(i?"climate.mode_off":"climate.standby",this.hass),o=i?"mdi:power-off":"mdi:thermostat",n=t.attributes?.inactive_reason;return this._renderStandby(o,s,n)}const i=t.state,s=t.attributes??{},o=Vi[i]??"mdi:thermostat",n=this.hass.formatEntityState,r="function"==typeof n?n(t)??i:i;if(null!=(a=s.inactive_reason)&&"active"!==a)return this._renderStandby(o,r,s.inactive_reason);var a;const l=s.temperature_unit??"°",c=void 0!==s.active_temperature?`${s.active_temperature.toFixed(1)}${l}`:"—",d=!0===s.temp_switch,h=(e,t)=>null==t||Number.isNaN(t)?null:`${Le(e,this.hass)} ${t.toFixed(1)}${l}`,u=d?null:[h("climate.threshold_low",s.temp_low),h("climate.threshold_high",s.temp_high)].filter(e=>null!==e).join(" ")||null,p=[...d?[h("climate.threshold_low",s.temp_low),h("climate.threshold_high",s.temp_high)]:[],h("climate.threshold_summer_outside",s.temp_summer_outside)].filter(e=>null!==e).join(" ")||null,_=[void 0!==s.indoor_temperature?{label:Le("climate.indoor",this.hass),value:s.indoor_temperature,unit:l,threshold:u}:null,void 0!==s.outdoor_temperature?{label:Le("climate.outdoor",this.hass),value:s.outdoor_temperature,unit:l,threshold:p}:null].filter(e=>null!==e),g=[{label:Le("climate.presence",this.hass),value:s.is_presence,icon:"mdi:account-check"},{label:Le("climate.sunny",this.hass),value:s.is_sunny,icon:"mdi:white-balance-sunny"},{label:Le("climate.lux",this.hass),value:s.lux_active,icon:"mdi:brightness-7"},{label:Le("climate.irradiance",this.hass),value:s.irradiance_active,icon:"mdi:solar-power"}].filter(e=>void 0!==e.value);return L`
       <div class="wrap">
         <div class="head">
           <span class="label">${Le("climate.title",this.hass)}</span>
-          <span class="dim">${Le("climate.active",this.hass,{strategy:l})}</span>
+          <span class="dim">${Le("climate.active",this.hass,{strategy:c})}</span>
         </div>
         <div class="strategy">
           <ha-icon icon=${o}></ha-icon>
-          <span class="strategy-name">${a}</span>
+          <span class="strategy-name">${r}</span>
         </div>
-        ${p.length?L`
+        ${_.length?L`
               <div class="temps">
-                ${p.map(e=>L`
+                ${_.map(e=>L`
                     <div class="temp">
                       <span class="temp-label dim">${e.label}</span>
                       <span class="temp-value">${e.value.toFixed(1)}${e.unit}</span>
@@ -1368,9 +1357,9 @@ function e(e,t,i,s){var o,n=arguments.length,r=n<3?t:null===s?s=Object.getOwnPro
                   `)}
               </div>
             `:q}
-        ${_.length?L`
+        ${g.length?L`
               <div class="conditions">
-                ${_.map(e=>L`
+                ${g.map(e=>L`
                     <div class="chip ${e.value?"on":"off"}" ${bt(e.label)}>
                       <ha-icon icon=${e.icon}></ha-icon>
                       <span>${e.label}</span>
@@ -1378,6 +1367,17 @@ function e(e,t,i,s){var o,n=arguments.length,r=n<3?t:null===s?s=Object.getOwnPro
                   `)}
               </div>
             `:q}
+      </div>
+    `}_renderStandby(e,t,i){const s=i&&!Gi.has(i)?Le(`climate.reason.${i}`,this.hass):void 0;return L`
+      <div class="wrap">
+        <div class="head">
+          <span class="label">${Le("climate.title",this.hass)}</span>
+        </div>
+        <div class="strategy standby">
+          <ha-icon icon=${e}></ha-icon>
+          <span class="strategy-name dim">${t}</span>
+        </div>
+        ${s?L`<div class="standby-reason dim">${s}</div>`:q}
       </div>
     `}};Li.styles=r`
     :host {

--- a/harness/src/control-panel.ts
+++ b/harness/src/control-panel.ts
@@ -371,7 +371,12 @@ export class AcpHarnessControlPanel extends LitElement {
         climate_strategy: 'intermediate',
         indoor_temp: 21,
         outdoor_temp: 18,
-        climate_inactive_reason: 'outside_time_window',
+        // adaptive-cover-pro-card#168: state-gen now threads this flag into the
+        // active-slug branch's inactive_reason (previously hardcoded 'active').
+        // Keep the base default 'active' so the default panel stays
+        // active-looking with the default 'intermediate' strategy; the
+        // climate-not-winner scenario overrides this to demonstrate #168.
+        climate_inactive_reason: 'active',
         climate_temp_low: 18,
         climate_temp_high: 25,
         climate_temp_summer_outside: 22,

--- a/harness/src/mock/state-gen.ts
+++ b/harness/src/mock/state-gen.ts
@@ -293,7 +293,7 @@ function addEntryStates(
           temp_low: f.climate_temp_low,
           temp_high: f.climate_temp_high,
           temp_summer_outside: f.climate_temp_summer_outside,
-          inactive_reason: 'active',
+          inactive_reason: f.climate_inactive_reason,
           is_presence: true,
           is_sunny: sun.elevation > 0,
           lux_active: sun.elevation > 5,

--- a/harness/src/scenarios.ts
+++ b/harness/src/scenarios.ts
@@ -988,6 +988,22 @@ export const SCENARIOS: Scenario[] = [
     },
   },
   {
+    id: 'climate-not-winner',
+    label: 'Climate computed but not in control (#168)',
+    description:
+      'Climate computes "intermediate" but its thresholds aren\'t met (inactive_reason: thresholds_not_met), so the pipeline winner is Default, not climate. The climate panel must NOT paint climate as in-control: the strategy icon/label gray out and a "Temperatures within the comfort band — no action needed" reason line appears, matching the standby treatment rather than the full active view (#168).',
+    build: () => {
+      const c = baseConfig('2026-06-21', 12 * 60);
+      c.scenario = 'climate-not-winner';
+      c.decisionMode = 'scripted';
+      c.scriptedWinner = 'default';
+      const f = c.entries[0].flags;
+      f.climate_strategy = 'intermediate';
+      f.climate_inactive_reason = 'thresholds_not_met';
+      return c;
+    },
+  },
+  {
     id: 'compass-actual-vs-target',
     label: 'Compass — actual vs target divergence',
     description:

--- a/src/components/climate-panel.ts
+++ b/src/components/climate-panel.ts
@@ -31,6 +31,16 @@ interface ClimateAttrs {
 //   active    → the handler is active and should not reach the standby branch.
 const SUPPRESSED_REASONS = new Set(['mode_off', 'active']);
 
+// adaptive-cover-pro-card#168: the `climate_status` sensor STATE (summer_mode /
+// winter_mode / intermediate) only records which strategy climate *computed* —
+// it is not proof climate is the pipeline winner. `inactive_reason` is the
+// integration's authority on whether climate actually holds control.
+// undefined = older integration (no slug emitted) → treat as in-control for
+// backward compat; 'active' is the in-control slug itself.
+export function climateInControl(inactiveReason: string | undefined): boolean {
+  return inactiveReason == null || inactiveReason === 'active';
+}
+
 // Keyed by slug states emitted by the integration's `climate_status` sensor
 // (adaptive-cover-pro#453). The visible strategy label is sourced from
 // `hass.formatEntityState`, which goes through the integration's translations.
@@ -68,33 +78,26 @@ export class ClimatePanel extends LitElement {
       const label = modeOff ? t('climate.mode_off', this.hass) : t('climate.standby', this.hass);
       const icon = modeOff ? 'mdi:power-off' : 'mdi:thermostat';
       const reasonSlug = (st.attributes as unknown as ClimateAttrs)?.inactive_reason;
-      // Older integrations omit the slug → no reason line (backward-compat).
-      // mode_off / active are suppressed (see SUPPRESSED_REASONS).
-      const reasonLine =
-        reasonSlug && !SUPPRESSED_REASONS.has(reasonSlug)
-          ? t(`climate.reason.${reasonSlug}`, this.hass)
-          : undefined;
-      return html`
-        <div class="wrap">
-          <div class="head">
-            <span class="label">${t('climate.title', this.hass)}</span>
-          </div>
-          <div class="strategy standby">
-            <ha-icon icon=${icon}></ha-icon>
-            <span class="strategy-name dim">${label}</span>
-          </div>
-          ${reasonLine ? html`<div class="standby-reason dim">${reasonLine}</div>` : nothing}
-        </div>
-      `;
+      return this._renderStandby(icon, label, reasonSlug);
     }
 
     const strategy = st.state;
     const attrs = (st.attributes as unknown as ClimateAttrs) ?? {};
     const icon = STRATEGY_ICONS[strategy] ?? 'mdi:thermostat';
-    const unit = attrs.temperature_unit ?? '°';
     const fmt = (this.hass as unknown as { formatEntityState?: (s: unknown) => string })
       .formatEntityState;
     const strategyLabel = typeof fmt === 'function' ? (fmt(st) ?? strategy) : strategy;
+
+    // adaptive-cover-pro-card#168: the sensor STATE only records which strategy
+    // climate *computed* — inactive_reason is the authority on whether climate
+    // actually holds control. When it doesn't, show the same grayed standby
+    // treatment as the unknown/'' branch above (with the resolved strategy
+    // label instead of "Standby") rather than the full active view.
+    if (!climateInControl(attrs.inactive_reason)) {
+      return this._renderStandby(icon, strategyLabel, attrs.inactive_reason);
+    }
+
+    const unit = attrs.temperature_unit ?? '°';
     const activeValue =
       attrs.active_temperature !== undefined
         ? `${attrs.active_temperature.toFixed(1)}${unit}`
@@ -214,6 +217,35 @@ export class ClimatePanel extends LitElement {
               </div>
             `
           : nothing}
+      </div>
+    `;
+  }
+
+  // Shared grayed standby treatment: dimmed strategy label + icon, plus an
+  // optional localized reason line. Used both when the sensor state itself is
+  // unknown/'' (no strategy computed) and when a strategy slug is present but
+  // inactive_reason says climate isn't in control (#168).
+  private _renderStandby(
+    icon: string,
+    label: string,
+    reasonSlug: string | undefined,
+  ): TemplateResult {
+    // Older integrations omit the slug → no reason line (backward-compat).
+    // mode_off / active are suppressed (see SUPPRESSED_REASONS).
+    const reasonLine =
+      reasonSlug && !SUPPRESSED_REASONS.has(reasonSlug)
+        ? t(`climate.reason.${reasonSlug}`, this.hass)
+        : undefined;
+    return html`
+      <div class="wrap">
+        <div class="head">
+          <span class="label">${t('climate.title', this.hass)}</span>
+        </div>
+        <div class="strategy standby">
+          <ha-icon icon=${icon}></ha-icon>
+          <span class="strategy-name dim">${label}</span>
+        </div>
+        ${reasonLine ? html`<div class="standby-reason dim">${reasonLine}</div>` : nothing}
       </div>
     `;
   }

--- a/tests/components.test.ts
+++ b/tests/components.test.ts
@@ -4,6 +4,7 @@ import '../src/components/cover-bar';
 import '../src/components/overrides-panel';
 import '../src/components/header-pill';
 import '../src/components/climate-panel';
+import { climateInControl } from '../src/components/climate-panel';
 import type { HomeAssistant } from 'custom-card-helpers';
 import type { DiscoveredEntities } from '../src/types';
 
@@ -577,5 +578,46 @@ describe('acp-climate-panel', () => {
     ).toBe('high 25.0°C');
     // outdoor: summer absent → whole sub-line omitted, no "—" clutter
     expect(temps[1].querySelector('.temp-threshold')).toBeNull();
+  });
+
+  // --- issue #168: climate_status STATE is not sole authority; inactive_reason gates control ---
+
+  describe('climateInControl', () => {
+    it('undefined (older integration) → true', () => {
+      expect(climateInControl(undefined)).toBe(true);
+    });
+
+    it('"active" → true', () => {
+      expect(climateInControl('active')).toBe(true);
+    });
+
+    it.each(['thresholds_not_met', 'other_mode_active', 'mode_off', 'outside_time_window'])(
+      '"%s" → false',
+      (slug) => {
+        expect(climateInControl(slug)).toBe(false);
+      },
+    );
+  });
+
+  it('active strategy + inactive_reason "thresholds_not_met" → standby treatment, no temps, no Active line', async () => {
+    const el = await mount<LitLike>('acp-climate-panel');
+    el.hass = makeHass('intermediate', {
+      active_temperature: 21,
+      temperature_unit: '°C',
+      indoor_temperature: 21,
+      outdoor_temperature: 18,
+      temp_low: 18,
+      temp_high: 25,
+      temp_summer_outside: 22,
+      inactive_reason: 'thresholds_not_met',
+    });
+    el.discovered = makeDiscovered(false);
+    await flush(el);
+    expect(el.shadowRoot!.querySelector('.strategy.standby')).toBeTruthy();
+    expect(el.shadowRoot!.querySelector('.standby-reason')?.textContent?.trim()).toBe(
+      'Temperatures within the comfort band — no action needed',
+    );
+    expect(el.shadowRoot!.querySelector('.temps')).toBeNull();
+    expect(el.shadowRoot!.querySelector('.head .dim')).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
The climate panel (`acp-climate-panel`) was the only card surface still deriving "climate is active" from the `climate_status` sensor state slug (`intermediate`/`summer_mode`/`winter_mode`) alone — it consulted `inactive_reason` only in its standby branch. So when climate computed a strategy but wasn't in control (e.g. `inactive_reason='thresholds_not_met'`, pipeline winner `default`), the panel still painted the full active view.

Now the panel branches on a pure `climateInControl(inactive_reason)` predicate: any non-`active` reason routes the active strategy slug through a shared standby treatment (dimmed label, no temps/conditions/"Active" line, localized reason line) instead of the active view. Backward-compatible — a missing or `active` reason renders exactly as before. The winner badges (tile, more-info dialog, decision strip) already single-source from `control_method`/`decision_trace` and were correct; they are unchanged.

Harness mirrored: `state-gen.ts` now threads the `climate_inactive_reason` flag, the default flag keeps the default panel active-looking, and a new `climate-not-winner` scenario exercises the fix.

## Testing
- ✅ 1046 tests passing (net +7)
- ✅ `tsc --noEmit` clean, `./scripts/lint` clean
- ✅ `dist/` rebuilt

## Related Issues
Refs #168