### PR TITLE
feat: show Opening/Closing motion for no-feedback covers

### DIFF
--- a/src/adaptive-cover-pro-tile-card.ts
+++ b/src/adaptive-cover-pro-tile-card.ts
@@ -385,8 +385,18 @@ export class AdaptiveCoverProTileCard extends LitElement {
     // automatic control — replacing the old standalone Resume pill.
     const resumable = manualActive && !!discovered.entities.reset_override_button;
 
+    const transitDir = this._transitState(discovered);
+    const transitTpl = transitDir
+      ? html`<ha-icon
+          class="transit transit-${transitDir}"
+          icon=${transitDir === 'opening' ? 'mdi:arrow-up-thin' : 'mdi:arrow-down-thin'}
+          ${tooltip(t('covers.' + transitDir, this.hass))}
+        ></ha-icon>`
+      : nothing;
     const positionTpl =
-      labelParts.length > 0 ? html`<div class="position">${labelParts.join(' · ')}</div>` : nothing;
+      labelParts.length > 0
+        ? html`<div class="position">${transitTpl}${labelParts.join(' · ')}</div>`
+        : nothing;
     const floorChipTpl = showFloorChip
       ? html`<span
           class=${`acp-floor-chip${activeFloor!.clamping ? '' : ' is-armed'}${
@@ -527,6 +537,20 @@ export class AdaptiveCoverProTileCard extends LitElement {
     if (!st) return null;
     const v = parseFloat(st.state);
     return Number.isNaN(v) ? null : v;
+  }
+
+  /** In-transit direction for this entry's resolved cover, read from the
+   *  target sensor's `transit_states` attribute (no-feedback covers publish it
+   *  while mid-move). Returns null when absent or for a different cover. */
+  private _transitState(discovered: DiscoveredEntities): 'opening' | 'closing' | null {
+    const id = discovered.entities.target_position_sensor;
+    if (!id) return null;
+    const cover = this._resolvedCover(discovered);
+    if (!cover) return null;
+    const transit = this.hass.states[id]?.attributes?.transit_states as
+      | Record<string, 'opening' | 'closing'>
+      | undefined;
+    return transit?.[cover] ?? null;
   }
 
   private _liveCoverPosition(cover: string | undefined): number | null {
@@ -809,6 +833,7 @@ export class AdaptiveCoverProTileCard extends LitElement {
     .detail-line .position {
       padding: 0;
       text-align: left;
+      justify-content: flex-start;
       /* Push the badge + floor chip to the right edge of the row so they sit
          flush against the controls column. */
       margin-right: auto;
@@ -857,6 +882,7 @@ export class AdaptiveCoverProTileCard extends LitElement {
     }
     .tile-body.detailed .position {
       text-align: left;
+      justify-content: flex-start;
       padding: 0;
     }
     .tile-body.detailed .controls {
@@ -937,6 +963,31 @@ export class AdaptiveCoverProTileCard extends LitElement {
          column edge — combined with the fixed-width position grid column, this
          keeps the ▲ ■ ▼ row aligned across stacked tiles. */
       text-align: right;
+      display: inline-flex;
+      align-items: center;
+      justify-content: flex-end;
+      gap: 2px;
+    }
+    /* In-transit motion indicator for no-feedback covers: a small direction
+       arrow beside the position/state, sized to the readout text. */
+    .transit {
+      --mdc-icon-size: 1em;
+      color: var(--primary-color);
+      flex-shrink: 0;
+    }
+    @media (prefers-reduced-motion: no-preference) {
+      .transit {
+        animation: acp-transit-pulse 1.1s ease-in-out infinite;
+      }
+    }
+    @keyframes acp-transit-pulse {
+      0%,
+      100% {
+        opacity: 1;
+      }
+      50% {
+        opacity: 0.35;
+      }
     }
     .controls {
       grid-area: controls;

--- a/src/components/cover-bar.ts
+++ b/src/components/cover-bar.ts
@@ -61,6 +61,18 @@ export class CoverBar extends LitElement {
     };
   }
 
+  /** Per-cover in-transit direction from the target sensor's `transit_states`
+   *  attribute (guarded like {@link _target}). No-feedback covers publish this
+   *  while mid-move; absent/empty otherwise. */
+  private _transit(): Record<string, 'opening' | 'closing'> {
+    const id = this.discovered.entities.target_position_sensor;
+    if (!id) return {};
+    const st = this.hass.states[id];
+    if (!st) return {};
+    const attrs = st.attributes as unknown as CoverPositionAttributes;
+    return attrs?.transit_states ?? {};
+  }
+
   private _mismatched(): Set<string> {
     const id = this.discovered.entities.position_mismatch_binary;
     if (!id) return new Set();
@@ -126,6 +138,7 @@ export class CoverBar extends LitElement {
     // the cover away from the solar target), so don't flag it as an alert — the
     // marker/fill gap already shows it. Keep the badge for genuine mismatches.
     const overrideDivergence = isOverrideDivergence(this.hass, this.discovered);
+    const transit = this._transit();
     const entries = Object.entries(covers);
     if (entries.length === 0) {
       return html`<div class="placeholder">${t('covers.placeholder', this.hass)}</div>`;
@@ -158,7 +171,14 @@ export class CoverBar extends LitElement {
         ${entries.map(
           ([id, actual]) => html`
             <div class="cover-group">
-              ${this._bar(id, actual, target, mismatched.has(id), overrideDivergence)}
+              ${this._bar(
+                id,
+                actual,
+                target,
+                mismatched.has(id),
+                overrideDivergence,
+                transit[id] ?? null,
+              )}
               ${secondaryAxes.map(
                 (axis) =>
                   html`<acp-tilt-bar
@@ -188,6 +208,7 @@ export class CoverBar extends LitElement {
     target: number | null,
     mismatch: boolean,
     overrideDivergence: boolean,
+    transitDir: 'opening' | 'closing' | null,
   ): TemplateResult {
     const friendly =
       (this.hass.states[entityId]?.attributes?.friendly_name as string | undefined) ?? entityId;
@@ -205,7 +226,15 @@ export class CoverBar extends LitElement {
         >
           ${friendly}
         </div>
-        <div class="num">${formatPercent(actual)}</div>
+        <div class="num">
+          ${transitDir
+            ? html`<ha-icon
+                class="transit transit-${transitDir}"
+                icon=${transitDir === 'opening' ? 'mdi:arrow-up-thin' : 'mdi:arrow-down-thin'}
+                ${tooltip(t('covers.' + transitDir, this.hass))}
+              ></ha-icon>`
+            : nothing}${formatPercent(actual)}
+        </div>
         <div
           class="track"
           @click=${(e: MouseEvent) => this._handleTrackClick(e, entityId)}
@@ -367,6 +396,31 @@ export class CoverBar extends LitElement {
     .num {
       font-variant-numeric: tabular-nums;
       text-align: right;
+      display: inline-flex;
+      align-items: center;
+      justify-content: flex-end;
+      gap: 2px;
+    }
+    /* In-transit motion indicator for no-feedback covers: a small direction
+       arrow beside the percent, sized to the .num text. */
+    .transit {
+      --mdc-icon-size: 1em;
+      color: var(--primary-color);
+      flex-shrink: 0;
+    }
+    @media (prefers-reduced-motion: no-preference) {
+      .transit {
+        animation: acp-transit-pulse 1.1s ease-in-out infinite;
+      }
+    }
+    @keyframes acp-transit-pulse {
+      0%,
+      100% {
+        opacity: 1;
+      }
+      50% {
+        opacity: 0.35;
+      }
     }
     .warn {
       color: var(--warning-color, orange);

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -172,6 +172,8 @@ export const de: EnDict = {
     target: 'Ziel: {pct}',
     target_solar: 'Sonnenziel: {pct}',
     click_to_set: 'Klicken zum Festlegen der Position',
+    opening: 'Öffnet…',
+    closing: 'Schließt…',
     target_tooltip: 'Ziel {pct}%',
     target_tooltip_override:
       'Theoretisches Sonnenziel {pct}% — Beschattung wird durch manuelle Übersteuerung gehalten',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -164,6 +164,8 @@ export const en = {
     target: 'Target: {pct}',
     target_solar: 'Solar target: {pct}',
     click_to_set: 'Click to set position',
+    opening: 'Opening…',
+    closing: 'Closing…',
     target_tooltip: 'Target {pct}%',
     target_tooltip_override: 'Would-be solar target {pct}% — cover is held by manual override',
     tilt_title: 'Tilt',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -174,6 +174,8 @@ export const fr: EnDict = {
     target: 'Cible : {pct}',
     target_solar: 'Cible solaire : {pct}',
     click_to_set: 'Cliquer pour définir la position',
+    opening: 'Ouverture…',
+    closing: 'Fermeture…',
     target_tooltip: 'Cible {pct}%',
     target_tooltip_override:
       'Cible solaire théorique {pct}% — le store est maintenu par la commande manuelle',

--- a/src/types.ts
+++ b/src/types.ts
@@ -417,6 +417,11 @@ export interface LastSkippedAttributes {
 
 export interface CoverPositionAttributes {
   actual_positions: Record<string, number | null>;
+  /** Per-cover in-transit direction for no-feedback (Somfy-RTS-style) covers,
+   *  keyed by cover entity_id. Present only while a cover is mid-move (~45s
+   *  window); absent/empty otherwise. Lets the card show motion the way a
+   *  position cover shows a changing %. */
+  transit_states?: Record<string, 'opening' | 'closing'>;
   all_at_target: boolean;
   control_method: HandlerName | string;
   reason: string;

--- a/tests/cover-bar.test.ts
+++ b/tests/cover-bar.test.ts
@@ -581,6 +581,63 @@ describe('acp-cover-bar legacy fallback parity (no discovery, no set_axes)', () 
   });
 });
 
+describe('acp-cover-bar transit motion indicator', () => {
+  function transitHass(transit?: Record<string, 'opening' | 'closing'>): HomeAssistant {
+    return {
+      states: {
+        'sensor.cover_position': {
+          state: '50',
+          attributes: {
+            actual_positions: { 'cover.x': 50 },
+            ...(transit ? { transit_states: transit } : {}),
+          },
+        },
+        'cover.x': { state: 'open', attributes: { friendly_name: 'Cover X' } },
+      },
+      callService: vi.fn(),
+    } as unknown as HomeAssistant;
+  }
+
+  async function mount(hass: HomeAssistant): Promise<CoverBarLike> {
+    const el = document.createElement('acp-cover-bar') as CoverBarLike;
+    document.body.appendChild(el);
+    el.hass = hass;
+    el.discovered = {
+      ...baseDiscovered,
+      entities: { target_position_sensor: 'sensor.cover_position' },
+    };
+    await el.updateComplete;
+    return el;
+  }
+
+  it('renders a closing indicator with a resolved label when the cover is mid-close', async () => {
+    const el = await mount(transitHass({ 'cover.x': 'closing' }));
+    const indicator = el.shadowRoot!.querySelector('.num .transit-closing');
+    expect(indicator).not.toBeNull();
+    // Label resolves via covers.closing i18n key.
+    expect(indicator!.getAttribute('data-tooltip')).toContain('Closing');
+    // The percent still renders alongside the motion indicator.
+    expect(el.shadowRoot!.querySelector('.num')!.textContent).toContain('50');
+  });
+
+  it('renders an opening indicator when the cover is mid-open', async () => {
+    const el = await mount(transitHass({ 'cover.x': 'opening' }));
+    const indicator = el.shadowRoot!.querySelector('.num .transit-opening');
+    expect(indicator).not.toBeNull();
+    expect(indicator!.getAttribute('data-tooltip')).toContain('Opening');
+  });
+
+  it('renders no transit indicator when transit_states is absent', async () => {
+    const el = await mount(transitHass());
+    expect(el.shadowRoot!.querySelector('.transit')).toBeNull();
+  });
+
+  it('renders no transit indicator for a cover not present in transit_states', async () => {
+    const el = await mount(transitHass({ 'cover.other': 'closing' }));
+    expect(el.shadowRoot!.querySelector('.transit')).toBeNull();
+  });
+});
+
 describe('acp-cover-bar track-click → set_position', () => {
   it('calls adaptive_cover_pro.set_position when the track is clicked', async () => {
     const callService = vi.fn();

--- a/tests/tile-card.test.ts
+++ b/tests/tile-card.test.ts
@@ -639,6 +639,56 @@ describe('adaptive-cover-pro-tile-card render', () => {
   });
 });
 
+describe('adaptive-cover-pro-tile-card transit motion indicator', () => {
+  it('renders the opening indicator when transit_states marks the cover opening', async () => {
+    const el = await mount(
+      { type: TYPE, entry_id: ENTRY },
+      makeHass({
+        coverPositionSensorAttrs: {
+          actual_positions: { 'cover.left': 40, 'cover.right': 45 },
+          transit_states: { 'cover.left': 'opening' },
+        },
+      }),
+    );
+    const indicator = el.shadowRoot!.querySelector('.position .transit-opening');
+    expect(indicator).toBeTruthy();
+    expect(indicator!.getAttribute('data-tooltip')).toContain('Opening');
+  });
+
+  it('renders the closing indicator when transit_states marks the cover closing', async () => {
+    const el = await mount(
+      { type: TYPE, entry_id: ENTRY },
+      makeHass({
+        coverPositionSensorAttrs: {
+          actual_positions: { 'cover.left': 40, 'cover.right': 45 },
+          transit_states: { 'cover.left': 'closing' },
+        },
+      }),
+    );
+    const indicator = el.shadowRoot!.querySelector('.position .transit-closing');
+    expect(indicator).toBeTruthy();
+    expect(indicator!.getAttribute('data-tooltip')).toContain('Closing');
+  });
+
+  it('renders no transit indicator when transit_states is absent', async () => {
+    const el = await mount({ type: TYPE, entry_id: ENTRY }, makeHass());
+    expect(el.shadowRoot!.querySelector('.position .transit')).toBeFalsy();
+  });
+
+  it('renders no transit indicator for a cover not present in transit_states', async () => {
+    const el = await mount(
+      { type: TYPE, entry_id: ENTRY },
+      makeHass({
+        coverPositionSensorAttrs: {
+          actual_positions: { 'cover.left': 40, 'cover.right': 45 },
+          transit_states: { 'cover.other': 'closing' },
+        },
+      }),
+    );
+    expect(el.shadowRoot!.querySelector('.position .transit')).toBeFalsy();
+  });
+});
+
 describe('adaptive-cover-pro-tile-card group entry (issue #185)', () => {
   const GROUP_ENTRY = 'group_xyz';
   const GROUP_REGISTRY: EntityRegistryEntry[] = [


### PR DESCRIPTION
## Summary
The integration (adaptive-cover-pro #893) now publishes a `transit_states` attribute on the Cover_Position sensor while a no-feedback (Somfy-RTS-style) open/close-only cover is mid-move (`{ "<cover_entity_id>": "opening" | "closing" }`, present for a ~45 s window). This card renders an animated up/down arrow with an "Opening…/Closing…" tooltip next to the position readout, so these covers show motion the way a position cover shows a changing %.

## What changed
- **Cover bars** (`cover-bar.ts`): new `_transit()` reader off `target_position_sensor`; per-cover direction threaded into `_bar`; `<ha-icon>` arrow (`mdi:arrow-up-thin`/`down-thin`) with `covers.opening`/`covers.closing` tooltip in the `.num` cell alongside the %.
- **Tile card** (`adaptive-cover-pro-tile-card.ts`): new `_transitState()` keyed by the resolved cover; same indicator in the position readout for both detailed and one-line layouts.
- **i18n**: `covers.opening`/`covers.closing` in en/de/fr.
- **types**: `transit_states?` on `CoverPositionAttributes`.
- Reduced-motion aware pulse; discovery-driven (no hardcoded ids); no new dependencies.

## Testing
- ✅ 1202 tests passing (57 files); typecheck + eslint/prettier clean
- New cover-bar + tile-card tests: indicator renders with correct direction, absent when no `transit_states`, and not shown for non-matching covers

Requires integration build with `transit_states` (adaptive-cover-pro #893, on develop).