### PR TITLE
fix: keep temperature tiles visible in climate standby (#198)

### DIFF
--- a/dist/adaptive-cover-pro-card.js
+++ b/dist/adaptive-cover-pro-card.js
@@ -1453,27 +1453,17 @@ function e(e,t,s,i){var o,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
     ha-icon {
       --mdc-icon-size: 18px;
     }
-  `,e([ge({attribute:!1})],ni.prototype,"hass",void 0),e([ge({attribute:!1})],ni.prototype,"discovered",void 0),e([ge({type:Boolean,reflect:!0})],ni.prototype,"compact",void 0),e([ge({type:Boolean,attribute:"reset-enabled"})],ni.prototype,"resetEnabled",void 0),ni=e([he("acp-overrides-panel")],ni);const ri=new Set(["mode_off","active"]),ai={summer_mode:"mdi:weather-sunny",winter_mode:"mdi:snowflake",intermediate:"mdi:weather-partly-cloudy"};let li=class extends ce{constructor(){super(...arguments),this.compact=!1}shouldUpdate(e){if(e.size>1||!e.has("hass"))return!0;const t=e.get("hass"),s=this.discovered?.entities;return me(t,this.hass,[s?.climate_status_sensor,s?.climate_mode_switch])}render(){if(!this.hass||!this.discovered)return q;const e=this.discovered.entities.climate_status_sensor;if(!e)return q;const t=this.hass.states[e];if(!t||"unavailable"===t.state)return q;if("unknown"===t.state||""===t.state){const e=this.discovered.entities.climate_mode_switch,s=!!e&&"off"===this.hass.states[e]?.state,i=We(s?"climate.mode_off":"climate.standby",this.hass),o=s?"mdi:power-off":"mdi:thermostat",n=t.attributes?.inactive_reason;return this._renderStandby(o,i,n)}const s=t.state,i=t.attributes??{},o=ai[s]??"mdi:thermostat",n=this.hass.formatEntityState,r="function"==typeof n?n(t)??s:s;if(null!=(a=i.inactive_reason)&&"active"!==a)return this._renderStandby(o,r,i.inactive_reason);var a;const l=i.temperature_unit??"°",c=void 0!==i.active_temperature?`${i.active_temperature.toFixed(1)}${l}`:"—",d=!0===i.temp_switch,h=(e,t)=>null==t||Number.isNaN(t)?null:`${We(e,this.hass)} ${t.toFixed(1)}${l}`,u=d?null:[h("climate.threshold_low",i.temp_low),h("climate.threshold_high",i.temp_high)].filter(e=>null!==e).join(" ")||null,p=[...d?[h("climate.threshold_low",i.temp_low),h("climate.threshold_high",i.temp_high)]:[],h("climate.threshold_summer_outside",i.temp_summer_outside)].filter(e=>null!==e).join(" ")||null,g=[void 0!==i.indoor_temperature?{label:We("climate.indoor",this.hass),value:i.indoor_temperature,unit:l,threshold:u}:null,void 0!==i.outdoor_temperature?{label:We("climate.outdoor",this.hass),value:i.outdoor_temperature,unit:l,threshold:p}:null].filter(e=>null!==e),_=[{label:We("climate.presence",this.hass),value:i.is_presence,icon:"mdi:account-check"},{label:We("climate.sunny",this.hass),value:i.is_sunny,icon:"mdi:white-balance-sunny"},{label:We("climate.lux",this.hass),value:i.lux_active,icon:"mdi:brightness-7"},{label:We("climate.irradiance",this.hass),value:i.irradiance_active,icon:"mdi:solar-power"}].filter(e=>void 0!==e.value);return V`
+  `,e([ge({attribute:!1})],ni.prototype,"hass",void 0),e([ge({attribute:!1})],ni.prototype,"discovered",void 0),e([ge({type:Boolean,reflect:!0})],ni.prototype,"compact",void 0),e([ge({type:Boolean,attribute:"reset-enabled"})],ni.prototype,"resetEnabled",void 0),ni=e([he("acp-overrides-panel")],ni);const ri=new Set(["mode_off","active"]),ai={summer_mode:"mdi:weather-sunny",winter_mode:"mdi:snowflake",intermediate:"mdi:weather-partly-cloudy"};let li=class extends ce{constructor(){super(...arguments),this.compact=!1}shouldUpdate(e){if(e.size>1||!e.has("hass"))return!0;const t=e.get("hass"),s=this.discovered?.entities;return me(t,this.hass,[s?.climate_status_sensor,s?.climate_mode_switch])}render(){if(!this.hass||!this.discovered)return q;const e=this.discovered.entities.climate_status_sensor;if(!e)return q;const t=this.hass.states[e];if(!t||"unavailable"===t.state)return q;if("unknown"===t.state||""===t.state){const e=this.discovered.entities.climate_mode_switch,s=!!e&&"off"===this.hass.states[e]?.state,i=We(s?"climate.mode_off":"climate.standby",this.hass),o=s?"mdi:power-off":"mdi:thermostat",n=t.attributes?.inactive_reason;return this._renderStandby(o,i,n)}const s=t.state,i=t.attributes??{},o=ai[s]??"mdi:thermostat",n=this.hass.formatEntityState,r="function"==typeof n?n(t)??s:s,a=i.temperature_unit??"°",l=!0===i.temp_switch,c=(e,t)=>null==t||Number.isNaN(t)?null:`${We(e,this.hass)} ${t.toFixed(1)}${a}`,d=l?null:[c("climate.threshold_low",i.temp_low),c("climate.threshold_high",i.temp_high)].filter(e=>null!==e).join(" ")||null,h=[...l?[c("climate.threshold_low",i.temp_low),c("climate.threshold_high",i.temp_high)]:[],c("climate.threshold_summer_outside",i.temp_summer_outside)].filter(e=>null!==e).join(" ")||null,u=[void 0!==i.indoor_temperature?{label:We("climate.indoor",this.hass),value:i.indoor_temperature,unit:a,threshold:d}:null,void 0!==i.outdoor_temperature?{label:We("climate.outdoor",this.hass),value:i.outdoor_temperature,unit:a,threshold:h}:null].filter(e=>null!==e);if(null!=(p=i.inactive_reason)&&"active"!==p)return this._renderStandby(o,r,i.inactive_reason,u);var p;const g=void 0!==i.active_temperature?`${i.active_temperature.toFixed(1)}${a}`:"—",_=[{label:We("climate.presence",this.hass),value:i.is_presence,icon:"mdi:account-check"},{label:We("climate.sunny",this.hass),value:i.is_sunny,icon:"mdi:white-balance-sunny"},{label:We("climate.lux",this.hass),value:i.lux_active,icon:"mdi:brightness-7"},{label:We("climate.irradiance",this.hass),value:i.irradiance_active,icon:"mdi:solar-power"}].filter(e=>void 0!==e.value);return V`
       <div class="wrap">
         <div class="head">
           <span class="label">${We("climate.title",this.hass)}</span>
-          <span class="dim">${We("climate.active",this.hass,{strategy:c})}</span>
+          <span class="dim">${We("climate.active",this.hass,{strategy:g})}</span>
         </div>
         <div class="strategy">
           <ha-icon icon=${o}></ha-icon>
           <span class="strategy-name">${r}</span>
         </div>
-        ${g.length?V`
-              <div class="temps">
-                ${g.map(e=>V`
-                    <div class="temp">
-                      <span class="temp-label dim">${e.label}</span>
-                      <span class="temp-value">${e.value.toFixed(1)}${e.unit}</span>
-                      ${e.threshold?V`<span class="temp-threshold dim">${e.threshold}</span>`:q}
-                    </div>
-                  `)}
-              </div>
-            `:q}
+        ${this._renderTemps(u)}
         ${_.length?V`
               <div class="conditions">
                 ${_.map(e=>V`
@@ -1485,7 +1475,7 @@ function e(e,t,s,i){var o,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
               </div>
             `:q}
       </div>
-    `}_renderStandby(e,t,s){const i=s&&!ri.has(s)?We(`climate.reason.${s}`,this.hass):void 0;return V`
+    `}_renderStandby(e,t,s,i=[]){const o=s&&!ri.has(s)?We(`climate.reason.${s}`,this.hass):void 0;return V`
       <div class="wrap">
         <div class="head">
           <span class="label">${We("climate.title",this.hass)}</span>
@@ -1494,9 +1484,20 @@ function e(e,t,s,i){var o,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
           <ha-icon icon=${e}></ha-icon>
           <span class="strategy-name dim">${t}</span>
         </div>
-        ${i?V`<div class="standby-reason dim">${i}</div>`:q}
+        ${o?V`<div class="standby-reason dim">${o}</div>`:q}
+        ${this._renderTemps(i)}
       </div>
-    `}};li.styles=r`
+    `}_renderTemps(e){return e.length?V`
+      <div class="temps">
+        ${e.map(e=>V`
+            <div class="temp">
+              <span class="temp-label dim">${e.label}</span>
+              <span class="temp-value">${e.value.toFixed(1)}${e.unit}</span>
+              ${e.threshold?V`<span class="temp-threshold dim">${e.threshold}</span>`:q}
+            </div>
+          `)}
+      </div>
+    `:q}};li.styles=r`
     :host {
       display: block;
     }

--- a/harness/src/scenarios.ts
+++ b/harness/src/scenarios.ts
@@ -1147,7 +1147,7 @@ export const SCENARIOS: Scenario[] = [
     id: 'climate-not-winner',
     label: 'Climate computed but not in control (#168)',
     description:
-      'Climate computes "intermediate" but its thresholds aren\'t met (inactive_reason: thresholds_not_met), so the pipeline winner is Default, not climate. The climate panel must NOT paint climate as in-control: the strategy icon/label gray out and a "Temperatures within the comfort band — no action needed" reason line appears, matching the standby treatment rather than the full active view (#168).',
+      'Climate computes "intermediate" but its thresholds aren\'t met (inactive_reason: thresholds_not_met), so the pipeline winner is Default, not climate. The climate panel must NOT paint climate as in-control: the strategy icon/label gray out and a "Temperatures within the comfort band — no action needed" reason line appears, matching the standby treatment rather than the full active view (#168). The indoor/outdoor temperature tiles still render in this grayed standby state — they are sensor readings independent of pipeline control and must persist through standby rather than disappearing alongside the suppressed active label (#198).',
     build: () => {
       const c = baseConfig('2026-06-21', 12 * 60);
       c.scenario = 'climate-not-winner';
@@ -1156,6 +1156,8 @@ export const SCENARIOS: Scenario[] = [
       const f = c.entries[0].flags;
       f.climate_strategy = 'intermediate';
       f.climate_inactive_reason = 'thresholds_not_met';
+      f.indoor_temp = 22;
+      f.outdoor_temp = 27;
       return c;
     },
   },

--- a/src/components/climate-panel.ts
+++ b/src/components/climate-panel.ts
@@ -26,6 +26,15 @@ interface ClimateAttrs {
   inactive_reason?: string;
 }
 
+// A single indoor/outdoor temperature tile, shared by the active render and
+// the standby-via-inactive_reason render (adaptive-cover-pro-card#198).
+interface TempRow {
+  label: string;
+  value: number;
+  unit: string;
+  threshold: string | null;
+}
+
 // Reason slugs that should NOT render a dedicated standby sub-line:
 //   mode_off  → the existing "Climate mode off" label already conveys it.
 //   active    → the handler is active and should not reach the standby branch.
@@ -88,20 +97,7 @@ export class ClimatePanel extends LitElement {
       .formatEntityState;
     const strategyLabel = typeof fmt === 'function' ? (fmt(st) ?? strategy) : strategy;
 
-    // adaptive-cover-pro-card#168: the sensor STATE only records which strategy
-    // climate *computed* — inactive_reason is the authority on whether climate
-    // actually holds control. When it doesn't, show the same grayed standby
-    // treatment as the unknown/'' branch above (with the resolved strategy
-    // label instead of "Standby") rather than the full active view.
-    if (!climateInControl(attrs.inactive_reason)) {
-      return this._renderStandby(icon, strategyLabel, attrs.inactive_reason);
-    }
-
     const unit = attrs.temperature_unit ?? '°';
-    const activeValue =
-      attrs.active_temperature !== undefined
-        ? `${attrs.active_temperature.toFixed(1)}${unit}`
-        : '—';
 
     // Threshold pairing (adaptive-cover-pro#590). Season math:
     //   current = temp_switch ? outdoor : indoor
@@ -135,7 +131,11 @@ export class ClimatePanel extends LitElement {
         .filter((f): f is string => f !== null)
         .join(' ') || null;
 
-    const temps = [
+    // Temperature readings are sensor values independent of pipeline control —
+    // compute them before the inactive_reason guard below so both the active
+    // render and the standby-via-inactive_reason render can show them
+    // (adaptive-cover-pro-card#198).
+    const temps: TempRow[] = [
       attrs.indoor_temperature !== undefined
         ? {
             label: t('climate.indoor', this.hass),
@@ -152,10 +152,23 @@ export class ClimatePanel extends LitElement {
             threshold: outdoorThreshold,
           }
         : null,
-    ].filter(
-      (row): row is { label: string; value: number; unit: string; threshold: string | null } =>
-        row !== null,
-    );
+    ].filter((row): row is TempRow => row !== null);
+
+    // adaptive-cover-pro-card#168: the sensor STATE only records which strategy
+    // climate *computed* — inactive_reason is the authority on whether climate
+    // actually holds control. When it doesn't, show the same grayed standby
+    // treatment as the unknown/'' branch above (with the resolved strategy
+    // label instead of "Standby") rather than the full active view. The
+    // temperature readings above are still shown (#198) — only the
+    // active-strategy label/Active-line are suppressed.
+    if (!climateInControl(attrs.inactive_reason)) {
+      return this._renderStandby(icon, strategyLabel, attrs.inactive_reason, temps);
+    }
+
+    const activeValue =
+      attrs.active_temperature !== undefined
+        ? `${attrs.active_temperature.toFixed(1)}${unit}`
+        : '—';
 
     const conditions: Array<{ label: string; value: boolean | undefined; icon: string }> = [
       {
@@ -186,23 +199,7 @@ export class ClimatePanel extends LitElement {
           <ha-icon icon=${icon}></ha-icon>
           <span class="strategy-name">${strategyLabel}</span>
         </div>
-        ${temps.length
-          ? html`
-              <div class="temps">
-                ${temps.map(
-                  (row) => html`
-                    <div class="temp">
-                      <span class="temp-label dim">${row.label}</span>
-                      <span class="temp-value">${row.value.toFixed(1)}${row.unit}</span>
-                      ${row.threshold
-                        ? html`<span class="temp-threshold dim">${row.threshold}</span>`
-                        : nothing}
-                    </div>
-                  `,
-                )}
-              </div>
-            `
-          : nothing}
+        ${this._renderTemps(temps)}
         ${conditions.length
           ? html`
               <div class="conditions">
@@ -223,12 +220,14 @@ export class ClimatePanel extends LitElement {
 
   // Shared grayed standby treatment: dimmed strategy label + icon, plus an
   // optional localized reason line. Used both when the sensor state itself is
-  // unknown/'' (no strategy computed) and when a strategy slug is present but
-  // inactive_reason says climate isn't in control (#168).
+  // unknown/'' (no strategy computed, no temps to show) and when a strategy
+  // slug is present but inactive_reason says climate isn't in control (#168) —
+  // that second case still has temperature readings to show (#198).
   private _renderStandby(
     icon: string,
     label: string,
     reasonSlug: string | undefined,
+    temps: TempRow[] = [],
   ): TemplateResult {
     // Older integrations omit the slug → no reason line (backward-compat).
     // mode_off / active are suppressed (see SUPPRESSED_REASONS).
@@ -246,6 +245,28 @@ export class ClimatePanel extends LitElement {
           <span class="strategy-name dim">${label}</span>
         </div>
         ${reasonLine ? html`<div class="standby-reason dim">${reasonLine}</div>` : nothing}
+        ${this._renderTemps(temps)}
+      </div>
+    `;
+  }
+
+  // Indoor/outdoor temperature tiles, shared by the active render and the
+  // standby-via-inactive_reason render (adaptive-cover-pro-card#198).
+  private _renderTemps(temps: TempRow[]): TemplateResult | typeof nothing {
+    if (!temps.length) return nothing;
+    return html`
+      <div class="temps">
+        ${temps.map(
+          (row) => html`
+            <div class="temp">
+              <span class="temp-label dim">${row.label}</span>
+              <span class="temp-value">${row.value.toFixed(1)}${row.unit}</span>
+              ${row.threshold
+                ? html`<span class="temp-threshold dim">${row.threshold}</span>`
+                : nothing}
+            </div>
+          `,
+        )}
       </div>
     `;
   }

--- a/tests/components.test.ts
+++ b/tests/components.test.ts
@@ -599,7 +599,7 @@ describe('acp-climate-panel', () => {
     );
   });
 
-  it('active strategy + inactive_reason "thresholds_not_met" → standby treatment, no temps, no Active line', async () => {
+  it('active strategy + inactive_reason "thresholds_not_met" → standby treatment, temps still render, no Active line', async () => {
     const el = await mount<LitLike>('acp-climate-panel');
     el.hass = makeHass('intermediate', {
       active_temperature: 21,
@@ -617,7 +617,10 @@ describe('acp-climate-panel', () => {
     expect(el.shadowRoot!.querySelector('.standby-reason')?.textContent?.trim()).toBe(
       'Temperatures within the comfort band — no action needed',
     );
-    expect(el.shadowRoot!.querySelector('.temps')).toBeNull();
+    const temps = Array.from(el.shadowRoot!.querySelectorAll('.temp'));
+    expect(temps.length).toBe(2);
+    expect(temps[0].querySelector('.temp-value')?.textContent?.trim()).toBe('21.0°C');
+    expect(temps[1].querySelector('.temp-value')?.textContent?.trim()).toBe('18.0°C');
     expect(el.shadowRoot!.querySelector('.head .dim')).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
Since v2.11.0 the climate panel's standby guard returned before the temperature array was built, so `indoor_temperature` / `outdoor_temperature` tiles vanished whenever `inactive_reason` was anything other than `active` (i.e. whenever climate was not the pipeline winner). Those readings are independent sensor values, not climate-handler output, so they should always show when `temp_entity` / `outside_temp` are configured.

This computes the temps array before the `climateInControl` guard and renders it in the standby path via a shared `_renderTemps` helper, so temperature tiles stay visible in the grayed standby state. The standby label and suppressed "Active:" line behaviour from v2.11.0 is unchanged.

## Testing
- ✅ 1164 tests passing (`npm run test`)
- ✅ Lint, typecheck, and clean build (`dist/` regenerated and committed)
- ✅ Harness `climate-not-winner` scenario updated to demonstrate temps persisting through standby

## Related Issues
Refs #198