### PR TITLE
fix: stop the bar-only tile overlapping its name (#260)

### DIFF
--- a/dist/adaptive-cover-pro-card.js
+++ b/dist/adaptive-cover-pro-card.js
@@ -1,7 +1,7 @@
 /*! adaptive-cover-pro-card v2.15.0 | MIT License | https://github.com/jrhubott/adaptive-cover-pro-card */
-function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPropertyDescriptor(t,o):i;if("object"==typeof Reflect&&"function"==typeof Reflect.decorate)r=Reflect.decorate(e,t,o,i);else for(var a=e.length-1;a>=0;a--)(s=e[a])&&(r=(n<3?s(r):n>3?s(t,o,r):s(t,o))||r);return n>3&&r&&Object.defineProperty(t,o,r),r}"function"==typeof SuppressedError&&SuppressedError;const t=globalThis,o=t.ShadowRoot&&(void 0===t.ShadyCSS||t.ShadyCSS.nativeShadow)&&"adoptedStyleSheets"in Document.prototype&&"replace"in CSSStyleSheet.prototype,i=Symbol(),s=new WeakMap;let n=class{constructor(e,t,o){if(this._$cssResult$=!0,o!==i)throw Error("CSSResult is not constructable. Use `unsafeCSS` or `css` instead.");this.cssText=e,this.t=t}get styleSheet(){let e=this.o;const t=this.t;if(o&&void 0===e){const o=void 0!==t&&1===t.length;o&&(e=s.get(t)),void 0===e&&((this.o=e=new CSSStyleSheet).replaceSync(this.cssText),o&&s.set(t,e))}return e}toString(){return this.cssText}};const r=(e,...t)=>{const o=1===e.length?e[0]:t.reduce((t,o,i)=>t+(e=>{if(!0===e._$cssResult$)return e.cssText;if("number"==typeof e)return e;throw Error("Value passed to 'css' function must be a 'css' function result: "+e+". Use 'unsafeCSS' to pass non-literal values, but take care to ensure page security.")})(o)+e[i+1],e[0]);return new n(o,e,i)},a=o?e=>e:e=>e instanceof CSSStyleSheet?(e=>{let t="";for(const o of e.cssRules)t+=o.cssText;return(e=>new n("string"==typeof e?e:e+"",void 0,i))(t)})(e):e,{is:l,defineProperty:c,getOwnPropertyDescriptor:d,getOwnPropertyNames:h,getOwnPropertySymbols:p,getPrototypeOf:u}=Object,_=globalThis,g=_.trustedTypes,m=g?g.emptyScript:"",v=_.reactiveElementPolyfillSupport,f=(e,t)=>e,b={toAttribute(e,t){switch(t){case Boolean:e=e?m:null;break;case Object:case Array:e=null==e?e:JSON.stringify(e)}return e},fromAttribute(e,t){let o=e;switch(t){case Boolean:o=null!==e;break;case Number:o=null===e?null:Number(e);break;case Object:case Array:try{o=JSON.parse(e)}catch(e){o=null}}return o}},y=(e,t)=>!l(e,t),w={attribute:!0,type:String,converter:b,reflect:!1,useDefault:!1,hasChanged:y};Symbol.metadata??=Symbol("metadata"),_.litPropertyMetadata??=new WeakMap;let x=class extends HTMLElement{static addInitializer(e){this._$Ei(),(this.l??=[]).push(e)}static get observedAttributes(){return this.finalize(),this._$Eh&&[...this._$Eh.keys()]}static createProperty(e,t=w){if(t.state&&(t.attribute=!1),this._$Ei(),this.prototype.hasOwnProperty(e)&&((t=Object.create(t)).wrapped=!0),this.elementProperties.set(e,t),!t.noAccessor){const o=Symbol(),i=this.getPropertyDescriptor(e,o,t);void 0!==i&&c(this.prototype,e,i)}}static getPropertyDescriptor(e,t,o){const{get:i,set:s}=d(this.prototype,e)??{get(){return this[t]},set(e){this[t]=e}};return{get:i,set(t){const n=i?.call(this);s?.call(this,t),this.requestUpdate(e,n,o)},configurable:!0,enumerable:!0}}static getPropertyOptions(e){return this.elementProperties.get(e)??w}static _$Ei(){if(this.hasOwnProperty(f("elementProperties")))return;const e=u(this);e.finalize(),void 0!==e.l&&(this.l=[...e.l]),this.elementProperties=new Map(e.elementProperties)}static finalize(){if(this.hasOwnProperty(f("finalized")))return;if(this.finalized=!0,this._$Ei(),this.hasOwnProperty(f("properties"))){const e=this.properties,t=[...h(e),...p(e)];for(const o of t)this.createProperty(o,e[o])}const e=this[Symbol.metadata];if(null!==e){const t=litPropertyMetadata.get(e);if(void 0!==t)for(const[e,o]of t)this.elementProperties.set(e,o)}this._$Eh=new Map;for(const[e,t]of this.elementProperties){const o=this._$Eu(e,t);void 0!==o&&this._$Eh.set(o,e)}this.elementStyles=this.finalizeStyles(this.styles)}static finalizeStyles(e){const t=[];if(Array.isArray(e)){const o=new Set(e.flat(1/0).reverse());for(const e of o)t.unshift(a(e))}else void 0!==e&&t.push(a(e));return t}static _$Eu(e,t){const o=t.attribute;return!1===o?void 0:"string"==typeof o?o:"string"==typeof e?e.toLowerCase():void 0}constructor(){super(),this._$Ep=void 0,this.isUpdatePending=!1,this.hasUpdated=!1,this._$Em=null,this._$Ev()}_$Ev(){this._$ES=new Promise(e=>this.enableUpdating=e),this._$AL=new Map,this._$E_(),this.requestUpdate(),this.constructor.l?.forEach(e=>e(this))}addController(e){(this._$EO??=new Set).add(e),void 0!==this.renderRoot&&this.isConnected&&e.hostConnected?.()}removeController(e){this._$EO?.delete(e)}_$E_(){const e=new Map,t=this.constructor.elementProperties;for(const o of t.keys())this.hasOwnProperty(o)&&(e.set(o,this[o]),delete this[o]);e.size>0&&(this._$Ep=e)}createRenderRoot(){const e=this.shadowRoot??this.attachShadow(this.constructor.shadowRootOptions);return((e,i)=>{if(o)e.adoptedStyleSheets=i.map(e=>e instanceof CSSStyleSheet?e:e.styleSheet);else for(const o of i){const i=document.createElement("style"),s=t.litNonce;void 0!==s&&i.setAttribute("nonce",s),i.textContent=o.cssText,e.appendChild(i)}})(e,this.constructor.elementStyles),e}connectedCallback(){this.renderRoot??=this.createRenderRoot(),this.enableUpdating(!0),this._$EO?.forEach(e=>e.hostConnected?.())}enableUpdating(e){}disconnectedCallback(){this._$EO?.forEach(e=>e.hostDisconnected?.())}attributeChangedCallback(e,t,o){this._$AK(e,o)}_$ET(e,t){const o=this.constructor.elementProperties.get(e),i=this.constructor._$Eu(e,o);if(void 0!==i&&!0===o.reflect){const s=(void 0!==o.converter?.toAttribute?o.converter:b).toAttribute(t,o.type);this._$Em=e,null==s?this.removeAttribute(i):this.setAttribute(i,s),this._$Em=null}}_$AK(e,t){const o=this.constructor,i=o._$Eh.get(e);if(void 0!==i&&this._$Em!==i){const e=o.getPropertyOptions(i),s="function"==typeof e.converter?{fromAttribute:e.converter}:void 0!==e.converter?.fromAttribute?e.converter:b;this._$Em=i;const n=s.fromAttribute(t,e.type);this[i]=n??this._$Ej?.get(i)??n,this._$Em=null}}requestUpdate(e,t,o,i=!1,s){if(void 0!==e){const n=this.constructor;if(!1===i&&(s=this[e]),o??=n.getPropertyOptions(e),!((o.hasChanged??y)(s,t)||o.useDefault&&o.reflect&&s===this._$Ej?.get(e)&&!this.hasAttribute(n._$Eu(e,o))))return;this.C(e,t,o)}!1===this.isUpdatePending&&(this._$ES=this._$EP())}C(e,t,{useDefault:o,reflect:i,wrapped:s},n){o&&!(this._$Ej??=new Map).has(e)&&(this._$Ej.set(e,n??t??this[e]),!0!==s||void 0!==n)||(this._$AL.has(e)||(this.hasUpdated||o||(t=void 0),this._$AL.set(e,t)),!0===i&&this._$Em!==e&&(this._$Eq??=new Set).add(e))}async _$EP(){this.isUpdatePending=!0;try{await this._$ES}catch(e){Promise.reject(e)}const e=this.scheduleUpdate();return null!=e&&await e,!this.isUpdatePending}scheduleUpdate(){return this.performUpdate()}performUpdate(){if(!this.isUpdatePending)return;if(!this.hasUpdated){if(this.renderRoot??=this.createRenderRoot(),this._$Ep){for(const[e,t]of this._$Ep)this[e]=t;this._$Ep=void 0}const e=this.constructor.elementProperties;if(e.size>0)for(const[t,o]of e){const{wrapped:e}=o,i=this[t];!0!==e||this._$AL.has(t)||void 0===i||this.C(t,void 0,o,i)}}let e=!1;const t=this._$AL;try{e=this.shouldUpdate(t),e?(this.willUpdate(t),this._$EO?.forEach(e=>e.hostUpdate?.()),this.update(t)):this._$EM()}catch(t){throw e=!1,this._$EM(),t}e&&this._$AE(t)}willUpdate(e){}_$AE(e){this._$EO?.forEach(e=>e.hostUpdated?.()),this.hasUpdated||(this.hasUpdated=!0,this.firstUpdated(e)),this.updated(e)}_$EM(){this._$AL=new Map,this.isUpdatePending=!1}get updateComplete(){return this.getUpdateComplete()}getUpdateComplete(){return this._$ES}shouldUpdate(e){return!0}update(e){this._$Eq&&=this._$Eq.forEach(e=>this._$ET(e,this[e])),this._$EM()}updated(e){}firstUpdated(e){}};x.elementStyles=[],x.shadowRootOptions={mode:"open"},x[f("elementProperties")]=new Map,x[f("finalized")]=new Map,v?.({ReactiveElement:x}),(_.reactiveElementVersions??=[]).push("2.1.2");const $=globalThis,k=e=>e,A=$.trustedTypes,S=A?A.createPolicy("lit-html",{createHTML:e=>e}):void 0,C="$lit$",E=`lit$${Math.random().toFixed(9).slice(2)}$`,z="?"+E,M=`<${z}>`,I=document,T=()=>I.createComment(""),P=e=>null===e||"object"!=typeof e&&"function"!=typeof e,O=Array.isArray,F="[ \t\n\f\r]",B=/<(?:(!--|\/[^a-zA-Z])|(\/?[a-zA-Z][^>\s]*)|(\/?$))/g,N=/-->/g,D=/>/g,R=RegExp(`>|${F}(?:([^\\s"'>=/]+)(${F}*=${F}*(?:[^ \t\n\f\r"'\`<>=]|("|')|))|$)`,"g"),j=/'/g,K=/"/g,L=/^(?:script|style|textarea|title)$/i,G=e=>(t,...o)=>({_$litType$:e,strings:t,values:o}),W=G(1),H=G(2),U=Symbol.for("lit-noChange"),V=Symbol.for("lit-nothing"),q=new WeakMap,Y=I.createTreeWalker(I,129);function Q(e,t){if(!O(e)||!e.hasOwnProperty("raw"))throw Error("invalid template strings array");return void 0!==S?S.createHTML(t):t}class Z{constructor({strings:e,_$litType$:t},o){let i;this.parts=[];let s=0,n=0;const r=e.length-1,a=this.parts,[l,c]=((e,t)=>{const o=e.length-1,i=[];let s,n=2===t?"<svg>":3===t?"<math>":"",r=B;for(let t=0;t<o;t++){const o=e[t];let a,l,c=-1,d=0;for(;d<o.length&&(r.lastIndex=d,l=r.exec(o),null!==l);)d=r.lastIndex,r===B?"!--"===l[1]?r=N:void 0!==l[1]?r=D:void 0!==l[2]?(L.test(l[2])&&(s=RegExp("</"+l[2],"g")),r=R):void 0!==l[3]&&(r=R):r===R?">"===l[0]?(r=s??B,c=-1):void 0===l[1]?c=-2:(c=r.lastIndex-l[2].length,a=l[1],r=void 0===l[3]?R:'"'===l[3]?K:j):r===K||r===j?r=R:r===N||r===D?r=B:(r=R,s=void 0);const h=r===R&&e[t+1].startsWith("/>")?" ":"";n+=r===B?o+M:c>=0?(i.push(a),o.slice(0,c)+C+o.slice(c)+E+h):o+E+(-2===c?t:h)}return[Q(e,n+(e[o]||"<?>")+(2===t?"</svg>":3===t?"</math>":"")),i]})(e,t);if(this.el=Z.createElement(l,o),Y.currentNode=this.el.content,2===t||3===t){const e=this.el.content.firstChild;e.replaceWith(...e.childNodes)}for(;null!==(i=Y.nextNode())&&a.length<r;){if(1===i.nodeType){if(i.hasAttributes())for(const e of i.getAttributeNames())if(e.endsWith(C)){const t=c[n++],o=i.getAttribute(e).split(E),r=/([.?@])?(.*)/.exec(t);a.push({type:1,index:s,name:r[2],strings:o,ctor:"."===r[1]?oe:"?"===r[1]?ie:"@"===r[1]?se:te}),i.removeAttribute(e)}else e.startsWith(E)&&(a.push({type:6,index:s}),i.removeAttribute(e));if(L.test(i.tagName)){const e=i.textContent.split(E),t=e.length-1;if(t>0){i.textContent=A?A.emptyScript:"";for(let o=0;o<t;o++)i.append(e[o],T()),Y.nextNode(),a.push({type:2,index:++s});i.append(e[t],T())}}}else if(8===i.nodeType)if(i.data===z)a.push({type:2,index:s});else{let e=-1;for(;-1!==(e=i.data.indexOf(E,e+1));)a.push({type:7,index:s}),e+=E.length-1}s++}}static createElement(e,t){const o=I.createElement("template");return o.innerHTML=e,o}}function X(e,t,o=e,i){if(t===U)return t;let s=void 0!==i?o._$Co?.[i]:o._$Cl;const n=P(t)?void 0:t._$litDirective$;return s?.constructor!==n&&(s?._$AO?.(!1),void 0===n?s=void 0:(s=new n(e),s._$AT(e,o,i)),void 0!==i?(o._$Co??=[])[i]=s:o._$Cl=s),void 0!==s&&(t=X(e,s._$AS(e,t.values),s,i)),t}class J{constructor(e,t){this._$AV=[],this._$AN=void 0,this._$AD=e,this._$AM=t}get parentNode(){return this._$AM.parentNode}get _$AU(){return this._$AM._$AU}u(e){const{el:{content:t},parts:o}=this._$AD,i=(e?.creationScope??I).importNode(t,!0);Y.currentNode=i;let s=Y.nextNode(),n=0,r=0,a=o[0];for(;void 0!==a;){if(n===a.index){let t;2===a.type?t=new ee(s,s.nextSibling,this,e):1===a.type?t=new a.ctor(s,a.name,a.strings,this,e):6===a.type&&(t=new ne(s,this,e)),this._$AV.push(t),a=o[++r]}n!==a?.index&&(s=Y.nextNode(),n++)}return Y.currentNode=I,i}p(e){let t=0;for(const o of this._$AV)void 0!==o&&(void 0!==o.strings?(o._$AI(e,o,t),t+=o.strings.length-2):o._$AI(e[t])),t++}}class ee{get _$AU(){return this._$AM?._$AU??this._$Cv}constructor(e,t,o,i){this.type=2,this._$AH=V,this._$AN=void 0,this._$AA=e,this._$AB=t,this._$AM=o,this.options=i,this._$Cv=i?.isConnected??!0}get parentNode(){let e=this._$AA.parentNode;const t=this._$AM;return void 0!==t&&11===e?.nodeType&&(e=t.parentNode),e}get startNode(){return this._$AA}get endNode(){return this._$AB}_$AI(e,t=this){e=X(this,e,t),P(e)?e===V||null==e||""===e?(this._$AH!==V&&this._$AR(),this._$AH=V):e!==this._$AH&&e!==U&&this._(e):void 0!==e._$litType$?this.$(e):void 0!==e.nodeType?this.T(e):(e=>O(e)||"function"==typeof e?.[Symbol.iterator])(e)?this.k(e):this._(e)}O(e){return this._$AA.parentNode.insertBefore(e,this._$AB)}T(e){this._$AH!==e&&(this._$AR(),this._$AH=this.O(e))}_(e){this._$AH!==V&&P(this._$AH)?this._$AA.nextSibling.data=e:this.T(I.createTextNode(e)),this._$AH=e}$(e){const{values:t,_$litType$:o}=e,i="number"==typeof o?this._$AC(e):(void 0===o.el&&(o.el=Z.createElement(Q(o.h,o.h[0]),this.options)),o);if(this._$AH?._$AD===i)this._$AH.p(t);else{const e=new J(i,this),o=e.u(this.options);e.p(t),this.T(o),this._$AH=e}}_$AC(e){let t=q.get(e.strings);return void 0===t&&q.set(e.strings,t=new Z(e)),t}k(e){O(this._$AH)||(this._$AH=[],this._$AR());const t=this._$AH;let o,i=0;for(const s of e)i===t.length?t.push(o=new ee(this.O(T()),this.O(T()),this,this.options)):o=t[i],o._$AI(s),i++;i<t.length&&(this._$AR(o&&o._$AB.nextSibling,i),t.length=i)}_$AR(e=this._$AA.nextSibling,t){for(this._$AP?.(!1,!0,t);e!==this._$AB;){const t=k(e).nextSibling;k(e).remove(),e=t}}setConnected(e){void 0===this._$AM&&(this._$Cv=e,this._$AP?.(e))}}class te{get tagName(){return this.element.tagName}get _$AU(){return this._$AM._$AU}constructor(e,t,o,i,s){this.type=1,this._$AH=V,this._$AN=void 0,this.element=e,this.name=t,this._$AM=i,this.options=s,o.length>2||""!==o[0]||""!==o[1]?(this._$AH=Array(o.length-1).fill(new String),this.strings=o):this._$AH=V}_$AI(e,t=this,o,i){const s=this.strings;let n=!1;if(void 0===s)e=X(this,e,t,0),n=!P(e)||e!==this._$AH&&e!==U,n&&(this._$AH=e);else{const i=e;let r,a;for(e=s[0],r=0;r<s.length-1;r++)a=X(this,i[o+r],t,r),a===U&&(a=this._$AH[r]),n||=!P(a)||a!==this._$AH[r],a===V?e=V:e!==V&&(e+=(a??"")+s[r+1]),this._$AH[r]=a}n&&!i&&this.j(e)}j(e){e===V?this.element.removeAttribute(this.name):this.element.setAttribute(this.name,e??"")}}class oe extends te{constructor(){super(...arguments),this.type=3}j(e){this.element[this.name]=e===V?void 0:e}}class ie extends te{constructor(){super(...arguments),this.type=4}j(e){this.element.toggleAttribute(this.name,!!e&&e!==V)}}class se extends te{constructor(e,t,o,i,s){super(e,t,o,i,s),this.type=5}_$AI(e,t=this){if((e=X(this,e,t,0)??V)===U)return;const o=this._$AH,i=e===V&&o!==V||e.capture!==o.capture||e.once!==o.once||e.passive!==o.passive,s=e!==V&&(o===V||i);i&&this.element.removeEventListener(this.name,this,o),s&&this.element.addEventListener(this.name,this,e),this._$AH=e}handleEvent(e){"function"==typeof this._$AH?this._$AH.call(this.options?.host??this.element,e):this._$AH.handleEvent(e)}}class ne{constructor(e,t,o){this.element=e,this.type=6,this._$AN=void 0,this._$AM=t,this.options=o}get _$AU(){return this._$AM._$AU}_$AI(e){X(this,e)}}const re={I:ee},ae=$.litHtmlPolyfillSupport;ae?.(Z,ee),($.litHtmlVersions??=[]).push("3.3.2");const le=globalThis;let ce=class extends x{constructor(){super(...arguments),this.renderOptions={host:this},this._$Do=void 0}createRenderRoot(){const e=super.createRenderRoot();return this.renderOptions.renderBefore??=e.firstChild,e}update(e){const t=this.render();this.hasUpdated||(this.renderOptions.isConnected=this.isConnected),super.update(e),this._$Do=((e,t,o)=>{const i=o?.renderBefore??t;let s=i._$litPart$;if(void 0===s){const e=o?.renderBefore??null;i._$litPart$=s=new ee(t.insertBefore(T(),e),e,void 0,o??{})}return s._$AI(e),s})(t,this.renderRoot,this.renderOptions)}connectedCallback(){super.connectedCallback(),this._$Do?.setConnected(!0)}disconnectedCallback(){super.disconnectedCallback(),this._$Do?.setConnected(!1)}render(){return U}};ce._$litElement$=!0,ce.finalized=!0,le.litElementHydrateSupport?.({LitElement:ce});const de=le.litElementPolyfillSupport;de?.({LitElement:ce}),(le.litElementVersions??=[]).push("4.2.2");const he=e=>(t,o)=>{void 0!==o?o.addInitializer(()=>{customElements.define(e,t)}):customElements.define(e,t)},pe={attribute:!0,type:String,converter:b,reflect:!1,hasChanged:y},ue=(e=pe,t,o)=>{const{kind:i,metadata:s}=o;let n=globalThis.litPropertyMetadata.get(s);if(void 0===n&&globalThis.litPropertyMetadata.set(s,n=new Map),"setter"===i&&((e=Object.create(e)).wrapped=!0),n.set(o.name,e),"accessor"===i){const{name:i}=o;return{set(o){const s=t.get.call(this);t.set.call(this,o),this.requestUpdate(i,s,e,!0,o)},init(t){return void 0!==t&&this.C(i,void 0,e,t),t}}}if("setter"===i){const{name:i}=o;return function(o){const s=this[i];t.call(this,o),this.requestUpdate(i,s,e,!0,o)}}throw Error("Unsupported decorator location: "+i)};function _e(e){return(t,o)=>"object"==typeof o?ue(e,t,o):((e,t,o)=>{const i=t.hasOwnProperty(o);return t.constructor.createProperty(o,e),i?Object.getOwnPropertyDescriptor(t,o):void 0})(e,t,o)}function ge(e){return _e({...e,state:!0,attribute:!1})}function me(e,t,o){if(!e)return!0;for(const i of o)if(i&&e.states[i]!==t.states[i])return!0;return!1}const ve="2.15.0",fe="adaptive-cover-pro-card",be="adaptive-cover-pro-card-editor",ye="adaptive-cover-pro-sky-compass-card",we="adaptive-cover-pro-sky-compass-card-editor",xe="adaptive-cover-pro-tile-card",$e="adaptive-cover-pro-tile-card-editor",ke="adaptive-cover-pro-decision-card",Ae="adaptive-cover-pro-decision-card-editor",Se="adaptive-cover-pro-solar-chart-card",Ce="adaptive-cover-pro-solar-chart-card-editor",Ee="adaptive-cover-pro-history-card",ze="adaptive-cover-pro-history-card-editor",Me="adaptive_cover_pro",Ie=["force","weather","group_scene","manual","group_lock","custom_position","motion","cloud","climate","glare_zone","solar","default","floor_clamp"],Te={force:"Force Override",weather:"Weather Safety",group_scene:"Group Scene",manual:"Manual Override",group_lock:"Group Lock",custom_position:"Custom Position",motion:"Occupancy Timeout",cloud:"Cloud Suppression",climate:"Climate",glare_zone:"Glare Zone",solar:"Solar Tracking",default:"Default",floor_clamp:"Min Floor"},Pe={force:"handler.force",weather:"handler.weather",group_scene:"handler.group_scene",manual:"handler.manual",group_lock:"handler.group_lock",custom_position:"handler.custom_position",motion:"handler.motion",cloud:"handler.cloud",climate:"handler.climate",glare_zone:"handler.glare_zone",solar:"handler.solar",default:"handler.default",floor_clamp:"handler.floor_clamp"},Oe={cover_blind:"mdi:blinds-horizontal",cover_awning:"mdi:awning-outline",cover_tilt:"mdi:blinds",cover_venetian:"mdi:blinds"},Fe={cover_blind:"mdi:blinds-open",cover_awning:"mdi:awning-outline",cover_tilt:"mdi:blinds-open",cover_venetian:"mdi:blinds-open"},Be={cover_blind:"mdi:blinds-horizontal-closed",cover_awning:"mdi:window-closed-variant",cover_tilt:"mdi:blinds",cover_venetian:"mdi:blinds"},Ne={awning:{open:"mdi:awning-outline",partial:"mdi:awning-outline",closed:"mdi:awning-outline"},blind:{open:"mdi:blinds-open",partial:"mdi:blinds-horizontal",closed:"mdi:blinds-horizontal-closed"},curtain:{open:"mdi:curtains",partial:"mdi:curtains",closed:"mdi:curtains-closed"},damper:{open:"mdi:circle",partial:"mdi:circle-slice-8",closed:"mdi:circle-slice-8"},door:{open:"mdi:door-open",partial:"mdi:door-open",closed:"mdi:door-closed"},garage:{open:"mdi:garage-open",partial:"mdi:garage-open",closed:"mdi:garage"},gate:{open:"mdi:gate-open",partial:"mdi:gate-open",closed:"mdi:gate"},shade:{open:"mdi:roller-shade",partial:"mdi:roller-shade",closed:"mdi:roller-shade-closed"},shutter:{open:"mdi:window-shutter-open",partial:"mdi:window-shutter",closed:"mdi:window-shutter"},window:{open:"mdi:window-open",partial:"mdi:window-open",closed:"mdi:window-closed"}},De=new Set(["awning","curtain","door","gate"]),Re={manual:"manual",force:"force",weather:"weather",glare_zone:"glare_zone",climate:"climate",cloud:"cloud",custom_position:"custom_position",solar:"solar",motion:"motion",group_scene:"group",group_lock:"group"},je={auto:{label:"Auto",bg:"rgba(76, 175, 80, 0.18)",fg:"#2e7d32"},manual:{label:"Manual",bg:"rgba(255, 152, 0, 0.22)",fg:"#e65100"},force:{label:"Force",bg:"rgba(244, 67, 54, 0.22)",fg:"#b71c1c"},weather:{label:"Sun protection",bg:"rgba(244, 67, 54, 0.22)",fg:"#b71c1c"},glare_zone:{label:"Glare",bg:"rgba(244, 67, 54, 0.22)",fg:"#b71c1c"},climate:{label:"Climate",bg:"rgba(0, 150, 136, 0.22)",fg:"#00695c"},cloud:{label:"Cloudy",bg:"rgba(33, 150, 243, 0.22)",fg:"#0d47a1"},custom_position:{label:"Custom",bg:"rgba(156, 39, 176, 0.22)",fg:"#6a1b9a"},solar:{label:"Solar tracking",bg:"rgba(76, 175, 80, 0.22)",fg:"#1b5e20"},motion:{label:"Occupancy",bg:"rgba(255, 235, 59, 0.22)",fg:"#827717"},off:{label:"Off",bg:"rgba(97, 97, 97, 0.28)",fg:"#212121"},off_schedule:{label:"Off-schedule",bg:"rgba(96, 125, 139, 0.22)",fg:"#37474f"},group:{label:"Group",bg:"rgba(76, 175, 80, 0.18)",fg:"#2e7d32"}},Ke={auto:"badge.auto",manual:"badge.manual",force:"badge.force",weather:"badge.weather",glare_zone:"badge.glare_zone",climate:"badge.climate",cloud:"badge.cloud",custom_position:"badge.custom_position",solar:"badge.solar",motion:"badge.motion",off:"badge.off",off_schedule:"badge.off_schedule",group:"badge.group"},Le={auto:"mdi:autorenew",manual:"mdi:hand-back-right",force:"mdi:flash",weather:"mdi:shield-sun",glare_zone:"mdi:weather-sunny-alert",climate:"mdi:thermostat",cloud:"mdi:weather-cloudy",custom_position:"mdi:bookmark",solar:"mdi:white-balance-sunny",motion:"mdi:motion-sensor",off:"mdi:power",off_schedule:"mdi:clock-alert-outline",group:"mdi:window-shutter-cog"},Ge={integration_enabled:!0,automatic_control:!0,reset_manual_override:!0},We={position:"target_position_sensor",tilt:"target_tilt_sensor"},He={tilt:"covers.tilt_title"},Ue="mdi:chart-box",Ve={active:"control_status.active",outside_time_window:"control_status.outside_time_window",position_delta_too_small:"control_status.position_delta_too_small",time_delta_too_small:"control_status.time_delta_too_small",manual_override:"control_status.manual_override",automatic_control_off:"control_status.automatic_control_off",sun_not_visible:"control_status.sun_not_visible",force_override_active:"control_status.force_override_active",weather_override_active:"control_status.weather_override_active",motion_timeout:"control_status.motion_timeout"},qe=new Set(["active"]),Ye=[{role:"integration_enabled_switch",key:"history.track_enabled",cls:"ctx-enabled"},{role:"automatic_control_switch",key:"history.track_auto",cls:"ctx-auto"},{role:"sun_infront_binary",key:"history.track_sun",cls:"ctx-sun"},{role:"glare_active_binary",key:"history.track_glare",cls:"ctx-glare"},{role:"manual_override_binary",key:"history.track_manual",cls:"ctx-manual"},{role:"position_mismatch_binary",key:"history.track_mismatch",cls:"ctx-mismatch"}],Qe=[6,12,24,48,72],Ze={pipeline_evaluated:"info",cover_command_sent:"action",cover_command_skipped:"warn",end_time_default_sent:"action",manual_override_gate_closed:"warn",sun_entered_fov:"info",sun_left_fov:"info",sunset_window_opened:"info",transit_cleared:"info",transit_optimistic_target_replay:"info",transit_progress_forward:"info",transit_startup_delay:"warn",transit_timeout_cleared:"warn",reconcile_gave_up:"warn",reconcile_skipped_in_transit:"warn"},Xe={"sensor:Cover_Position":"target_position_sensor","sensor:Cover_Tilt":"target_tilt_sensor","sensor:sun_position":"sun_sensor","sensor:Start Sun":"start_sensor","sensor:End Sun":"end_sensor","sensor:control_status":"control_status_sensor","sensor:decision_trace":"decision_trace_sensor","sensor:last_cover_action":"last_action_sensor","sensor:last_skipped_action":"last_skipped_sensor","sensor:manual_override_end_time":"manual_override_end_sensor","sensor:position_verification":"position_verification_sensor","sensor:motion_status":"motion_status_sensor","sensor:climate_status":"climate_status_sensor","sensor:position_forecast":"position_forecast_sensor","sensor:solar_calculation":"solar_calculation_sensor","binary_sensor:sun_motion":"sun_infront_binary","binary_sensor:manual_override":"manual_override_binary","binary_sensor:position_mismatch":"position_mismatch_binary","binary_sensor:glare_active":"glare_active_binary","switch:Integration Enabled":"integration_enabled_switch","switch:Automatic Control":"automatic_control_switch","switch:Manual Override":"manual_toggle_switch","switch:Climate Mode":"climate_mode_switch","switch:Motion Control":"motion_control_switch","button:Reset Manual Override":"reset_override_button","sensor:group_position":"group_position_sensor","sensor:group_state":"group_state_sensor","sensor:group_active_scene":"group_active_scene_sensor","sensor:group_climate_mode":"group_climate_mode_sensor","sensor:group_who_won":"group_who_won_sensor","select:group_scene_select":"group_scene_select","switch:group_automation":"group_automation_switch","switch:group_lock":"group_lock_switch","button:group_scene_all_open":"group_scene_all_open_button","button:group_scene_all_closed":"group_scene_all_closed_button","button:group_scene_privacy":"group_scene_privacy_button","button:group_clear_overrides":"group_clear_overrides_button","cover:group_cover":"group_cover"},Je={en:{handler:{force:"Force Override",weather:"Weather Safety",group_scene:"Group Scene",manual:"Manual Override",group_lock:"Group Lock",custom_position:"Custom Position",motion:"Occupancy Timeout",cloud:"Cloud Suppression",climate:"Climate",glare_zone:"Glare Zone",solar:"Solar Tracking",default:"Default",floor_clamp:"Min Floor"},badge:{auto:"Auto",manual:"Manual",force:"Force",weather:"Weather safety",glare_zone:"Glare",climate:"Climate",cloud:"Cloudy",custom_position:"Custom",solar:"Solar tracking",motion:"Occupancy idle",off:"Off",off_schedule:"Off-schedule",floor_suffix:" ↥",safety:"Safety",group:"Group"},group:{title:"Cover Group",scene:"Scene",scene_auto:"Auto",scene_all_open:"All open",scene_all_closed:"All closed",scene_privacy:"Privacy",state_open:"Open",state_closed:"Closed",state_mixed:"Mixed",state_unknown:"Unknown",lock:"Lock group",unlock:"Unlock group",automation:"Automation",automation_count:"{count} of {total} members automating",clear_overrides:"Clear overrides",clear_overrides_none:"No member overrides to clear",who_won:"{count} of {total} members are group-driven — a group scene or the group lock is currently deciding their position",members:"Members",member_placeholder:"No members reported by the integration.",position:"Position",open:"Open group",close:"Close group",stop:"Stop group",position_slider_label:"Group position"},forecast:{event:{sunrise:"Sunrise",sunset:"Sunset",fov_enter:"Sun enters window sun acceptance angle",fov_exit:"Sun leaves window sun acceptance angle"},hover_hint:"Hover the curve for time + forecast position; hover a colored line for the event it marks.",solar_only_note:"Solar geometry only — does not reflect manual overrides, custom positions, cloud suppression, or weather.",legend_forecast:"Forecast",legend_actual:"Actual"},dialog:{extend:{title:"Extend manual override",presets_label:"Until",relative_label:"Add time",absolute_label:"End at",preview:"Override until {time}",confirm:"Extend",cancel:"Cancel",tomorrow_suffix:" (tomorrow)"},configure_integration:"Configure integration",open_device_page:"Open device page",close:"Close",target:"Target",resume_auto:"Resume Auto",hide_advanced:"▼ Hide advanced",show_advanced:"▶ Advanced",custom_positions:"Custom positions",floor_tooltip:"Floor — slot raises position above raw calc",floor:"↥",disable_slot:"Disable slot {slot}",enable_slot:"Enable slot {slot}",on:"On",off:"Off",controls:"Controls",automatic:"Automatic",climate:"Climate",motion:"Occupancy",toggle_hint:"{label} {state} — tap to toggle",state_on:"on",state_off:"off",todays_forecast:"Today's forecast"},overrides:{title:"Overrides",manual:"Manual",force:"Force",motion:"Occupancy",active:"Active",off:"Off",ends_in:"ends in {time}",active_count:"{count} active",timeout:"expires in {time}",reset_manual:"Reset Manual"},climate:{title:"Climate",active:"Active: {strategy}",indoor:"Indoor",outdoor:"Outdoor",presence:"Presence",sunny:"Sunny",lux:"Lux",irradiance:"Irradiance",mode_off:"Climate mode off",standby:"Standby",threshold_low:"low",threshold_high:"high",threshold_summer_outside:"summer",reason:{outside_time_window:"Outside the operating time window",thresholds_not_met:"Temperatures within the comfort band — no action needed",other_mode_active:"Another control mode is currently active",readings_unavailable:"Temperature readings unavailable",mode_off:"Climate mode is turned off"}},compass:{placeholder_no_entries:"No Adaptive Cover Pro entries selected.",placeholder_no_sun:"Sun sensor not yet populated.",sun_tooltip:"Sun: {az} az / {el} el",sunrise_tooltip:"Sunrise: {time}",sunset_tooltip:"Sunset: {time}",moon_tooltip:"Moon: {phase} ({pct}%)",sun_path_tooltip:"Sun path (today)",in_fov_check:"✓ in SAA",in_fov:"in SAA",in_fov_tooltip:"Sun is currently within this window’s sun acceptance angle",none:"—",sun:"Sun",moon:"Moon",sun_up_not_hitting:"Sun (up, not hitting)",sun_below_horizon:"Sun (below horizon)",window_fov:"Window SAA",sun_path:"Sun path",sunrise:"Sunrise",sunset:"Sunset",cover_target:"Cover target",cover_held:"Cover position (held)",window_normal:"Window azimuth",stat_sun:"Sun: ",stat_azi:"Azi: ",stat_elev:"Elev: ",stat_window:"Window: ",active_sun_arc:"Active sun arc {from} – {to}{elev}",fov_arc:"SAA {left} left / {right} right{elev}",window_normal_tooltip:"Window azimuth: {bearing}",cover_position_target:"Target: {pct}%",cover_position_target_awning:"Target (extended): {pct}%",cover_position_actual:"Actual: {pct}%",blind_spot:"Blind spot: {from} – {to}",elev_suffix:" · elev {min}–{max}"},covers:{placeholder:"No covers reported by the integration.",title:"Covers",target:"Target: {pct}",target_solar:"Solar target: {pct}",click_to_set:"Click to set position",position_slider_label:"Cover position slider",position_open_value:"{pct} open",opening:"Opening…",closing:"Closing…",target_tooltip:"Target {pct}%",target_tooltip_override:"Would-be solar target {pct}% — cover is held by manual override",target_tooltip_motor:"Motor: {pct}% (before calibration)",tilt_title:"Tilt",tilt_target:"Tilt: {pct}",tilt_click_to_set:"Click to set tilt",tilt_target_tooltip:"Tilt target {pct}%"},decision:{placeholder:"Decision trace not yet populated.",pipeline:"Pipeline",winner:"Winner: {name}",summary_tooltip:"Why this position?",not_evaluated:"not evaluated",floor_suffix:" floor",outside_schedule:"Outside schedule — automatic control paused",outside_schedule_tooltip:"The configured schedule window is not active, so automatic positioning is paused.",solar_would_be:"solar {pct}",next_change_in:"Next adjustment allowed in {time}"},solar:{title:"Solar Calculation",axis_position:"Position axis",axis_tilt:"Tilt axis",group_inputs:"Inputs",group_intermediates:"Intermediates",group_output:"Output",show_all:"Show all {count} values",show_less:"Show less",no_target:"No solar target — {status}",status:{direct_sun:"Direct sun",fov_exit:"Default · SAA exit",elevation_limit:"Default · elevation limit",sunset_offset:"Default · sunset offset",blind_spot:"Default · blind spot",default:"Default"},field:{sol_elev_deg:"Sun elevation",gamma_deg:"Relative azimuth (γ)",position_pct:"Position",effective_distance_m:"Effective distance",adjusted_height_m:"Adjusted height",safety_margin:"Safety margin",awn_angle_deg:"Awning angle",vertical_position_m:"Vertical position",length_m:"Extension length",slat_angle_raw_deg:"Slat angle",tilt_mode:"Tilt mode",max_degrees:"Max angle"}},header:{on:"ON",off:"OFF",integration_enabled:"Integration Enabled",auto:"Auto",automatic_control:"Automatic Control"},tile:{motion_pending:"Occupancy timeout pending",motion_detected:"Occupancy detected",icon_action_label:"Cover icon action",open:"Open",stop:"Stop",close:"Close",resume_aria:"Resume automatic control",extend_aria:"Extend manual override",registry_failed:"Registry fetch failed: {error}",loading:"Loading…",entry_not_found:"Adaptive Cover Pro entry {entry} not found.",unavailable:"Unavailable"},formatters:{expired:"expired"},elevation:{title:"Sun today",fov_window:"SAA: {from} → {to}",fov_windows:"SAA: {windows}",fov_window_named:"{name}: {windows}",no_fov_today:"Sun does not enter SAA today",placeholder:"Sun elevation chart unavailable.",schedule:"Schedule {from} – {to}",schedule_from:"Schedule from {from}",schedule_until:"Schedule until {to}",schedule_start_tooltip:"Schedule start",schedule_end_tooltip:"Schedule end"},control_status:{active:"Active",outside_time_window:"Outside time window",position_delta_too_small:"Position change too small",time_delta_too_small:"Too soon since last move",manual_override:"Manual override",automatic_control_off:"Automatic control off",sun_not_visible:"Sun not visible",force_override_active:"Force override",weather_override_active:"Weather safety",motion_timeout:"Occupancy timeout"},history:{title:"History",open:"History",close:"Close",refresh:"Refresh",loading:"Loading history…",no_data:"No recorded data",window_label:"History window",window_hours:"{hours}h",show_more:"Show more",expand:"Expand to full view",collapse:"Back to history",today:"Today",yesterday:"Yesterday",section_tracks:"Timeline",track_position:"Position",track_who_won:"Who won",track_control_status:"Control status",track_enabled:"Integration",track_auto:"Automatic control",track_sun:"Sun in SAA",track_glare:"Glare",track_manual:"Manual override",track_mismatch:"Position mismatch",legend_target:"Target",legend_actual:"Actual",legend_per_cover:"Per cover",legend_saa:"Sun in SAA",legend_night:"Night",stat_moves:"moves",stat_travel:"pts travelled",stat_override:"in manual override",copy_diagnostics:"Copy diagnostics",copied:"Copied",no_recorder_data:"Not recorded — check your recorder settings",activity_title:"Activity",activity_empty:"No recorded activity in this window.",advanced:"Advanced — event buffer",events_search:"Filter events…",events_count:"{shown} of {total} events",events_empty:"No events match the filter.",events_unavailable:"Event buffer unavailable — the integration did not return diagnostics.",buffer_size:"Buffer size: {size}",data_window:"Buffer window: {from} → {to}"},root:{loading_registry:"Loading Adaptive Cover Pro registry…",no_entities_title:"No Adaptive Cover Pro entities found",footer_version:"adaptive-cover-pro-card v{version}",compass_no_match:"No matching Adaptive Cover Pro entities",compass_configured:"Configured entries: {entries}",compass_not_found:"Entries not found: {entries}"},editor:{common:{entry_id:"Adaptive Cover Pro instance",support_alt:"Buy me a coffee",title_optional:"Title (optional)",title_placeholder:"e.g. West-facing windows",north_offset:"Compass north offset (°)",north_offset_hint:'Rotate the compass clockwise so "up" matches your map. Default: 0.',loading_entries:"Loading Adaptive Cover Pro config entries…",load_failed:"Failed to load config entries: {error}",no_entries:"No Adaptive Cover Pro config entries found. Add an instance under",no_entries_path:"Settings → Devices & Services",no_entries_then:", then come back.",entry_id_manual_placeholder:"Enter config entry ID manually",entry_id_fallback_label:"Entry ID",unknown_entry:"(unknown: {entry})",reset:"Reset"},main:{sections:"Sections",sections_hint:"Toggle which parts of the card are shown.",section_sky_label:"Sky compass",section_sky_desc:"Sun vs. window SAA, polar plot",section_elevation_label:"Sun today",section_elevation_desc:"Elevation-vs-time chart with SAA band and current-time cursor",section_decision_label:"Decision strip",section_decision_desc:"All 10 pipeline handlers with the winning row highlighted",section_covers_label:"Cover positions",section_covers_desc:"Per-cover live vs. target bars; click to set position",section_overrides_label:"Overrides panel",section_overrides_desc:"Manual, force, occupancy tiles + reset button",section_climate_label:"Climate panel",section_climate_desc:"Summer/winter/intermediate strategy; shows standby when climate mode is off or inactive",section_solar_label:"Solar calculation",section_solar_desc:"Raw solar geometry breakdown (inputs → intermediates → output); requires the integration’s solar_calculation sensor",controls:"Controls",controls_hint:"Render as read-only (visible but not clickable).",integration_pill_label:"Integration ON/OFF pill",integration_pill_desc:"Allow toggling the integration from the card header.",automatic_pill_label:"Automatic Control pill",automatic_pill_desc:"Allow toggling automatic control from the card header.",reset_button_label:"Reset Manual Override button",reset_button_desc:"Allow pressing the reset tile in the overrides panel.",display:"Display",compact_label:"Compact mode",compact_desc:"Tighter spacing between sections.",show_compass_stats_label:"Show compass stats",show_compass_stats_desc:"Azi, Elev, ∠, and Window angle below the sky compass.",show_compass_legend_label:"Show compass legend",show_compass_legend_desc:"Color key below the sky compass.",show_moon_label:"Show moon on compass",show_moon_desc:"Moon position and phase overlay on the sky compass.",hide_inactive_label:"Hide inactive handlers",hide_inactive_desc:"Show only the winner and actively matched pipeline handlers.",state_color_label:"Color icon by state",state_color_desc:"Header cover icon takes on the theme’s open/closed/active color."},tile:{name:"Title override",icon:"Icon override",cover:"Cover entity",layout:"Layout",show_position:"Show position %",show_state:"Show state (Open/Closed)",show_decision_summary:"Show decision summary",show_controls:"Show ↑ ■ ↓ controls",covers:"Position bars (order)",covers_hint:"Drag a row, or use the arrows, to set the order the position bars appear in. The eye hides a bar without unbinding the cover.",covers_move_up:"Move up",covers_move_down:"Move down",covers_hide:"Hide this bar",covers_show:"Show this bar",controls_cover:"Cover driven by ↑ ■ ↓",controls_axis:"Axis driven by ↑ ■ ↓",show_badge:"Show contextual badge",show_position_bar:"Show position bar",show_tilt:"Show tilt bar",content_section:"Content",controls_section:"Controls",dialog_section:"Dialog sections",group_row_section:"Group controls",show_scene_select:"Show scene selector",show_lock:"Show group lock",show_automation:"Show member automation toggle",show_clear_overrides:"Show clear-overrides button",show_member_badges:"Show member override badges",badge_section:"Badges",badge_auto:"Auto",badge_solar:"Solar tracking",badge_force:"Force override",badge_weather:"Weather safety",badge_manual:"Manual override",badge_custom_position:"Custom position",badge_motion:"Occupancy",badge_climate:"Climate",badge_glare_zone:"Glare zone",badge_cloud:"Cloud suppression",show_compass:"Show sun compass in dialog",show_elevation_chart:"Show sun-today chart in dialog",show_solar_calc:"Show solar calculation in dialog",show_motion_icon:"Show occupancy indicator",state_color:"Color icon by state",interactions_section:"Interactions",tap_action:"Tap action",icon_tap_action:"Icon tap behavior",hold_action:"Hold action",double_tap_action:"Double-tap action",cover_blank_hint:"Leave blank to use the first managed cover automatically.",name_composed_hint:"A composed name is set in YAML. Type a new title here to replace it with plain text.",layout_option_one_line:"One line (compact)",layout_option_detailed:"Detailed (title, state, indicators)"},compass:{instances:"Adaptive Cover Pro instances",instances_hint:"Pick one or more. Each selected entry adds an overlay to the compass.",cover_colors:"Cover colors",cover_colors_hint:"Override the default palette color for each overlay.",default_color:"default",display:"Display",toggle_compact_label:"Compact mode",toggle_compact_desc:"Smaller SVG, legend hidden.",toggle_legend_label:"Legend",toggle_legend_desc:"Color swatches + entry labels below compass.",toggle_stats_label:"Stats",toggle_stats_desc:"Sun + per-window numeric rows.",toggle_moon_label:"Moon",toggle_moon_desc:"Render moon position and phase.",toggle_cardinals_label:"Cardinal labels",toggle_cardinals_desc:"N/E/S/W letters around the compass.",toggle_blind_spot_label:"Blind spots",toggle_blind_spot_desc:"Hatched wedges for each window’s blind range.",toggle_sun_path_label:"Sun path",toggle_sun_path_desc:"Today’s sun arc across the sky.",toggle_sunrise_sunset_label:"Sunrise / sunset markers",toggle_sunrise_sunset_desc:"Small dots at rise and set azimuths.",toggle_cover_fill_label:"Cover closure fill",toggle_cover_fill_desc:"Inner wedge showing how closed each cover is.",toggle_window_arrow_label:"Window-normal arrow",toggle_window_arrow_desc:"Line from center toward each window’s azimuth.",toggle_elevation_chart_label:"Sun-today chart",toggle_elevation_chart_desc:"Elevation-vs-time chart below the compass, with SAA band and elevation limits."},decision:{title:"Title (optional)",compact_label:"Compact mode",compact_desc:"Tighter rows; also hides inactive handlers.",hide_inactive_handlers_label:"Hide inactive handlers",hide_inactive_handlers_desc:"Show only the winner and actively matched pipeline handlers.",show_decision_summary_label:"Show decision summary",show_decision_summary_desc:'Render a plain-English "Why this position?" sentence above the strip.'},solar_chart:{instances:"Adaptive Cover Pro instances",instances_hint:"Pick one or more. Each selected entry adds a SAA overlay to the chart.",cover_colors:"Cover colors",cover_colors_hint:"Override the default palette color for each overlay.",default_color:"default",display:"Display",toggle_compact_label:"Compact mode",toggle_compact_desc:"Smaller chart, tighter spacing."},history:{title:"Title (optional)",hours_label:"History window",hours_desc:"How far back the tracks reach, counting from now.",track_position_label:"Position track",track_position_desc:"Recorded cover position over the window.",track_who_won_label:"Who-won track",track_who_won_desc:"Banded strip of the winning pipeline handler over time.",track_context_label:"Context tracks",track_context_desc:"Sun-in-SAA, glare and manual-override spans.",track_actions_label:"Cover actions list",track_actions_desc:"Recorded cover actions and skipped actions, newest first.",advanced_open_label:"Start with Advanced open",advanced_open_desc:"Expand the event-buffer section on load.",hide_advanced_label:"Hide Advanced section",hide_advanced_desc:"Never show the diagnostic event buffer on this card."}}},fr:{handler:{force:"Dérogation forcée",weather:"Sécurité météo",group_scene:"Scène de groupe",manual:"Dérogation manuelle",group_lock:"Verrouillage de groupe",custom_position:"Position personnalisée",motion:"Délai d'occupation",cloud:"Désactivation par temps nuageux",climate:"Climatique",glare_zone:"Zone d'éblouissement",solar:"Suivi solaire",default:"Par défaut",floor_clamp:"Plancher"},badge:{auto:"Auto",manual:"Manuel",force:"Forcé",weather:"Sécurité météo",glare_zone:"Éblouissement",climate:"Climatique",cloud:"Nuageux",custom_position:"Personnalisé",solar:"Suivi solaire",motion:"Occupation inactive",off:"Off",off_schedule:"Hors planning",floor_suffix:" ↥",safety:"Sécurité",group:"Groupe"},group:{title:"Groupe de couvertures",scene:"Scène",scene_auto:"Auto",scene_all_open:"Tout ouvrir",scene_all_closed:"Tout fermer",scene_privacy:"Intimité",state_open:"Ouvert",state_closed:"Fermé",state_mixed:"Mixte",state_unknown:"Inconnu",lock:"Verrouiller le groupe",unlock:"Déverrouiller le groupe",automation:"Automatisation",automation_count:"{count} membre(s) sur {total} automatisé(s)",clear_overrides:"Effacer les dérogations",clear_overrides_none:"Aucune dérogation de membre à effacer",who_won:"{count} membre(s) sur {total} sont pilotés par le groupe — une scène de groupe ou le verrouillage du groupe détermine actuellement leur position",members:"Membres",member_placeholder:"Aucun membre signalé par l'intégration.",position:"Position",open:"Ouvrir le groupe",close:"Fermer le groupe",stop:"Arrêter le groupe",position_slider_label:"Position du groupe"},forecast:{event:{sunrise:"Lever du soleil",sunset:"Coucher du soleil",fov_enter:"Le soleil entre dans l'angle d'acceptation solaire de la fenêtre",fov_exit:"Le soleil quitte l'angle d'acceptation solaire de la fenêtre"},hover_hint:"Survolez la courbe pour voir l'heure et la position prévue ; survolez une ligne colorée pour voir l'événement qu'elle indique.",solar_only_note:"Géométrie solaire uniquement — ne tient pas compte des dérogations manuelles, des positions personnalisées, de la désactivation par temps nuageux ni des conditions météo.",legend_forecast:"Prévision",legend_actual:"Réel"},dialog:{extend:{title:"Prolonger la dérogation manuelle",presets_label:"Jusqu'à",relative_label:"Ajouter du temps",absolute_label:"Fin à",preview:"Dérogation jusqu'à {time}",confirm:"Prolonger",cancel:"Annuler",tomorrow_suffix:" (demain)"},configure_integration:"Configurer l'intégration",open_device_page:"Ouvrir la page de l'appareil",close:"Fermer",target:"Cible",resume_auto:"Reprendre l'automatique",hide_advanced:"▼ Masquer les options avancées",show_advanced:"▶ Afficher les options avancées",custom_positions:"Positions personnalisées",floor_tooltip:"Plancher — cette valeur force une position minimale au-dessus du calcul automatique",floor:"↥",disable_slot:"Désactiver le créneau {slot}",enable_slot:"Activer le créneau {slot}",on:"Activé",off:"Désactivé",controls:"Commandes",automatic:"Automatique",climate:"Climatique",motion:"Occupation",toggle_hint:"{label} {state} — appuyez pour basculer",state_on:"activé",state_off:"désactivé",todays_forecast:"Prévisions du jour"},overrides:{title:"Dérogations",manual:"Manuel",force:"Forcé",motion:"Occupation",active:"Actif",off:"Désactivé",ends_in:"se termine dans {time}",active_count:"{count} dérogation(s) active(s)",timeout:"expire dans {time}",reset_manual:"Réinitialiser le mode manuel"},climate:{title:"Climatique",active:"Actif : {strategy}",indoor:"Intérieur",outdoor:"Extérieur",presence:"Présence",sunny:"Ensoleillé",lux:"Lux",irradiance:"Irradiance",mode_off:"Mode climatique désactivé",standby:"En veille",threshold_low:"bas",threshold_high:"haut",threshold_summer_outside:"été",reason:{outside_time_window:"En dehors de la plage horaire de fonctionnement",thresholds_not_met:"Températures dans la plage de confort — aucune action requise",other_mode_active:"Un autre mode de contrôle est actuellement actif",readings_unavailable:"Relevés de température indisponibles",mode_off:"Le mode climatique est désactivé"}},compass:{placeholder_no_entries:"Aucune instance Adaptive Cover Pro sélectionnée.",placeholder_no_sun:"Le capteur solaire n'est pas encore renseigné.",sun_tooltip:"Soleil : {az} az / {el} él",sunrise_tooltip:"Lever du soleil : {time}",sunset_tooltip:"Coucher du soleil : {time}",moon_tooltip:"Lune : {phase} ({pct}%)",sun_path_tooltip:"Trajectoire solaire (aujourd'hui)",in_fov_check:"✓ dans le SAA",in_fov:"dans le SAA",in_fov_tooltip:"Le soleil est actuellement dans l'angle d'acceptation solaire de cette fenêtre",none:"—",sun:"Soleil",moon:"Lune",sun_up_not_hitting:"Soleil (levé, ne frappe pas)",sun_below_horizon:"Soleil (sous l’horizon)",window_fov:"SAA de la fenêtre",sun_path:"Trajectoire solaire",sunrise:"Lever du soleil",sunset:"Coucher du soleil",cover_target:"Cible du store",cover_held:"Position du store (maintenue)",window_normal:"Azimut de la fenêtre",stat_sun:"Soleil : ",stat_azi:"Azi : ",stat_elev:"Élév : ",stat_window:"Fenêtre : ",active_sun_arc:"Arc solaire actif {from} – {to}{elev}",fov_arc:"SAA {left} gauche / {right} droite{elev}",window_normal_tooltip:"Azimut de la fenêtre : {bearing}",cover_position_target:"Cible : {pct}%",cover_position_target_awning:"Cible (déployé) : {pct}%",cover_position_actual:"Réel : {pct}%",blind_spot:"Soleil masqué : {from} - {to}",elev_suffix:" · élév {min}–{max}"},covers:{placeholder:"Aucun store signalé par l'intégration.",title:"Stores",target:"Cible : {pct}",target_solar:"Cible solaire : {pct}",click_to_set:"Cliquer pour définir la position",position_slider_label:"Curseur de position du store",position_open_value:"{pct} ouvert",opening:"Ouverture…",closing:"Fermeture…",target_tooltip:"Cible {pct}%",target_tooltip_override:"Cible solaire théorique {pct}% — le store est maintenu par la commande manuelle",target_tooltip_motor:"Moteur : {pct}% (avant étalonnage)",tilt_title:"Inclinaison",tilt_target:"Inclinaison : {pct}",tilt_click_to_set:"Cliquer pour définir l'inclinaison",tilt_target_tooltip:"Cible inclinaison {pct}%"},decision:{placeholder:"La trace de décision n'est pas encore renseignée.",pipeline:"Pipeline",winner:"Actif : {name}",summary_tooltip:"Pourquoi cette position ?",not_evaluated:"non évalué",floor_suffix:" plancher",outside_schedule:"Hors planning — contrôle automatique en pause",outside_schedule_tooltip:"La fenêtre de planning configurée n'est pas active, le positionnement automatique est donc en pause.",solar_would_be:"solaire {pct}",next_change_in:"Prochain ajustement autorisé dans {time}"},solar:{title:"Calcul solaire",axis_position:"Axe de position",axis_tilt:"Axe d'inclinaison",group_inputs:"Entrées",group_intermediates:"Intermédiaires",group_output:"Sortie",show_all:"Afficher les {count} valeurs",show_less:"Afficher moins",no_target:"Pas de cible solaire — {status}",status:{direct_sun:"Soleil direct",fov_exit:"Par défaut · sortie du SAA",elevation_limit:"Par défaut · limite d'élévation",sunset_offset:"Par défaut · décalage coucher du soleil",blind_spot:"Par défaut · angle mort",default:"Par défaut"},field:{sol_elev_deg:"Élévation du soleil",gamma_deg:"Azimut relatif (γ)",position_pct:"Position",effective_distance_m:"Distance effective",adjusted_height_m:"Hauteur ajustée",safety_margin:"Marge de sécurité",awn_angle_deg:"Angle du store",vertical_position_m:"Position verticale",length_m:"Longueur d'extension",slat_angle_raw_deg:"Angle des lamelles",tilt_mode:"Mode d'inclinaison",max_degrees:"Angle maximal"}},header:{on:"ON",off:"OFF",integration_enabled:"Intégration activée",auto:"Auto",automatic_control:"Contrôle automatique"},tile:{motion_pending:"Délai d'occupation en cours",motion_detected:"Occupation détectée",icon_action_label:"Action de l'icône du store",open:"Ouvrir",stop:"Arrêter",close:"Fermer",resume_aria:"Reprendre le contrôle automatique",extend_aria:"Prolonger la dérogation manuelle",registry_failed:"Échec de la récupération du registre : {error}",loading:"Chargement…",entry_not_found:"Instance Adaptive Cover Pro {entry} introuvable.",unavailable:"Indisponible"},formatters:{expired:"expiré"},elevation:{title:"Soleil aujourd'hui",fov_window:"SAA : {from} → {to}",fov_windows:"SAA : {windows}",fov_window_named:"{name} : {windows}",no_fov_today:"Le soleil n'entre pas dans le SAA aujourd'hui",placeholder:"Graphique d'élévation solaire indisponible.",schedule:"Programmation {from} – {to}",schedule_from:"Programmation à partir de {from}",schedule_until:"Programmation jusqu'à {to}",schedule_start_tooltip:"Début de programmation",schedule_end_tooltip:"Fin de programmation"},control_status:{active:"Actif",outside_time_window:"Hors plage horaire",position_delta_too_small:"Changement de position trop faible",time_delta_too_small:"Trop tôt depuis le dernier mouvement",manual_override:"Dérogation manuelle",automatic_control_off:"Contrôle automatique désactivé",sun_not_visible:"Soleil non visible",force_override_active:"Dérogation forcée",weather_override_active:"Sécurité météo",motion_timeout:"Délai d'occupation"},history:{title:"Historique",open:"Historique",close:"Fermer",refresh:"Actualiser",loading:"Chargement de l'historique…",no_data:"Aucune donnée enregistrée",window_label:"Fenêtre d'historique",window_hours:"{hours} h",show_more:"Afficher plus",expand:"Afficher en plein écran",collapse:"Retour à l'historique",today:"Aujourd'hui",yesterday:"Hier",section_tracks:"Chronologie",track_position:"Position",track_who_won:"Gagnant",track_control_status:"État du contrôle",track_enabled:"Intégration",track_auto:"Contrôle automatique",track_sun:"Soleil dans SAA",track_glare:"Éblouissement",track_manual:"Dérogation manuelle",track_mismatch:"Écart de position",legend_target:"Cible",legend_actual:"Réel",legend_per_cover:"Par store",legend_saa:"Soleil dans SAA",legend_night:"Nuit",stat_moves:"mouvements",stat_travel:"pts parcourus",stat_override:"en dérogation manuelle",copy_diagnostics:"Copier les diagnostics",copied:"Copié",no_recorder_data:"Non enregistré — vérifiez la configuration du recorder",activity_title:"Activité",activity_empty:"Aucune activité enregistrée sur cette période.",advanced:"Avancé — tampon d'événements",events_search:"Filtrer les événements…",events_count:"{shown} événements sur {total}",events_empty:"Aucun événement ne correspond au filtre.",events_unavailable:"Tampon d'événements indisponible — l'intégration n'a pas renvoyé de diagnostics.",buffer_size:"Taille du tampon : {size}",data_window:"Fenêtre du tampon : {from} → {to}"},root:{loading_registry:"Chargement du registre Adaptive Cover Pro…",no_entities_title:"Aucune entité Adaptive Cover Pro trouvée",footer_version:"adaptive-cover-pro-card v{version}",compass_no_match:"Aucune entité Adaptive Cover Pro correspondante",compass_configured:"Instances configurées : {entries}",compass_not_found:"Instances introuvables : {entries}"},editor:{common:{entry_id:"Instance Adaptive Cover Pro",support_alt:"Offrez-moi un café",title_optional:"Titre (facultatif)",title_placeholder:"ex. Fenêtres côté ouest",north_offset:"Décalage nord de la boussole (°)",north_offset_hint:"Faites pivoter la boussole dans le sens horaire pour que « haut » corresponde à votre carte. Par défaut : 0.",loading_entries:"Chargement des entrées de configuration Adaptive Cover Pro…",load_failed:"Échec du chargement des entrées de configuration : {error}",no_entries:"Aucune entrée de configuration Adaptive Cover Pro trouvée. Ajoutez une instance sous",no_entries_path:"Paramètres → Appareils et services",no_entries_then:", puis revenez ici.",entry_id_manual_placeholder:"Saisir manuellement l'ID d'entrée de configuration",entry_id_fallback_label:"ID d'entrée",unknown_entry:"(inconnu : {entry})",reset:"Réinitialiser"},main:{sections:"Sections",sections_hint:"Activer ou désactiver les parties de la carte affichées.",section_sky_label:"Boussole céleste",section_sky_desc:"Soleil par rapport au SAA de la fenêtre, tracé polaire",section_elevation_label:"Soleil aujourd'hui",section_elevation_desc:"Graphique élévation/temps avec bande SAA et curseur temps réel",section_decision_label:"Bande de décision",section_decision_desc:"Les 10 gestionnaires du pipeline avec la ligne gagnante mise en évidence",section_covers_label:"Positions des stores",section_covers_desc:"Barres position réelle/cible par store ; cliquer pour définir la position",section_overrides_label:"Panneau des dérogations",section_overrides_desc:"Tuiles Manuel, Forcé, Occupation + bouton de réinitialisation",section_climate_label:"Panneau climatique",section_climate_desc:"Stratégie été/hiver/intermédiaire ; affiche le mode veille si le mode climatique est désactivé ou inactif",section_solar_label:"Calcul solaire",section_solar_desc:"Décomposition de la géométrie solaire brute (entrées → intermédiaires → sortie) ; nécessite le capteur solar_calculation de l’intégration",controls:"Commandes",controls_hint:"Afficher en lecture seule (visible mais non cliquable).",integration_pill_label:"Bouton ON/OFF de l'intégration",integration_pill_desc:"Permettre de basculer l'intégration depuis l'en-tête de la carte.",automatic_pill_label:"Bouton contrôle automatique",automatic_pill_desc:"Permettre de basculer le contrôle automatique depuis l'en-tête de la carte.",reset_button_label:"Bouton de réinitialisation de la dérogation manuelle",reset_button_desc:"Permettre d'appuyer sur la tuile de réinitialisation dans le panneau des dérogations.",display:"Affichage",compact_label:"Mode compact",compact_desc:"Espacement réduit entre les sections.",show_compass_stats_label:"Afficher les statistiques de la boussole",show_compass_stats_desc:"Azi, Élév, ∠ et angle de fenêtre sous la boussole céleste.",show_compass_legend_label:"Afficher la légende de la boussole",show_compass_legend_desc:"Clé de couleur sous la boussole céleste.",show_moon_label:"Afficher la lune sur la boussole",show_moon_desc:"Position et phase de la lune en superposition sur la boussole céleste.",hide_inactive_label:"Masquer les gestionnaires inactifs",hide_inactive_desc:"Afficher uniquement le gestionnaire sélectionné et les gestionnaires du pipeline actifs.",state_color_label:"Colorer l'icône selon l'état",state_color_desc:"L'icône d'en-tête prend la couleur ouvert/fermé/actif du thème."},tile:{name:"Titre personnalisé",icon:"Icône personnalisée",cover:"Entité de store",layout:"Disposition",show_position:"Afficher la position %",show_state:"Afficher l'état (Ouvert/Fermé)",show_decision_summary:"Afficher le résumé de décision",show_controls:"Afficher les commandes ↑ ■ ↓",covers:"Barres de position (ordre)",covers_hint:"Faites glisser une ligne, ou utilisez les flèches, pour définir l'ordre des barres de position. L'œil masque une barre sans dissocier le volet.",covers_move_up:"Monter",covers_move_down:"Descendre",covers_hide:"Masquer cette barre",covers_show:"Afficher cette barre",controls_cover:"Volet piloté par ↑ ■ ↓",controls_axis:"Axe piloté par ↑ ■ ↓",show_badge:"Afficher le badge contextuel",show_position_bar:"Afficher la barre de position",show_tilt:"Afficher la barre d'inclinaison",content_section:"Contenu",controls_section:"Commandes",dialog_section:"Sections de la boîte de dialogue",group_row_section:"Commandes de groupe",show_scene_select:"Afficher le sélecteur de scène",show_lock:"Afficher le verrouillage du groupe",show_automation:"Afficher l'interrupteur d'automatisation des membres",show_clear_overrides:"Afficher le bouton d’effacement des dérogations",show_member_badges:"Afficher les badges de dérogation des membres",badge_section:"Badges",badge_auto:"Auto",badge_solar:"Suivi solaire",badge_force:"Dérogation forcée",badge_weather:"Sécurité météo",badge_manual:"Dérogation manuelle",badge_custom_position:"Position personnalisée",badge_motion:"Occupation",badge_climate:"Climatique",badge_glare_zone:"Zone d'éblouissement",badge_cloud:"Suppression nuageuse",show_compass:"Afficher la boussole solaire dans le dialogue",show_elevation_chart:"Afficher le graphique du soleil dans le dialogue",show_solar_calc:"Afficher le calcul solaire dans le dialogue",show_motion_icon:"Afficher l'indicateur d'occupation",state_color:"Colorer l'icône selon l'état",interactions_section:"Interactions",tap_action:"Action au toucher",icon_tap_action:"Action au toucher de l'icône",hold_action:"Action au maintien",double_tap_action:"Action au double toucher",cover_blank_hint:"Laisser vide pour utiliser automatiquement le premier store géré.",name_composed_hint:"Un titre composé est défini en YAML. Saisissez un nouveau titre ici pour le remplacer par du texte simple.",layout_option_one_line:"Une ligne (compact)",layout_option_detailed:"Détaillé (titre, état, indicateurs)"},compass:{instances:"Instances Adaptive Cover Pro",instances_hint:"Sélectionnez une ou plusieurs instances. Chaque instance sélectionnée ajoute une superposition à la boussole.",cover_colors:"Couleurs des stores",cover_colors_hint:"Remplacer la couleur de palette par défaut pour chaque superposition.",default_color:"par défaut",display:"Affichage",toggle_compact_label:"Mode compact",toggle_compact_desc:"SVG plus petit, légende masquée.",toggle_legend_label:"Légende",toggle_legend_desc:"Échantillons de couleur et étiquettes d'instance sous la boussole.",toggle_stats_label:"Statistiques",toggle_stats_desc:"Soleil + lignes numériques par fenêtre.",toggle_moon_label:"Lune",toggle_moon_desc:"Afficher la position et la phase de la lune.",toggle_cardinals_label:"Points cardinaux",toggle_cardinals_desc:"Lettres N/E/S/O autour de la boussole.",toggle_blind_spot_label:"Zones de soleil masqué",toggle_blind_spot_desc:"Secteurs hachurés pour la plage où le soleil est masqué de chaque fenêtre.",toggle_sun_path_label:"Trajectoire solaire",toggle_sun_path_desc:"Arc solaire du jour dans le ciel.",toggle_sunrise_sunset_label:"Repères lever / coucher du soleil",toggle_sunrise_sunset_desc:"Petits points aux azimuts de lever et coucher du soleil.",toggle_cover_fill_label:"Remplissage de fermeture du store",toggle_cover_fill_desc:"Secteur intérieur indiquant le taux de fermeture de chaque store.",toggle_window_arrow_label:"Flèche de normale de fenêtre",toggle_window_arrow_desc:"Ligne du centre vers l'azimut de chaque fenêtre.",toggle_elevation_chart_label:"Graphique du soleil",toggle_elevation_chart_desc:"Graphique élévation/temps sous la boussole, avec bande SAA et limites d'élévation."},decision:{title:"Titre (facultatif)",compact_label:"Mode compact",compact_desc:"Lignes plus serrées ; masque aussi les gestionnaires inactifs.",hide_inactive_handlers_label:"Masquer les gestionnaires inactifs",hide_inactive_handlers_desc:"Afficher uniquement le gestionnaire sélectionné et les gestionnaires du pipeline actifs.",show_decision_summary_label:"Afficher le résumé de décision",show_decision_summary_desc:"Afficher une phrase explicite « Pourquoi cette position ? » au-dessus de la bande."},solar_chart:{instances:"Instances Adaptive Cover Pro",instances_hint:"Sélectionnez une ou plusieurs instances. Chaque instance sélectionnée ajoute une superposition SAA au graphique.",cover_colors:"Couleurs des stores",cover_colors_hint:"Remplacer la couleur de palette par défaut pour chaque superposition.",default_color:"par défaut",display:"Affichage",toggle_compact_label:"Mode compact",toggle_compact_desc:"Graphique plus petit, espacement plus serré."},history:{title:"Titre (facultatif)",hours_label:"Fenêtre d'historique",hours_desc:"Profondeur de l'historique affiché, à partir de maintenant.",track_position_label:"Piste Position",track_position_desc:"Position enregistrée du store sur la période.",track_who_won_label:"Piste Gagnant",track_who_won_desc:"Bandes du gestionnaire de pipeline gagnant au fil du temps.",track_context_label:"Pistes de contexte",track_context_desc:"Périodes soleil-dans-SAA, éblouissement et dérogation manuelle.",track_actions_label:"Liste des actions",track_actions_desc:"Actions de store enregistrées et ignorées, les plus récentes en premier.",advanced_open_label:"Ouvrir Avancé au démarrage",advanced_open_desc:"Déplier la section du tampon d'événements au chargement.",hide_advanced_label:"Masquer la section Avancé",hide_advanced_desc:"Ne jamais afficher le tampon d'événements de diagnostic sur cette carte."}}},de:{handler:{force:"Zwangsübersteuerung",weather:"Wettersicherheit",group_scene:"Gruppenszene",manual:"Manuelle Übersteuerung",group_lock:"Gruppensperre",custom_position:"Benutzerdefinierte Position",motion:"Anwesenheits-Timeout",cloud:"Wolkenunterdrückung",climate:"Klima",glare_zone:"Blendungszone",solar:"Sonnenverfolgung",default:"Standard",floor_clamp:"Mindestposition"},badge:{auto:"Auto",manual:"Manuell",force:"Zwang",weather:"Wettersicherheit",glare_zone:"Blendung",climate:"Klima",cloud:"Bewölkt",custom_position:"Benutzerdefiniert",solar:"Sonnenverfolgung",motion:"Anwesenheit inaktiv",off:"Aus",off_schedule:"Außerhalb des Zeitplans",floor_suffix:" ↥",safety:"Sicherheit",group:"Gruppe"},group:{title:"Abdeckungsgruppe",scene:"Szene",scene_auto:"Auto",scene_all_open:"Alle öffnen",scene_all_closed:"Alle schließen",scene_privacy:"Sichtschutz",state_open:"Offen",state_closed:"Geschlossen",state_mixed:"Gemischt",state_unknown:"Unbekannt",lock:"Gruppe sperren",unlock:"Gruppe entsperren",automation:"Automatisierung",automation_count:"{count} von {total} Mitgliedern automatisiert",clear_overrides:"Übersteuerungen löschen",clear_overrides_none:"Keine Mitglieder-Übersteuerungen zum Löschen",who_won:"{count} von {total} Mitgliedern sind gruppengesteuert — eine Gruppenszene oder die Gruppensperre bestimmt derzeit ihre Position",members:"Mitglieder",member_placeholder:"Keine Mitglieder von der Integration gemeldet.",position:"Position",open:"Gruppe öffnen",close:"Gruppe schließen",stop:"Gruppe stoppen",position_slider_label:"Gruppenposition"},forecast:{event:{sunrise:"Sonnenaufgang",sunset:"Sonnenuntergang",fov_enter:"Sonne tritt in den Sonnenakzeptanzwinkel des Fensters ein",fov_exit:"Sonne verlässt den Sonnenakzeptanzwinkel des Fensters"},hover_hint:"Kurve überfahren für Uhrzeit und prognostizierte Position; farbige Linie überfahren für das markierte Ereignis.",solar_only_note:"Nur Sonnengeometrie — berücksichtigt keine manuellen Übersteuerungen, benutzerdefinierten Positionen, Wolkenunterdrückung oder Wetter.",legend_forecast:"Prognose",legend_actual:"Ist"},dialog:{extend:{title:"Manuelle Übersteuerung verlängern",presets_label:"Bis",relative_label:"Zeit hinzufügen",absolute_label:"Ende um",preview:"Übersteuerung bis {time}",confirm:"Verlängern",cancel:"Abbrechen",tomorrow_suffix:" (morgen)"},configure_integration:"Integration konfigurieren",open_device_page:"Geräteseite öffnen",close:"Schließen",target:"Ziel",resume_auto:"Automatik fortsetzen",hide_advanced:"▼ Erweitert ausblenden",show_advanced:"▶ Erweitert",custom_positions:"Benutzerdefinierte Positionen",floor_tooltip:"Mindestposition — hebt die Position über den berechneten Wert",floor:"↥",disable_slot:"Slot {slot} deaktivieren",enable_slot:"Slot {slot} aktivieren",on:"An",off:"Aus",controls:"Steuerung",automatic:"Automatisch",climate:"Klima",motion:"Anwesenheit",toggle_hint:"{label} {state} — tippen zum Umschalten",state_on:"an",state_off:"aus",todays_forecast:"Heutige Prognose"},overrides:{title:"Übersteuerungen",manual:"Manuell",force:"Zwang",motion:"Anwesenheit",active:"Aktiv",off:"Aus",ends_in:"endet in {time}",active_count:"{count} aktiv",timeout:"läuft in {time} ab",reset_manual:"Manuell zurücksetzen"},climate:{title:"Klima",active:"Aktiv: {strategy}",indoor:"Innen",outdoor:"Außen",presence:"Anwesenheit",sunny:"Sonnig",lux:"Lux",irradiance:"Einstrahlung",mode_off:"Klimamodus deaktiviert",standby:"Bereitschaft",threshold_low:"niedrig",threshold_high:"hoch",threshold_summer_outside:"Sommer",reason:{outside_time_window:"Außerhalb des Betriebszeitfensters",thresholds_not_met:"Temperaturen im Komfortbereich — keine Maßnahme erforderlich",other_mode_active:"Ein anderer Steuermodus ist derzeit aktiv",readings_unavailable:"Temperaturwerte nicht verfügbar",mode_off:"Klimamodus ist deaktiviert"}},compass:{placeholder_no_entries:"Kein Adaptive Cover Pro-Eintrag ausgewählt.",placeholder_no_sun:"Sonnensensor noch nicht befüllt.",sun_tooltip:"Sonne: {az} az / {el} el",sunrise_tooltip:"Sonnenaufgang: {time}",sunset_tooltip:"Sonnenuntergang: {time}",moon_tooltip:"Mond: {phase} ({pct}%)",sun_path_tooltip:"Sonnenbahn (heute)",in_fov_check:"✓ im SAA",in_fov:"im SAA",in_fov_tooltip:"Sonne befindet sich derzeit im Sonnenakzeptanzwinkel dieses Fensters",none:"—",sun:"Sonne",moon:"Mond",sun_up_not_hitting:"Sonne (aufgegangen, trifft nicht)",sun_below_horizon:"Sonne (unter dem Horizont)",window_fov:"Fenster-SAA",sun_path:"Sonnenbahn",sunrise:"Sonnenaufgang",sunset:"Sonnenuntergang",cover_target:"Beschattungsziel",cover_held:"Beschattungsposition (gehalten)",window_normal:"Fensterazimut",stat_sun:"Sonne: ",stat_azi:"Azi: ",stat_elev:"Elev: ",stat_window:"Fenster: ",active_sun_arc:"Aktiver Sonnenbogen {from} – {to}{elev}",fov_arc:"SAA {left} links / {right} rechts{elev}",window_normal_tooltip:"Fensterazimut: {bearing}",cover_position_target:"Ziel: {pct}%",cover_position_target_awning:"Ziel (ausgefahren): {pct}%",cover_position_actual:"Aktuell: {pct}%",blind_spot:"Blindfleck: {from} – {to}",elev_suffix:" · Elev {min}–{max}"},covers:{placeholder:"Keine Beschattungen von der Integration gemeldet.",title:"Beschattungen",target:"Ziel: {pct}",target_solar:"Sonnenziel: {pct}",click_to_set:"Klicken zum Festlegen der Position",position_slider_label:"Positionsschieberegler",position_open_value:"{pct} offen",opening:"Öffnet…",closing:"Schließt…",target_tooltip:"Ziel {pct}%",target_tooltip_override:"Theoretisches Sonnenziel {pct}% — Beschattung wird durch manuelle Übersteuerung gehalten",target_tooltip_motor:"Motor: {pct}% (vor Kalibrierung)",tilt_title:"Neigung",tilt_target:"Neigung: {pct}",tilt_click_to_set:"Klicken zum Festlegen der Neigung",tilt_target_tooltip:"Neigungsziel {pct}%"},decision:{placeholder:"Entscheidungsprotokoll noch nicht befüllt.",pipeline:"Pipeline",winner:"Gewinner: {name}",summary_tooltip:"Warum diese Position?",not_evaluated:"nicht ausgewertet",floor_suffix:" Mindestposition",outside_schedule:"Außerhalb des Zeitplans — automatische Steuerung pausiert",outside_schedule_tooltip:"Das konfigurierte Zeitplanfenster ist nicht aktiv, daher ist die automatische Positionierung pausiert.",solar_would_be:"solar {pct}",next_change_in:"Nächste Anpassung erlaubt in {time}"},solar:{title:"Sonnenberechnung",axis_position:"Positionsachse",axis_tilt:"Neigungsachse",group_inputs:"Eingaben",group_intermediates:"Zwischenwerte",group_output:"Ausgabe",show_all:"Alle {count} Werte anzeigen",show_less:"Weniger anzeigen",no_target:"Kein Sonnenziel — {status}",status:{direct_sun:"Direkte Sonne",fov_exit:"Standard · SAA-Austritt",elevation_limit:"Standard · Höhengrenze",sunset_offset:"Standard · Sonnenuntergangs-Versatz",blind_spot:"Standard · Blindfleck",default:"Standard"},field:{sol_elev_deg:"Sonnenhöhe",gamma_deg:"Relativer Azimut (γ)",position_pct:"Position",effective_distance_m:"Effektive Distanz",adjusted_height_m:"Angepasste Höhe",safety_margin:"Sicherheitsabstand",awn_angle_deg:"Markisenwinkel",vertical_position_m:"Vertikale Position",length_m:"Ausfahrlänge",slat_angle_raw_deg:"Lamellenwinkel",tilt_mode:"Neigungsmodus",max_degrees:"Maximaler Winkel"}},header:{on:"ON",off:"OFF",integration_enabled:"Integration aktiviert",auto:"Auto",automatic_control:"Automatische Steuerung"},tile:{motion_pending:"Anwesenheits-Timeout läuft",motion_detected:"Anwesenheit erkannt",icon_action_label:"Aktion des Beschattungssymbols",open:"Öffnen",stop:"Stopp",close:"Schließen",resume_aria:"Automatische Steuerung fortsetzen",extend_aria:"Manuelle Übersteuerung verlängern",registry_failed:"Registry-Abruf fehlgeschlagen: {error}",loading:"Wird geladen…",entry_not_found:"Adaptive Cover Pro-Eintrag {entry} nicht gefunden.",unavailable:"Nicht verfügbar"},formatters:{expired:"abgelaufen"},elevation:{title:"Sonne heute",fov_window:"SAA: {from} → {to}",fov_windows:"SAA: {windows}",fov_window_named:"{name}: {windows}",no_fov_today:"Sonne tritt heute nicht in den SAA ein",placeholder:"Sonnenhöhen-Diagramm nicht verfügbar.",schedule:"Zeitplan {from} – {to}",schedule_from:"Zeitplan ab {from}",schedule_until:"Zeitplan bis {to}",schedule_start_tooltip:"Zeitplanstart",schedule_end_tooltip:"Zeitplanende"},control_status:{active:"Aktiv",outside_time_window:"Außerhalb des Zeitfensters",position_delta_too_small:"Positionsänderung zu gering",time_delta_too_small:"Zu kurz seit der letzten Bewegung",manual_override:"Manuelle Übersteuerung",automatic_control_off:"Automatische Steuerung aus",sun_not_visible:"Sonne nicht sichtbar",force_override_active:"Zwangsübersteuerung",weather_override_active:"Wettersicherheit",motion_timeout:"Anwesenheits-Timeout"},history:{title:"Verlauf",open:"Verlauf",close:"Schließen",refresh:"Aktualisieren",loading:"Verlauf wird geladen…",no_data:"Keine aufgezeichneten Daten",window_label:"Verlaufszeitraum",window_hours:"{hours} Std.",show_more:"Mehr anzeigen",expand:"Vollansicht öffnen",collapse:"Zurück zum Verlauf",today:"Heute",yesterday:"Gestern",section_tracks:"Zeitverlauf",track_position:"Position",track_who_won:"Gewinner",track_control_status:"Steuerungsstatus",track_enabled:"Integration",track_auto:"Automatische Steuerung",track_sun:"Sonne im SAA",track_glare:"Blendung",track_manual:"Manuelle Übersteuerung",track_mismatch:"Positionsabweichung",legend_target:"Ziel",legend_actual:"Ist",legend_per_cover:"Pro Beschattung",legend_saa:"Sonne im SAA",legend_night:"Nacht",stat_moves:"Bewegungen",stat_travel:"Pkt. zurückgelegt",stat_override:"in manueller Übersteuerung",copy_diagnostics:"Diagnose kopieren",copied:"Kopiert",no_recorder_data:"Nicht aufgezeichnet — Recorder-Einstellungen prüfen",activity_title:"Aktivität",activity_empty:"Keine aufgezeichnete Aktivität in diesem Zeitraum.",advanced:"Erweitert — Ereignispuffer",events_search:"Ereignisse filtern…",events_count:"{shown} von {total} Ereignissen",events_empty:"Keine Ereignisse entsprechen dem Filter.",events_unavailable:"Ereignispuffer nicht verfügbar — die Integration hat keine Diagnose zurückgegeben.",buffer_size:"Puffergröße: {size}",data_window:"Pufferzeitraum: {from} → {to}"},root:{loading_registry:"Adaptive Cover Pro-Registry wird geladen…",no_entities_title:"Keine Adaptive Cover Pro-Entitäten gefunden",footer_version:"adaptive-cover-pro-card v{version}",compass_no_match:"Keine passenden Adaptive Cover Pro-Entitäten",compass_configured:"Konfigurierte Einträge: {entries}",compass_not_found:"Einträge nicht gefunden: {entries}"},editor:{common:{entry_id:"Adaptive Cover Pro-Instanz",support_alt:"Kauf mir einen Kaffee",title_optional:"Titel (optional)",title_placeholder:"z. B. Fenster Westseite",north_offset:"Kompass-Nordversatz (°)",north_offset_hint:'Kompass im Uhrzeigersinn drehen, sodass „oben" Ihrer Karte entspricht. Standard: 0.',loading_entries:"Adaptive Cover Pro-Konfigurationseinträge werden geladen…",load_failed:"Konfigurationseinträge konnten nicht geladen werden: {error}",no_entries:"Keine Adaptive Cover Pro-Konfigurationseinträge gefunden. Fügen Sie eine Instanz unter",no_entries_path:"Einstellungen → Geräte & Dienste",no_entries_then:" hinzu und kehren Sie dann zurück.",entry_id_manual_placeholder:"Konfigurations-Eintrags-ID manuell eingeben",entry_id_fallback_label:"Eintrags-ID",unknown_entry:"(unbekannt: {entry})",reset:"Zurücksetzen"},main:{sections:"Abschnitte",sections_hint:"Sichtbare Bereiche der Karte ein- oder ausblenden.",section_sky_label:"Himmelskompass",section_sky_desc:"Sonne vs. Fenster-SAA, Polardiagramm",section_elevation_label:"Sonne heute",section_elevation_desc:"Höhen-Zeit-Diagramm mit SAA-Bereich und aktuellem Zeitcursor",section_decision_label:"Entscheidungsleiste",section_decision_desc:"Alle 10 Pipeline-Handler mit hervorgehobener Gewinnerzeile",section_covers_label:"Beschattungspositionen",section_covers_desc:"Aktuelle und Zielposition je Beschattung; klicken zum Festlegen der Position",section_overrides_label:"Übersteuerungsbereich",section_overrides_desc:"Kacheln für Manuell, Zwang, Anwesenheit + Zurücksetzen-Schaltfläche",section_climate_label:"Klimabereich",section_climate_desc:"Sommer-/Winter-/Übergangsstrategie; zeigt Bereitschaft, wenn Klimamodus deaktiviert oder inaktiv ist",section_solar_label:"Sonnenberechnung",section_solar_desc:"Aufschlüsselung der Sonnengeometrie (Eingaben → Zwischenwerte → Ausgabe); erfordert den solar_calculation-Sensor der Integration",controls:"Steuerung",controls_hint:"Als schreibgeschützt anzeigen (sichtbar, aber nicht klickbar).",integration_pill_label:"Integration EIN/AUS-Schalter",integration_pill_desc:"Integration über den Karten-Header umschalten.",automatic_pill_label:"Automatische Steuerung-Schalter",automatic_pill_desc:"Automatische Steuerung über den Karten-Header umschalten.",reset_button_label:'Schaltfläche „Manuelle Übersteuerung zurücksetzen"',reset_button_desc:"Zurücksetzen-Kachel im Übersteuerungsbereich betätigen lassen.",display:"Anzeige",compact_label:"Kompaktmodus",compact_desc:"Engerer Abstand zwischen Abschnitten.",show_compass_stats_label:"Kompassstatistiken anzeigen",show_compass_stats_desc:"Azi, Elev, ∠ und Fensterwinkel unterhalb des Himmelskompasses.",show_compass_legend_label:"Kompasslegende anzeigen",show_compass_legend_desc:"Farbschlüssel unterhalb des Himmelskompasses.",show_moon_label:"Mond auf Kompass anzeigen",show_moon_desc:"Mondposition und Mondphase als Überlagerung auf dem Himmelskompass.",hide_inactive_label:"Inaktive Handler ausblenden",hide_inactive_desc:"Nur den Gewinner und aktiv übereinstimmende Pipeline-Handler anzeigen.",state_color_label:"Symbol nach Status einfärben",state_color_desc:"Kopfzeilen-Symbol nimmt die Offen/Geschlossen/Aktiv-Farbe des Themes an."},tile:{name:"Titel überschreiben",icon:"Symbol überschreiben",cover:"Beschattungsentität",layout:"Layout",show_position:"Position % anzeigen",show_state:"Status anzeigen (Offen/Geschlossen)",show_decision_summary:"Entscheidungszusammenfassung anzeigen",show_controls:"Steuerung ↑ ■ ↓ anzeigen",covers:"Positionsleisten (Reihenfolge)",covers_hint:"Ziehen Sie eine Zeile oder verwenden Sie die Pfeile, um die Reihenfolge der Positionsleisten festzulegen. Das Auge blendet eine Leiste aus, ohne den Behang zu entfernen.",covers_move_up:"Nach oben",covers_move_down:"Nach unten",covers_hide:"Diese Leiste ausblenden",covers_show:"Diese Leiste anzeigen",controls_cover:"Von ↑ ■ ↓ gesteuerter Behang",controls_axis:"Von ↑ ■ ↓ gesteuerte Achse",show_badge:"Kontextbadge anzeigen",show_position_bar:"Positionsleiste anzeigen",show_tilt:"Neigungsleiste anzeigen",content_section:"Inhalt",controls_section:"Bedienelemente",dialog_section:"Dialogbereiche",group_row_section:"Gruppensteuerung",show_scene_select:"Szenenauswahl anzeigen",show_lock:"Gruppensperre anzeigen",show_automation:"Umschalter für Mitglieder-Automatisierung anzeigen",show_clear_overrides:"Schaltfläche „Übersteuerungen löschen“ anzeigen",show_member_badges:"Mitglieder-Übersteuerungs-Badges anzeigen",badge_section:"Badges",badge_auto:"Auto",badge_solar:"Sonnenverfolgung",badge_force:"Zwangsübersteuerung",badge_weather:"Wettersicherheit",badge_manual:"Manuelle Übersteuerung",badge_custom_position:"Benutzerdefinierte Position",badge_motion:"Anwesenheit",badge_climate:"Klima",badge_glare_zone:"Blendungszone",badge_cloud:"Wolkenunterdrückung",show_compass:"Sonnenkompass im Dialog anzeigen",show_elevation_chart:"Sonne-heute-Diagramm im Dialog anzeigen",show_solar_calc:"Sonnenberechnung im Dialog anzeigen",show_motion_icon:"Anwesenheitsanzeige einblenden",state_color:"Symbol nach Status einfärben",interactions_section:"Interaktionen",tap_action:"Tipp-Aktion",icon_tap_action:"Tipp-Aktion für Symbol",hold_action:"Gedrückthalten-Aktion",double_tap_action:"Doppeltippen-Aktion",cover_blank_hint:"Leer lassen, um automatisch die erste verwaltete Beschattung zu verwenden.",name_composed_hint:"In YAML ist ein zusammengesetzter Titel festgelegt. Hier einen neuen Titel eingeben, um ihn durch einfachen Text zu ersetzen.",layout_option_one_line:"Eine Zeile (kompakt)",layout_option_detailed:"Detailliert (Titel, Status, Indikatoren)"},compass:{instances:"Adaptive Cover Pro-Instanzen",instances_hint:"Eine oder mehrere auswählen. Jeder gewählte Eintrag fügt dem Kompass eine Überlagerung hinzu.",cover_colors:"Beschattungsfarben",cover_colors_hint:"Standardpalettenfarbe für jede Überlagerung überschreiben.",default_color:"Standard",display:"Anzeige",toggle_compact_label:"Kompaktmodus",toggle_compact_desc:"Kleineres SVG, Legende ausgeblendet.",toggle_legend_label:"Legende",toggle_legend_desc:"Farbmuster und Eintragsbezeichnungen unterhalb des Kompasses.",toggle_stats_label:"Statistiken",toggle_stats_desc:"Sonne + numerische Zeilen je Fenster.",toggle_moon_label:"Mond",toggle_moon_desc:"Mondposition und Mondphase anzeigen.",toggle_cardinals_label:"Himmelsrichtungen",toggle_cardinals_desc:"N/O/S/W-Buchstaben rund um den Kompass.",toggle_blind_spot_label:"Blindflecke",toggle_blind_spot_desc:"Schraffierte Sektoren für den Blindfleckbereich jedes Fensters.",toggle_sun_path_label:"Sonnenbahn",toggle_sun_path_desc:"Heutiger Sonnenbogen am Himmel.",toggle_sunrise_sunset_label:"Sonnenaufgangs-/Untergangsmarkierungen",toggle_sunrise_sunset_desc:"Kleine Punkte bei Aufgangs- und Untergangsazimut.",toggle_cover_fill_label:"Schlussfüllbereich der Beschattung",toggle_cover_fill_desc:"Innerer Sektor, der zeigt, wie weit jede Beschattung geschlossen ist.",toggle_window_arrow_label:"Fenster-Normalenpfeil",toggle_window_arrow_desc:"Linie vom Mittelpunkt zum Azimut jedes Fensters.",toggle_elevation_chart_label:"Sonne-heute-Diagramm",toggle_elevation_chart_desc:"Höhen-Zeit-Diagramm unterhalb des Kompasses, mit SAA-Bereich und Höhengrenzen."},decision:{title:"Titel (optional)",compact_label:"Kompaktmodus",compact_desc:"Engere Zeilen; blendet inaktive Handler ebenfalls aus.",hide_inactive_handlers_label:"Inaktive Handler ausblenden",hide_inactive_handlers_desc:"Nur den Gewinner und aktiv übereinstimmende Pipeline-Handler anzeigen.",show_decision_summary_label:"Entscheidungszusammenfassung anzeigen",show_decision_summary_desc:'Einen verständlichen Satz „Warum diese Position?" oberhalb der Leiste anzeigen.'},solar_chart:{instances:"Adaptive Cover Pro-Instanzen",instances_hint:"Eine oder mehrere auswählen. Jeder gewählte Eintrag fügt dem Diagramm eine SAA-Überlagerung hinzu.",cover_colors:"Beschattungsfarben",cover_colors_hint:"Standardpalettenfarbe für jede Überlagerung überschreiben.",default_color:"Standard",display:"Anzeige",toggle_compact_label:"Kompaktmodus",toggle_compact_desc:"Kleineres Diagramm, engerer Abstand."},history:{title:"Titel (optional)",hours_label:"Verlaufszeitraum",hours_desc:"Wie weit die Spuren zurückreichen, gerechnet ab jetzt.",track_position_label:"Positionsspur",track_position_desc:"Aufgezeichnete Beschattungsposition im Zeitraum.",track_who_won_label:"Gewinner-Spur",track_who_won_desc:"Bänder des jeweils gewinnenden Pipeline-Handlers im Zeitverlauf.",track_context_label:"Kontextspuren",track_context_desc:"Zeiträume für Sonne-im-SAA, Blendung und manuelle Übersteuerung.",track_actions_label:"Aktionsliste",track_actions_desc:"Aufgezeichnete und übersprungene Beschattungsaktionen, neueste zuerst.",advanced_open_label:"Erweitert beim Start öffnen",advanced_open_desc:"Den Ereignispuffer-Abschnitt beim Laden ausklappen.",hide_advanced_label:"Erweitert-Abschnitt ausblenden",hide_advanced_desc:"Den Diagnose-Ereignispuffer auf dieser Karte nie anzeigen."}}}};function et(e,t){const o=t.split(".");let i=e;for(const e of o){if("object"!=typeof i||null===i)return;i=i[e]}return"string"==typeof i?i:void 0}function tt(e,t){return t?e.replace(/\{(\w+)\}/g,(e,o)=>Object.prototype.hasOwnProperty.call(t,o)?String(t[o]):e):e}function ot(e,t,o){const i=function(e){const t=(e?.locale?.language??e?.language??"en").toLowerCase().split("-")[0];return t in Je?t:"en"}(t),s=et(Je[i],e);if(void 0!==s)return tt(s,o);if("en"!==i){const t=et(Je.en,e);if(void 0!==t)return tt(t,o)}return e}function it(e){return null==e||Number.isNaN(e)?"—":`${Math.round(e)}%`}function st(e){return!e||"unavailable"===e||"unknown"===e}function nt(e){return!e||"unavailable"===e}function rt(e,t,o){if(!e||!t)return null;const i=e.states[t];if(!i||nt(i.state))return null;const s=o?{...i,state:o}:i;if("function"==typeof e.formatEntityState){const t=e.formatEntityState(s);if(t)return t}if("function"==typeof e.localize){const t=e.localize(`component.cover.entity_component._.state.${s.state}`);if(t)return t}return s.state.charAt(0).toUpperCase()+s.state.slice(1)}function at(e){return null==e||Number.isNaN(e)?"—":`${e.toFixed(1)}°`}function lt(e,t){if(!e)return"—";const o=new Date(e);return Number.isNaN(o.getTime())?"—":o.toLocaleTimeString([],{hour:"2-digit",minute:"2-digit",timeZone:t})}function ct(e,t){if(!e)return"—";const o=new Date(e).getTime();if(Number.isNaN(o))return"—";const i=Math.round((o-Date.now())/1e3);return i<=0?t?ot("formatters.expired",t):"expired":function(e){if(null==e||Number.isNaN(e))return"—";const t=Math.max(0,Math.round(e));if(t<60)return`${t}s`;const o=Math.floor(t/60);return o<60?`${o}m ${t%60}s`:`${Math.floor(o/60)}h ${o%60}m`}(i)}function dt(e,t){if(null!==t&&!Number.isNaN(t)){if(t>=95)return e.open;if(t<=5)return e.closed}return e.partial}function ht(e){const{explicitIcon:t,deviceClass:o,coverType:i,position:s}=e;if("string"==typeof t&&t.length>0)return t;if(o){const e=Ne[o];if(e)return dt(e,s)}return function(e,t){return dt({open:Fe[e]??"mdi:window-shutter-open",partial:Oe[e]??"mdi:window-shutter",closed:Be[e]??"mdi:window-shutter"},t)}(i,s)}function pt(e){return e&&De.has(e)?"mdi:arrow-expand-horizontal":"mdi:arrow-up"}function ut(e){return e&&De.has(e)?"mdi:arrow-collapse-horizontal":"mdi:arrow-down"}function _t(e){if(nt(e)||!e)return"var(--state-unavailable-color)";const t=e.toLowerCase(),o="closed"!==t&&"unknown"!==t?"active":"inactive";return`var(--state-cover-${t}-color, var(--state-cover-${o}-color, var(--state-cover-color, var(--state-${o}-color))))`}function gt(e,t){return t.openBlocksSun?e:t.min+t.max-e}const mt=100,vt="%",ft=new Set(["cover_awning","cover_oscillating_awning"]);function bt(e,t){return"position"===t&&ft.has(e.cover_type)}function yt(e){return e.charAt(0).toUpperCase()+e.slice(1)}function wt(e){const t=e.discovery?.axes;if(Array.isArray(t))return t.filter(e=>!!e&&"string"==typeof e.id&&!1!==e.supported).map(t=>({id:t.id,label:t.label??yt(t.id),min:"number"==typeof t.min?t.min:0,max:"number"==typeof t.max?t.max:mt,unit:"string"==typeof t.unit?t.unit:vt,stateAttr:"string"==typeof t.state_attr?t.state_attr:void 0,targetRole:We[t.id],inverted:!0===t.inverted,openBlocksSun:"boolean"==typeof t.open_blocks_sun?t.open_blocks_sun:bt(e,t.id)}));const o=[{id:"position",label:yt("position"),min:0,max:mt,unit:vt,stateAttr:"current_position",targetRole:"target_position_sensor",inverted:!1,openBlocksSun:bt(e,"position")}];return e.entities.target_tilt_sensor&&o.push({id:"tilt",label:yt("tilt"),min:0,max:mt,unit:vt,stateAttr:"current_tilt_position",targetRole:"target_tilt_sensor",inverted:!1,openBlocksSun:!1}),o}function xt(e){return wt(e).find(e=>"position"===e.id)??{id:"position",label:"Position",min:0,max:mt,unit:vt,stateAttr:"current_position",targetRole:"target_position_sensor",inverted:!1,openBlocksSun:bt(e,"position")}}function $t(e){return wt(e).find(e=>"position"===e.id)?.inverted??!1}const kt=[12,16];function At(e,t,o=0){const i=(e-90+o)*Math.PI/180;return{x:t*Math.cos(i),y:t*Math.sin(i)}}function St(e){return 1-Math.max(0,Math.min(90,e))/90}function Ct(e,t,o,i=0,s=0){const n=e=>(e%360+360)%360,r=n(e),a=n(t);let l=a-r;l<0&&(l+=360);const c=l>180?1:0,d=At(r,o,s),h=At(a,o,s);if(i<=0)return`M 0 0 L ${d.x} ${d.y} A ${o} ${o} 0 ${c} 1 ${h.x} ${h.y} Z`;const p=At(a,i,s),u=At(r,i,s);return[`M ${d.x} ${d.y}`,`A ${o} ${o} 0 ${c} 1 ${h.x} ${h.y}`,`L ${p.x} ${p.y}`,`A ${i} ${i} 0 ${c} 0 ${u.x} ${u.y}`,"Z"].join(" ")}function Et(e,t,o=0){return At(e,St(t),o)}function zt(e){return(e%360+360)%360}function Mt(e,t,o,i){const s=i??0;let n=-1,r=-1;for(let i=t;i<=o&&i<e.length;i++)e[i].elevation>s&&(-1===n&&(n=i),r=i);return-1===n?null:{wedgeStart:e[n].azimuth,wedgeEnd:e[r].azimuth}}function It(e,t,o){const i=(e-t)/864e5;return Math.max(0,Math.min(o,i*o))}function Tt(e,t,o){return t+(1-(Number.isNaN(e)?0:Math.max(0,Math.min(100,e)))/100)*o}function Pt(e,t,o){return((e-t)%360+360)%360<=((o-t)%360+360)%360}function Ot(e,t,o,i){return Pt(o,e,t)||Pt(i,e,t)||Pt(e,o,i)||Pt(t,o,i)}function Ft(e){const t=Object.values(e).filter(e=>"number"==typeof e);return 0===t.length?null:t.reduce((e,t)=>e+t,0)/t.length}function Bt(e,t,o,i){const s=t?e/100:1-e/100;return Math.min(o*s,i)}function Nt(e,t,o){return e&&null!=t&&Number.isFinite(t)?t===o?null:t:null}function Dt(e,t){return e<.5?-4*t*e:4*t*(1-e)}function Rt(e,t,o,i,s){const n=At(o,1),r=-n.y,a=n.x,l=e-n.x*i,c=t-n.y*i;return`M ${e} ${t} L ${l+r*s} ${c+a*s} L ${l-r*s} ${c-a*s} Z`}function jt(e,t){const o=t.entities.target_position_sensor;if(!o)return null;const i=parseFloat(e.states[o]?.state??"");return Number.isNaN(i)?null:i}function Kt(e,t){const o=t.entities.target_position_sensor;if(!o)return null;const i=e.states[o]?.attributes,s=i?.linear_position;return"number"==typeof s&&Number.isFinite(s)?s:null}function Lt(e,t){return Kt(e,t)??jt(e,t)}function Gt(e,t){const o=t.entities.target_position_sensor;if(!o)return null;const i=e.states[o]?.attributes,s=i?.raw_calculated_position;return"number"==typeof s&&Number.isFinite(s)?s:null}function Wt(e,t){const o=t.entities.target_position_sensor;if(!o)return{};const i=e.states[o]?.attributes,s=i?.linear_actual_positions;if(s&&"object"==typeof s)return s;const n=i?.actual_positions;return n?$t(t)?Object.fromEntries(Object.entries(n).map(([e,t])=>[e,"number"==typeof t?100-t:null])):n:{}}function Ht(e,t,o){if(!o)return null;const i=e.states[o]?.attributes?.current_position;return"number"!=typeof i||Number.isNaN(i)?null:$t(t)?100-i:i}function Ut(e,t,o){if(!o||!t.stateAttr)return null;const i=e.states[o]?.attributes?.[t.stateAttr];return"number"!=typeof i||Number.isNaN(i)?null:t.inverted?100-i:i}function Vt(e,t){return Ft(Wt(e,t))}function qt(e,t){const o=t.entities.manual_override_binary;return!!o&&"on"===e.states[o]?.state}function Yt(e,t){const o=Lt(e,t);return Nt(qt(e,t),Gt(e,t),o)??o}const{I:Qt}=re,Zt=e=>e,Xt=()=>document.createComment(""),Jt=(e,t,o)=>{const i=e._$AA.parentNode,s=void 0===t?e._$AB:t._$AA;if(void 0===o){const t=i.insertBefore(Xt(),s),n=i.insertBefore(Xt(),s);o=new Qt(t,n,e,e.options)}else{const t=o._$AB.nextSibling,n=o._$AM,r=n!==e;if(r){let t;o._$AQ?.(e),o._$AM=e,void 0!==o._$AP&&(t=e._$AU)!==n._$AU&&o._$AP(t)}if(t!==s||r){let e=o._$AA;for(;e!==t;){const t=Zt(e).nextSibling;Zt(i).insertBefore(e,s),e=t}}}return o},eo=(e,t,o=e)=>(e._$AI(t,o),e),to={},oo=(e,t=to)=>e._$AH=t,io=e=>{e._$AR(),e._$AA.remove()},so=e=>(...t)=>({_$litDirective$:e,values:t});class no{constructor(e){}get _$AU(){return this._$AM._$AU}_$AT(e,t,o){this._$Ct=e,this._$AM=t,this._$Ci=o}_$AS(e,t){return this.update(e,t)}update(e,t){return this.render(...t)}}const ro=(e,t)=>{const o=e._$AN;if(void 0===o)return!1;for(const e of o)e._$AO?.(t,!1),ro(e,t);return!0},ao=e=>{let t,o;do{if(void 0===(t=e._$AM))break;o=t._$AN,o.delete(e),e=t}while(0===o?.size)},lo=e=>{for(let t;t=e._$AM;e=t){let o=t._$AN;if(void 0===o)t._$AN=o=new Set;else if(o.has(e))break;o.add(e),po(t)}};function co(e){void 0!==this._$AN?(ao(this),this._$AM=e,lo(this)):this._$AM=e}function ho(e,t=!1,o=0){const i=this._$AH,s=this._$AN;if(void 0!==s&&0!==s.size)if(t)if(Array.isArray(i))for(let e=o;e<i.length;e++)ro(i[e],!1),ao(i[e]);else null!=i&&(ro(i,!1),ao(i));else ro(this,e)}const po=e=>{2==e.type&&(e._$AP??=ho,e._$AQ??=co)};class uo extends no{constructor(){super(...arguments),this._$AN=void 0}_$AT(e,t,o){super._$AT(e,t,o),lo(this),this.isConnected=e._$AU}_$AO(e,t=!0){e!==this.isConnected&&(this.isConnected=e,e?this.reconnected?.():this.disconnected?.()),t&&(ro(this,e),ao(this))}setValue(e){if((()=>void 0===this._$Ct.strings)())this._$Ct._$AI(e,this);else{const t=[...this._$Ct._$AH];t[this._$Ci]=e,this._$Ct._$AI(t,this,0)}}disconnected(){}reconnected(){}}let _o=class extends ce{constructor(){super(...arguments),this.text="",this.cursorX=0,this.cursorY=0,this.offset=kt,this.visible=!1,this._x=0,this._y=0}connectedCallback(){super.connectedCallback(),this.hasAttribute("role")||this.setAttribute("role","tooltip")}updated(){if(!this.visible)return;this.setAttribute("aria-hidden","false");const e=this.shadowRoot?.querySelector(".bubble"),t=e?.offsetWidth??0,o=e?.offsetHeight??0,i="undefined"!=typeof window?window.innerWidth:0,s="undefined"!=typeof window?window.innerHeight:0,{x:n,y:r}=function(e){const{cursorX:t,cursorY:o,ttW:i,ttH:s,vpW:n,vpH:r}=e,[a,l]=e.offset??kt;let c=t+a,d=!1;c+i>n&&(c=t-a-i,d=!0),c<0&&(c=0);let h=o+l;return h+s>r&&(h=o-l-s),h<0&&(h=0),{x:c,y:h,flipped:d}}({cursorX:this.cursorX,cursorY:this.cursorY,ttW:t,ttH:o,vpW:i,vpH:s,offset:this.offset});n!==this._x&&(this._x=n),r!==this._y&&(this._y=r)}render(){return this.visible?W`<div class="bubble" style="transform: translate3d(${this._x}px, ${this._y}px, 0)">
+function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPropertyDescriptor(t,o):i;if("object"==typeof Reflect&&"function"==typeof Reflect.decorate)r=Reflect.decorate(e,t,o,i);else for(var a=e.length-1;a>=0;a--)(s=e[a])&&(r=(n<3?s(r):n>3?s(t,o,r):s(t,o))||r);return n>3&&r&&Object.defineProperty(t,o,r),r}"function"==typeof SuppressedError&&SuppressedError;const t=globalThis,o=t.ShadowRoot&&(void 0===t.ShadyCSS||t.ShadyCSS.nativeShadow)&&"adoptedStyleSheets"in Document.prototype&&"replace"in CSSStyleSheet.prototype,i=Symbol(),s=new WeakMap;let n=class{constructor(e,t,o){if(this._$cssResult$=!0,o!==i)throw Error("CSSResult is not constructable. Use `unsafeCSS` or `css` instead.");this.cssText=e,this.t=t}get styleSheet(){let e=this.o;const t=this.t;if(o&&void 0===e){const o=void 0!==t&&1===t.length;o&&(e=s.get(t)),void 0===e&&((this.o=e=new CSSStyleSheet).replaceSync(this.cssText),o&&s.set(t,e))}return e}toString(){return this.cssText}};const r=e=>new n("string"==typeof e?e:e+"",void 0,i),a=(e,...t)=>{const o=1===e.length?e[0]:t.reduce((t,o,i)=>t+(e=>{if(!0===e._$cssResult$)return e.cssText;if("number"==typeof e)return e;throw Error("Value passed to 'css' function must be a 'css' function result: "+e+". Use 'unsafeCSS' to pass non-literal values, but take care to ensure page security.")})(o)+e[i+1],e[0]);return new n(o,e,i)},l=o?e=>e:e=>e instanceof CSSStyleSheet?(e=>{let t="";for(const o of e.cssRules)t+=o.cssText;return r(t)})(e):e,{is:c,defineProperty:d,getOwnPropertyDescriptor:h,getOwnPropertyNames:p,getOwnPropertySymbols:u,getPrototypeOf:_}=Object,g=globalThis,m=g.trustedTypes,v=m?m.emptyScript:"",f=g.reactiveElementPolyfillSupport,b=(e,t)=>e,y={toAttribute(e,t){switch(t){case Boolean:e=e?v:null;break;case Object:case Array:e=null==e?e:JSON.stringify(e)}return e},fromAttribute(e,t){let o=e;switch(t){case Boolean:o=null!==e;break;case Number:o=null===e?null:Number(e);break;case Object:case Array:try{o=JSON.parse(e)}catch(e){o=null}}return o}},w=(e,t)=>!c(e,t),x={attribute:!0,type:String,converter:y,reflect:!1,useDefault:!1,hasChanged:w};Symbol.metadata??=Symbol("metadata"),g.litPropertyMetadata??=new WeakMap;let $=class extends HTMLElement{static addInitializer(e){this._$Ei(),(this.l??=[]).push(e)}static get observedAttributes(){return this.finalize(),this._$Eh&&[...this._$Eh.keys()]}static createProperty(e,t=x){if(t.state&&(t.attribute=!1),this._$Ei(),this.prototype.hasOwnProperty(e)&&((t=Object.create(t)).wrapped=!0),this.elementProperties.set(e,t),!t.noAccessor){const o=Symbol(),i=this.getPropertyDescriptor(e,o,t);void 0!==i&&d(this.prototype,e,i)}}static getPropertyDescriptor(e,t,o){const{get:i,set:s}=h(this.prototype,e)??{get(){return this[t]},set(e){this[t]=e}};return{get:i,set(t){const n=i?.call(this);s?.call(this,t),this.requestUpdate(e,n,o)},configurable:!0,enumerable:!0}}static getPropertyOptions(e){return this.elementProperties.get(e)??x}static _$Ei(){if(this.hasOwnProperty(b("elementProperties")))return;const e=_(this);e.finalize(),void 0!==e.l&&(this.l=[...e.l]),this.elementProperties=new Map(e.elementProperties)}static finalize(){if(this.hasOwnProperty(b("finalized")))return;if(this.finalized=!0,this._$Ei(),this.hasOwnProperty(b("properties"))){const e=this.properties,t=[...p(e),...u(e)];for(const o of t)this.createProperty(o,e[o])}const e=this[Symbol.metadata];if(null!==e){const t=litPropertyMetadata.get(e);if(void 0!==t)for(const[e,o]of t)this.elementProperties.set(e,o)}this._$Eh=new Map;for(const[e,t]of this.elementProperties){const o=this._$Eu(e,t);void 0!==o&&this._$Eh.set(o,e)}this.elementStyles=this.finalizeStyles(this.styles)}static finalizeStyles(e){const t=[];if(Array.isArray(e)){const o=new Set(e.flat(1/0).reverse());for(const e of o)t.unshift(l(e))}else void 0!==e&&t.push(l(e));return t}static _$Eu(e,t){const o=t.attribute;return!1===o?void 0:"string"==typeof o?o:"string"==typeof e?e.toLowerCase():void 0}constructor(){super(),this._$Ep=void 0,this.isUpdatePending=!1,this.hasUpdated=!1,this._$Em=null,this._$Ev()}_$Ev(){this._$ES=new Promise(e=>this.enableUpdating=e),this._$AL=new Map,this._$E_(),this.requestUpdate(),this.constructor.l?.forEach(e=>e(this))}addController(e){(this._$EO??=new Set).add(e),void 0!==this.renderRoot&&this.isConnected&&e.hostConnected?.()}removeController(e){this._$EO?.delete(e)}_$E_(){const e=new Map,t=this.constructor.elementProperties;for(const o of t.keys())this.hasOwnProperty(o)&&(e.set(o,this[o]),delete this[o]);e.size>0&&(this._$Ep=e)}createRenderRoot(){const e=this.shadowRoot??this.attachShadow(this.constructor.shadowRootOptions);return((e,i)=>{if(o)e.adoptedStyleSheets=i.map(e=>e instanceof CSSStyleSheet?e:e.styleSheet);else for(const o of i){const i=document.createElement("style"),s=t.litNonce;void 0!==s&&i.setAttribute("nonce",s),i.textContent=o.cssText,e.appendChild(i)}})(e,this.constructor.elementStyles),e}connectedCallback(){this.renderRoot??=this.createRenderRoot(),this.enableUpdating(!0),this._$EO?.forEach(e=>e.hostConnected?.())}enableUpdating(e){}disconnectedCallback(){this._$EO?.forEach(e=>e.hostDisconnected?.())}attributeChangedCallback(e,t,o){this._$AK(e,o)}_$ET(e,t){const o=this.constructor.elementProperties.get(e),i=this.constructor._$Eu(e,o);if(void 0!==i&&!0===o.reflect){const s=(void 0!==o.converter?.toAttribute?o.converter:y).toAttribute(t,o.type);this._$Em=e,null==s?this.removeAttribute(i):this.setAttribute(i,s),this._$Em=null}}_$AK(e,t){const o=this.constructor,i=o._$Eh.get(e);if(void 0!==i&&this._$Em!==i){const e=o.getPropertyOptions(i),s="function"==typeof e.converter?{fromAttribute:e.converter}:void 0!==e.converter?.fromAttribute?e.converter:y;this._$Em=i;const n=s.fromAttribute(t,e.type);this[i]=n??this._$Ej?.get(i)??n,this._$Em=null}}requestUpdate(e,t,o,i=!1,s){if(void 0!==e){const n=this.constructor;if(!1===i&&(s=this[e]),o??=n.getPropertyOptions(e),!((o.hasChanged??w)(s,t)||o.useDefault&&o.reflect&&s===this._$Ej?.get(e)&&!this.hasAttribute(n._$Eu(e,o))))return;this.C(e,t,o)}!1===this.isUpdatePending&&(this._$ES=this._$EP())}C(e,t,{useDefault:o,reflect:i,wrapped:s},n){o&&!(this._$Ej??=new Map).has(e)&&(this._$Ej.set(e,n??t??this[e]),!0!==s||void 0!==n)||(this._$AL.has(e)||(this.hasUpdated||o||(t=void 0),this._$AL.set(e,t)),!0===i&&this._$Em!==e&&(this._$Eq??=new Set).add(e))}async _$EP(){this.isUpdatePending=!0;try{await this._$ES}catch(e){Promise.reject(e)}const e=this.scheduleUpdate();return null!=e&&await e,!this.isUpdatePending}scheduleUpdate(){return this.performUpdate()}performUpdate(){if(!this.isUpdatePending)return;if(!this.hasUpdated){if(this.renderRoot??=this.createRenderRoot(),this._$Ep){for(const[e,t]of this._$Ep)this[e]=t;this._$Ep=void 0}const e=this.constructor.elementProperties;if(e.size>0)for(const[t,o]of e){const{wrapped:e}=o,i=this[t];!0!==e||this._$AL.has(t)||void 0===i||this.C(t,void 0,o,i)}}let e=!1;const t=this._$AL;try{e=this.shouldUpdate(t),e?(this.willUpdate(t),this._$EO?.forEach(e=>e.hostUpdate?.()),this.update(t)):this._$EM()}catch(t){throw e=!1,this._$EM(),t}e&&this._$AE(t)}willUpdate(e){}_$AE(e){this._$EO?.forEach(e=>e.hostUpdated?.()),this.hasUpdated||(this.hasUpdated=!0,this.firstUpdated(e)),this.updated(e)}_$EM(){this._$AL=new Map,this.isUpdatePending=!1}get updateComplete(){return this.getUpdateComplete()}getUpdateComplete(){return this._$ES}shouldUpdate(e){return!0}update(e){this._$Eq&&=this._$Eq.forEach(e=>this._$ET(e,this[e])),this._$EM()}updated(e){}firstUpdated(e){}};$.elementStyles=[],$.shadowRootOptions={mode:"open"},$[b("elementProperties")]=new Map,$[b("finalized")]=new Map,f?.({ReactiveElement:$}),(g.reactiveElementVersions??=[]).push("2.1.2");const k=globalThis,A=e=>e,S=k.trustedTypes,C=S?S.createPolicy("lit-html",{createHTML:e=>e}):void 0,E="$lit$",z=`lit$${Math.random().toFixed(9).slice(2)}$`,M="?"+z,T=`<${M}>`,I=document,P=()=>I.createComment(""),O=e=>null===e||"object"!=typeof e&&"function"!=typeof e,B=Array.isArray,F="[ \t\n\f\r]",N=/<(?:(!--|\/[^a-zA-Z])|(\/?[a-zA-Z][^>\s]*)|(\/?$))/g,D=/-->/g,R=/>/g,j=RegExp(`>|${F}(?:([^\\s"'>=/]+)(${F}*=${F}*(?:[^ \t\n\f\r"'\`<>=]|("|')|))|$)`,"g"),K=/'/g,L=/"/g,G=/^(?:script|style|textarea|title)$/i,W=e=>(t,...o)=>({_$litType$:e,strings:t,values:o}),H=W(1),U=W(2),V=Symbol.for("lit-noChange"),q=Symbol.for("lit-nothing"),Y=new WeakMap,Q=I.createTreeWalker(I,129);function Z(e,t){if(!B(e)||!e.hasOwnProperty("raw"))throw Error("invalid template strings array");return void 0!==C?C.createHTML(t):t}class X{constructor({strings:e,_$litType$:t},o){let i;this.parts=[];let s=0,n=0;const r=e.length-1,a=this.parts,[l,c]=((e,t)=>{const o=e.length-1,i=[];let s,n=2===t?"<svg>":3===t?"<math>":"",r=N;for(let t=0;t<o;t++){const o=e[t];let a,l,c=-1,d=0;for(;d<o.length&&(r.lastIndex=d,l=r.exec(o),null!==l);)d=r.lastIndex,r===N?"!--"===l[1]?r=D:void 0!==l[1]?r=R:void 0!==l[2]?(G.test(l[2])&&(s=RegExp("</"+l[2],"g")),r=j):void 0!==l[3]&&(r=j):r===j?">"===l[0]?(r=s??N,c=-1):void 0===l[1]?c=-2:(c=r.lastIndex-l[2].length,a=l[1],r=void 0===l[3]?j:'"'===l[3]?L:K):r===L||r===K?r=j:r===D||r===R?r=N:(r=j,s=void 0);const h=r===j&&e[t+1].startsWith("/>")?" ":"";n+=r===N?o+T:c>=0?(i.push(a),o.slice(0,c)+E+o.slice(c)+z+h):o+z+(-2===c?t:h)}return[Z(e,n+(e[o]||"<?>")+(2===t?"</svg>":3===t?"</math>":"")),i]})(e,t);if(this.el=X.createElement(l,o),Q.currentNode=this.el.content,2===t||3===t){const e=this.el.content.firstChild;e.replaceWith(...e.childNodes)}for(;null!==(i=Q.nextNode())&&a.length<r;){if(1===i.nodeType){if(i.hasAttributes())for(const e of i.getAttributeNames())if(e.endsWith(E)){const t=c[n++],o=i.getAttribute(e).split(z),r=/([.?@])?(.*)/.exec(t);a.push({type:1,index:s,name:r[2],strings:o,ctor:"."===r[1]?ie:"?"===r[1]?se:"@"===r[1]?ne:oe}),i.removeAttribute(e)}else e.startsWith(z)&&(a.push({type:6,index:s}),i.removeAttribute(e));if(G.test(i.tagName)){const e=i.textContent.split(z),t=e.length-1;if(t>0){i.textContent=S?S.emptyScript:"";for(let o=0;o<t;o++)i.append(e[o],P()),Q.nextNode(),a.push({type:2,index:++s});i.append(e[t],P())}}}else if(8===i.nodeType)if(i.data===M)a.push({type:2,index:s});else{let e=-1;for(;-1!==(e=i.data.indexOf(z,e+1));)a.push({type:7,index:s}),e+=z.length-1}s++}}static createElement(e,t){const o=I.createElement("template");return o.innerHTML=e,o}}function J(e,t,o=e,i){if(t===V)return t;let s=void 0!==i?o._$Co?.[i]:o._$Cl;const n=O(t)?void 0:t._$litDirective$;return s?.constructor!==n&&(s?._$AO?.(!1),void 0===n?s=void 0:(s=new n(e),s._$AT(e,o,i)),void 0!==i?(o._$Co??=[])[i]=s:o._$Cl=s),void 0!==s&&(t=J(e,s._$AS(e,t.values),s,i)),t}class ee{constructor(e,t){this._$AV=[],this._$AN=void 0,this._$AD=e,this._$AM=t}get parentNode(){return this._$AM.parentNode}get _$AU(){return this._$AM._$AU}u(e){const{el:{content:t},parts:o}=this._$AD,i=(e?.creationScope??I).importNode(t,!0);Q.currentNode=i;let s=Q.nextNode(),n=0,r=0,a=o[0];for(;void 0!==a;){if(n===a.index){let t;2===a.type?t=new te(s,s.nextSibling,this,e):1===a.type?t=new a.ctor(s,a.name,a.strings,this,e):6===a.type&&(t=new re(s,this,e)),this._$AV.push(t),a=o[++r]}n!==a?.index&&(s=Q.nextNode(),n++)}return Q.currentNode=I,i}p(e){let t=0;for(const o of this._$AV)void 0!==o&&(void 0!==o.strings?(o._$AI(e,o,t),t+=o.strings.length-2):o._$AI(e[t])),t++}}class te{get _$AU(){return this._$AM?._$AU??this._$Cv}constructor(e,t,o,i){this.type=2,this._$AH=q,this._$AN=void 0,this._$AA=e,this._$AB=t,this._$AM=o,this.options=i,this._$Cv=i?.isConnected??!0}get parentNode(){let e=this._$AA.parentNode;const t=this._$AM;return void 0!==t&&11===e?.nodeType&&(e=t.parentNode),e}get startNode(){return this._$AA}get endNode(){return this._$AB}_$AI(e,t=this){e=J(this,e,t),O(e)?e===q||null==e||""===e?(this._$AH!==q&&this._$AR(),this._$AH=q):e!==this._$AH&&e!==V&&this._(e):void 0!==e._$litType$?this.$(e):void 0!==e.nodeType?this.T(e):(e=>B(e)||"function"==typeof e?.[Symbol.iterator])(e)?this.k(e):this._(e)}O(e){return this._$AA.parentNode.insertBefore(e,this._$AB)}T(e){this._$AH!==e&&(this._$AR(),this._$AH=this.O(e))}_(e){this._$AH!==q&&O(this._$AH)?this._$AA.nextSibling.data=e:this.T(I.createTextNode(e)),this._$AH=e}$(e){const{values:t,_$litType$:o}=e,i="number"==typeof o?this._$AC(e):(void 0===o.el&&(o.el=X.createElement(Z(o.h,o.h[0]),this.options)),o);if(this._$AH?._$AD===i)this._$AH.p(t);else{const e=new ee(i,this),o=e.u(this.options);e.p(t),this.T(o),this._$AH=e}}_$AC(e){let t=Y.get(e.strings);return void 0===t&&Y.set(e.strings,t=new X(e)),t}k(e){B(this._$AH)||(this._$AH=[],this._$AR());const t=this._$AH;let o,i=0;for(const s of e)i===t.length?t.push(o=new te(this.O(P()),this.O(P()),this,this.options)):o=t[i],o._$AI(s),i++;i<t.length&&(this._$AR(o&&o._$AB.nextSibling,i),t.length=i)}_$AR(e=this._$AA.nextSibling,t){for(this._$AP?.(!1,!0,t);e!==this._$AB;){const t=A(e).nextSibling;A(e).remove(),e=t}}setConnected(e){void 0===this._$AM&&(this._$Cv=e,this._$AP?.(e))}}class oe{get tagName(){return this.element.tagName}get _$AU(){return this._$AM._$AU}constructor(e,t,o,i,s){this.type=1,this._$AH=q,this._$AN=void 0,this.element=e,this.name=t,this._$AM=i,this.options=s,o.length>2||""!==o[0]||""!==o[1]?(this._$AH=Array(o.length-1).fill(new String),this.strings=o):this._$AH=q}_$AI(e,t=this,o,i){const s=this.strings;let n=!1;if(void 0===s)e=J(this,e,t,0),n=!O(e)||e!==this._$AH&&e!==V,n&&(this._$AH=e);else{const i=e;let r,a;for(e=s[0],r=0;r<s.length-1;r++)a=J(this,i[o+r],t,r),a===V&&(a=this._$AH[r]),n||=!O(a)||a!==this._$AH[r],a===q?e=q:e!==q&&(e+=(a??"")+s[r+1]),this._$AH[r]=a}n&&!i&&this.j(e)}j(e){e===q?this.element.removeAttribute(this.name):this.element.setAttribute(this.name,e??"")}}class ie extends oe{constructor(){super(...arguments),this.type=3}j(e){this.element[this.name]=e===q?void 0:e}}class se extends oe{constructor(){super(...arguments),this.type=4}j(e){this.element.toggleAttribute(this.name,!!e&&e!==q)}}class ne extends oe{constructor(e,t,o,i,s){super(e,t,o,i,s),this.type=5}_$AI(e,t=this){if((e=J(this,e,t,0)??q)===V)return;const o=this._$AH,i=e===q&&o!==q||e.capture!==o.capture||e.once!==o.once||e.passive!==o.passive,s=e!==q&&(o===q||i);i&&this.element.removeEventListener(this.name,this,o),s&&this.element.addEventListener(this.name,this,e),this._$AH=e}handleEvent(e){"function"==typeof this._$AH?this._$AH.call(this.options?.host??this.element,e):this._$AH.handleEvent(e)}}class re{constructor(e,t,o){this.element=e,this.type=6,this._$AN=void 0,this._$AM=t,this.options=o}get _$AU(){return this._$AM._$AU}_$AI(e){J(this,e)}}const ae={I:te},le=k.litHtmlPolyfillSupport;le?.(X,te),(k.litHtmlVersions??=[]).push("3.3.2");const ce=globalThis;let de=class extends ${constructor(){super(...arguments),this.renderOptions={host:this},this._$Do=void 0}createRenderRoot(){const e=super.createRenderRoot();return this.renderOptions.renderBefore??=e.firstChild,e}update(e){const t=this.render();this.hasUpdated||(this.renderOptions.isConnected=this.isConnected),super.update(e),this._$Do=((e,t,o)=>{const i=o?.renderBefore??t;let s=i._$litPart$;if(void 0===s){const e=o?.renderBefore??null;i._$litPart$=s=new te(t.insertBefore(P(),e),e,void 0,o??{})}return s._$AI(e),s})(t,this.renderRoot,this.renderOptions)}connectedCallback(){super.connectedCallback(),this._$Do?.setConnected(!0)}disconnectedCallback(){super.disconnectedCallback(),this._$Do?.setConnected(!1)}render(){return V}};de._$litElement$=!0,de.finalized=!0,ce.litElementHydrateSupport?.({LitElement:de});const he=ce.litElementPolyfillSupport;he?.({LitElement:de}),(ce.litElementVersions??=[]).push("4.2.2");const pe=e=>(t,o)=>{void 0!==o?o.addInitializer(()=>{customElements.define(e,t)}):customElements.define(e,t)},ue={attribute:!0,type:String,converter:y,reflect:!1,hasChanged:w},_e=(e=ue,t,o)=>{const{kind:i,metadata:s}=o;let n=globalThis.litPropertyMetadata.get(s);if(void 0===n&&globalThis.litPropertyMetadata.set(s,n=new Map),"setter"===i&&((e=Object.create(e)).wrapped=!0),n.set(o.name,e),"accessor"===i){const{name:i}=o;return{set(o){const s=t.get.call(this);t.set.call(this,o),this.requestUpdate(i,s,e,!0,o)},init(t){return void 0!==t&&this.C(i,void 0,e,t),t}}}if("setter"===i){const{name:i}=o;return function(o){const s=this[i];t.call(this,o),this.requestUpdate(i,s,e,!0,o)}}throw Error("Unsupported decorator location: "+i)};function ge(e){return(t,o)=>"object"==typeof o?_e(e,t,o):((e,t,o)=>{const i=t.hasOwnProperty(o);return t.constructor.createProperty(o,e),i?Object.getOwnPropertyDescriptor(t,o):void 0})(e,t,o)}function me(e){return ge({...e,state:!0,attribute:!1})}function ve(e,t,o){if(!e)return!0;for(const i of o)if(i&&e.states[i]!==t.states[i])return!0;return!1}const fe="2.15.0",be="adaptive-cover-pro-card",ye="adaptive-cover-pro-card-editor",we="adaptive-cover-pro-sky-compass-card",xe="adaptive-cover-pro-sky-compass-card-editor",$e="adaptive-cover-pro-tile-card",ke="adaptive-cover-pro-tile-card-editor",Ae="adaptive-cover-pro-decision-card",Se="adaptive-cover-pro-decision-card-editor",Ce="adaptive-cover-pro-solar-chart-card",Ee="adaptive-cover-pro-solar-chart-card-editor",ze="adaptive-cover-pro-history-card",Me="adaptive-cover-pro-history-card-editor",Te="adaptive_cover_pro",Ie=["force","weather","group_scene","manual","group_lock","custom_position","motion","cloud","climate","glare_zone","solar","default","floor_clamp"],Pe={force:"Force Override",weather:"Weather Safety",group_scene:"Group Scene",manual:"Manual Override",group_lock:"Group Lock",custom_position:"Custom Position",motion:"Occupancy Timeout",cloud:"Cloud Suppression",climate:"Climate",glare_zone:"Glare Zone",solar:"Solar Tracking",default:"Default",floor_clamp:"Min Floor"},Oe={force:"handler.force",weather:"handler.weather",group_scene:"handler.group_scene",manual:"handler.manual",group_lock:"handler.group_lock",custom_position:"handler.custom_position",motion:"handler.motion",cloud:"handler.cloud",climate:"handler.climate",glare_zone:"handler.glare_zone",solar:"handler.solar",default:"handler.default",floor_clamp:"handler.floor_clamp"},Be={cover_blind:"mdi:blinds-horizontal",cover_awning:"mdi:awning-outline",cover_tilt:"mdi:blinds",cover_venetian:"mdi:blinds"},Fe={cover_blind:"mdi:blinds-open",cover_awning:"mdi:awning-outline",cover_tilt:"mdi:blinds-open",cover_venetian:"mdi:blinds-open"},Ne={cover_blind:"mdi:blinds-horizontal-closed",cover_awning:"mdi:window-closed-variant",cover_tilt:"mdi:blinds",cover_venetian:"mdi:blinds"},De={awning:{open:"mdi:awning-outline",partial:"mdi:awning-outline",closed:"mdi:awning-outline"},blind:{open:"mdi:blinds-open",partial:"mdi:blinds-horizontal",closed:"mdi:blinds-horizontal-closed"},curtain:{open:"mdi:curtains",partial:"mdi:curtains",closed:"mdi:curtains-closed"},damper:{open:"mdi:circle",partial:"mdi:circle-slice-8",closed:"mdi:circle-slice-8"},door:{open:"mdi:door-open",partial:"mdi:door-open",closed:"mdi:door-closed"},garage:{open:"mdi:garage-open",partial:"mdi:garage-open",closed:"mdi:garage"},gate:{open:"mdi:gate-open",partial:"mdi:gate-open",closed:"mdi:gate"},shade:{open:"mdi:roller-shade",partial:"mdi:roller-shade",closed:"mdi:roller-shade-closed"},shutter:{open:"mdi:window-shutter-open",partial:"mdi:window-shutter",closed:"mdi:window-shutter"},window:{open:"mdi:window-open",partial:"mdi:window-open",closed:"mdi:window-closed"}},Re=new Set(["awning","curtain","door","gate"]),je={manual:"manual",force:"force",weather:"weather",glare_zone:"glare_zone",climate:"climate",cloud:"cloud",custom_position:"custom_position",solar:"solar",motion:"motion",group_scene:"group",group_lock:"group"},Ke={auto:{label:"Auto",bg:"rgba(76, 175, 80, 0.18)",fg:"#2e7d32"},manual:{label:"Manual",bg:"rgba(255, 152, 0, 0.22)",fg:"#e65100"},force:{label:"Force",bg:"rgba(244, 67, 54, 0.22)",fg:"#b71c1c"},weather:{label:"Sun protection",bg:"rgba(244, 67, 54, 0.22)",fg:"#b71c1c"},glare_zone:{label:"Glare",bg:"rgba(244, 67, 54, 0.22)",fg:"#b71c1c"},climate:{label:"Climate",bg:"rgba(0, 150, 136, 0.22)",fg:"#00695c"},cloud:{label:"Cloudy",bg:"rgba(33, 150, 243, 0.22)",fg:"#0d47a1"},custom_position:{label:"Custom",bg:"rgba(156, 39, 176, 0.22)",fg:"#6a1b9a"},solar:{label:"Solar tracking",bg:"rgba(76, 175, 80, 0.22)",fg:"#1b5e20"},motion:{label:"Occupancy",bg:"rgba(255, 235, 59, 0.22)",fg:"#827717"},off:{label:"Off",bg:"rgba(97, 97, 97, 0.28)",fg:"#212121"},off_schedule:{label:"Off-schedule",bg:"rgba(96, 125, 139, 0.22)",fg:"#37474f"},group:{label:"Group",bg:"rgba(76, 175, 80, 0.18)",fg:"#2e7d32"}},Le={auto:"badge.auto",manual:"badge.manual",force:"badge.force",weather:"badge.weather",glare_zone:"badge.glare_zone",climate:"badge.climate",cloud:"badge.cloud",custom_position:"badge.custom_position",solar:"badge.solar",motion:"badge.motion",off:"badge.off",off_schedule:"badge.off_schedule",group:"badge.group"},Ge={auto:"mdi:autorenew",manual:"mdi:hand-back-right",force:"mdi:flash",weather:"mdi:shield-sun",glare_zone:"mdi:weather-sunny-alert",climate:"mdi:thermostat",cloud:"mdi:weather-cloudy",custom_position:"mdi:bookmark",solar:"mdi:white-balance-sunny",motion:"mdi:motion-sensor",off:"mdi:power",off_schedule:"mdi:clock-alert-outline",group:"mdi:window-shutter-cog"},We={integration_enabled:!0,automatic_control:!0,reset_manual_override:!0},He={position:"target_position_sensor",tilt:"target_tilt_sensor"},Ue={tilt:"covers.tilt_title"},Ve="mdi:chart-box",qe={active:"control_status.active",outside_time_window:"control_status.outside_time_window",position_delta_too_small:"control_status.position_delta_too_small",time_delta_too_small:"control_status.time_delta_too_small",manual_override:"control_status.manual_override",automatic_control_off:"control_status.automatic_control_off",sun_not_visible:"control_status.sun_not_visible",force_override_active:"control_status.force_override_active",weather_override_active:"control_status.weather_override_active",motion_timeout:"control_status.motion_timeout"},Ye=new Set(["active"]),Qe=[{role:"integration_enabled_switch",key:"history.track_enabled",cls:"ctx-enabled"},{role:"automatic_control_switch",key:"history.track_auto",cls:"ctx-auto"},{role:"sun_infront_binary",key:"history.track_sun",cls:"ctx-sun"},{role:"glare_active_binary",key:"history.track_glare",cls:"ctx-glare"},{role:"manual_override_binary",key:"history.track_manual",cls:"ctx-manual"},{role:"position_mismatch_binary",key:"history.track_mismatch",cls:"ctx-mismatch"}],Ze=[6,12,24,48,72],Xe={pipeline_evaluated:"info",cover_command_sent:"action",cover_command_skipped:"warn",end_time_default_sent:"action",manual_override_gate_closed:"warn",sun_entered_fov:"info",sun_left_fov:"info",sunset_window_opened:"info",transit_cleared:"info",transit_optimistic_target_replay:"info",transit_progress_forward:"info",transit_startup_delay:"warn",transit_timeout_cleared:"warn",reconcile_gave_up:"warn",reconcile_skipped_in_transit:"warn"},Je={"sensor:Cover_Position":"target_position_sensor","sensor:Cover_Tilt":"target_tilt_sensor","sensor:sun_position":"sun_sensor","sensor:Start Sun":"start_sensor","sensor:End Sun":"end_sensor","sensor:control_status":"control_status_sensor","sensor:decision_trace":"decision_trace_sensor","sensor:last_cover_action":"last_action_sensor","sensor:last_skipped_action":"last_skipped_sensor","sensor:manual_override_end_time":"manual_override_end_sensor","sensor:position_verification":"position_verification_sensor","sensor:motion_status":"motion_status_sensor","sensor:climate_status":"climate_status_sensor","sensor:position_forecast":"position_forecast_sensor","sensor:solar_calculation":"solar_calculation_sensor","binary_sensor:sun_motion":"sun_infront_binary","binary_sensor:manual_override":"manual_override_binary","binary_sensor:position_mismatch":"position_mismatch_binary","binary_sensor:glare_active":"glare_active_binary","switch:Integration Enabled":"integration_enabled_switch","switch:Automatic Control":"automatic_control_switch","switch:Manual Override":"manual_toggle_switch","switch:Climate Mode":"climate_mode_switch","switch:Motion Control":"motion_control_switch","button:Reset Manual Override":"reset_override_button","sensor:group_position":"group_position_sensor","sensor:group_state":"group_state_sensor","sensor:group_active_scene":"group_active_scene_sensor","sensor:group_climate_mode":"group_climate_mode_sensor","sensor:group_who_won":"group_who_won_sensor","select:group_scene_select":"group_scene_select","switch:group_automation":"group_automation_switch","switch:group_lock":"group_lock_switch","button:group_scene_all_open":"group_scene_all_open_button","button:group_scene_all_closed":"group_scene_all_closed_button","button:group_scene_privacy":"group_scene_privacy_button","button:group_clear_overrides":"group_clear_overrides_button","cover:group_cover":"group_cover"},et={en:{handler:{force:"Force Override",weather:"Weather Safety",group_scene:"Group Scene",manual:"Manual Override",group_lock:"Group Lock",custom_position:"Custom Position",motion:"Occupancy Timeout",cloud:"Cloud Suppression",climate:"Climate",glare_zone:"Glare Zone",solar:"Solar Tracking",default:"Default",floor_clamp:"Min Floor"},badge:{auto:"Auto",manual:"Manual",force:"Force",weather:"Weather safety",glare_zone:"Glare",climate:"Climate",cloud:"Cloudy",custom_position:"Custom",solar:"Solar tracking",motion:"Occupancy idle",off:"Off",off_schedule:"Off-schedule",floor_suffix:" ↥",safety:"Safety",group:"Group"},group:{title:"Cover Group",scene:"Scene",scene_auto:"Auto",scene_all_open:"All open",scene_all_closed:"All closed",scene_privacy:"Privacy",state_open:"Open",state_closed:"Closed",state_mixed:"Mixed",state_unknown:"Unknown",lock:"Lock group",unlock:"Unlock group",automation:"Automation",automation_count:"{count} of {total} members automating",clear_overrides:"Clear overrides",clear_overrides_none:"No member overrides to clear",who_won:"{count} of {total} members are group-driven — a group scene or the group lock is currently deciding their position",members:"Members",member_placeholder:"No members reported by the integration.",position:"Position",open:"Open group",close:"Close group",stop:"Stop group",position_slider_label:"Group position"},forecast:{event:{sunrise:"Sunrise",sunset:"Sunset",fov_enter:"Sun enters window sun acceptance angle",fov_exit:"Sun leaves window sun acceptance angle"},hover_hint:"Hover the curve for time + forecast position; hover a colored line for the event it marks.",solar_only_note:"Solar geometry only — does not reflect manual overrides, custom positions, cloud suppression, or weather.",legend_forecast:"Forecast",legend_actual:"Actual"},dialog:{battery:"{level}% battery",battery_named:"{name}: {level}%",battery_unknown:"Battery level unknown",extend:{title:"Extend manual override",presets_label:"Until",relative_label:"Add time",absolute_label:"End at",preview:"Override until {time}",confirm:"Extend",cancel:"Cancel",tomorrow_suffix:" (tomorrow)"},configure_integration:"Configure integration",open_device_page:"Open device page",close:"Close",target:"Target",resume_auto:"Resume Auto",hide_advanced:"▼ Hide advanced",show_advanced:"▶ Advanced",custom_positions:"Custom positions",floor_tooltip:"Floor — slot raises position above raw calc",floor:"↥",disable_slot:"Disable slot {slot}",enable_slot:"Enable slot {slot}",on:"On",off:"Off",controls:"Controls",automatic:"Automatic",climate:"Climate",motion:"Occupancy",toggle_hint:"{label} {state} — tap to toggle",state_on:"on",state_off:"off",todays_forecast:"Today's forecast"},overrides:{title:"Overrides",manual:"Manual",force:"Force",motion:"Occupancy",active:"Active",off:"Off",ends_in:"ends in {time}",active_count:"{count} active",timeout:"expires in {time}",reset_manual:"Reset Manual"},climate:{title:"Climate",active:"Active: {strategy}",indoor:"Indoor",outdoor:"Outdoor",presence:"Presence",sunny:"Sunny",lux:"Lux",irradiance:"Irradiance",mode_off:"Climate mode off",standby:"Standby",threshold_low:"low",threshold_high:"high",threshold_summer_outside:"summer",reason:{outside_time_window:"Outside the operating time window",thresholds_not_met:"Temperatures within the comfort band — no action needed",other_mode_active:"Another control mode is currently active",readings_unavailable:"Temperature readings unavailable",mode_off:"Climate mode is turned off"}},compass:{placeholder_no_entries:"No Adaptive Cover Pro entries selected.",placeholder_no_sun:"Sun sensor not yet populated.",sun_tooltip:"Sun: {az} az / {el} el",sunrise_tooltip:"Sunrise: {time}",sunset_tooltip:"Sunset: {time}",moon_tooltip:"Moon: {phase} ({pct}%)",sun_path_tooltip:"Sun path (today)",in_fov_check:"✓ in SAA",in_fov:"in SAA",in_fov_tooltip:"Sun is currently within this window’s sun acceptance angle",none:"—",sun:"Sun",moon:"Moon",sun_up_not_hitting:"Sun (up, not hitting)",sun_below_horizon:"Sun (below horizon)",window_fov:"Window SAA",sun_path:"Sun path",sunrise:"Sunrise",sunset:"Sunset",cover_target:"Cover target",cover_held:"Cover position (held)",window_normal:"Window azimuth",stat_sun:"Sun: ",stat_azi:"Azi: ",stat_elev:"Elev: ",stat_window:"Window: ",active_sun_arc:"Active sun arc {from} – {to}{elev}",fov_arc:"SAA {left} left / {right} right{elev}",window_normal_tooltip:"Window azimuth: {bearing}",cover_position_target:"Target: {pct}%",cover_position_target_awning:"Target (extended): {pct}%",cover_position_actual:"Actual: {pct}%",blind_spot:"Blind spot: {from} – {to}",elev_suffix:" · elev {min}–{max}"},covers:{placeholder:"No covers reported by the integration.",title:"Covers",target:"Target: {pct}",target_solar:"Solar target: {pct}",click_to_set:"Click to set position",position_slider_label:"Cover position slider",position_open_value:"{pct} open",opening:"Opening…",closing:"Closing…",target_tooltip:"Target {pct}%",target_tooltip_override:"Would-be solar target {pct}% — cover is held by manual override",target_tooltip_motor:"Motor: {pct}% (before calibration)",tilt_title:"Tilt",tilt_target:"Tilt: {pct}",tilt_click_to_set:"Click to set tilt",tilt_target_tooltip:"Tilt target {pct}%"},decision:{placeholder:"Decision trace not yet populated.",pipeline:"Pipeline",winner:"Winner: {name}",summary_tooltip:"Why this position?",not_evaluated:"not evaluated",floor_suffix:" floor",outside_schedule:"Outside schedule — automatic control paused",outside_schedule_tooltip:"The configured schedule window is not active, so automatic positioning is paused.",solar_would_be:"solar {pct}",next_change_in:"Next adjustment allowed in {time}"},solar:{title:"Solar Calculation",axis_position:"Position axis",axis_tilt:"Tilt axis",group_inputs:"Inputs",group_intermediates:"Intermediates",group_output:"Output",show_all:"Show all {count} values",show_less:"Show less",no_target:"No solar target — {status}",status:{direct_sun:"Direct sun",fov_exit:"Default · SAA exit",elevation_limit:"Default · elevation limit",sunset_offset:"Default · sunset offset",blind_spot:"Default · blind spot",default:"Default"},field:{sol_elev_deg:"Sun elevation",gamma_deg:"Relative azimuth (γ)",position_pct:"Position",effective_distance_m:"Effective distance",adjusted_height_m:"Adjusted height",safety_margin:"Safety margin",awn_angle_deg:"Awning angle",vertical_position_m:"Vertical position",length_m:"Extension length",slat_angle_raw_deg:"Slat angle",tilt_mode:"Tilt mode",max_degrees:"Max angle"}},header:{on:"ON",off:"OFF",integration_enabled:"Integration Enabled",auto:"Auto",automatic_control:"Automatic Control"},tile:{motion_pending:"Occupancy timeout pending",motion_detected:"Occupancy detected",battery_low:"Low battery — {level}%",battery_unknown:"Battery level unknown",icon_action_label:"Cover icon action",open:"Open",stop:"Stop",close:"Close",resume_aria:"Resume automatic control",extend_aria:"Extend manual override",registry_failed:"Registry fetch failed: {error}",loading:"Loading…",entry_not_found:"Adaptive Cover Pro entry {entry} not found.",unavailable:"Unavailable"},formatters:{expired:"expired"},elevation:{title:"Sun today",fov_window:"SAA: {from} → {to}",fov_windows:"SAA: {windows}",fov_window_named:"{name}: {windows}",no_fov_today:"Sun does not enter SAA today",placeholder:"Sun elevation chart unavailable.",schedule:"Schedule {from} – {to}",schedule_from:"Schedule from {from}",schedule_until:"Schedule until {to}",schedule_start_tooltip:"Schedule start",schedule_end_tooltip:"Schedule end"},control_status:{active:"Active",outside_time_window:"Outside time window",position_delta_too_small:"Position change too small",time_delta_too_small:"Too soon since last move",manual_override:"Manual override",automatic_control_off:"Automatic control off",sun_not_visible:"Sun not visible",force_override_active:"Force override",weather_override_active:"Weather safety",motion_timeout:"Occupancy timeout"},history:{title:"History",open:"History",close:"Close",refresh:"Refresh",loading:"Loading history…",no_data:"No recorded data",window_label:"History window",window_hours:"{hours}h",show_more:"Show more",expand:"Expand to full view",collapse:"Back to history",today:"Today",yesterday:"Yesterday",section_tracks:"Timeline",track_position:"Position",track_who_won:"Who won",track_control_status:"Control status",track_enabled:"Integration",track_auto:"Automatic control",track_sun:"Sun in SAA",track_glare:"Glare",track_manual:"Manual override",track_mismatch:"Position mismatch",legend_target:"Target",legend_actual:"Actual",legend_per_cover:"Per cover",legend_saa:"Sun in SAA",legend_night:"Night",stat_moves:"moves",stat_travel:"pts travelled",stat_override:"in manual override",copy_diagnostics:"Copy diagnostics",copied:"Copied",no_recorder_data:"Not recorded — check your recorder settings",activity_title:"Activity",activity_empty:"No recorded activity in this window.",advanced:"Advanced — event buffer",events_search:"Filter events…",events_count:"{shown} of {total} events",events_empty:"No events match the filter.",events_unavailable:"Event buffer unavailable — the integration did not return diagnostics.",buffer_size:"Buffer size: {size}",data_window:"Buffer window: {from} → {to}"},root:{loading_registry:"Loading Adaptive Cover Pro registry…",no_entities_title:"No Adaptive Cover Pro entities found",footer_version:"adaptive-cover-pro-card v{version}",compass_no_match:"No matching Adaptive Cover Pro entities",compass_configured:"Configured entries: {entries}",compass_not_found:"Entries not found: {entries}"},editor:{common:{entry_id:"Adaptive Cover Pro instance",support_alt:"Buy me a coffee",title_optional:"Title (optional)",title_placeholder:"e.g. West-facing windows",north_offset:"Compass north offset (°)",north_offset_hint:'Rotate the compass clockwise so "up" matches your map. Default: 0.',loading_entries:"Loading Adaptive Cover Pro config entries…",load_failed:"Failed to load config entries: {error}",no_entries:"No Adaptive Cover Pro config entries found. Add an instance under",no_entries_path:"Settings → Devices & Services",no_entries_then:", then come back.",entry_id_manual_placeholder:"Enter config entry ID manually",entry_id_fallback_label:"Entry ID",unknown_entry:"(unknown: {entry})",reset:"Reset"},main:{sections:"Sections",sections_hint:"Toggle which parts of the card are shown.",section_sky_label:"Sky compass",section_sky_desc:"Sun vs. window SAA, polar plot",section_elevation_label:"Sun today",section_elevation_desc:"Elevation-vs-time chart with SAA band and current-time cursor",section_decision_label:"Decision strip",section_decision_desc:"All 10 pipeline handlers with the winning row highlighted",section_covers_label:"Cover positions",section_covers_desc:"Per-cover live vs. target bars; click to set position",section_overrides_label:"Overrides panel",section_overrides_desc:"Manual, force, occupancy tiles + reset button",section_climate_label:"Climate panel",section_climate_desc:"Summer/winter/intermediate strategy; shows standby when climate mode is off or inactive",section_solar_label:"Solar calculation",section_solar_desc:"Raw solar geometry breakdown (inputs → intermediates → output); requires the integration’s solar_calculation sensor",controls:"Controls",controls_hint:"Render as read-only (visible but not clickable).",integration_pill_label:"Integration ON/OFF pill",integration_pill_desc:"Allow toggling the integration from the card header.",automatic_pill_label:"Automatic Control pill",automatic_pill_desc:"Allow toggling automatic control from the card header.",reset_button_label:"Reset Manual Override button",reset_button_desc:"Allow pressing the reset tile in the overrides panel.",display:"Display",compact_label:"Compact mode",compact_desc:"Tighter spacing between sections.",show_compass_stats_label:"Show compass stats",show_compass_stats_desc:"Azi, Elev, ∠, and Window angle below the sky compass.",show_compass_legend_label:"Show compass legend",show_compass_legend_desc:"Color key below the sky compass.",show_moon_label:"Show moon on compass",show_moon_desc:"Moon position and phase overlay on the sky compass.",hide_inactive_label:"Hide inactive handlers",hide_inactive_desc:"Show only the winner and actively matched pipeline handlers.",state_color_label:"Color icon by state",state_color_desc:"Header cover icon takes on the theme’s open/closed/active color."},tile:{name:"Title override",icon:"Icon override",cover:"Cover entity",layout:"Layout",show_position:"Show position %",show_state:"Show state (Open/Closed)",show_decision_summary:"Show decision summary",show_controls:"Show ↑ ■ ↓ controls",covers:"Position bars (order)",covers_hint:"Drag a row, or use the arrows, to set the order the position bars appear in. The eye hides a bar without unbinding the cover.",covers_move_up:"Move up",covers_move_down:"Move down",covers_hide:"Hide this bar",covers_show:"Show this bar",controls_cover:"Cover driven by ↑ ■ ↓",controls_axis:"Axis driven by ↑ ■ ↓",show_badge:"Show contextual badge",show_position_bar:"Show position bar",show_tilt:"Show tilt bar",content_section:"Content",controls_section:"Controls",dialog_section:"Dialog sections",group_row_section:"Group controls",show_scene_select:"Show scene selector",show_lock:"Show group lock",show_automation:"Show member automation toggle",show_clear_overrides:"Show clear-overrides button",show_member_badges:"Show member override badges",badge_section:"Badges",badge_auto:"Auto",badge_solar:"Solar tracking",badge_force:"Force override",badge_weather:"Weather safety",badge_manual:"Manual override",badge_custom_position:"Custom position",badge_motion:"Occupancy",badge_climate:"Climate",badge_glare_zone:"Glare zone",badge_cloud:"Cloud suppression",show_compass:"Show sun compass in dialog",show_elevation_chart:"Show sun-today chart in dialog",show_solar_calc:"Show solar calculation in dialog",show_motion_icon:"Show occupancy indicator",state_color:"Color icon by state",interactions_section:"Interactions",tap_action:"Tap action",icon_tap_action:"Icon tap behavior",hold_action:"Hold action",double_tap_action:"Double-tap action",cover_blank_hint:"Leave blank to use the first managed cover automatically.",name_composed_hint:"A composed name is set in YAML. Type a new title here to replace it with plain text.",layout_option_one_line:"One line (compact)",layout_option_detailed:"Detailed (title, state, indicators)"},compass:{instances:"Adaptive Cover Pro instances",instances_hint:"Pick one or more. Each selected entry adds an overlay to the compass.",cover_colors:"Cover colors",cover_colors_hint:"Override the default palette color for each overlay.",default_color:"default",display:"Display",toggle_compact_label:"Compact mode",toggle_compact_desc:"Smaller SVG, legend hidden.",toggle_legend_label:"Legend",toggle_legend_desc:"Color swatches + entry labels below compass.",toggle_stats_label:"Stats",toggle_stats_desc:"Sun + per-window numeric rows.",toggle_moon_label:"Moon",toggle_moon_desc:"Render moon position and phase.",toggle_cardinals_label:"Cardinal labels",toggle_cardinals_desc:"N/E/S/W letters around the compass.",toggle_blind_spot_label:"Blind spots",toggle_blind_spot_desc:"Hatched wedges for each window’s blind range.",toggle_sun_path_label:"Sun path",toggle_sun_path_desc:"Today’s sun arc across the sky.",toggle_sunrise_sunset_label:"Sunrise / sunset markers",toggle_sunrise_sunset_desc:"Small dots at rise and set azimuths.",toggle_cover_fill_label:"Cover closure fill",toggle_cover_fill_desc:"Inner wedge showing how closed each cover is.",toggle_window_arrow_label:"Window-normal arrow",toggle_window_arrow_desc:"Line from center toward each window’s azimuth.",toggle_elevation_chart_label:"Sun-today chart",toggle_elevation_chart_desc:"Elevation-vs-time chart below the compass, with SAA band and elevation limits."},decision:{title:"Title (optional)",compact_label:"Compact mode",compact_desc:"Tighter rows; also hides inactive handlers.",hide_inactive_handlers_label:"Hide inactive handlers",hide_inactive_handlers_desc:"Show only the winner and actively matched pipeline handlers.",show_decision_summary_label:"Show decision summary",show_decision_summary_desc:'Render a plain-English "Why this position?" sentence above the strip.'},solar_chart:{instances:"Adaptive Cover Pro instances",instances_hint:"Pick one or more. Each selected entry adds a SAA overlay to the chart.",cover_colors:"Cover colors",cover_colors_hint:"Override the default palette color for each overlay.",default_color:"default",display:"Display",toggle_compact_label:"Compact mode",toggle_compact_desc:"Smaller chart, tighter spacing."},history:{title:"Title (optional)",hours_label:"History window",hours_desc:"How far back the tracks reach, counting from now.",track_position_label:"Position track",track_position_desc:"Recorded cover position over the window.",track_who_won_label:"Who-won track",track_who_won_desc:"Banded strip of the winning pipeline handler over time.",track_context_label:"Context tracks",track_context_desc:"Sun-in-SAA, glare and manual-override spans.",track_actions_label:"Cover actions list",track_actions_desc:"Recorded cover actions and skipped actions, newest first.",advanced_open_label:"Start with Advanced open",advanced_open_desc:"Expand the event-buffer section on load.",hide_advanced_label:"Hide Advanced section",hide_advanced_desc:"Never show the diagnostic event buffer on this card."}}},fr:{handler:{force:"Dérogation forcée",weather:"Sécurité météo",group_scene:"Scène de groupe",manual:"Dérogation manuelle",group_lock:"Verrouillage de groupe",custom_position:"Position personnalisée",motion:"Délai d'occupation",cloud:"Désactivation par temps nuageux",climate:"Climatique",glare_zone:"Zone d'éblouissement",solar:"Suivi solaire",default:"Par défaut",floor_clamp:"Plancher"},badge:{auto:"Auto",manual:"Manuel",force:"Forcé",weather:"Sécurité météo",glare_zone:"Éblouissement",climate:"Climatique",cloud:"Nuageux",custom_position:"Personnalisé",solar:"Suivi solaire",motion:"Occupation inactive",off:"Off",off_schedule:"Hors planning",floor_suffix:" ↥",safety:"Sécurité",group:"Groupe"},group:{title:"Groupe de couvertures",scene:"Scène",scene_auto:"Auto",scene_all_open:"Tout ouvrir",scene_all_closed:"Tout fermer",scene_privacy:"Intimité",state_open:"Ouvert",state_closed:"Fermé",state_mixed:"Mixte",state_unknown:"Inconnu",lock:"Verrouiller le groupe",unlock:"Déverrouiller le groupe",automation:"Automatisation",automation_count:"{count} membre(s) sur {total} automatisé(s)",clear_overrides:"Effacer les dérogations",clear_overrides_none:"Aucune dérogation de membre à effacer",who_won:"{count} membre(s) sur {total} sont pilotés par le groupe — une scène de groupe ou le verrouillage du groupe détermine actuellement leur position",members:"Membres",member_placeholder:"Aucun membre signalé par l'intégration.",position:"Position",open:"Ouvrir le groupe",close:"Fermer le groupe",stop:"Arrêter le groupe",position_slider_label:"Position du groupe"},forecast:{event:{sunrise:"Lever du soleil",sunset:"Coucher du soleil",fov_enter:"Le soleil entre dans l'angle d'acceptation solaire de la fenêtre",fov_exit:"Le soleil quitte l'angle d'acceptation solaire de la fenêtre"},hover_hint:"Survolez la courbe pour voir l'heure et la position prévue ; survolez une ligne colorée pour voir l'événement qu'elle indique.",solar_only_note:"Géométrie solaire uniquement — ne tient pas compte des dérogations manuelles, des positions personnalisées, de la désactivation par temps nuageux ni des conditions météo.",legend_forecast:"Prévision",legend_actual:"Réel"},dialog:{battery:"Batterie {level}%",battery_named:"{name} : {level}%",battery_unknown:"Niveau de batterie inconnu",extend:{title:"Prolonger la dérogation manuelle",presets_label:"Jusqu'à",relative_label:"Ajouter du temps",absolute_label:"Fin à",preview:"Dérogation jusqu'à {time}",confirm:"Prolonger",cancel:"Annuler",tomorrow_suffix:" (demain)"},configure_integration:"Configurer l'intégration",open_device_page:"Ouvrir la page de l'appareil",close:"Fermer",target:"Cible",resume_auto:"Reprendre l'automatique",hide_advanced:"▼ Masquer les options avancées",show_advanced:"▶ Afficher les options avancées",custom_positions:"Positions personnalisées",floor_tooltip:"Plancher — cette valeur force une position minimale au-dessus du calcul automatique",floor:"↥",disable_slot:"Désactiver le créneau {slot}",enable_slot:"Activer le créneau {slot}",on:"Activé",off:"Désactivé",controls:"Commandes",automatic:"Automatique",climate:"Climatique",motion:"Occupation",toggle_hint:"{label} {state} — appuyez pour basculer",state_on:"activé",state_off:"désactivé",todays_forecast:"Prévisions du jour"},overrides:{title:"Dérogations",manual:"Manuel",force:"Forcé",motion:"Occupation",active:"Actif",off:"Désactivé",ends_in:"se termine dans {time}",active_count:"{count} dérogation(s) active(s)",timeout:"expire dans {time}",reset_manual:"Réinitialiser le mode manuel"},climate:{title:"Climatique",active:"Actif : {strategy}",indoor:"Intérieur",outdoor:"Extérieur",presence:"Présence",sunny:"Ensoleillé",lux:"Lux",irradiance:"Irradiance",mode_off:"Mode climatique désactivé",standby:"En veille",threshold_low:"bas",threshold_high:"haut",threshold_summer_outside:"été",reason:{outside_time_window:"En dehors de la plage horaire de fonctionnement",thresholds_not_met:"Températures dans la plage de confort — aucune action requise",other_mode_active:"Un autre mode de contrôle est actuellement actif",readings_unavailable:"Relevés de température indisponibles",mode_off:"Le mode climatique est désactivé"}},compass:{placeholder_no_entries:"Aucune instance Adaptive Cover Pro sélectionnée.",placeholder_no_sun:"Le capteur solaire n'est pas encore renseigné.",sun_tooltip:"Soleil : {az} az / {el} él",sunrise_tooltip:"Lever du soleil : {time}",sunset_tooltip:"Coucher du soleil : {time}",moon_tooltip:"Lune : {phase} ({pct}%)",sun_path_tooltip:"Trajectoire solaire (aujourd'hui)",in_fov_check:"✓ dans le SAA",in_fov:"dans le SAA",in_fov_tooltip:"Le soleil est actuellement dans l'angle d'acceptation solaire de cette fenêtre",none:"—",sun:"Soleil",moon:"Lune",sun_up_not_hitting:"Soleil (levé, ne frappe pas)",sun_below_horizon:"Soleil (sous l’horizon)",window_fov:"SAA de la fenêtre",sun_path:"Trajectoire solaire",sunrise:"Lever du soleil",sunset:"Coucher du soleil",cover_target:"Cible du store",cover_held:"Position du store (maintenue)",window_normal:"Azimut de la fenêtre",stat_sun:"Soleil : ",stat_azi:"Azi : ",stat_elev:"Élév : ",stat_window:"Fenêtre : ",active_sun_arc:"Arc solaire actif {from} – {to}{elev}",fov_arc:"SAA {left} gauche / {right} droite{elev}",window_normal_tooltip:"Azimut de la fenêtre : {bearing}",cover_position_target:"Cible : {pct}%",cover_position_target_awning:"Cible (déployé) : {pct}%",cover_position_actual:"Réel : {pct}%",blind_spot:"Soleil masqué : {from} - {to}",elev_suffix:" · élév {min}–{max}"},covers:{placeholder:"Aucun store signalé par l'intégration.",title:"Stores",target:"Cible : {pct}",target_solar:"Cible solaire : {pct}",click_to_set:"Cliquer pour définir la position",position_slider_label:"Curseur de position du store",position_open_value:"{pct} ouvert",opening:"Ouverture…",closing:"Fermeture…",target_tooltip:"Cible {pct}%",target_tooltip_override:"Cible solaire théorique {pct}% — le store est maintenu par la commande manuelle",target_tooltip_motor:"Moteur : {pct}% (avant étalonnage)",tilt_title:"Inclinaison",tilt_target:"Inclinaison : {pct}",tilt_click_to_set:"Cliquer pour définir l'inclinaison",tilt_target_tooltip:"Cible inclinaison {pct}%"},decision:{placeholder:"La trace de décision n'est pas encore renseignée.",pipeline:"Pipeline",winner:"Actif : {name}",summary_tooltip:"Pourquoi cette position ?",not_evaluated:"non évalué",floor_suffix:" plancher",outside_schedule:"Hors planning — contrôle automatique en pause",outside_schedule_tooltip:"La fenêtre de planning configurée n'est pas active, le positionnement automatique est donc en pause.",solar_would_be:"solaire {pct}",next_change_in:"Prochain ajustement autorisé dans {time}"},solar:{title:"Calcul solaire",axis_position:"Axe de position",axis_tilt:"Axe d'inclinaison",group_inputs:"Entrées",group_intermediates:"Intermédiaires",group_output:"Sortie",show_all:"Afficher les {count} valeurs",show_less:"Afficher moins",no_target:"Pas de cible solaire — {status}",status:{direct_sun:"Soleil direct",fov_exit:"Par défaut · sortie du SAA",elevation_limit:"Par défaut · limite d'élévation",sunset_offset:"Par défaut · décalage coucher du soleil",blind_spot:"Par défaut · angle mort",default:"Par défaut"},field:{sol_elev_deg:"Élévation du soleil",gamma_deg:"Azimut relatif (γ)",position_pct:"Position",effective_distance_m:"Distance effective",adjusted_height_m:"Hauteur ajustée",safety_margin:"Marge de sécurité",awn_angle_deg:"Angle du store",vertical_position_m:"Position verticale",length_m:"Longueur d'extension",slat_angle_raw_deg:"Angle des lamelles",tilt_mode:"Mode d'inclinaison",max_degrees:"Angle maximal"}},header:{on:"ON",off:"OFF",integration_enabled:"Intégration activée",auto:"Auto",automatic_control:"Contrôle automatique"},tile:{motion_pending:"Délai d'occupation en cours",motion_detected:"Occupation détectée",battery_low:"Batterie faible — {level}%",battery_unknown:"Niveau de batterie inconnu",icon_action_label:"Action de l'icône du store",open:"Ouvrir",stop:"Arrêter",close:"Fermer",resume_aria:"Reprendre le contrôle automatique",extend_aria:"Prolonger la dérogation manuelle",registry_failed:"Échec de la récupération du registre : {error}",loading:"Chargement…",entry_not_found:"Instance Adaptive Cover Pro {entry} introuvable.",unavailable:"Indisponible"},formatters:{expired:"expiré"},elevation:{title:"Soleil aujourd'hui",fov_window:"SAA : {from} → {to}",fov_windows:"SAA : {windows}",fov_window_named:"{name} : {windows}",no_fov_today:"Le soleil n'entre pas dans le SAA aujourd'hui",placeholder:"Graphique d'élévation solaire indisponible.",schedule:"Programmation {from} – {to}",schedule_from:"Programmation à partir de {from}",schedule_until:"Programmation jusqu'à {to}",schedule_start_tooltip:"Début de programmation",schedule_end_tooltip:"Fin de programmation"},control_status:{active:"Actif",outside_time_window:"Hors plage horaire",position_delta_too_small:"Changement de position trop faible",time_delta_too_small:"Trop tôt depuis le dernier mouvement",manual_override:"Dérogation manuelle",automatic_control_off:"Contrôle automatique désactivé",sun_not_visible:"Soleil non visible",force_override_active:"Dérogation forcée",weather_override_active:"Sécurité météo",motion_timeout:"Délai d'occupation"},history:{title:"Historique",open:"Historique",close:"Fermer",refresh:"Actualiser",loading:"Chargement de l'historique…",no_data:"Aucune donnée enregistrée",window_label:"Fenêtre d'historique",window_hours:"{hours} h",show_more:"Afficher plus",expand:"Afficher en plein écran",collapse:"Retour à l'historique",today:"Aujourd'hui",yesterday:"Hier",section_tracks:"Chronologie",track_position:"Position",track_who_won:"Gagnant",track_control_status:"État du contrôle",track_enabled:"Intégration",track_auto:"Contrôle automatique",track_sun:"Soleil dans SAA",track_glare:"Éblouissement",track_manual:"Dérogation manuelle",track_mismatch:"Écart de position",legend_target:"Cible",legend_actual:"Réel",legend_per_cover:"Par store",legend_saa:"Soleil dans SAA",legend_night:"Nuit",stat_moves:"mouvements",stat_travel:"pts parcourus",stat_override:"en dérogation manuelle",copy_diagnostics:"Copier les diagnostics",copied:"Copié",no_recorder_data:"Non enregistré — vérifiez la configuration du recorder",activity_title:"Activité",activity_empty:"Aucune activité enregistrée sur cette période.",advanced:"Avancé — tampon d'événements",events_search:"Filtrer les événements…",events_count:"{shown} événements sur {total}",events_empty:"Aucun événement ne correspond au filtre.",events_unavailable:"Tampon d'événements indisponible — l'intégration n'a pas renvoyé de diagnostics.",buffer_size:"Taille du tampon : {size}",data_window:"Fenêtre du tampon : {from} → {to}"},root:{loading_registry:"Chargement du registre Adaptive Cover Pro…",no_entities_title:"Aucune entité Adaptive Cover Pro trouvée",footer_version:"adaptive-cover-pro-card v{version}",compass_no_match:"Aucune entité Adaptive Cover Pro correspondante",compass_configured:"Instances configurées : {entries}",compass_not_found:"Instances introuvables : {entries}"},editor:{common:{entry_id:"Instance Adaptive Cover Pro",support_alt:"Offrez-moi un café",title_optional:"Titre (facultatif)",title_placeholder:"ex. Fenêtres côté ouest",north_offset:"Décalage nord de la boussole (°)",north_offset_hint:"Faites pivoter la boussole dans le sens horaire pour que « haut » corresponde à votre carte. Par défaut : 0.",loading_entries:"Chargement des entrées de configuration Adaptive Cover Pro…",load_failed:"Échec du chargement des entrées de configuration : {error}",no_entries:"Aucune entrée de configuration Adaptive Cover Pro trouvée. Ajoutez une instance sous",no_entries_path:"Paramètres → Appareils et services",no_entries_then:", puis revenez ici.",entry_id_manual_placeholder:"Saisir manuellement l'ID d'entrée de configuration",entry_id_fallback_label:"ID d'entrée",unknown_entry:"(inconnu : {entry})",reset:"Réinitialiser"},main:{sections:"Sections",sections_hint:"Activer ou désactiver les parties de la carte affichées.",section_sky_label:"Boussole céleste",section_sky_desc:"Soleil par rapport au SAA de la fenêtre, tracé polaire",section_elevation_label:"Soleil aujourd'hui",section_elevation_desc:"Graphique élévation/temps avec bande SAA et curseur temps réel",section_decision_label:"Bande de décision",section_decision_desc:"Les 10 gestionnaires du pipeline avec la ligne gagnante mise en évidence",section_covers_label:"Positions des stores",section_covers_desc:"Barres position réelle/cible par store ; cliquer pour définir la position",section_overrides_label:"Panneau des dérogations",section_overrides_desc:"Tuiles Manuel, Forcé, Occupation + bouton de réinitialisation",section_climate_label:"Panneau climatique",section_climate_desc:"Stratégie été/hiver/intermédiaire ; affiche le mode veille si le mode climatique est désactivé ou inactif",section_solar_label:"Calcul solaire",section_solar_desc:"Décomposition de la géométrie solaire brute (entrées → intermédiaires → sortie) ; nécessite le capteur solar_calculation de l’intégration",controls:"Commandes",controls_hint:"Afficher en lecture seule (visible mais non cliquable).",integration_pill_label:"Bouton ON/OFF de l'intégration",integration_pill_desc:"Permettre de basculer l'intégration depuis l'en-tête de la carte.",automatic_pill_label:"Bouton contrôle automatique",automatic_pill_desc:"Permettre de basculer le contrôle automatique depuis l'en-tête de la carte.",reset_button_label:"Bouton de réinitialisation de la dérogation manuelle",reset_button_desc:"Permettre d'appuyer sur la tuile de réinitialisation dans le panneau des dérogations.",display:"Affichage",compact_label:"Mode compact",compact_desc:"Espacement réduit entre les sections.",show_compass_stats_label:"Afficher les statistiques de la boussole",show_compass_stats_desc:"Azi, Élév, ∠ et angle de fenêtre sous la boussole céleste.",show_compass_legend_label:"Afficher la légende de la boussole",show_compass_legend_desc:"Clé de couleur sous la boussole céleste.",show_moon_label:"Afficher la lune sur la boussole",show_moon_desc:"Position et phase de la lune en superposition sur la boussole céleste.",hide_inactive_label:"Masquer les gestionnaires inactifs",hide_inactive_desc:"Afficher uniquement le gestionnaire sélectionné et les gestionnaires du pipeline actifs.",state_color_label:"Colorer l'icône selon l'état",state_color_desc:"L'icône d'en-tête prend la couleur ouvert/fermé/actif du thème."},tile:{name:"Titre personnalisé",icon:"Icône personnalisée",cover:"Entité de store",layout:"Disposition",show_position:"Afficher la position %",show_state:"Afficher l'état (Ouvert/Fermé)",show_decision_summary:"Afficher le résumé de décision",show_controls:"Afficher les commandes ↑ ■ ↓",covers:"Barres de position (ordre)",covers_hint:"Faites glisser une ligne, ou utilisez les flèches, pour définir l'ordre des barres de position. L'œil masque une barre sans dissocier le volet.",covers_move_up:"Monter",covers_move_down:"Descendre",covers_hide:"Masquer cette barre",covers_show:"Afficher cette barre",controls_cover:"Volet piloté par ↑ ■ ↓",controls_axis:"Axe piloté par ↑ ■ ↓",show_badge:"Afficher le badge contextuel",show_position_bar:"Afficher la barre de position",show_tilt:"Afficher la barre d'inclinaison",content_section:"Contenu",controls_section:"Commandes",dialog_section:"Sections de la boîte de dialogue",group_row_section:"Commandes de groupe",show_scene_select:"Afficher le sélecteur de scène",show_lock:"Afficher le verrouillage du groupe",show_automation:"Afficher l'interrupteur d'automatisation des membres",show_clear_overrides:"Afficher le bouton d’effacement des dérogations",show_member_badges:"Afficher les badges de dérogation des membres",badge_section:"Badges",badge_auto:"Auto",badge_solar:"Suivi solaire",badge_force:"Dérogation forcée",badge_weather:"Sécurité météo",badge_manual:"Dérogation manuelle",badge_custom_position:"Position personnalisée",badge_motion:"Occupation",badge_climate:"Climatique",badge_glare_zone:"Zone d'éblouissement",badge_cloud:"Suppression nuageuse",show_compass:"Afficher la boussole solaire dans le dialogue",show_elevation_chart:"Afficher le graphique du soleil dans le dialogue",show_solar_calc:"Afficher le calcul solaire dans le dialogue",show_motion_icon:"Afficher l'indicateur d'occupation",state_color:"Colorer l'icône selon l'état",interactions_section:"Interactions",tap_action:"Action au toucher",icon_tap_action:"Action au toucher de l'icône",hold_action:"Action au maintien",double_tap_action:"Action au double toucher",cover_blank_hint:"Laisser vide pour utiliser automatiquement le premier store géré.",name_composed_hint:"Un titre composé est défini en YAML. Saisissez un nouveau titre ici pour le remplacer par du texte simple.",layout_option_one_line:"Une ligne (compact)",layout_option_detailed:"Détaillé (titre, état, indicateurs)"},compass:{instances:"Instances Adaptive Cover Pro",instances_hint:"Sélectionnez une ou plusieurs instances. Chaque instance sélectionnée ajoute une superposition à la boussole.",cover_colors:"Couleurs des stores",cover_colors_hint:"Remplacer la couleur de palette par défaut pour chaque superposition.",default_color:"par défaut",display:"Affichage",toggle_compact_label:"Mode compact",toggle_compact_desc:"SVG plus petit, légende masquée.",toggle_legend_label:"Légende",toggle_legend_desc:"Échantillons de couleur et étiquettes d'instance sous la boussole.",toggle_stats_label:"Statistiques",toggle_stats_desc:"Soleil + lignes numériques par fenêtre.",toggle_moon_label:"Lune",toggle_moon_desc:"Afficher la position et la phase de la lune.",toggle_cardinals_label:"Points cardinaux",toggle_cardinals_desc:"Lettres N/E/S/O autour de la boussole.",toggle_blind_spot_label:"Zones de soleil masqué",toggle_blind_spot_desc:"Secteurs hachurés pour la plage où le soleil est masqué de chaque fenêtre.",toggle_sun_path_label:"Trajectoire solaire",toggle_sun_path_desc:"Arc solaire du jour dans le ciel.",toggle_sunrise_sunset_label:"Repères lever / coucher du soleil",toggle_sunrise_sunset_desc:"Petits points aux azimuts de lever et coucher du soleil.",toggle_cover_fill_label:"Remplissage de fermeture du store",toggle_cover_fill_desc:"Secteur intérieur indiquant le taux de fermeture de chaque store.",toggle_window_arrow_label:"Flèche de normale de fenêtre",toggle_window_arrow_desc:"Ligne du centre vers l'azimut de chaque fenêtre.",toggle_elevation_chart_label:"Graphique du soleil",toggle_elevation_chart_desc:"Graphique élévation/temps sous la boussole, avec bande SAA et limites d'élévation."},decision:{title:"Titre (facultatif)",compact_label:"Mode compact",compact_desc:"Lignes plus serrées ; masque aussi les gestionnaires inactifs.",hide_inactive_handlers_label:"Masquer les gestionnaires inactifs",hide_inactive_handlers_desc:"Afficher uniquement le gestionnaire sélectionné et les gestionnaires du pipeline actifs.",show_decision_summary_label:"Afficher le résumé de décision",show_decision_summary_desc:"Afficher une phrase explicite « Pourquoi cette position ? » au-dessus de la bande."},solar_chart:{instances:"Instances Adaptive Cover Pro",instances_hint:"Sélectionnez une ou plusieurs instances. Chaque instance sélectionnée ajoute une superposition SAA au graphique.",cover_colors:"Couleurs des stores",cover_colors_hint:"Remplacer la couleur de palette par défaut pour chaque superposition.",default_color:"par défaut",display:"Affichage",toggle_compact_label:"Mode compact",toggle_compact_desc:"Graphique plus petit, espacement plus serré."},history:{title:"Titre (facultatif)",hours_label:"Fenêtre d'historique",hours_desc:"Profondeur de l'historique affiché, à partir de maintenant.",track_position_label:"Piste Position",track_position_desc:"Position enregistrée du store sur la période.",track_who_won_label:"Piste Gagnant",track_who_won_desc:"Bandes du gestionnaire de pipeline gagnant au fil du temps.",track_context_label:"Pistes de contexte",track_context_desc:"Périodes soleil-dans-SAA, éblouissement et dérogation manuelle.",track_actions_label:"Liste des actions",track_actions_desc:"Actions de store enregistrées et ignorées, les plus récentes en premier.",advanced_open_label:"Ouvrir Avancé au démarrage",advanced_open_desc:"Déplier la section du tampon d'événements au chargement.",hide_advanced_label:"Masquer la section Avancé",hide_advanced_desc:"Ne jamais afficher le tampon d'événements de diagnostic sur cette carte."}}},de:{handler:{force:"Zwangsübersteuerung",weather:"Wettersicherheit",group_scene:"Gruppenszene",manual:"Manuelle Übersteuerung",group_lock:"Gruppensperre",custom_position:"Benutzerdefinierte Position",motion:"Anwesenheits-Timeout",cloud:"Wolkenunterdrückung",climate:"Klima",glare_zone:"Blendungszone",solar:"Sonnenverfolgung",default:"Standard",floor_clamp:"Mindestposition"},badge:{auto:"Auto",manual:"Manuell",force:"Zwang",weather:"Wettersicherheit",glare_zone:"Blendung",climate:"Klima",cloud:"Bewölkt",custom_position:"Benutzerdefiniert",solar:"Sonnenverfolgung",motion:"Anwesenheit inaktiv",off:"Aus",off_schedule:"Außerhalb des Zeitplans",floor_suffix:" ↥",safety:"Sicherheit",group:"Gruppe"},group:{title:"Abdeckungsgruppe",scene:"Szene",scene_auto:"Auto",scene_all_open:"Alle öffnen",scene_all_closed:"Alle schließen",scene_privacy:"Sichtschutz",state_open:"Offen",state_closed:"Geschlossen",state_mixed:"Gemischt",state_unknown:"Unbekannt",lock:"Gruppe sperren",unlock:"Gruppe entsperren",automation:"Automatisierung",automation_count:"{count} von {total} Mitgliedern automatisiert",clear_overrides:"Übersteuerungen löschen",clear_overrides_none:"Keine Mitglieder-Übersteuerungen zum Löschen",who_won:"{count} von {total} Mitgliedern sind gruppengesteuert — eine Gruppenszene oder die Gruppensperre bestimmt derzeit ihre Position",members:"Mitglieder",member_placeholder:"Keine Mitglieder von der Integration gemeldet.",position:"Position",open:"Gruppe öffnen",close:"Gruppe schließen",stop:"Gruppe stoppen",position_slider_label:"Gruppenposition"},forecast:{event:{sunrise:"Sonnenaufgang",sunset:"Sonnenuntergang",fov_enter:"Sonne tritt in den Sonnenakzeptanzwinkel des Fensters ein",fov_exit:"Sonne verlässt den Sonnenakzeptanzwinkel des Fensters"},hover_hint:"Kurve überfahren für Uhrzeit und prognostizierte Position; farbige Linie überfahren für das markierte Ereignis.",solar_only_note:"Nur Sonnengeometrie — berücksichtigt keine manuellen Übersteuerungen, benutzerdefinierten Positionen, Wolkenunterdrückung oder Wetter.",legend_forecast:"Prognose",legend_actual:"Ist"},dialog:{battery:"Batterie {level}%",battery_named:"{name}: {level}%",battery_unknown:"Batteriestand unbekannt",extend:{title:"Manuelle Übersteuerung verlängern",presets_label:"Bis",relative_label:"Zeit hinzufügen",absolute_label:"Ende um",preview:"Übersteuerung bis {time}",confirm:"Verlängern",cancel:"Abbrechen",tomorrow_suffix:" (morgen)"},configure_integration:"Integration konfigurieren",open_device_page:"Geräteseite öffnen",close:"Schließen",target:"Ziel",resume_auto:"Automatik fortsetzen",hide_advanced:"▼ Erweitert ausblenden",show_advanced:"▶ Erweitert",custom_positions:"Benutzerdefinierte Positionen",floor_tooltip:"Mindestposition — hebt die Position über den berechneten Wert",floor:"↥",disable_slot:"Slot {slot} deaktivieren",enable_slot:"Slot {slot} aktivieren",on:"An",off:"Aus",controls:"Steuerung",automatic:"Automatisch",climate:"Klima",motion:"Anwesenheit",toggle_hint:"{label} {state} — tippen zum Umschalten",state_on:"an",state_off:"aus",todays_forecast:"Heutige Prognose"},overrides:{title:"Übersteuerungen",manual:"Manuell",force:"Zwang",motion:"Anwesenheit",active:"Aktiv",off:"Aus",ends_in:"endet in {time}",active_count:"{count} aktiv",timeout:"läuft in {time} ab",reset_manual:"Manuell zurücksetzen"},climate:{title:"Klima",active:"Aktiv: {strategy}",indoor:"Innen",outdoor:"Außen",presence:"Anwesenheit",sunny:"Sonnig",lux:"Lux",irradiance:"Einstrahlung",mode_off:"Klimamodus deaktiviert",standby:"Bereitschaft",threshold_low:"niedrig",threshold_high:"hoch",threshold_summer_outside:"Sommer",reason:{outside_time_window:"Außerhalb des Betriebszeitfensters",thresholds_not_met:"Temperaturen im Komfortbereich — keine Maßnahme erforderlich",other_mode_active:"Ein anderer Steuermodus ist derzeit aktiv",readings_unavailable:"Temperaturwerte nicht verfügbar",mode_off:"Klimamodus ist deaktiviert"}},compass:{placeholder_no_entries:"Kein Adaptive Cover Pro-Eintrag ausgewählt.",placeholder_no_sun:"Sonnensensor noch nicht befüllt.",sun_tooltip:"Sonne: {az} az / {el} el",sunrise_tooltip:"Sonnenaufgang: {time}",sunset_tooltip:"Sonnenuntergang: {time}",moon_tooltip:"Mond: {phase} ({pct}%)",sun_path_tooltip:"Sonnenbahn (heute)",in_fov_check:"✓ im SAA",in_fov:"im SAA",in_fov_tooltip:"Sonne befindet sich derzeit im Sonnenakzeptanzwinkel dieses Fensters",none:"—",sun:"Sonne",moon:"Mond",sun_up_not_hitting:"Sonne (aufgegangen, trifft nicht)",sun_below_horizon:"Sonne (unter dem Horizont)",window_fov:"Fenster-SAA",sun_path:"Sonnenbahn",sunrise:"Sonnenaufgang",sunset:"Sonnenuntergang",cover_target:"Beschattungsziel",cover_held:"Beschattungsposition (gehalten)",window_normal:"Fensterazimut",stat_sun:"Sonne: ",stat_azi:"Azi: ",stat_elev:"Elev: ",stat_window:"Fenster: ",active_sun_arc:"Aktiver Sonnenbogen {from} – {to}{elev}",fov_arc:"SAA {left} links / {right} rechts{elev}",window_normal_tooltip:"Fensterazimut: {bearing}",cover_position_target:"Ziel: {pct}%",cover_position_target_awning:"Ziel (ausgefahren): {pct}%",cover_position_actual:"Aktuell: {pct}%",blind_spot:"Blindfleck: {from} – {to}",elev_suffix:" · Elev {min}–{max}"},covers:{placeholder:"Keine Beschattungen von der Integration gemeldet.",title:"Beschattungen",target:"Ziel: {pct}",target_solar:"Sonnenziel: {pct}",click_to_set:"Klicken zum Festlegen der Position",position_slider_label:"Positionsschieberegler",position_open_value:"{pct} offen",opening:"Öffnet…",closing:"Schließt…",target_tooltip:"Ziel {pct}%",target_tooltip_override:"Theoretisches Sonnenziel {pct}% — Beschattung wird durch manuelle Übersteuerung gehalten",target_tooltip_motor:"Motor: {pct}% (vor Kalibrierung)",tilt_title:"Neigung",tilt_target:"Neigung: {pct}",tilt_click_to_set:"Klicken zum Festlegen der Neigung",tilt_target_tooltip:"Neigungsziel {pct}%"},decision:{placeholder:"Entscheidungsprotokoll noch nicht befüllt.",pipeline:"Pipeline",winner:"Gewinner: {name}",summary_tooltip:"Warum diese Position?",not_evaluated:"nicht ausgewertet",floor_suffix:" Mindestposition",outside_schedule:"Außerhalb des Zeitplans — automatische Steuerung pausiert",outside_schedule_tooltip:"Das konfigurierte Zeitplanfenster ist nicht aktiv, daher ist die automatische Positionierung pausiert.",solar_would_be:"solar {pct}",next_change_in:"Nächste Anpassung erlaubt in {time}"},solar:{title:"Sonnenberechnung",axis_position:"Positionsachse",axis_tilt:"Neigungsachse",group_inputs:"Eingaben",group_intermediates:"Zwischenwerte",group_output:"Ausgabe",show_all:"Alle {count} Werte anzeigen",show_less:"Weniger anzeigen",no_target:"Kein Sonnenziel — {status}",status:{direct_sun:"Direkte Sonne",fov_exit:"Standard · SAA-Austritt",elevation_limit:"Standard · Höhengrenze",sunset_offset:"Standard · Sonnenuntergangs-Versatz",blind_spot:"Standard · Blindfleck",default:"Standard"},field:{sol_elev_deg:"Sonnenhöhe",gamma_deg:"Relativer Azimut (γ)",position_pct:"Position",effective_distance_m:"Effektive Distanz",adjusted_height_m:"Angepasste Höhe",safety_margin:"Sicherheitsabstand",awn_angle_deg:"Markisenwinkel",vertical_position_m:"Vertikale Position",length_m:"Ausfahrlänge",slat_angle_raw_deg:"Lamellenwinkel",tilt_mode:"Neigungsmodus",max_degrees:"Maximaler Winkel"}},header:{on:"ON",off:"OFF",integration_enabled:"Integration aktiviert",auto:"Auto",automatic_control:"Automatische Steuerung"},tile:{motion_pending:"Anwesenheits-Timeout läuft",motion_detected:"Anwesenheit erkannt",battery_low:"Batterie schwach — {level}%",battery_unknown:"Batteriestand unbekannt",icon_action_label:"Aktion des Beschattungssymbols",open:"Öffnen",stop:"Stopp",close:"Schließen",resume_aria:"Automatische Steuerung fortsetzen",extend_aria:"Manuelle Übersteuerung verlängern",registry_failed:"Registry-Abruf fehlgeschlagen: {error}",loading:"Wird geladen…",entry_not_found:"Adaptive Cover Pro-Eintrag {entry} nicht gefunden.",unavailable:"Nicht verfügbar"},formatters:{expired:"abgelaufen"},elevation:{title:"Sonne heute",fov_window:"SAA: {from} → {to}",fov_windows:"SAA: {windows}",fov_window_named:"{name}: {windows}",no_fov_today:"Sonne tritt heute nicht in den SAA ein",placeholder:"Sonnenhöhen-Diagramm nicht verfügbar.",schedule:"Zeitplan {from} – {to}",schedule_from:"Zeitplan ab {from}",schedule_until:"Zeitplan bis {to}",schedule_start_tooltip:"Zeitplanstart",schedule_end_tooltip:"Zeitplanende"},control_status:{active:"Aktiv",outside_time_window:"Außerhalb des Zeitfensters",position_delta_too_small:"Positionsänderung zu gering",time_delta_too_small:"Zu kurz seit der letzten Bewegung",manual_override:"Manuelle Übersteuerung",automatic_control_off:"Automatische Steuerung aus",sun_not_visible:"Sonne nicht sichtbar",force_override_active:"Zwangsübersteuerung",weather_override_active:"Wettersicherheit",motion_timeout:"Anwesenheits-Timeout"},history:{title:"Verlauf",open:"Verlauf",close:"Schließen",refresh:"Aktualisieren",loading:"Verlauf wird geladen…",no_data:"Keine aufgezeichneten Daten",window_label:"Verlaufszeitraum",window_hours:"{hours} Std.",show_more:"Mehr anzeigen",expand:"Vollansicht öffnen",collapse:"Zurück zum Verlauf",today:"Heute",yesterday:"Gestern",section_tracks:"Zeitverlauf",track_position:"Position",track_who_won:"Gewinner",track_control_status:"Steuerungsstatus",track_enabled:"Integration",track_auto:"Automatische Steuerung",track_sun:"Sonne im SAA",track_glare:"Blendung",track_manual:"Manuelle Übersteuerung",track_mismatch:"Positionsabweichung",legend_target:"Ziel",legend_actual:"Ist",legend_per_cover:"Pro Beschattung",legend_saa:"Sonne im SAA",legend_night:"Nacht",stat_moves:"Bewegungen",stat_travel:"Pkt. zurückgelegt",stat_override:"in manueller Übersteuerung",copy_diagnostics:"Diagnose kopieren",copied:"Kopiert",no_recorder_data:"Nicht aufgezeichnet — Recorder-Einstellungen prüfen",activity_title:"Aktivität",activity_empty:"Keine aufgezeichnete Aktivität in diesem Zeitraum.",advanced:"Erweitert — Ereignispuffer",events_search:"Ereignisse filtern…",events_count:"{shown} von {total} Ereignissen",events_empty:"Keine Ereignisse entsprechen dem Filter.",events_unavailable:"Ereignispuffer nicht verfügbar — die Integration hat keine Diagnose zurückgegeben.",buffer_size:"Puffergröße: {size}",data_window:"Pufferzeitraum: {from} → {to}"},root:{loading_registry:"Adaptive Cover Pro-Registry wird geladen…",no_entities_title:"Keine Adaptive Cover Pro-Entitäten gefunden",footer_version:"adaptive-cover-pro-card v{version}",compass_no_match:"Keine passenden Adaptive Cover Pro-Entitäten",compass_configured:"Konfigurierte Einträge: {entries}",compass_not_found:"Einträge nicht gefunden: {entries}"},editor:{common:{entry_id:"Adaptive Cover Pro-Instanz",support_alt:"Kauf mir einen Kaffee",title_optional:"Titel (optional)",title_placeholder:"z. B. Fenster Westseite",north_offset:"Kompass-Nordversatz (°)",north_offset_hint:'Kompass im Uhrzeigersinn drehen, sodass „oben" Ihrer Karte entspricht. Standard: 0.',loading_entries:"Adaptive Cover Pro-Konfigurationseinträge werden geladen…",load_failed:"Konfigurationseinträge konnten nicht geladen werden: {error}",no_entries:"Keine Adaptive Cover Pro-Konfigurationseinträge gefunden. Fügen Sie eine Instanz unter",no_entries_path:"Einstellungen → Geräte & Dienste",no_entries_then:" hinzu und kehren Sie dann zurück.",entry_id_manual_placeholder:"Konfigurations-Eintrags-ID manuell eingeben",entry_id_fallback_label:"Eintrags-ID",unknown_entry:"(unbekannt: {entry})",reset:"Zurücksetzen"},main:{sections:"Abschnitte",sections_hint:"Sichtbare Bereiche der Karte ein- oder ausblenden.",section_sky_label:"Himmelskompass",section_sky_desc:"Sonne vs. Fenster-SAA, Polardiagramm",section_elevation_label:"Sonne heute",section_elevation_desc:"Höhen-Zeit-Diagramm mit SAA-Bereich und aktuellem Zeitcursor",section_decision_label:"Entscheidungsleiste",section_decision_desc:"Alle 10 Pipeline-Handler mit hervorgehobener Gewinnerzeile",section_covers_label:"Beschattungspositionen",section_covers_desc:"Aktuelle und Zielposition je Beschattung; klicken zum Festlegen der Position",section_overrides_label:"Übersteuerungsbereich",section_overrides_desc:"Kacheln für Manuell, Zwang, Anwesenheit + Zurücksetzen-Schaltfläche",section_climate_label:"Klimabereich",section_climate_desc:"Sommer-/Winter-/Übergangsstrategie; zeigt Bereitschaft, wenn Klimamodus deaktiviert oder inaktiv ist",section_solar_label:"Sonnenberechnung",section_solar_desc:"Aufschlüsselung der Sonnengeometrie (Eingaben → Zwischenwerte → Ausgabe); erfordert den solar_calculation-Sensor der Integration",controls:"Steuerung",controls_hint:"Als schreibgeschützt anzeigen (sichtbar, aber nicht klickbar).",integration_pill_label:"Integration EIN/AUS-Schalter",integration_pill_desc:"Integration über den Karten-Header umschalten.",automatic_pill_label:"Automatische Steuerung-Schalter",automatic_pill_desc:"Automatische Steuerung über den Karten-Header umschalten.",reset_button_label:'Schaltfläche „Manuelle Übersteuerung zurücksetzen"',reset_button_desc:"Zurücksetzen-Kachel im Übersteuerungsbereich betätigen lassen.",display:"Anzeige",compact_label:"Kompaktmodus",compact_desc:"Engerer Abstand zwischen Abschnitten.",show_compass_stats_label:"Kompassstatistiken anzeigen",show_compass_stats_desc:"Azi, Elev, ∠ und Fensterwinkel unterhalb des Himmelskompasses.",show_compass_legend_label:"Kompasslegende anzeigen",show_compass_legend_desc:"Farbschlüssel unterhalb des Himmelskompasses.",show_moon_label:"Mond auf Kompass anzeigen",show_moon_desc:"Mondposition und Mondphase als Überlagerung auf dem Himmelskompass.",hide_inactive_label:"Inaktive Handler ausblenden",hide_inactive_desc:"Nur den Gewinner und aktiv übereinstimmende Pipeline-Handler anzeigen.",state_color_label:"Symbol nach Status einfärben",state_color_desc:"Kopfzeilen-Symbol nimmt die Offen/Geschlossen/Aktiv-Farbe des Themes an."},tile:{name:"Titel überschreiben",icon:"Symbol überschreiben",cover:"Beschattungsentität",layout:"Layout",show_position:"Position % anzeigen",show_state:"Status anzeigen (Offen/Geschlossen)",show_decision_summary:"Entscheidungszusammenfassung anzeigen",show_controls:"Steuerung ↑ ■ ↓ anzeigen",covers:"Positionsleisten (Reihenfolge)",covers_hint:"Ziehen Sie eine Zeile oder verwenden Sie die Pfeile, um die Reihenfolge der Positionsleisten festzulegen. Das Auge blendet eine Leiste aus, ohne den Behang zu entfernen.",covers_move_up:"Nach oben",covers_move_down:"Nach unten",covers_hide:"Diese Leiste ausblenden",covers_show:"Diese Leiste anzeigen",controls_cover:"Von ↑ ■ ↓ gesteuerter Behang",controls_axis:"Von ↑ ■ ↓ gesteuerte Achse",show_badge:"Kontextbadge anzeigen",show_position_bar:"Positionsleiste anzeigen",show_tilt:"Neigungsleiste anzeigen",content_section:"Inhalt",controls_section:"Bedienelemente",dialog_section:"Dialogbereiche",group_row_section:"Gruppensteuerung",show_scene_select:"Szenenauswahl anzeigen",show_lock:"Gruppensperre anzeigen",show_automation:"Umschalter für Mitglieder-Automatisierung anzeigen",show_clear_overrides:"Schaltfläche „Übersteuerungen löschen“ anzeigen",show_member_badges:"Mitglieder-Übersteuerungs-Badges anzeigen",badge_section:"Badges",badge_auto:"Auto",badge_solar:"Sonnenverfolgung",badge_force:"Zwangsübersteuerung",badge_weather:"Wettersicherheit",badge_manual:"Manuelle Übersteuerung",badge_custom_position:"Benutzerdefinierte Position",badge_motion:"Anwesenheit",badge_climate:"Klima",badge_glare_zone:"Blendungszone",badge_cloud:"Wolkenunterdrückung",show_compass:"Sonnenkompass im Dialog anzeigen",show_elevation_chart:"Sonne-heute-Diagramm im Dialog anzeigen",show_solar_calc:"Sonnenberechnung im Dialog anzeigen",show_motion_icon:"Anwesenheitsanzeige einblenden",state_color:"Symbol nach Status einfärben",interactions_section:"Interaktionen",tap_action:"Tipp-Aktion",icon_tap_action:"Tipp-Aktion für Symbol",hold_action:"Gedrückthalten-Aktion",double_tap_action:"Doppeltippen-Aktion",cover_blank_hint:"Leer lassen, um automatisch die erste verwaltete Beschattung zu verwenden.",name_composed_hint:"In YAML ist ein zusammengesetzter Titel festgelegt. Hier einen neuen Titel eingeben, um ihn durch einfachen Text zu ersetzen.",layout_option_one_line:"Eine Zeile (kompakt)",layout_option_detailed:"Detailliert (Titel, Status, Indikatoren)"},compass:{instances:"Adaptive Cover Pro-Instanzen",instances_hint:"Eine oder mehrere auswählen. Jeder gewählte Eintrag fügt dem Kompass eine Überlagerung hinzu.",cover_colors:"Beschattungsfarben",cover_colors_hint:"Standardpalettenfarbe für jede Überlagerung überschreiben.",default_color:"Standard",display:"Anzeige",toggle_compact_label:"Kompaktmodus",toggle_compact_desc:"Kleineres SVG, Legende ausgeblendet.",toggle_legend_label:"Legende",toggle_legend_desc:"Farbmuster und Eintragsbezeichnungen unterhalb des Kompasses.",toggle_stats_label:"Statistiken",toggle_stats_desc:"Sonne + numerische Zeilen je Fenster.",toggle_moon_label:"Mond",toggle_moon_desc:"Mondposition und Mondphase anzeigen.",toggle_cardinals_label:"Himmelsrichtungen",toggle_cardinals_desc:"N/O/S/W-Buchstaben rund um den Kompass.",toggle_blind_spot_label:"Blindflecke",toggle_blind_spot_desc:"Schraffierte Sektoren für den Blindfleckbereich jedes Fensters.",toggle_sun_path_label:"Sonnenbahn",toggle_sun_path_desc:"Heutiger Sonnenbogen am Himmel.",toggle_sunrise_sunset_label:"Sonnenaufgangs-/Untergangsmarkierungen",toggle_sunrise_sunset_desc:"Kleine Punkte bei Aufgangs- und Untergangsazimut.",toggle_cover_fill_label:"Schlussfüllbereich der Beschattung",toggle_cover_fill_desc:"Innerer Sektor, der zeigt, wie weit jede Beschattung geschlossen ist.",toggle_window_arrow_label:"Fenster-Normalenpfeil",toggle_window_arrow_desc:"Linie vom Mittelpunkt zum Azimut jedes Fensters.",toggle_elevation_chart_label:"Sonne-heute-Diagramm",toggle_elevation_chart_desc:"Höhen-Zeit-Diagramm unterhalb des Kompasses, mit SAA-Bereich und Höhengrenzen."},decision:{title:"Titel (optional)",compact_label:"Kompaktmodus",compact_desc:"Engere Zeilen; blendet inaktive Handler ebenfalls aus.",hide_inactive_handlers_label:"Inaktive Handler ausblenden",hide_inactive_handlers_desc:"Nur den Gewinner und aktiv übereinstimmende Pipeline-Handler anzeigen.",show_decision_summary_label:"Entscheidungszusammenfassung anzeigen",show_decision_summary_desc:'Einen verständlichen Satz „Warum diese Position?" oberhalb der Leiste anzeigen.'},solar_chart:{instances:"Adaptive Cover Pro-Instanzen",instances_hint:"Eine oder mehrere auswählen. Jeder gewählte Eintrag fügt dem Diagramm eine SAA-Überlagerung hinzu.",cover_colors:"Beschattungsfarben",cover_colors_hint:"Standardpalettenfarbe für jede Überlagerung überschreiben.",default_color:"Standard",display:"Anzeige",toggle_compact_label:"Kompaktmodus",toggle_compact_desc:"Kleineres Diagramm, engerer Abstand."},history:{title:"Titel (optional)",hours_label:"Verlaufszeitraum",hours_desc:"Wie weit die Spuren zurückreichen, gerechnet ab jetzt.",track_position_label:"Positionsspur",track_position_desc:"Aufgezeichnete Beschattungsposition im Zeitraum.",track_who_won_label:"Gewinner-Spur",track_who_won_desc:"Bänder des jeweils gewinnenden Pipeline-Handlers im Zeitverlauf.",track_context_label:"Kontextspuren",track_context_desc:"Zeiträume für Sonne-im-SAA, Blendung und manuelle Übersteuerung.",track_actions_label:"Aktionsliste",track_actions_desc:"Aufgezeichnete und übersprungene Beschattungsaktionen, neueste zuerst.",advanced_open_label:"Erweitert beim Start öffnen",advanced_open_desc:"Den Ereignispuffer-Abschnitt beim Laden ausklappen.",hide_advanced_label:"Erweitert-Abschnitt ausblenden",hide_advanced_desc:"Den Diagnose-Ereignispuffer auf dieser Karte nie anzeigen."}}}};function tt(e,t){const o=t.split(".");let i=e;for(const e of o){if("object"!=typeof i||null===i)return;i=i[e]}return"string"==typeof i?i:void 0}function ot(e,t){return t?e.replace(/\{(\w+)\}/g,(e,o)=>Object.prototype.hasOwnProperty.call(t,o)?String(t[o]):e):e}function it(e,t,o){const i=function(e){const t=(e?.locale?.language??e?.language??"en").toLowerCase().split("-")[0];return t in et?t:"en"}(t),s=tt(et[i],e);if(void 0!==s)return ot(s,o);if("en"!==i){const t=tt(et.en,e);if(void 0!==t)return ot(t,o)}return e}function st(e){return null==e||Number.isNaN(e)?"—":`${Math.round(e)}%`}function nt(e){return!e||"unavailable"===e||"unknown"===e}function rt(e){return!e||"unavailable"===e}function at(e,t,o){if(!e||!t)return null;const i=e.states[t];if(!i||rt(i.state))return null;const s=o?{...i,state:o}:i;if("function"==typeof e.formatEntityState){const t=e.formatEntityState(s);if(t)return t}if("function"==typeof e.localize){const t=e.localize(`component.cover.entity_component._.state.${s.state}`);if(t)return t}return s.state.charAt(0).toUpperCase()+s.state.slice(1)}function lt(e){return null==e||Number.isNaN(e)?"—":`${e.toFixed(1)}°`}function ct(e,t){if(!e)return"—";const o=new Date(e);return Number.isNaN(o.getTime())?"—":o.toLocaleTimeString([],{hour:"2-digit",minute:"2-digit",timeZone:t})}function dt(e,t){if(!e)return"—";const o=new Date(e).getTime();if(Number.isNaN(o))return"—";const i=Math.round((o-Date.now())/1e3);return i<=0?t?it("formatters.expired",t):"expired":function(e){if(null==e||Number.isNaN(e))return"—";const t=Math.max(0,Math.round(e));if(t<60)return`${t}s`;const o=Math.floor(t/60);return o<60?`${o}m ${t%60}s`:`${Math.floor(o/60)}h ${o%60}m`}(i)}function ht(e,t){if(null!==t&&!Number.isNaN(t)){if(t>=95)return e.open;if(t<=5)return e.closed}return e.partial}function pt(e){const{explicitIcon:t,deviceClass:o,coverType:i,position:s}=e;if("string"==typeof t&&t.length>0)return t;if(o){const e=De[o];if(e)return ht(e,s)}return function(e,t){return ht({open:Fe[e]??"mdi:window-shutter-open",partial:Be[e]??"mdi:window-shutter",closed:Ne[e]??"mdi:window-shutter"},t)}(i,s)}function ut(e){return e&&Re.has(e)?"mdi:arrow-expand-horizontal":"mdi:arrow-up"}function _t(e){return e&&Re.has(e)?"mdi:arrow-collapse-horizontal":"mdi:arrow-down"}const gt="var(--state-cover-active-color, var(--state-cover-color, var(--state-active-color, var(--primary-color))))";function mt(e){if(rt(e)||!e)return"var(--state-unavailable-color)";const t=e.toLowerCase(),o="closed"!==t&&"unknown"!==t?"active":"inactive";return`var(--state-cover-${t}-color, var(--state-cover-${o}-color, var(--state-cover-color, var(--state-${o}-color))))`}function vt(e,t){return t.openBlocksSun?e:t.min+t.max-e}const ft=100,bt="%",yt=new Set(["cover_awning","cover_oscillating_awning"]);function wt(e,t){return"position"===t&&yt.has(e.cover_type)}function xt(e){return e.charAt(0).toUpperCase()+e.slice(1)}function $t(e){const t=e.discovery?.axes;if(Array.isArray(t))return t.filter(e=>!!e&&"string"==typeof e.id&&!1!==e.supported).map(t=>({id:t.id,label:t.label??xt(t.id),min:"number"==typeof t.min?t.min:0,max:"number"==typeof t.max?t.max:ft,unit:"string"==typeof t.unit?t.unit:bt,stateAttr:"string"==typeof t.state_attr?t.state_attr:void 0,targetRole:He[t.id],inverted:!0===t.inverted,openBlocksSun:"boolean"==typeof t.open_blocks_sun?t.open_blocks_sun:wt(e,t.id)}));const o=[{id:"position",label:xt("position"),min:0,max:ft,unit:bt,stateAttr:"current_position",targetRole:"target_position_sensor",inverted:!1,openBlocksSun:wt(e,"position")}];return e.entities.target_tilt_sensor&&o.push({id:"tilt",label:xt("tilt"),min:0,max:ft,unit:bt,stateAttr:"current_tilt_position",targetRole:"target_tilt_sensor",inverted:!1,openBlocksSun:!1}),o}function kt(e){return $t(e).find(e=>"position"===e.id)??{id:"position",label:"Position",min:0,max:ft,unit:bt,stateAttr:"current_position",targetRole:"target_position_sensor",inverted:!1,openBlocksSun:wt(e,"position")}}function At(e){return $t(e).find(e=>"position"===e.id)?.inverted??!1}const St=[12,16];function Ct(e,t,o=0){const i=(e-90+o)*Math.PI/180;return{x:t*Math.cos(i),y:t*Math.sin(i)}}function Et(e){return 1-Math.max(0,Math.min(90,e))/90}function zt(e,t,o,i=0,s=0){const n=e=>(e%360+360)%360,r=n(e),a=n(t);let l=a-r;l<0&&(l+=360);const c=l>180?1:0,d=Ct(r,o,s),h=Ct(a,o,s);if(i<=0)return`M 0 0 L ${d.x} ${d.y} A ${o} ${o} 0 ${c} 1 ${h.x} ${h.y} Z`;const p=Ct(a,i,s),u=Ct(r,i,s);return[`M ${d.x} ${d.y}`,`A ${o} ${o} 0 ${c} 1 ${h.x} ${h.y}`,`L ${p.x} ${p.y}`,`A ${i} ${i} 0 ${c} 0 ${u.x} ${u.y}`,"Z"].join(" ")}function Mt(e,t,o=0){return Ct(e,Et(t),o)}function Tt(e){return(e%360+360)%360}function It(e,t,o,i){const s=i??0;let n=-1,r=-1;for(let i=t;i<=o&&i<e.length;i++)e[i].elevation>s&&(-1===n&&(n=i),r=i);return-1===n?null:{wedgeStart:e[n].azimuth,wedgeEnd:e[r].azimuth}}function Pt(e,t,o){const i=(e-t)/864e5;return Math.max(0,Math.min(o,i*o))}function Ot(e,t,o){return t+(1-(Number.isNaN(e)?0:Math.max(0,Math.min(100,e)))/100)*o}function Bt(e,t,o){return((e-t)%360+360)%360<=((o-t)%360+360)%360}function Ft(e,t,o,i){return Bt(o,e,t)||Bt(i,e,t)||Bt(e,o,i)||Bt(t,o,i)}function Nt(e){const t=Object.values(e).filter(e=>"number"==typeof e);return 0===t.length?null:t.reduce((e,t)=>e+t,0)/t.length}function Dt(e,t,o,i){const s=t?e/100:1-e/100;return Math.min(o*s,i)}function Rt(e,t,o){return e&&null!=t&&Number.isFinite(t)?t===o?null:t:null}function jt(e,t){return e<.5?-4*t*e:4*t*(1-e)}function Kt(e,t,o,i,s){const n=Ct(o,1),r=-n.y,a=n.x,l=e-n.x*i,c=t-n.y*i;return`M ${e} ${t} L ${l+r*s} ${c+a*s} L ${l-r*s} ${c-a*s} Z`}function Lt(e,t){const o=t.entities.target_position_sensor;if(!o)return null;const i=parseFloat(e.states[o]?.state??"");return Number.isNaN(i)?null:i}function Gt(e,t){const o=t.entities.target_position_sensor;if(!o)return null;const i=e.states[o]?.attributes,s=i?.linear_position;return"number"==typeof s&&Number.isFinite(s)?s:null}function Wt(e,t){return Gt(e,t)??Lt(e,t)}function Ht(e,t){const o=t.entities.target_position_sensor;if(!o)return null;const i=e.states[o]?.attributes,s=i?.raw_calculated_position;return"number"==typeof s&&Number.isFinite(s)?s:null}function Ut(e,t){const o=t.entities.target_position_sensor;if(!o)return{};const i=e.states[o]?.attributes,s=i?.linear_actual_positions;if(s&&"object"==typeof s)return s;const n=i?.actual_positions;return n?At(t)?Object.fromEntries(Object.entries(n).map(([e,t])=>[e,"number"==typeof t?100-t:null])):n:{}}function Vt(e,t,o){if(!o)return null;const i=e.states[o]?.attributes?.current_position;return"number"!=typeof i||Number.isNaN(i)?null:At(t)?100-i:i}function qt(e,t,o){if(!o||!t.stateAttr)return null;const i=e.states[o]?.attributes?.[t.stateAttr];return"number"!=typeof i||Number.isNaN(i)?null:t.inverted?100-i:i}function Yt(e,t){return Nt(Ut(e,t))}function Qt(e,t){const o=t.entities.manual_override_binary;return!!o&&"on"===e.states[o]?.state}function Zt(e,t){const o=Wt(e,t);return Rt(Qt(e,t),Ht(e,t),o)??o}const{I:Xt}=ae,Jt=e=>e,eo=()=>document.createComment(""),to=(e,t,o)=>{const i=e._$AA.parentNode,s=void 0===t?e._$AB:t._$AA;if(void 0===o){const t=i.insertBefore(eo(),s),n=i.insertBefore(eo(),s);o=new Xt(t,n,e,e.options)}else{const t=o._$AB.nextSibling,n=o._$AM,r=n!==e;if(r){let t;o._$AQ?.(e),o._$AM=e,void 0!==o._$AP&&(t=e._$AU)!==n._$AU&&o._$AP(t)}if(t!==s||r){let e=o._$AA;for(;e!==t;){const t=Jt(e).nextSibling;Jt(i).insertBefore(e,s),e=t}}}return o},oo=(e,t,o=e)=>(e._$AI(t,o),e),io={},so=(e,t=io)=>e._$AH=t,no=e=>{e._$AR(),e._$AA.remove()},ro=e=>(...t)=>({_$litDirective$:e,values:t});class ao{constructor(e){}get _$AU(){return this._$AM._$AU}_$AT(e,t,o){this._$Ct=e,this._$AM=t,this._$Ci=o}_$AS(e,t){return this.update(e,t)}update(e,t){return this.render(...t)}}const lo=(e,t)=>{const o=e._$AN;if(void 0===o)return!1;for(const e of o)e._$AO?.(t,!1),lo(e,t);return!0},co=e=>{let t,o;do{if(void 0===(t=e._$AM))break;o=t._$AN,o.delete(e),e=t}while(0===o?.size)},ho=e=>{for(let t;t=e._$AM;e=t){let o=t._$AN;if(void 0===o)t._$AN=o=new Set;else if(o.has(e))break;o.add(e),_o(t)}};function po(e){void 0!==this._$AN?(co(this),this._$AM=e,ho(this)):this._$AM=e}function uo(e,t=!1,o=0){const i=this._$AH,s=this._$AN;if(void 0!==s&&0!==s.size)if(t)if(Array.isArray(i))for(let e=o;e<i.length;e++)lo(i[e],!1),co(i[e]);else null!=i&&(lo(i,!1),co(i));else lo(this,e)}const _o=e=>{2==e.type&&(e._$AP??=uo,e._$AQ??=po)};class go extends ao{constructor(){super(...arguments),this._$AN=void 0}_$AT(e,t,o){super._$AT(e,t,o),ho(this),this.isConnected=e._$AU}_$AO(e,t=!0){e!==this.isConnected&&(this.isConnected=e,e?this.reconnected?.():this.disconnected?.()),t&&(lo(this,e),co(this))}setValue(e){if((()=>void 0===this._$Ct.strings)())this._$Ct._$AI(e,this);else{const t=[...this._$Ct._$AH];t[this._$Ci]=e,this._$Ct._$AI(t,this,0)}}disconnected(){}reconnected(){}}let mo=class extends de{constructor(){super(...arguments),this.text="",this.cursorX=0,this.cursorY=0,this.offset=St,this.visible=!1,this._x=0,this._y=0}connectedCallback(){super.connectedCallback(),this.hasAttribute("role")||this.setAttribute("role","tooltip")}updated(){if(!this.visible)return;this.setAttribute("aria-hidden","false");const e=this.shadowRoot?.querySelector(".bubble"),t=e?.offsetWidth??0,o=e?.offsetHeight??0,i="undefined"!=typeof window?window.innerWidth:0,s="undefined"!=typeof window?window.innerHeight:0,{x:n,y:r}=function(e){const{cursorX:t,cursorY:o,ttW:i,ttH:s,vpW:n,vpH:r}=e,[a,l]=e.offset??St;let c=t+a,d=!1;c+i>n&&(c=t-a-i,d=!0),c<0&&(c=0);let h=o+l;return h+s>r&&(h=o-l-s),h<0&&(h=0),{x:c,y:h,flipped:d}}({cursorX:this.cursorX,cursorY:this.cursorY,ttW:t,ttH:o,vpW:i,vpH:s,offset:this.offset});n!==this._x&&(this._x=n),r!==this._y&&(this._y=r)}render(){return this.visible?H`<div class="bubble" style="transform: translate3d(${this._x}px, ${this._y}px, 0)">
       ${this.text}
-    </div>`:(this.setAttribute("aria-hidden","true"),V)}};_o.styles=r`
+    </div>`:(this.setAttribute("aria-hidden","true"),q)}};mo.styles=a`
     :host {
       position: fixed;
       top: 0;
@@ -28,17 +28,17 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
       white-space: normal;
       word-break: break-word;
     }
-  `,e([_e({type:String})],_o.prototype,"text",void 0),e([_e({type:Number})],_o.prototype,"cursorX",void 0),e([_e({type:Number})],_o.prototype,"cursorY",void 0),e([_e({attribute:!1})],_o.prototype,"offset",void 0),e([_e({type:Boolean,reflect:!0})],_o.prototype,"visible",void 0),e([ge()],_o.prototype,"_x",void 0),e([ge()],_o.prototype,"_y",void 0),_o=e([he("acp-floating-tooltip")],_o);const go={enabled:!0,offset:kt,delay:400};function mo(e){void 0!==e.enabled&&(go.enabled=e.enabled),void 0!==e.offset&&(go.offset=e.offset),void 0!==e.delay&&(go.delay=e.delay)}const vo="acp-floating-tooltip-bubble",fo=new class{constructor(){this._el=null,this._refs=0}get id(){return vo}retain(){this._refs+=1,this._ensure()}release(){this._refs=Math.max(0,this._refs-1)}_ensure(){if("undefined"==typeof document)return null;if(this._el&&this._el.isConnected)return this._el;const e=document.createElement("acp-floating-tooltip");return e.id=vo,document.body.appendChild(e),this._el=e,e}show(e,t,o,i){const s=this._ensure();s&&(s.text=e,s.cursorX=t,s.cursorY=o,s.offset=i,s.visible=!0)}move(e,t){this._el&&this._el.visible&&(this._el.cursorX=e,this._el.cursorY=t)}hide(){this._el&&(this._el.visible=!1)}_reset(){this._el&&this._el.parentNode&&this._el.parentNode.removeChild(this._el),this._el=null,this._refs=0}},bo=so(class extends uo{constructor(e){if(super(e),this._el=null,this._text="",this._offset=kt,this._delay=400,this._enabled=!0,this._openTimer=null,this._shown=!1,this._retained=!1,this._lastX=0,this._lastY=0,this._onEnter=e=>this._handleEnter(e),this._onMove=e=>this._handleMove(e),this._onLeave=()=>this._dismiss(),this._onFocus=()=>this._handleFocus(),this._onBlur=()=>this._dismiss(),this._onKey=e=>{"Escape"===e.key&&this._dismiss()},this._onScroll=()=>this._dismiss(),6!==e.type)throw new Error("tooltip() can only be used as an element-part directive")}render(e,t){return V}update(e,[t,o]){const i=e.element;return this._text=t??"",this._offset=o?.offset??go.offset,this._delay=o?.delay??go.delay,this._enabled=o?.enabled??go.enabled,this._el!==i?(this._teardown(),this._el=i,this._wire()):this._applyAttributes(),this.render(t,o)}_wire(){const e=this._el;e&&(this._applyAttributes(),this._enabled&&(fo.retain(),this._retained=!0,e.addEventListener("pointerenter",this._onEnter),e.addEventListener("pointermove",this._onMove),e.addEventListener("pointerleave",this._onLeave),e.addEventListener("focusin",this._onFocus),e.addEventListener("focusout",this._onBlur),e.addEventListener("keydown",this._onKey),window.addEventListener("scroll",this._onScroll,!0)))}_applyAttributes(){const e=this._el;e&&(this._enabled?(e.removeAttribute("title"),e.setAttribute("data-tooltip",this._text),e.setAttribute("aria-describedby",fo.id)):(e.removeAttribute("data-tooltip"),e.removeAttribute("aria-describedby"),e.removeAttribute("acp-tt-shown"),e.setAttribute("title",this._text)))}_handleEnter(e){this._lastX=e.clientX,this._lastY=e.clientY,this._armOpen()}_handleFocus(){const e=this._el;if(e&&"function"==typeof e.getBoundingClientRect){const t=e.getBoundingClientRect();this._lastX=t.left+t.width/2,this._lastY=t.bottom}this._armOpen()}_armOpen(){null===this._openTimer&&(this._openTimer=setTimeout(()=>{this._openTimer=null,this._open()},this._delay))}_open(){this._el&&(fo.show(this._text,this._lastX,this._lastY,this._offset),this._shown=!0,this._el.setAttribute("acp-tt-shown",""))}_handleMove(e){this._lastX=e.clientX,this._lastY=e.clientY,this._shown&&fo.move(this._lastX,this._lastY)}_dismiss(){null!==this._openTimer&&(clearTimeout(this._openTimer),this._openTimer=null),this._shown&&(fo.hide(),this._shown=!1),this._el?.removeAttribute("acp-tt-shown")}_teardown(){const e=this._el;e&&(this._dismiss(),e.removeEventListener("pointerenter",this._onEnter),e.removeEventListener("pointermove",this._onMove),e.removeEventListener("pointerleave",this._onLeave),e.removeEventListener("focusin",this._onFocus),e.removeEventListener("focusout",this._onBlur),e.removeEventListener("keydown",this._onKey),"undefined"!=typeof window&&window.removeEventListener("scroll",this._onScroll,!0),this._retained&&(fo.release(),this._retained=!1),e.removeAttribute("data-tooltip"),e.removeAttribute("aria-describedby"),e.removeAttribute("acp-tt-shown"),this._el=null)}disconnected(){this._teardown()}reconnected(){this._wire()}});function yo(){let e=null;return(t,o,i)=>{const s=o.entry_id??"";if(!s)return e=null,null;const n=null!==e&&e.registry===i&&e.entryId===s,r=n?e.base:xo(s,i);if(!r)return e={registry:i,entryId:s,base:null,devices:null,areas:null,posState:null,ctrlState:null,result:null},null;const a=t.devices,l=t.areas,c=r.entities.target_position_sensor??r.entities.group_position_sensor,d=r.entities.control_status_sensor,h=c?t.states[c]:void 0,p=d?t.states[d]:void 0;if(n&&null!==e&&null!==e.result&&e.devices===a&&e.areas===l&&e.posState===h&&e.ctrlState===p)return e.result;const u=$o(t,s,r);return e={registry:i,entryId:s,base:r,devices:a,areas:l,posState:h,ctrlState:p,result:u},u}}function wo(){const e=new Map;let t=[],o=[],i={list:[],missing:[]};return(s,n,r,a)=>{const l=n.map(t=>{let o=e.get(t);return o||(o=yo(),e.set(t,o)),o(s,{type:a,entry_id:t},r)});if(e.size>n.length)for(const t of e.keys())n.includes(t)||e.delete(t);const c=t.length===n.length&&t.every((e,t)=>e===n[t])&&o.length===l.length&&o.every((e,t)=>e===l[t]);if(c)return i;t=n.slice(),o=l;const d=[],h=[];return n.forEach((e,t)=>{const o=l[t];o?d.push(o):h.push(e)}),i={list:d,missing:h},i}}function xo(e,t){const o={},i=`${e}_`;let s,n=!1;for(const r of t){if(r.config_entry_id!==e)continue;if(r.platform!==Me)continue;if(n=!0,!s&&r.device_id&&(s=r.device_id),!r.unique_id.startsWith(i))continue;const t=r.unique_id.slice(i.length),a=r.entity_id.split(".")[0],l=Xe[`${a}:${t}`];l&&(o[l]=r.entity_id)}return n&&0!==Object.keys(o).length?{entities:o,deviceId:s}:null}function $o(e,t,o){const{entities:i,deviceId:s}=o,n=e;let r=t;if(n.devices)for(const e of Object.values(n.devices))if(e.config_entries?.includes(t)){r=e.name_by_user??e.name??t;break}const a=s?n.devices?.[s]?.area_id:void 0,l=a?e.areas?.[a]?.name:void 0,c=!!i.group_active_scene_sensor,d=[];if(c){const t=i.group_position_sensor;if(t){const o=e.states[t]?.attributes?.member_positions;o&&d.push(...Object.keys(o))}}else{const t=i.target_position_sensor;if(t){const o=e.states[t]?.attributes?.actual_positions;o&&d.push(...Object.keys(o))}}let h,p="cover_blind";const u=i.control_status_sensor;if(u){const t=e.states[u]?.attributes;t?.cover_type&&(p=t.cover_type);const o=t?.cover_discovery;o&&"object"==typeof o&&Array.isArray(o.axes)&&(h=o)}return{entry_id:t,entry_title:r,cover_type:p,entities:i,managed_covers:d,device_id:s,is_group:c,...h?{discovery:h}:{},...l?{area_name:l}:{}}}function ko(e,t,o){const i=t.entry_id;if(!i)return null;const s=xo(i,o);return s?$o(e,i,s):null}async function Ao(e){return e.callWS({type:"config/entity_registry/list"})}function So(e,t){let o=null,i=!1;return e.connection.subscribeEvents(e=>t(e.data),"entity_registry_updated").then(e=>{i?e():o=e}).catch(()=>{}),()=>{i=!0,o&&o()}}let Co=null,Eo=null;function zo(){return Co}function Mo(e,t=!1){if(Eo)return Eo;if(!t&&Co)return Promise.resolve(Co);const o=Ao(e).then(e=>(Co=e,Eo=null,e)).catch(e=>{throw Eo=null,e});return Eo=o,o}let Io=null,To=null;function Po(e){if(Io===e&&To)return To;const t=new Map;for(const o of e)t.set(o.entity_id,o);return Io=e,To=t,t}function Oo(e,t){return function(){if(Co||Eo)return;const e=globalThis.hassConnection;e&&(Eo=e.then(({conn:e})=>e.sendMessagePromise({type:"config/entity_registry/list"})).then(e=>(Co=e,Eo=null,e)).catch(e=>{throw Eo=null,e}),Eo.catch(()=>{}))}(),(o,i)=>{const s=function(e,t){const o=zo();if(!o)return e.callWS&&Mo(e).catch(()=>{}),null;const i=Po(o),s=i.get(t);if(s?.platform===Me)return s.config_entry_id;if(!t.startsWith("cover."))return null;for(const[o,s]of Object.entries(e.states)){const e=s?.attributes,n=e?.actual_positions??e?.member_positions;if(!n||!(t in n))continue;const r=i.get(o);if(r?.platform===Me)return r.config_entry_id}return null}(o,i);return s?{config:"entry_ids"===t?{type:e,entry_ids:[s]}:{type:e,entry_id:s}}:null}}async function Fo(e){const[t,o]=await Promise.all([e.callWS({type:"config_entries/get",domain:Me}),Ao(e)]),i=new Set(o.filter(e=>e.platform===Me&&null!=e.config_entry_id).map(e=>e.config_entry_id));return t.filter(e=>e.domain===Me&&i.has(e.entry_id)).map(e=>({entry_id:e.entry_id,title:e.title}))}function Bo(e){return`acp-card:registry:v1:${e}`}const No={get(e){try{const t=localStorage.getItem(Bo(e));if(!t)return null;const o=JSON.parse(t);return 1!==o.schemaVersion?null:o.entries?.length?"number"==typeof o.fetchedAt&&Date.now()-o.fetchedAt>6e4?null:o:null}catch{return null}},set(e,t){if(0!==t.length)try{const o={schemaVersion:1,cardVersion:ve,fetchedAt:Date.now(),entries:t};localStorage.setItem(Bo(e),JSON.stringify(o))}catch{}},invalidate(e){try{localStorage.removeItem(Bo(e))}catch{}},clear(){try{const e="acp-card:registry:v1:",t=[];for(let o=0;o<localStorage.length;o++){const i=localStorage.key(o);i?.startsWith(e)&&t.push(i)}t.forEach(e=>localStorage.removeItem(e))}catch{}}};function Do(e){return`${e.entity_id}|${e.unique_id}|${e.platform}|${e.config_entry_id??""}`}function Ro(e,t,o){return e.filter(e=>e.config_entry_id===t&&void 0===o)}let jo=class extends ce{constructor(){super(...arguments),this.on=!1,this.readonly=!1,this.label="",this.title=""}_handleClick(){this.readonly||this.dispatchEvent(new CustomEvent("pill-click",{bubbles:!0,composed:!0}))}render(){return W`
+  `,e([ge({type:String})],mo.prototype,"text",void 0),e([ge({type:Number})],mo.prototype,"cursorX",void 0),e([ge({type:Number})],mo.prototype,"cursorY",void 0),e([ge({attribute:!1})],mo.prototype,"offset",void 0),e([ge({type:Boolean,reflect:!0})],mo.prototype,"visible",void 0),e([me()],mo.prototype,"_x",void 0),e([me()],mo.prototype,"_y",void 0),mo=e([pe("acp-floating-tooltip")],mo);const vo={enabled:!0,offset:St,delay:400};function fo(e){void 0!==e.enabled&&(vo.enabled=e.enabled),void 0!==e.offset&&(vo.offset=e.offset),void 0!==e.delay&&(vo.delay=e.delay)}const bo="acp-floating-tooltip-bubble",yo=new class{constructor(){this._el=null,this._refs=0}get id(){return bo}retain(){this._refs+=1,this._ensure()}release(){this._refs=Math.max(0,this._refs-1)}_ensure(){if("undefined"==typeof document)return null;if(this._el&&this._el.isConnected)return this._el;const e=document.createElement("acp-floating-tooltip");return e.id=bo,document.body.appendChild(e),this._el=e,e}show(e,t,o,i){const s=this._ensure();s&&(s.text=e,s.cursorX=t,s.cursorY=o,s.offset=i,s.visible=!0)}move(e,t){this._el&&this._el.visible&&(this._el.cursorX=e,this._el.cursorY=t)}hide(){this._el&&(this._el.visible=!1)}_reset(){this._el&&this._el.parentNode&&this._el.parentNode.removeChild(this._el),this._el=null,this._refs=0}},wo=ro(class extends go{constructor(e){if(super(e),this._el=null,this._text="",this._offset=St,this._delay=400,this._enabled=!0,this._openTimer=null,this._shown=!1,this._retained=!1,this._lastX=0,this._lastY=0,this._onEnter=e=>this._handleEnter(e),this._onMove=e=>this._handleMove(e),this._onLeave=()=>this._dismiss(),this._onFocus=()=>this._handleFocus(),this._onBlur=()=>this._dismiss(),this._onKey=e=>{"Escape"===e.key&&this._dismiss()},this._onScroll=()=>this._dismiss(),6!==e.type)throw new Error("tooltip() can only be used as an element-part directive")}render(e,t){return q}update(e,[t,o]){const i=e.element;return this._text=t??"",this._offset=o?.offset??vo.offset,this._delay=o?.delay??vo.delay,this._enabled=o?.enabled??vo.enabled,this._el!==i?(this._teardown(),this._el=i,this._wire()):this._applyAttributes(),this.render(t,o)}_wire(){const e=this._el;e&&(this._applyAttributes(),this._enabled&&(yo.retain(),this._retained=!0,e.addEventListener("pointerenter",this._onEnter),e.addEventListener("pointermove",this._onMove),e.addEventListener("pointerleave",this._onLeave),e.addEventListener("focusin",this._onFocus),e.addEventListener("focusout",this._onBlur),e.addEventListener("keydown",this._onKey),window.addEventListener("scroll",this._onScroll,!0)))}_applyAttributes(){const e=this._el;e&&(this._enabled?(e.removeAttribute("title"),e.setAttribute("data-tooltip",this._text),e.setAttribute("aria-describedby",yo.id)):(e.removeAttribute("data-tooltip"),e.removeAttribute("aria-describedby"),e.removeAttribute("acp-tt-shown"),e.setAttribute("title",this._text)))}_handleEnter(e){this._lastX=e.clientX,this._lastY=e.clientY,this._armOpen()}_handleFocus(){const e=this._el;if(e&&"function"==typeof e.getBoundingClientRect){const t=e.getBoundingClientRect();this._lastX=t.left+t.width/2,this._lastY=t.bottom}this._armOpen()}_armOpen(){null===this._openTimer&&(this._openTimer=setTimeout(()=>{this._openTimer=null,this._open()},this._delay))}_open(){this._el&&(yo.show(this._text,this._lastX,this._lastY,this._offset),this._shown=!0,this._el.setAttribute("acp-tt-shown",""))}_handleMove(e){this._lastX=e.clientX,this._lastY=e.clientY,this._shown&&yo.move(this._lastX,this._lastY)}_dismiss(){null!==this._openTimer&&(clearTimeout(this._openTimer),this._openTimer=null),this._shown&&(yo.hide(),this._shown=!1),this._el?.removeAttribute("acp-tt-shown")}_teardown(){const e=this._el;e&&(this._dismiss(),e.removeEventListener("pointerenter",this._onEnter),e.removeEventListener("pointermove",this._onMove),e.removeEventListener("pointerleave",this._onLeave),e.removeEventListener("focusin",this._onFocus),e.removeEventListener("focusout",this._onBlur),e.removeEventListener("keydown",this._onKey),"undefined"!=typeof window&&window.removeEventListener("scroll",this._onScroll,!0),this._retained&&(yo.release(),this._retained=!1),e.removeAttribute("data-tooltip"),e.removeAttribute("aria-describedby"),e.removeAttribute("acp-tt-shown"),this._el=null)}disconnected(){this._teardown()}reconnected(){this._wire()}});function xo(){let e=null;return(t,o,i)=>{const s=o.entry_id??"";if(!s)return e=null,null;const n=null!==e&&e.registry===i&&e.entryId===s,r=n?e.base:ko(s,i);if(!r)return e={registry:i,entryId:s,base:null,devices:null,areas:null,posState:null,ctrlState:null,result:null},null;const a=t.devices,l=t.areas,c=r.entities.target_position_sensor??r.entities.group_position_sensor,d=r.entities.control_status_sensor,h=c?t.states[c]:void 0,p=d?t.states[d]:void 0;if(n&&null!==e&&null!==e.result&&e.devices===a&&e.areas===l&&e.posState===h&&e.ctrlState===p)return e.result;const u=Ao(t,s,r);return e={registry:i,entryId:s,base:r,devices:a,areas:l,posState:h,ctrlState:p,result:u},u}}function $o(){const e=new Map;let t=[],o=[],i={list:[],missing:[]};return(s,n,r,a)=>{const l=n.map(t=>{let o=e.get(t);return o||(o=xo(),e.set(t,o)),o(s,{type:a,entry_id:t},r)});if(e.size>n.length)for(const t of e.keys())n.includes(t)||e.delete(t);const c=t.length===n.length&&t.every((e,t)=>e===n[t])&&o.length===l.length&&o.every((e,t)=>e===l[t]);if(c)return i;t=n.slice(),o=l;const d=[],h=[];return n.forEach((e,t)=>{const o=l[t];o?d.push(o):h.push(e)}),i={list:d,missing:h},i}}function ko(e,t){const o={},i=`${e}_`;let s,n=!1;for(const r of t){if(r.config_entry_id!==e)continue;if(r.platform!==Te)continue;if(n=!0,!s&&r.device_id&&(s=r.device_id),!r.unique_id.startsWith(i))continue;const t=r.unique_id.slice(i.length),a=r.entity_id.split(".")[0],l=Je[`${a}:${t}`];l&&(o[l]=r.entity_id)}return n&&0!==Object.keys(o).length?{entities:o,deviceId:s}:null}function Ao(e,t,o){const{entities:i,deviceId:s}=o,n=e;let r=t;if(n.devices)for(const e of Object.values(n.devices))if(e.config_entries?.includes(t)){r=e.name_by_user??e.name??t;break}const a=s?n.devices?.[s]?.area_id:void 0,l=a?e.areas?.[a]?.name:void 0,c=!!i.group_active_scene_sensor,d=[];if(c){const t=i.group_position_sensor;if(t){const o=e.states[t]?.attributes?.member_positions;o&&d.push(...Object.keys(o))}}else{const t=i.target_position_sensor;if(t){const o=e.states[t]?.attributes?.actual_positions;o&&d.push(...Object.keys(o))}}let h,p="cover_blind";const u=i.control_status_sensor;if(u){const t=e.states[u]?.attributes;t?.cover_type&&(p=t.cover_type);const o=t?.cover_discovery;o&&"object"==typeof o&&Array.isArray(o.axes)&&(h=o)}return{entry_id:t,entry_title:r,cover_type:p,entities:i,managed_covers:d,device_id:s,is_group:c,...h?{discovery:h}:{},...l?{area_name:l}:{}}}function So(e,t,o){const i=t.entry_id;if(!i)return null;const s=ko(i,o);return s?Ao(e,i,s):null}async function Co(e){return e.callWS({type:"config/entity_registry/list"})}function Eo(e,t){let o=null,i=!1;return e.connection.subscribeEvents(e=>t(e.data),"entity_registry_updated").then(e=>{i?e():o=e}).catch(()=>{}),()=>{i=!0,o&&o()}}let zo=null,Mo=null;function To(){return zo}function Io(e,t=!1){if(Mo)return Mo;if(!t&&zo)return Promise.resolve(zo);const o=Co(e).then(e=>(zo=e,Mo=null,e)).catch(e=>{throw Mo=null,e});return Mo=o,o}let Po=null,Oo=null;function Bo(e){if(Po===e&&Oo)return Oo;const t=new Map;for(const o of e)t.set(o.entity_id,o);return Po=e,Oo=t,t}function Fo(e,t){return function(){if(zo||Mo)return;const e=globalThis.hassConnection;e&&(Mo=e.then(({conn:e})=>e.sendMessagePromise({type:"config/entity_registry/list"})).then(e=>(zo=e,Mo=null,e)).catch(e=>{throw Mo=null,e}),Mo.catch(()=>{}))}(),(o,i)=>{const s=function(e,t){const o=To();if(!o)return e.callWS&&Io(e).catch(()=>{}),null;const i=Bo(o),s=i.get(t);if(s?.platform===Te)return s.config_entry_id;if(!t.startsWith("cover."))return null;for(const[o,s]of Object.entries(e.states)){const e=s?.attributes,n=e?.actual_positions??e?.member_positions;if(!n||!(t in n))continue;const r=i.get(o);if(r?.platform===Te)return r.config_entry_id}return null}(o,i);return s?{config:"entry_ids"===t?{type:e,entry_ids:[s]}:{type:e,entry_id:s}}:null}}async function No(e){const[t,o]=await Promise.all([e.callWS({type:"config_entries/get",domain:Te}),Co(e)]),i=new Set(o.filter(e=>e.platform===Te&&null!=e.config_entry_id).map(e=>e.config_entry_id));return t.filter(e=>e.domain===Te&&i.has(e.entry_id)).map(e=>({entry_id:e.entry_id,title:e.title}))}function Do(e){return`acp-card:registry:v1:${e}`}const Ro={get(e){try{const t=localStorage.getItem(Do(e));if(!t)return null;const o=JSON.parse(t);return 1!==o.schemaVersion?null:o.entries?.length?"number"==typeof o.fetchedAt&&Date.now()-o.fetchedAt>6e4?null:o:null}catch{return null}},set(e,t){if(0!==t.length)try{const o={schemaVersion:1,cardVersion:fe,fetchedAt:Date.now(),entries:t};localStorage.setItem(Do(e),JSON.stringify(o))}catch{}},invalidate(e){try{localStorage.removeItem(Do(e))}catch{}},clear(){try{const e="acp-card:registry:v1:",t=[];for(let o=0;o<localStorage.length;o++){const i=localStorage.key(o);i?.startsWith(e)&&t.push(i)}t.forEach(e=>localStorage.removeItem(e))}catch{}}};function jo(e){return`${e.entity_id}|${e.unique_id}|${e.platform}|${e.config_entry_id??""}`}function Ko(e,t,o){return e.filter(e=>e.config_entry_id===t&&void 0===o)}let Lo=class extends de{constructor(){super(...arguments),this.on=!1,this.readonly=!1,this.label="",this.title=""}_handleClick(){this.readonly||this.dispatchEvent(new CustomEvent("pill-click",{bubbles:!0,composed:!0}))}render(){return H`
       <button
         class="pill ${this.on?"on":"off"} ${this.readonly?"readonly":""}"
-        ${bo(this.title)}
-        aria-disabled=${this.readonly?"true":V}
+        ${wo(this.title)}
+        aria-disabled=${this.readonly?"true":q}
         tabindex=${this.readonly?"-1":"0"}
         @click=${this._handleClick}
       >
         ${this.label}
       </button>
-    `}};jo.styles=r`
+    `}};Lo.styles=a`
     .pill {
       padding: 2px 10px;
       border-radius: 999px;
@@ -73,52 +73,52 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
     .pill.on.readonly {
       opacity: 0.85;
     }
-  `,e([_e({type:Boolean})],jo.prototype,"on",void 0),e([_e({type:Boolean})],jo.prototype,"readonly",void 0),e([_e({type:String})],jo.prototype,"label",void 0),e([_e({type:String})],jo.prototype,"title",void 0),jo=e([he("acp-header-pill")],jo);const Ko=so(class extends no{constructor(e){if(super(e),1!==e.type||"class"!==e.name||e.strings?.length>2)throw Error("`classMap()` can only be used in the `class` attribute and must be the only part in the attribute.")}render(e){return" "+Object.keys(e).filter(t=>e[t]).join(" ")+" "}update(e,[t]){if(void 0===this.st){this.st=new Set,void 0!==e.strings&&(this.nt=new Set(e.strings.join(" ").split(/\s/).filter(e=>""!==e)));for(const e in t)t[e]&&!this.nt?.has(e)&&this.st.add(e);return this.render(t)}const o=e.element.classList;for(const e of this.st)e in t||(o.remove(e),this.st.delete(e));for(const e in t){const i=!!t[e];i===this.st.has(e)||this.nt?.has(e)||(i?(o.add(e),this.st.add(e)):(o.remove(e),this.st.delete(e)))}return U}});function Lo(e){return e&&e.__esModule&&Object.prototype.hasOwnProperty.call(e,"default")?e.default:e}var Go,Wo,Ho={exports:{}},Uo=(Go||(Go=1,Wo=Ho,function(){var e=Math.PI,t=Math.sin,o=Math.cos,i=Math.tan,s=Math.asin,n=Math.atan2,r=Math.acos,a=e/180,l=864e5,c=2440588,d=2451545;function h(e){return new Date((e+.5-c)*l)}function p(e){return function(e){return e.valueOf()/l-.5+c}(e)-d}var u=23.4397*a;function _(e,s){return n(t(e)*o(u)-i(s)*t(u),o(e))}function g(e,i){return s(t(i)*o(u)+o(i)*t(u)*t(e))}function m(e,s,r){return n(t(e),o(e)*t(s)-i(r)*o(s))}function v(e,i,n){return s(t(i)*t(n)+o(i)*o(n)*o(e))}function f(e,t){return a*(280.16+360.9856235*e)-t}function b(e){return a*(357.5291+.98560028*e)}function y(o){return o+a*(1.9148*t(o)+.02*t(2*o)+3e-4*t(3*o))+102.9372*a+e}function w(e){var t=y(b(e));return{dec:g(t,0),ra:_(t,0)}}var x={getPosition:function(e,t,o){var i=a*-o,s=a*t,n=p(e),r=w(n),l=f(n,i)-r.ra;return{azimuth:m(l,s,r.dec),altitude:v(l,s,r.dec)}}},$=x.times=[[-.833,"sunrise","sunset"],[-.3,"sunriseEnd","sunsetStart"],[-6,"dawn","dusk"],[-12,"nauticalDawn","nauticalDusk"],[-18,"nightEnd","night"],[6,"goldenHourEnd","goldenHour"]];x.addTime=function(e,t,o){$.push([e,t,o])};var k=9e-4;function A(t,o,i){return k+(t+o)/(2*e)+i}function S(e,o,i){return d+e+.0053*t(o)-.0069*t(2*i)}function C(e,i,s,n,a,l,c){var d=function(e,i,s){return r((t(e)-t(i)*t(s))/(o(i)*o(s)))}(e,s,n);return S(A(d,i,a),l,c)}function E(e){var i=a*(134.963+13.064993*e),s=a*(93.272+13.22935*e),n=a*(218.316+13.176396*e)+6.289*a*t(i),r=5.128*a*t(s),l=385001-20905*o(i);return{ra:_(n,r),dec:g(n,r),dist:l}}function z(e,t){return new Date(e.valueOf()+t*l/24)}x.getTimes=function(t,o,i,s){var n,r,l,c,d,u=a*-i,_=a*o,m=function(e){return-2.076*Math.sqrt(e)/60}(s=s||0),v=function(t,o){return Math.round(t-k-o/(2*e))}(p(t),u),f=A(0,u,v),w=b(f),x=y(w),E=g(x,0),z=S(f,w,x),M={solarNoon:h(z),nadir:h(z-.5)};for(n=0,r=$.length;n<r;n+=1)d=z-((c=C(((l=$[n])[0]+m)*a,u,_,E,v,w,x))-z),M[l[1]]=h(d),M[l[2]]=h(c);return M},x.getMoonPosition=function(e,s,r){var l=a*-r,c=a*s,d=p(e),h=E(d),u=f(d,l)-h.ra,_=v(u,c,h.dec),g=n(t(u),i(c)*o(h.dec)-t(h.dec)*o(u));return _+=function(e){return e<0&&(e=0),2967e-7/Math.tan(e+.00312536/(e+.08901179))}(_),{azimuth:m(u,c,h.dec),altitude:_,distance:h.dist,parallacticAngle:g}},x.getMoonIllumination=function(e){var i=p(e||new Date),s=w(i),a=E(i),l=149598e3,c=r(t(s.dec)*t(a.dec)+o(s.dec)*o(a.dec)*o(s.ra-a.ra)),d=n(l*t(c),a.dist-l*o(c)),h=n(o(s.dec)*t(s.ra-a.ra),t(s.dec)*o(a.dec)-o(s.dec)*t(a.dec)*o(s.ra-a.ra));return{fraction:(1+o(d))/2,phase:.5+.5*d*(h<0?-1:1)/Math.PI,angle:h}},x.getMoonTimes=function(e,t,o,i){var s=new Date(e);i?s.setUTCHours(0,0,0,0):s.setHours(0,0,0,0);for(var n,r,l,c,d,h,p,u,_,g,m,v,f,b=.133*a,y=x.getMoonPosition(s,t,o).altitude-b,w=1;w<=24&&(n=x.getMoonPosition(z(s,w),t,o).altitude-b,u=((d=(y+(r=x.getMoonPosition(z(s,w+1),t,o).altitude-b))/2-n)*(p=-(h=(r-y)/2)/(2*d))+h)*p+n,g=0,(_=h*h-4*d*n)>=0&&(m=p-(f=Math.sqrt(_)/(2*Math.abs(d))),v=p+f,Math.abs(m)<=1&&g++,Math.abs(v)<=1&&g++,m<-1&&(m=v)),1===g?y<0?l=w+m:c=w+m:2===g&&(l=w+(u<0?v:m),c=w+(u<0?m:v)),!l||!c);w+=2)y=r;var $={};return l&&($.rise=z(s,l)),c&&($.set=z(s,c)),l||c||($[u>0?"alwaysUp":"alwaysDown"]=!0),$},Wo.exports=x}()),Ho.exports),Vo=Lo(Uo);const qo=new Map;function Yo(e,t,o,i=10){const s=`${e},${t},${o.getTime()},${i}`,n=qo.get(s);if(n)return qo.delete(s),qo.set(s,n),n;const r=[],a=o.getTime()+864e5;for(let s=o.getTime();s<=a;s+=60*i*1e3){const o=new Date(s),i=Vo.getPosition(o,e,t);r.push({t:o,elevation:180*i.altitude/Math.PI,azimuth:((180*i.azimuth/Math.PI+180)%360+360)%360})}if(qo.set(s,r),qo.size>4){const e=qo.keys().next().value;void 0!==e&&qo.delete(e)}return r}function Qo(e=new Date){const t=new Date(e);return t.setHours(0,0,0,0),t}function Zo(e,t=new Date){if(!e)return Qo(t);const o=new Intl.DateTimeFormat("en-CA",{timeZone:e,year:"numeric",month:"2-digit",day:"2-digit"}).format(t),[i,s,n]=o.split("-").map(Number),r=Date.UTC(i,s-1,n,0,0,0),a=function(e,t){const o=new Intl.DateTimeFormat("en-US",{timeZone:e,year:"numeric",month:"2-digit",day:"2-digit",hour:"2-digit",minute:"2-digit",second:"2-digit",hourCycle:"h23"}).formatToParts(t),i={};for(const e of o)"literal"!==e.type&&(i[e.type]=Number(e.value));return Date.UTC(i.year,i.month-1,i.day,i.hour,i.minute,i.second)-t.getTime()}(e,new Date(r));return new Date(r-a)}function Xo(e,t,o,i){const s=((t-o)%360+360)%360;return((e-s)%360+360)%360<=((((t+i)%360+360)%360-s)%360+360)%360}function Jo(e,t,o,i){const s=[];let n=-1;for(let r=0;r<e.length;r++){const a=e[r];a.elevation>0&&Xo(a.azimuth,t,o,i)?-1===n&&(n=r):-1!==n&&(s.push({startIdx:n,endIdx:r-1}),n=-1)}return-1!==n&&s.push({startIdx:n,endIdx:e.length-1}),s}function ei(e){const t=[];let o=-1;for(let i=0;i<e.length;i++)e[i].elevation>0?-1===o&&(o=i):-1!==o&&(t.push({startIdx:o,endIdx:i-1}),o=-1);return-1!==o&&t.push({startIdx:o,endIdx:e.length-1}),t}function ti(e,t,o=new Date){const i=Vo.getMoonPosition(o,e,t),s=Vo.getMoonIllumination(o);return{azimuth:((180*i.azimuth/Math.PI+180)%360+360)%360,elevation:180*i.altitude/Math.PI,phase:s.phase,fraction:s.fraction,phaseName:oi(s.phase)}}function oi(e){return e<.0625||e>=.9375?"New Moon":e<.1875?"Waxing Crescent":e<.3125?"First Quarter":e<.4375?"Waxing Gibbous":e<.5625?"Full Moon":e<.6875?"Waning Gibbous":e<.8125?"Last Quarter":"Waning Crescent"}const ii=new Set(["outside_fov","in_fov_not_valid","hitting"]),si={night:"sun night",hitting:"sun valid",in_fov_not_valid:"sun in-fov",outside_fov:"sun up"};function ni(e){return e.belowHorizon?"night":e.sunState&&ii.has(e.sunState)?e.sunState:e.directSunValid?"hitting":e.inFov?"in_fov_not_valid":"outside_fov"}const ri=["#1f77b4","#ff7f0e","#2ca02c","#d62728","#9467bd","#17becf","#e377c2"];function ai(e){const t=ri.length;return ri[(e%t+t)%t]}function li(e,t){return"string"==typeof e&&e.length>0?{color:e,isOverride:!0}:{color:ai(t),isOverride:!1}}const ci="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAYAAADimHc4AABBS0lEQVR42tW9aaymWX4f9Dvbs7/7e9fqrrV7pmdpezw9nhnjOJETbI+3xEY4sUJEPgRiS5bhS1DAIghLkQgKwQEiJYCI+RCCIWAgibHHtohjj21m72Wmu6eX6aWqbt31XZ/9OQsfzjnPvdXu2ReHklrV03Or7nvP8l9+y/8Q/DH/IoSAANQA1BhjAKir//9wOMR0MknnO/Pd6XS6uzOfz6bT6WSQDQZCCFFVJdq2lVKp7XqzWebb/GK73Z4dPTg6OT4+yZfLJexf2/+ilFJKCNFaa/3H/vP/MS48AcCMMQqAAYAgCLC/tze+cf36ux9//LH3z2az982mkyfGo/EjYRjOGWMp4wyMMnRdB0IItNbQWoNSCq01OOcYDoelUvqiqIp76/XmxTfefPOZl1955TMvPP/C519/441FXdf9x2CUMhCijTFfcjPesoH//90Au+agxhjiT/pwOMD+3v4T+/t7P/iOxx77wTu3b38wy7Idxhjy7RZKK0ipoJSCEAJKKVNVlSGEmK7rQCmFEAKMMZIkCUnTlABAFEUYj8fI0hRRkoALDkLpxdHR0adeePHF3/z4xz/xm5/61Kc/d3Jy4j8e45zDGKO+3IJ/szeDfBsXn7kQo6MowiPXrl07vHbwb4xHoz/PGfvQeDgSo9EQUiq0XWuaplEwAKWUSClJJyXRxpAwCBAGAYIggJQSlFI0TYMgCMAYQzYYgBJigiCA1lrP5nPjvp6NpxMym8+RJgkMoO7dvffJj3/i4//kYx/7g//9M599+o2qKgGAcM7pt2sjyLdh4an7sHo8HuP2rVsfvnZ48FeDMPjJpmnGxhgYY8Apk2VZkrptaBRFhDGGQAjszncgpURelVBKgVIKow1mkwmGwyG22y3quoZSCmVVgVCCKAghhAClFEmSYDqdIo5jDAYDMxqP9SDLTFVV3BgDxhjatt0ePTj+p7//B3/w3/3+H/7h7y6XSwCg7kbob+VGkG9ljDfGUAAqS1PcvnX7+69ff/SvdbL9kaqq4GK+YoxBcE7bpiVlXYESAkop4iTBdDLB4f4B2qYFYRSj4RB1XUNrjSAIUNc1tpstKKOo6xpt20JKibZtEQQBKKVo2xZpmmI4GoEAGI/HGA6HAGC01sYYo9u25aPRCGma4uTs9Lc/9enP/Be/+3u/99HFYglCwBjjWmttvhWbQL6F4UZxIfDOxx//rv39/f9Edt1PFGUBxqhhjGshOOWcE2OAKAqhtca1g0NQQkAIQZKm4JwjS1N0bYsoitBJicVi0Sddn3iVUmjbFuPRCAbA+cUFOOdgjEFrha7tcHZ+Dm00hoMhRsMhxuMxoigC5xxaa5MkiW6ahgIgw+EAZVX/+u//wR/+4u/87u9+vCxLcM7ZlwtLX+8mkG/Vqb927XD8HU8++R83TfPvrVcbQSjRlBLDOWPEnXIpFYwGpJI4PNjD/u4eRCAQiAB1U2M8GqNpGhwdHYExBgMDpTQGWQbGGMIwxDrfwkgFEKBpGuzv7+Pw4BDL5RJd10FwAaUVqqrCcrlE23UQnINzjul0CiklAGAwGCCOY2y3WyWEIMPhkAoh9DbP/8H//Rsf/U8/8clPnrlE/SVvw9ezCeybHOtNGIbmyfe+58fe9cQTv7rZbH50vVozxpiy34tQQgiMMdBKA7Bl5Gw2RZImaLsObdehqipQQgEAz7/4Ak7OzrDNc9RNg9V6DUoolFK4f/8eVus1jDbIywJn5+fIiwLr9RqMMbz40hdwsbhAmiRgjGE6nWI8GqGuKtR1jaqq7GcxBuvNGkopGGNo27ak6zpVliVlhHzwwx/+0E/fvn3n3hdeeulzVVXBJWnzJaq8b/8GEAJuDNT+/l70Xe973y+FQfB3jx+cTLu2k4xxQimljDEwTiE7BYCAcVvLp1mKvf1dUGoXvG1aRGGIJEnwxr27WG82IIT0IUVKidV6g/PzC5R1AwJ7g9ziYTwaAQA2mw2CIMRoNAbn9sdM0xSHh4dYLBfY5jkiWymBc46mbuD7A0opGKVUCEGSNJVlWU7u3L71U0899f7rp2dn/+LBg+OGUsoJIfob3QT2TajrOQD53ve855137tz+Z6vl6iebptGUUiOEYFxwYtyNVVKBEoowEgAMoijEZDJGVVVo2xZJHMPAYLvd4vjkFF0n0dQN2k6h6zp0nYSSGkpq2JtkgyhjdvMYY1BaIxIB2qZF27aomhqMMgyyDNyFnuFgCMY5hBAoyxJd1/WbK5XCerVC3bao6xrGGBoEga7rWu/M50/9xJ/7cz/GRfCHTz/99BEh5BveBPaNLL4xhgsh5FPv/64fGY9Hv3Z+fvFYGAbSNpiUEEKgpD2ZWttFEyEHIYBSCmEY2g9BKZTWtoJpGjw4OUXbdpBK9n/WaBu2/G3QWoMxCgICQolLuBrGGJR1BSY4GGeo6xp104AxijTLQClF13VIkgRSSlRVhdFohK7r0CoJ1dneou5aVFWJxWqJPC+IlJICkEKIgw9+8AN/aTAYvPLZzz79Oa01p5R+3ZvAvpHFj+NYPvX+p35GK/WPV8tVMhqNlDaaN3Xz0AcwxriOlYExCillDyPUTQ0YQHCB5XKN9WZjQwCjAMHlSTcPJznOmU3MxoAQgBB7AxhjoNTmCP99OOdYbzfQSkMIgbquEYYhjDFo2xZlWYIQgjAIsbuzgyiK7OYDkFqjrErkeY66biinVFFKoyff/e6funbtWv7008/8ftu2zH+Wr3UT2Ne7+GmSyg889f5fAPQvNU1jhAhM27asbVpQSh+K25xzcMFA6cOborUGAQEIsNnkaNsWlDEwSkEZBYy7Qdr0OcJu5uVpJ4TY3oFRcM5tHmnbhzbefo39/+M4hupkXwEpZWGOJElAAGRZhiRJwKgNScZhTdoYFGWBuq5pwIUJwkBff/TRj9y6eTN89rnnfruqKsYYxVtT81faBPb1nvzvfN93/I0wFH8TxEjKGJVSUX8ajbFfGwQCXHAYGAQBhzH2lPpE52OyVhpSKnDBIdw/AKBcyPE1/+Wi2pAjuIA2GpSRK3X/lY1xiy8CgYAHaLsW08kUURih7dq+WyaE9CFpsVigaewN1kpBcPs1YRAChKBtG2itifulDg/2/9Rjjz+Wfvozn/3Npmk4pdR8S5KwX/woiuQHnvrAL0Drv9k0raSUsbKoiFLKfw04ZwjCAIQCWitQan9AIUTfOBFCYDRAr2yIb8IoJairFkrZW+K/v2/ALIRAAdjf/Yb4729DFEcQBOCcg1KKNIkRcIHNdgN/SoQQEEKgbVswxhDHMXZ2dgAAcRwjjmNwzpHEMeI4creIYTgcgjFGpJTUAN1oOPi+69evR08/8+xvKSk5eUtO+HK34Gu5AVwIIb/nwx/6GSXlLwkhZNu1rCzt4vsT6k8eYwRKKQyHIxweHqIoCrRt6zaIwxiDrpVQUoJQIAgDGBhobSClBiG0X3QA/e+++6WUggsGwJ72vr/Q2t4KQvvwl6UpwjCChgbc1+3M58iLAkIIEEIQxzEYY4iiCFEU9ZuS57mt0poWbdP0KKsPsXVds7pu5CBN/+SdO48Vn/7MZz72paqjr3sDCCGMEKI+/OEPfSSKwl8BjCKMsHyTkz8SHggFEwyc2xM1HA4RRRGKooCHiT2CSQjABUeSJP2fV1LCaPSb5OM6ZaQvNwHiFoBBSVsd+bCjtd1YEQikaYqmaUAZQ9006KQEJRRN10F1EmVVIgxDzKZTAMB2u0VZlj2453NEURQ2RxCC1EEkUso+nEopiTFGPfHOd3xkMBw+/8wzz36OUsoB6K90C77iBlBKqTFGP/XU+x/b3939aF7kYV01qKqaCiFgjC0zjXFhxIWEJE1w8+ZNfO/3fi+effbZPuwQQlBVle0JGIVWBl0n0bUS2thS1Bi72Iy7asgAjNsQJaWGEBxc2GqKc1tu+vhvN1L38V1rjTC0WFMURdhsNhBCYDAYIAojzKZTdF1nYQ3XQYdhCCll3yMEQYCmaSCCAFEYYrlawgAYDgb+kBAAZLlcmsfv3PlxbfQ/f/mVVx8wxt62Y/6qN8BjO7dv3Qq+88knP3r/6N6tump0VdVsOMiglEJdty7zX8beKA6QJAmUUrh37x7atu1PlK31W9i1IpBSQisDqWyTZrRx3SmDEMxtHGx4UvaWJGkEQuyf9TfDw9qXOJP9XlEUwRiDNE0xn8/RNA2apkErJUaDIRhjqKoKeZ5ju932Ycj/+YvlAk3bgDOO2WyGOAxtz9A2PfoqhMBwOCRlWer7R0fBhz70oT99/+jofzw+Pu7erjz9qjbAJ93xeKR+/Md/9L++e/fun12vt1JJyT2MUNcNKChAAUZZfyUNgK5rsd1usVquQaiN5fYDK7StfOhDMW5Di7CsFZRSYA4+aBsJQm1iVlL34cjnAZ98lVKuObMneDQaIY5je+so6WlMD1sbYyA4w97OHo6Oj/HyKy/j9Owc5xfnMACiMEQYhqjbFkVRuF7E9KUy5wLakkdXN4GenZ1JQsjOO594x/XPfPbpX3WVkf5SYejLbQADoH7wB37gI4Tgvzp+cCK11tyfsKZuQQgAYkBAH0rCAEAoAQEDpTZR2ripoJVGNsgAA1BGITgDdUjnI48eom3txnJuF1YIbsMRY2ibDkEoEAS2ctnZ2cF8Pndhy1Y1cRwjy7I+KY+GI8RhhDiM+jBFCEEURYjjBNsyx73791DVNYIwQCcllusVpFRglEJrhW2eW26h69DKDkkco+vafvM9lMEYQ9d1dLFYyL3dnfft7++/8Nmnn3mO+kX4am+ACz1473vfk73j8cd+/fU33hzKThGpFLFViuqRbEIIOGMghD7cZLnE6OHeKI76/20xHF9CWk43y2xIAwClbQyPosiGLiXBGYfSCpZqVP0NMsb0CzCdTjHIMiRxgk7ZBayqCoILhEEADQPKGIqiQBiGoJTi5OQEeZ73TZsF4lh/spMoRpamUFqDcQ5KLONW1hXKqkQaJ5jNZ33z5/+O8/OFef/73vf92zz/5dffeKNijJG3ywfsbZBNAITFcaz/zJ/5/r+13W4/srhYqqapmdIKBJcNDrHBGbjy3/yHeLgnED0G40+hkgpaGVuPB6IHwyz5biufuq5tmQjSM1z+6/ziN03T9xaj0cguEoAkidG0rY3XXYsojpAlCVarFbQxKMvS8gMuHNV1Cym7h34ObQzKuoZUNiHnRQHq4Imu67DZbtF1LaaTCYzjFNzPTZIkVmenp4Nbd27NX/zCF/6voijp2zVp7Evh+h/+8Ifes7sz/4f3798H44w1dUuM0f7cQxsFGANjQRoQQmGM7kORvx1hZBc/CIK+6ek6hTAMAKD/3dOU/hbEcdQDZZzzPpEHwoYJf3t8pdN1nf1zUeS6VwbK7WY3TYOz83PAALu7uxgMhyiLAlVV9QfFaINAiL7n0B4cdCfbh7lACIyGIxRVCSk7MMqwv7/vuWUEQYDVaoXJZEKbrlOM0vfv7uz+xrPPPXf37UIRfZvESyaTsblz5/Z/Xte1YIyhqRvCGe9xm/7vIBZ6sN2p7jfAnyBj0CdOKSUGAxeb3aJwbhcwDMO+EfLcrJQKWZZhsVj0i0sIgTb6ocUnBOg6G9byPLfAGiUo6wpa2ZDlw0tVV+CEoipKBEHQV1KccwShhTX8AfBNXd80dh1AACEEkiRBFIaWNCIEi9USQggURYHVaoUsy1BVlaNTO/Lkk+/927dv34ZSylw9oH/kBvjE+699z4f+xGg4+M+6rlNVVTEQY+FhqUAcoGZgQTECCs7FQ+EnDENXyVCXRC8rpO02ByEUs9nEQRQprl+/jizLeniaM4bG4fFhGPaLEMdxX+v7/6aUre8Zo33TtM1zZGmKyWiMMLAV0f7OLg7291HVNeqmRlXX2Gw2fVK2+UmDUtI3fxbPsvIXf8t2d3exv7sHzjmKssBsMkNe5FBK49FHHnGfhfl/KOdcBSK4OZvPP/mpT336pSvynIc3wJ/+2XRqPvjdH/jvtTZ3ABhCCG27DnleoK8xYdFFQigMdA8V+03wp8qDZB6/Jz3WAy+yAiEEo9EIbdvaMpJQDLMBNKxkxDZ7pg9jHsTzUPNgMIDW+uFwYgxmkykG2QCTyRjXDg9hjEGe5xgOh1iuVlit16jrGgQUSnm8G67EtP2H32QL8AGysyXx3s6ubda6DvP5HOPRCF3bYjab9TnKN3CDwcBst1sym83uvPnm3X/oBAP9HrC3nH79we/+wFM3b9z4W0mcmG1RsK5tURQ23mltwLnoKT5i8bCHsJhe58MZiDtNk8kEAJAkCbSWqOsWVVljMMiws7Njr7cBuq6DUgrTyRSc254giqKeNHdiq35D/K3y3S3nHGmaYm9vD5PRyIUr1sfz9XqNzWaD9WaD5WLVA4J+MykjPf7keQVjLKAoO9uh11WNpmsQhxEyx7INh0OkSQJyRSTmk3scx9QYY5q6enQwGv3OM888+9rVW8CvnH6kaYo7t2/9PACSF7mq65pa0qJzXShBmiboZAelalDCQK50oT3rJQSE4LbyyLI+dNhrbulFfysAgBGCvb09rDdrrLdbFFWJ8XiMwJ0ySokNfwSWWhQCy+XSbpLb/N3d3f5WAUBeFkijGMvV0pawSqGTHYqyRNt1oIygbTobRgn5I4ir31ytLV9AKAFxZXRRFGiaBmEYIssyaK0hXK7pug6DwQBKqf5Wjsdj/frrr9O9+fzfPzw8/J2jo6NLVNfFbWKM0e9597v3nnjnO/7+tiiCPC9oKAISBAHKskRbt1b60baQnQSl7KHW/yrGH4YhuLAJdTK2cVgbuzn5NgfnHIOBPT1plvZ9hJIK0AadlAjjCMzBxl654GGCqqoRRha7uaIZBee8Z7cmozGKsoSBwcnpKYwBNvnWUpZFaZuuTsEYm0+oC6daayRJ0sMZNs/Y72EAi9Z2EsPREHu7u0jT1JI6RoNRiizLEARBH4odJE6qqgJj9LY25n965ZVXFw5jM9SVXYwxhife+Y6fyotiUNe1CgQnURBAuqsEAigt+yZIa3UleclLqTkhALGNVBAEYIQiiSKMhqMeRqCU9CqG1dJ2nevNBlJJZIMB3vmOx3H98Bp2dndRNw3g/l7GONrOcsU+bFRVhYuLC6xWq55IaZoGy80ay/UKy9UKddPYA2Bsb0H7BpAjjkOX2nSPvvoiQil7W/0Np46rGAxTGJ+kXffNnFTGwyJN01iRgFLIi4JIKZXWJnz3E0/8xTiOoZSi9tDa66f39/eRpslfrOsagnFCtLEVgFKoKyvXMNrTXeaheO8xdR+GPC1YVRW2ZYG261A75QPnwuFCVv9T1zXyPAcjAGdWLHXt8BCj8Riz2QwGBlVVgjFLsPsKoyiKPjH7xHdxftEzWuv1GsvlEufn5yjLEmfn52hl5z6rlb9kgxRpliAIBGSn+q7cw9FXAT5jjLsBtiM2WluZpDGYTqc9FpXnOYqiwO7uLrIsQ1mW4IEAoZRuNhvMZ7OfvnXzJgWgKKXgvoO6cf3Rx9uu/QBjzDBCaSMtXr7Z5mjbru+SLSalQMGu1PsGSkkbRhyqKYTAdpsjSRK0ssPR8QO0bYswDC2hAYIojrDdbu0PBqAoC7z0yssoihyz2Qxnp2c9jtR1dvGapuk3ug8R2vLG69UWlALZwOadq4tX1zWKougBOqU1urYDFxyj8RBSKUjZ9pXPVU75Mk9qF64YGOdYbdbgVxg1IQRWq5X9MwQoisLmEm1ACaGGwBhj3vPe977nO59/4YXPAmDMGMMopfrDH/7gXzLG/CilTGmtGYitSk5OT1yj466hpxAJ7ROJ0qqvhrTWiJMInDNsNznSLEVVVlguV31J6iUp/n8HQQDuTjgIwfnFBY5PTnC+uLChT1kk1Td5Np7azrNtW8A1fBaWMIjCCEo7dNQ1a5ZftnDI7Vu38K53PYG6rnol3nw+eyiHXD39lns20EpBawMhAsxnU1BC0TUW9Y2TpG8YDYDTk9O+kjo5OUEYhoiiSAFgg0F2///9+Cd+V2vNKQAzn8+QZdkPtU2LuqkJ4wxJHOPk9NRWBK7stOSIRT/txbmMjR4ZBACtDJQyyAYpKKU4PT0DAelPX9u2WC6XPQiWJAm021wfh71KrSxL5PnWlo/rNbqug9YaZVlaYkepvtT0IUUErA9LVd2gaTqXPDW00lit1hYhjWNUZQ3Z2b7lhz/yERzs7/e5TEoFJRW6TkJ2ClLaG5AN0r5h7JTEg9MTPDg5Rufq/3t37/ah1VdDnZQYjUZEK43ZZPqDj1y7BmOMYgDM448/Ptzf3/3bm80m2W42ZDKekG2eO9xGuhpY2yrBaBhirCDKbYK/rn4DfLzmnKOqyp4p8yHDg2f+avsFjMIIVVmhaRvH6XK78KstkiQBd0IrrTXaxn42zjiSJEYYBpjNZhgMrKwkTVNEUYi6bno7U9dasE1phYvFha2IygrZIEPXdVgtVxgMh9BaYzAYQEqNsqxgtKVStdYIoxBRFCJNUhRFAWUUNtscSkncuHkTR0dHPXVZliWkUoijCEpKNE1DAE1Go/H8+OTkf3j9jTdyBgDf9b7vfH8QBD/ftp0ZDodESoltnmMymaDrLBndNJ0lymEXjAsOrT0VSUAIXIVkc4VW2glwLWbkQS6P2fuFj+O4T2iDLEMYBCjK0oUYu3haaUjV9d3lcrnCdpPDuA7cwC7YcDi0iVlwJHHibqVr8KTuu+0sS9G2LfKiRJLFGA1HiOIYnep6maTsFPK8wN7erm3EpMWVytKaQEQgUNUVttscjFKMRmPs7+1hs91g5LwIjDG0ssNgOEBdNyjKgmilNaUk6JT67Weffe5VzjnHaDR6SisNxpiijPHXXnsNhFAwzi3q4zSYHv0MQ4u9VLIGiAYItUkYFFEUALAJy5/ygAgoI8EoR1XVPXRcliXKsuwBLsYZmq7tgTYPTw9HGZTSveJNSVuv24WwOSSOYxweHmKz2WC5uMD+7j7KqkJZlkjSBEgskGiMpT+11piMRiDMAmq78zneePNNrFZrGKOx3RTQ2oYrT6f6217kBRacIY5idF0HKSXu378PQggO9/YBWKl8FEXQMLh7717fs+zv7mmlND3c3/uAEOKjfDwaIY3j923yHGEYom0brFZrXDs8xCBNkW+3lhjRCm3XgFGGpq0QhSEIJTCy5xDAGHehRrmumPa1P7S9+oEQaNum52uvlpMnp6cIggC3b9/Gm2++CcYotDZomrYnUOq6RuRqdxEwhGHQh7DtZoOqqhAEIaq6Rte2mIzGSJIEVV1DCN4nyjRJsL+7h052AKWo68aWxVXtum6ruvDd7NUwawn7qj9kbWtzzNGDBzg8OMAgzfoEfO/oPt68e7fvCWazGYqqRBLF79vZ2QENoxBSqXe5xolIqWCMxs2bNzBy8VAqCaMNGLElmi1BLYEeRzEIKAIRuiaovQw9DraWTvC6u7sDpTVGo3GfoHyy9Ak2z3Os12unarAL7NHIS4iYIY5DBEGAruuseqHtsNlsbBJnDKvVCnlVYjabYTQYwmiNIAwxm80cHRljMBwiCiMUeY7FcoE0TSy/4dBWzsVDDeal1JHCKUNQVzYXMcbwyLVrWC6WSNMUOzs7vfyGst7JiXv37tPX33gDlNJ3XDs8JOz6o48mh9cOfiEIgtF2uyWEEDKfzxFFEdbrNVrZucaqgwU+bcyllFsFg7EuFx8eBBcIQ+EALSsBJy5HNC4hDoaDvsWXUvaNj+86xRVixFtRPUlySeTb/OGVCVEcoaprMEIwGY/BuUAUhrh96xYE5+iktB6x4QjDwQCUsT5Op1mGsiqxXm/Q1E3fhPnfgyBAFDkvgWAgznum3EHzHoXBYADOGbTSuHHzJighuHf/Hlary+qtrmvEcUzGoxFdbde/zHd25nuUsnnpmobLK1aCcY4wCCHdDnPG0bZ138RQSiGVje0exCJOKOuVDmEkoJVG07QIQoHJdILFYtEDXk3T9qJd5QiUtm17GHo4HFoZiWt2uq5DFEW9UIrSqzIUBaMV6rrGdDTBcDTE2dkZiqJAlqS4eeMmjGvgfLeutcZ6u3Hls+r1qFd/Htv/cHBuemWHXyerIdXgAbNeBcpwfnZmDSJhgDhO+twhpUTXSrJeraGNng4Hw0POOd9VSiVaaxiAcMogdWe19VXtEEf74QCHdIJAqUvI1vt1ewmhoVBS9wtGQMC5cCfEwg11XfccMWAwm02x3eaI47iHNjximqZpj/H4EnNnZweqk1hvObpOIs8vXE8RW6+BUZeCKqdJJcZgPJ0iDAPcv3f/UqfUdbaI8CwbtawdCIVwPYnaWrKm62Qfkq5uQtO06FrbrddSYrVcuhvcOnOK7hV9ZVWZbZ6z4XC4x9M0mdd1DUKpIVoTxhniJAYBMBoMUVQlGPPyQIrpdIQir1yjZMPRVQxdCIamra+IZ1lfQ9+4cQNFUaCua6xWq76Rs7ShrbUHgwyd7BAFAYJA4Pz8AkmSYDwe9+GpLEucn51hmGXIkgR13fafQUqJ+XSKIAz6Djt0nILgAmlmFQ5pmqKqKjRNAyWl7fCdejuMAld6euEXcyGQPOQ/8EiAMbYvun/vCJRQjBzSG0VRn+u0hkvaGgzUEAPCGN2lXIix20VDKYXsJLTSKCoL2R7s7WMwyCACjigKkKaZVTFw+0GJK+2CIECchDDwBD2gjY3hTdMgjmOcnZ2BEILz83NUVe2qB6tgWK/XIJZEhlEGdd1gsVjAGIPFYoHJaIR3v/MJXH/kUcynU+zv7eHGjRsIRYj5fIa9vT2Mx2PszGaIoxjX9g8tg8Y5RBAgdFWblgqccYRRZD0AWkMq1XMGYRhAdhZyACjapr3s+N0N8ainr4zCMESaJqiqGl987TW0bYeLiwsQQhxQZ28PDHE4lLLDGoAxrapq6CTcJnaCI2W0hXCdnpJQitlshiRJ0DS1UyRbWnE0GmEwSBFGAgcHBxablx2M0X3p2DSNxeCDAMvlEttt3uNJjBFUVW2FukGAVmkEgiEIhCX1nQd4sVpBwSCJYyRxgjAI7c10He5sMsXB/j64I1jatu1FU7WDLPw/VVGgriokaQIhOAaDAXZ3dxHFUV/XK6XtYdTGWWSdH43Thxbf34K6aTAeDzGfz3B6cY6VY9+yLEOaJrZYgf364XDg/9yQvfvd7/reQIiPSCmNMYYqJyHkzMa+siz6+tdXRoSQno6z8KyVgfvmSkoJLji6VqKXRzhf2Gq1gtZWRU0Z7f1iPrFlgwH2d/ZRlAWKokRRFOCcYz6doqnqvkLyUPZ4PLYIptZWVuKk5v0QD0eSeJ6WUooiz7FypS6jDGVZYutwKenMgN6Vc1X9zRmznT+jUFpCcNFXS4NhhoPDfQTOyHGwt29tUFpjm+dYLtdgztlz89YNMxwM6Wa7+T3u3Yk+kXad5YD39/fROEm3pxqvWv+jyJ4Wr2iztKOysbWsoKQBY9yqoKl1yxR5ASkVojBCWdagFNAwPQnetjaR5UWOoiit8KnpIESA9WaDNrmUhCdJgjAMwTjDKBmCrEivnCOEuI49BGMMQRD0Dnsv/LLYkuWQ67pG09pGzKu7CWEQAXN07KWggHHb/9AwBGe8L5WF4Dg7O0cYhijLEscnx0jiGABwsL+P09NTyM4ChqNsYI2JUoE9+sgjTyVJ8qMAjFKKEuelGqXZQ2MAoiBE09QwQE9a+B/WY+GjwRClNTJbH7DsXFNmnKGC91ZTY7TTFD3c5HRS9mT8drvtw11VVYiiCFmaXpV9uN7h0ivsu+VsMICBQV3VTg4vEcUxGOdgjk71Ja+bV4EoiSGVRFVZWJwx6j6rQRAIxEnkyskOYRj0OiVKieNMTB92t9stUndIpJTIBhlGIxui4jAyjezoZrP9Ld517cblAOLxCwszUPu7+yZSK2hjkGXZZdKNIxRFiSzL0DgX+3q1htIah4cH+OKrr/fanapskKSW1LdKBwI4T/BVJJUAGKQptDGIHGjXdR3SJAWjFFIphM7kcX52Csqs8c5z0v5QhGGIqiyRpGlvc/WqCsaYy3N1z0kIIRBnqU3WINhsNla24sphQijKssRkMkGWZTg/P4cQAl0rEcVhD6sPh0NwznF6eor1Zu34Zasv8gyZ1hqcUnDONpwQugrDAHm+te0zIairCjBAGEXQNnk7OpH3BPhkPEbXtRhkAyh96d8NwgBFUWCz2YBQg8P9PaxXGxRFBc4F0ixBFEbY39/Hq6++2ocJT9CcnZ2hccxZ09Rw/Ckm00mvxUmzFFoq1E2NIHB4EiGY7+5eiraUxmA0xGg8BiUE6+Wql4psS6u68CSPMgaz+RyUEEBpRI89houLC9y7dx9FXjgjiW3Mrj/6KLI0w+f18zg9OXNhViPNrJ9ss9n0zpyTs3NMp1PbxBHa61LbtiXCMm8rXhTFuYWQGa3qGmmcIImTPuZXVeUSU9d7riiA6XgCQgle+eKrOD+/QBiEyAZ2h/0PRqnlbpVW7noGiKMYURihLktsNlvAAGmW9MIpIQTarsNqvYZWGovFAnEco2kaTMYjEEOwWq6scS5JnN+gxXg8RlPXvTKDcYYojDCfz3vr03a9AXNSlrIskcQxCKXY391B0zSAAabTKTSs0ODo6AgisOWpCDju3LmD9z75JI6PjzEZT9C1HerGqveSJAXnDBcXC+R57nCtAps8x2gwsNUko1hvNthuczKbTVEUxSnPi+IsTZJKShm3TWO0lOT6I4+AEntNlbb20eVq1cdqIQQuLi5QNTXOzs9R5hVW3QbHx6cw0AiDAGdnZwiDCIxxjMcJZCb70NXJDqv1CsbYuT9VVfWmbcEFzs/PnQulQxhGSJMEbdvi6MExAOD2jZtQSmE+2+m9Zz4ZegmJ5xru371nkdy66SsjSinW6zV4EGB3fw9JkuD87Az5ZotOdlgsFn31BQBSKdy8cQMH+wd45eVXQCnB7s4O0iTB6flZXwldXFz0hYzsLGx+cnKKOIysSE0ISNnh/PycjMcjlRfFCa/K6riu6nOt9aOXBLvGbG8HVVn2KGKSJLg4v3AK5Bjr7RaL1QKNsyj5ephSjq5TSMMAB4e2FNtut716QSmFxWJhdfsunF3Vk3oOwecDzmkfLjbbDSi5lLE3TYMsy6yq4gosst1uMRqNemfmVX0npTaWe/tqWZZW5l43yPMc948f4Pj4uD8UWZZhxDnSNENbVWgdVRonFjnd2dlBWZZ47bXXHF/MXddrDYOLxQK7u3NQ6p39MEkSE631Ks+LI9pJWWiY+65j1UrbUx+GIUAJttuNtZISgvlsBjjOdjQaQXYSSnYPeXl9DG4beakRpRR5bhUSZWlHjw0Gg76+vioF8Z6qIAjABUeel7h77x5aN99hNp0iSZJeE+orNW8vZYxhPp+7sFX3jaAQAtPptK+2sixD2zRYLZbYbDbI8y3Oz87ACUXgbpD3Ng+yDEkSQ2rnqKcUneog3SE4Ojrq+wTvArLGcYq26fDiiy/j/PzclvVdZ3Z2djAcDh/k2+0FdbN5XqS2cjCccywWSywWFzYuwo4LaOum520XywXGY+vB4s7s7BskpRWUklDK9hWr1aq/zuv1um/db9++jclk0oc1f/KbpsFms0VVVlaGThxZUpaIwgjj0ahXRHhq0/sOtNa90XqxWGCz2fbjzezfa0ff3Lh1E9dv3rAYj1QOSkgRhKH9mQlBlg0cWmvFXoxQGIegts435gsFf3BAiIM0NJS6VNXJTlo0wB4+bf9c8/JqvdFMKYXHHrtzM03SjxgYXVUVbZoadVU70rpA13auycowHA2RlwXWmw3yPLennPG+DiYgV/Q4ThzrkNPFYtEvlg8JtjKxfHLjcJcotPCHFYZJTCcTvOdd78Z4NO4bQd97+LDiRVLK/b1+Dmni8ocIAlBCEEYhxpMp8nwLzhkGg4GbqqWhpERdVwijCJ20/HCaphgOBmAO7BtkmZ1R19TW85ANsNlsHPRh5S92Qgx6uDxJIoRRhMVigeFwqGEMXa3Xv/Lsc5/7l1xKifOLi09nNzLU25r1DNV2Y4l3Y+UoYRj1P0ySJNhst3bQkROpWtKEALDEuzYaW/c1nHPked6PACCE9JKUq6a5trWEjMVb0NuPptMpErfoHrKwSmv7PebzOYbjEWTbocgLxIkVA8dx1COkXdeBM4Y4SXDv3l1IBx0zxqAd2JYNB0iyFNv1prcxCcFBDCDc7UgGGcazGbZ5jvVqgZVDVi21SqC1QhAIC+YRgDHiOVtfalOpJE5Pzz7Vtq0V52Zpujk8OPjZpmliKaWhlJIwDFHWNZI4dkOT7OkcZhmatoOBAae0HwmQbwsIwfoGazwZ9ZTh/v5+nwe8G8Y3JLKTqJsao9EIQjBrfaUMSlnSJ01ThFGEJI6glUKaxn3euCpzeeTR6wjDoJeHDwYDBGGIKIl7GCFNU1vFMYG6rdHUjYOfQyRp0hNChBCcnp32c4iUtg0ojMF4MkEgBMqiQBCGOL+4cDZWO2bhcrwCAReX8vrQ2l6NUooKEVQvvfTSf7RcrnIGgAkhqkcfeeRPd7K7QwjRXjgquw6BsJi6MgZRHPW6GsFtTa+cSLdpG3tyKQGIjfN7+/uQzoXuT71XDGuX7KVUgCGoyqqHFYwbDyM4xyOPPmIFs0GA6WRqySFjsNlssNls+h+udoR6kiS98yUIQwyHQ6xXa8RJYrmIpkHdNKjKqid/xpMJ9g8PsTy/QNd2aOoaZVni2uEhlNI4enCEqiwxm00hO4myKDCaTnDv/n3Udd2jpwQUUlroJQh532QaY6ulJIk1ANo0zaeffe7zf7dtW8oA8Kqu9c2b13fjOP4hpZTWWtOeMmztDDdjDBihtos9OICWErLrsFyvoLTFQ5xZ2VYZadorh7052lct3kVvnZANiLE8hIFx/mJ7i4SwamhCCLLEhqAoju0os6a2MkSny/dmaWMMlsulrTgcUa+UgnYVi3EchfctAECSpaAGvSYoLwoEQYCLs/MejLxYWMc8jEESJ67et2ivN4DbIYSqHyIShiEaZ7NK0wRaG00Ioefn57/88suv/gtCCaeEENV1HY6Pj3/d/TvzpSN1LvNNkWO9XmGbb3F+cY6zkxOLghqDwXCIwXCALMsQRVFvWhiOhjg4OEBZljg9PevpRF8OpqmVLXLGrGeY096Rcnn19UOlJmcMWikYrREGIWazKQaj0UMqu+PjYygpEYSBg7uJ8xRYMK9rOzs7dDTqhb6bzQanZ6eI0wSznR0QQvDg+Bh5WeD8wvK7fqQBnLA3CqP+sCVJAhjTj1gTQiAMrcc5CEMrGKhqNE3DCCE4PT39584voRkhxACgjPOzGzeu/1jbtteCIFCEEFpWFRi1wiVQaofhdS3W220/CNVOJwz6crJpGtvOa43ziwucnp4hCARu3LhhS70g6En1zWbjJBteXhj2RgutVT9Z5WBvHzeuXwdxKKOvTjzdaZm8rm+wwjBCmqY9E+Z1pt5T5qWTVgHXIUkTJGmKyWSCxeICxw8eYLFcYuPGIrdt50wXBEVRYu/A2lLv3n0Ty+XSNpBa9s5+b5fane/gzu07tuAAtJSSMsZefPqZ5/6G0xtp7hh7enT0QG+3219J0/S7y7I0HnfPiwKz2cxOHFEKAWeQ7hQqN/QOsBhKFEXWAOFkJEVRglHb/Z6cnGLo5CgA8Njjj4NSajfB8Qxt22KQZYiTBK1TOhsYDAeD3vpjwa4Ek9kUWZpBqw5VVTqyHH3H7UtUb7jwidvN/exhi+F4jKqsHI9Roior1E3zkOkkisLLRd3ZgVEKb7z2GpIo7jlqawG2PUUQBIijCPt7e5jNZlislmjbVksp6dHR0f+6Wq0UpZQbYyRz38QopZCmyZvj8fhntdaBg3RJURSYTqcIg8ASzFIhSxJkgwyFUyj75OqxFv9hN5s12rbBwcEBANOTImmS4pFr1xAlCeIwhJKql5BwxnD9kUcxHo+QpRmuXTvEbD5Hmlktz2A4wNzRozwQeOO111EVJaIkRhRFmM1mvcbf5owILBAgAMqi7OXxPiR6AkVrjaaqcbFY9DnEQx6+r0mSBIeH12zYtPg3wiBAlqbY5FsEIgCBhe/n0yn29/exdspupRQxxsiXX3n1Z8/PLxYOujHsCoTAuq5bX7/+6JMG5klKieKcU84ZNps10iRF6VQEeZGjKAsHAdgfwN8Co7TrEexoL3+CoiiCATAaDLC3s4s4jrG3v9eXbFEYYpBlVtrnEuR8OsV0PsPAjgjrMZgkSdA2NWTbIk5TqxUKQ+wfHCBKE0jnqKcAgsASIpRQbLcb11xaOCTLMjQO8/dCYM44mq5F0zQoXDL2ne/tW7cwHo2wzXMQRnF6dobQhSZf2bVuiEcgAgDGTvqlVEopmVLyoy+88IX/pixLSinVvUnPu+arqjbj8fhoPBr9Fa0Vuk4Sf0rqtgFjHFJ2jgWjjniPEMUx4CCG4XDYn740STCfzW3YSFLcunEDjFJwxt0YgjHCKMRysUAQBBiPx0jTFJPpFNP5HEmWgjuNUJ7nWC2WiJMYQRSBEMtXxEmCqizBOQMXDMOR7T+0M81VVYWmsofGGOO0o8FD9irOuR0QwsXlsKa66oE9i2kx3L55C5QQPPu558AYw96OhbHjNEEgApyenlq4Jo7dZK726jQVcnx88vPPP//Cq9SCYOatPmFjjKFt1949ONj/fiHErSAQqm1bSt2iOY07giCwC++qnoAz2+pTO65skA2cas5WJ6PB0Dohr/h9PblvGzBr6BNhYG/JcAhohSAKIUTQl7ej0QhBGAJOsWBLUadH8oinlKirGsvFAnVd4/z83BIq2iDfbgE3mtKDbWlqWbDDgwMbUssSr7/+BvJenm8PXJokyJIEi+XCfsbRCHlRYLlcQiuN9XqN9Xp9OQKNwA9+UlJKqrX67HOf+/x/uF6viT39bz+qgJZlZfZ2d+8Oh8N/283Xp/60KKWwXq97r5UnZwIRgBCKUAirdnCWgFZ2WG/WKOvKIYpJDxtbVJEgFAFAgGwwQF3XODw8RBiF/aIOh0McHh7aGUAO87k4O0UcJ9YW1DTgrjNVSqEs3Mw3VyBcpTq9koMxhtlshp29PVuuUktBnp6eIs9zSzhNbZI/PDjAaDhCWVUwTvHtGcD1et1P4PKL733DfuOapjFSSrparn7uuec+/wIIaG/Lf5sNMMYYVpblq3u7u3+CMfZYGIaqLEvq5/d496MvA7fb3E4OUQppliEUdtGEEBCcIxACYRTh5OwUIgiAK6LXruswdPW4n+WfJgmEm1aV53n/tkBd11gsFlheLJCkKcLASukZoyjKClxwVKWVsXjBrxCXg/uiMMLB4SGiKASjzMISMCjyAtt8i8XFRa8JmrohfkIIiDDE8clxP9w1zVKcn58jyzJst9sehrg6RuHi4gIDW7kpKSXjnH/iuc99/j9YrpbkrWOO33ZcTVGUZjqZfn48Hv27buogUVISWynZqYEgBAxucqGSPeYurkg1PLYym88gGO9nr40nE4wmY1DYhxrCMAQxwHA0vALs6X7EjTGWvM/z3E7UddMXpVLwk3qLsgTnl3OHPMlT1zXGkwkG46EVGTjf2Wq1QpHnqMoSxGteXUXjlSBSSuR5jsVyiUGW2T5htbRiZc5QlZUV/maZq/TQ+w/ciB0TRRG9++bdf+v5F158/Wrs/3IbYACw9WZztLszPxCCfzCKIkUpoXVtzQ+BO8neHVi7WdGxSz7aESS+RlbGQMoO0/EEaZrC6RYtKcOYUy6onjErygKMMleBWCjc88y+I22qCoPBEGtn0O7aS856MB71dfxkMsFwPIJWCsuLBc7OzpDnOUajUc96+c0KHEMnpV3g1WaNum3w+OOPI4pjbDcbBEJgPB5bA7bjsK9fv957hb1cJ89zxThjlND/+ROf+vR/Wdc1o5Sqr3pkWdM0RHbyD6bT6V9mjA3sCx4gUkqEIkAoBAI3DtIPNfLYTdO1vXOy6zrnLUbPpjWNddqEUWQhb2nlgltLWPcL7U1+vnb3eYgx1mM0xiXhZJABzpsWhSGybIB0OHAzoQk2q3Wv7IjC6OFZFU6W74XDXdehazsYbZBkKaIwhGzsMyqD0RCV66w9M+iZvtVq5dV3xoWl9Ruvv/ETX3zttcKBcuarHdpnCCF0vdmU49Hoi3Ec/fRwOFKEgJal9db6RORBNsu92g0JvLsliuzQjihCXuQg1L6MNJlMbJnohmkvFguAADfu3AZ18ySiOOr1PZd6ffSmD0oI2rpBvt1iPt9BwDnKukYQhVZR13aANjg/O7daUJcTJpMJojjqp2E1TQPlNrJwifzqABM/mMniOyHatkOaJOjcDfMCMd8rOApUcc5Z23Y/+5nPPvOxtm3p1Um6D02M/DJTE40xhm822+fns/lNSsn7hQik1ppeVQp7RUJv2lYKjNqSM3aJtSzK/uQGruT0IBlzuA8XArPZHFwInJ+e2a9xSc3yBm3vSVBOPUcoAeMcZVEg32wguw7b9cZ6xWo7lEkrq7bwrJmHj9u2Rd3UUO6RuKq2w/3i2HbUZekEZ10LAiBK7aJzYbVPnl71+c7xvdBaS0op11r/H5/81Kd/4fzinDPGvuTjP19pcKtp25Zpo39zOBz8JKV0j3OuqqqiQgiMsoFbBNY7TkaDAQi85ND0VtIotCdaw9iBfVqDC4HReAQYg6aqsVouUeQ5tFLggeiTmoeTa/cqxna1Rp7n4ELAKH2ZB1wVMxqNMB6PIYR4aCKiVXc3PcLaNm1vBumkRBRG2Nvb6wFG7ae0EIr5zk7/tVfJIJ/rqqpC13VaSsmEEG+8+OJLP/Laa6+1jLGH3iF760awr+ZlpM1m0w4Hw385HA7+MiFEuJhMDAwoAQhoP3OZC4E4jOzcTXY5UrgsS9hX8MI+zk5ndoa/7CTi1Iqz2qZFmmVu+jpxfHML7QbmMcYQBgESR6bIrgNhtAfAvMzF5x+vpDbG2JLREU29Ks5504jTh3pYJa9KKzjgHJzxPhTFadK/KeCFCK70NVJKo7VWDx4c/8gzzz77CrE2Uf2NDu82APjFxcXxeDz+QhxHf4Expuz4dkUCEVoYgFslcdu2yJLUScTZlXmaViHteYC9g307w3ObO/kgRZTESLMM2iVrX47aAX8cFASNyzVGKxAYLBZLa12NIsRRhJ3dXWw2m94G68FByxHHFsk1GlEQ9okcxjjDxuU86rKuoNoOlBDM5jPsHRxABLbh82MS9GXeME3TqNVqxVer9b/zmc88/WtSSf52Vc/XOz1dK6X4+cXF53d3d/MoCj8ihFAOUQLjHIM0BSEUTdtAwyYvj+1zLtxERdsFTx2RcnZ6hiAKkQ4y61p0Sd2LbH1P4DeDUDscoypKNK4hrGurY63KEuPJBJWrRqjnMRxGNR6P/etIyNIMgdOiWr9xAM5Fr38ihCBwXW0Qhtg/PEAcxTh6cNRrjzz04D6zXCwWQmv9i08/89zf3eZbzhiTbw03b5cHvpYHHHTXdTzP89/f29sN4zj+U1mWdW3bMGMM0jjBaDhEGIV2sd00FT8uwGM6YRgiSzOcOOYqzdK+C27bFmVu3Sv+pvgwVpZ2TJi84s1arzfIczv/U7rxOkVeeCsooihE11qp4Xq9RlVVvZdYOlzL9wudVm4sgoWqeSAQxwnSLMNiucB6vcJ0aqHuu3fvoixL/5Zld3R0JAD8vRde+MJff3B8/LaL/816wsQUZcnLqvqt27dvpQC+L4piCYB0XUdCZ4qLoxiz2RxJErvFsU7yOI4wGI5wcX4OKSXSNEUSJ9BKo6qry4mInexni959/Q0QYt+WjB3qyjjDarXuN6JX5uHKHNAg6DtVf6u8wNiT8UmSWFMGtTeXuIJhW+QglCLkwqK+AAYOXrl//36fJ5bLRXd6eiKU0v/gpZde/bnXXn+dvTXpfqVX9r7mR3woJWaz2bKyqn5zOMgizsWfDIJAcyEIASFBGIJxDumMyT2fKzgm47ErBSuEocWM4KqofGNfOfKLJASDURpcBCAA0ixFuc3R1DU26w1GkzEEF3148tiS3wAPJ3jfgC+XPVzu//FvCwRhiCSOoY0d/LGzswshuC1nqwrnFxe4d+8eLi4uYIwxp6enum07XlXN33v6mWd+7t69e37xzdfyxOHXvAFe8bVYLFjbdL+1M98pKCU/xDknURwpbQytyhKEWo+tlXbbYRp+8CshFHGcQEmFsWvKysJOSNnmue08lcJms0Xj3pTUrvX3vUZTNz0Q5rWefmzYVYd9mqYYDAYYjUY9NtQp2XMCfsKXd/T4A7RZrXFydgpOmR1z6Z5G32w2uigKopSiq9X6F59//sW//uDBgy+5+N/Kh9zMcrXieVF8bGc2f5FS8sNVXYcwRjJKqTIa3MEJQgioTqKTHbLBoDc/CyGQpElvsEiHAzsI2xg0bWsH4UmLzXj5n6+/PbnimyrP9V7O+zT9v191z1gOm/SOmSCwcLjXJBVFgbOzMywdrOAhcLdZsq5rppXu7t2//1c/+alP/9Jyufyyi/+V9uQbfcpQr9dr/uabd58bjUa/MRwOvq9pmr04TRS3b0iSQAR20qFDKI024MJqMQmltgRlDJOpHQG2Wi5R1fbRHI+3XJ3Ie1Wa7k+xV7x5EZSHE/yE3aujZuI47pHNMIpQlCXKqoRsO6zdlEXf2fuNbdvWaK1VVVW8LMtX7987+slnn/vcP+267st2ud+WxzwJIbrtWv7mm3fvR2H4jyaTyTVK6XelaUomk4lsmoZ6elC62XKM2mcF0yy1g7qVncROCcHiYgHZ2fEBnfP6+mmJo9GohxL8Lz+czymO+5N+tY/wIclPXDHGoHLj6/MiR11Wlu/uLkXDHt9pmkbmec601vTiYvG/feELL/3ky6+++gUDwxn90tXOt6QK+nKboLVm9+7fr5fL1f/Zdd1LnPPvCYJglGWZkUpppRXV2jiYgvZ+rSAQ1pN8Zc6mksq9rGSJoziJ+5DlnyD0Md9rfPw03u122wOEvo8Qwjr7tdZo6hr5NsditcLF4gLnFxdou7bngH1FpZRSbmgJq6r6/OjBg59/6aVXfuFicVEyqxBQ34wXtr9p7wk7BJVsNht29+69Z2Un/3EUhWPG2FOd7CghRHPGNBeC1u79RsE5GPHvghGURQmj/XsEjkg0ph81czUM9bV82/Qhp21b27Zz3tOfvsz0Uw83+RZ1W1vewt0cpTWiOPILr40xuus6tlwuyWa9/Uf3Hzz4C1/84hd/p2kb6sKc/mY9b/7N3ICHCJ3z8/Pt/ftH/4xz8f9EYXhdKXVHa02DMNScc13XNSGEEMoo2taaIpSU0I4Q8S4THz7smwJ2brP/b1fHwLRdZ8fruAFPHgNabzZYrdfgzDJYm+0GVdNAKYnxcOSFA4YQot07YjTPc3p2ev6xs7Pzv/LG3bt/5+zsbE0pZV5K8s18W/5b8qa8+4uJtY5R9c53vhN3bt/+s/P57K8Zo7/P25OEEDJJEhqGIdVSomlaJFHUi2MBWFtQmiKJYrRN079s5yGBpmn6mt8/BOpnD0kpEYQhus6OXijK0j7s4ObNqU7q1Wql267j3mIqO/Xx1Wb9d85Oz//JerOGMYYxSrX5Eo/w/Cv1pvyXeAqLAjBCCHN4eIi9vd0feOzO7Z8ZjUY/KoSIKKV+yqDknBOjNQ1FQFrXkHmnzNZBCIwxO//N3w53a/yQJ1+C9hJE2bmBrS1a633QZVkaKSVbLBakLEsoqbumaX5js93+t+vN5teWdtYPofZRZPXNPvXftg14y0YwB82a8XiE97z7PY/v7+39+dF4+G/O5/P3eetRlmUYDAaaEKKbuibGGNK1HVFSEo+7+yTuu2z/uxf+1nWNwupbTde2RkppKGO0VR21CjlL8J8cn34uL4pfzYvif7m4uHj+CkfMvtUL/23dgLfZCANAZ1mGvd1dzOfzD9y6eeOH9/b3/vUkSd4/GAwyr6/J3Rteggs0bWOqsjKAMdQNu6ibGhQEYRyBghCtNVFaEeWM3/k2dy9rVwiCsNxut0/fu3f/ty8Wi19frzefKIpCO5k6pXZ2mvpWhJp/JTbgLQ9bUheepJ9mNd+ZY3dn52A0Hn3HZDL+wCAbfOd8PnuHEOLQGDPpuo774RqEEnRNC6mUraauzJ6WXafarlu2bfugKIqXi7J85vT09FNFXj67WC7vVWUJfbmQ/qU7/e1a9D/2DXjLRhC3Gf70mSsPieLg4ACj0XDOKD24fv36/s58Z77ebKZFsR0QSgNnA+2MMVtjzGK73Z5LKU9W6/WDzWZ7VlWV8aDclZ+ZuTe9vi785pv56/8Dwh2X/Ffkm08AAAAASUVORK5CYII=",di=110;let hi=0,pi=class extends ce{constructor(){super(...arguments),this.discovered_list=[],this.compact=!1,this.showStats=!0,this.showLegend=!0,this.showMoon=!1,this.showCardinals=!0,this.showBlindSpot=!0,this.showSunPath=!0,this.showSunriseSunset=!0,this.showCoverFill=!0,this.showWindowArrow=!0,this.coverColors=[],this.northOffsetDeg=0,this._hiddenEntries=new Set,this._legendMoonMaskId="acp-legend-moon-"+hi++}shouldUpdate(e){return e.size>1||!e.has("hass")||me(e.get("hass"),this.hass,this._relevantIds())}_relevantIds(){const e=[];for(const t of this.discovered_list){const o=t.entities;e.push(o.sun_sensor,o.target_position_sensor,o.manual_override_binary,o.sun_infront_binary,o.decision_trace_sensor,o.start_sensor,o.end_sensor)}return e}_toggleEntry(e){const t=new Set(this._hiddenEntries);t.has(e)?t.delete(e):t.add(e),this._hiddenEntries=t}_sunFor(e){const t=e.entities.sun_sensor;if(!t)return null;const o=this.hass.states[t];if(!o)return null;const i=parseFloat(o.state);return Number.isNaN(i)?null:{...o.attributes,window_azimuth:o.attributes.window_azimuth}}_sunInfrontFor(e){const t=e.entities.sun_infront_binary;return!!t&&"on"===this.hass.states[t]?.state}_sunDotStateFor(e,t){const o=e.entities.decision_trace_sensor?this.hass.states[e.entities.decision_trace_sensor]?.attributes:void 0;return ni({belowHorizon:t.elevation<=0,sunState:o?.sun_state??null,directSunValid:o?.direct_sun_valid??!1,inFov:!0===t.in_fov})}_readActiveAzimuth(e){if(!e)return null;const t=this.hass.states[e];if(!t)return null;if("unavailable"===t.state||"unknown"===t.state)return null;const o=t.attributes.azimuth;return"number"==typeof o&&Number.isFinite(o)?o:null}_buildOverlays(){const e=[];return this.discovered_list.forEach((t,o)=>{const i=this._sunFor(t);if(!i)return;const s=t.entities.sun_sensor,n=parseFloat(this.hass.states[s]?.state??"0"),{color:r,isOverride:a}=li(this.coverColors?.[o],o);e.push({d:t,sun:i,sunAzi:n,sunInfront:this._sunInfrontFor(t),dotState:this._sunDotStateFor(t,i),coverPos:Yt(this.hass,t),actualPos:Vt(this.hass,t),coverType:t.cover_type,openBlocksSun:xt(t).openBlocksSun,color:r,isOverride:a,index:o})}),e}render(){if(!this.hass)return V;if(!this.discovered_list||0===this.discovered_list.length)return W`<div class="placeholder">${ot("compass.placeholder_no_entries",this.hass)}</div>`;const e=this._buildOverlays();if(0===e.length)return W`<div class="placeholder">${ot("compass.placeholder_no_sun",this.hass)}</div>`;const t=e.filter(e=>!this._hiddenEntries.has(e.d.entry_id)),o=zt(this.northOffsetDeg),i=e.length>1,s=e[0],n=s.sunAzi,r=s.sun.elevation,a=Et(n,r,o),l={night:-1,outside_fov:0,in_fov_not_valid:1,hitting:2},c=r<=0?"night":e.reduce((e,t)=>l[t.dotState]>l[e]?t.dotState:e,"outside_fov"),d=si[c],{latitude:h,longitude:p,time_zone:u}=this.hass.config,_=void 0!==h&&void 0!==p?Yo(h,p,Zo(u)):[],g=this.showMoon&&void 0!==h&&void 0!==p?ti(h,p):null,m=null!==g&&g.elevation>0,v=g?Dt(g.phase,6):0,f=m?Et(g.azimuth,g.elevation,o):null,b=f?f.x*di:0,y=f?f.y*di:0,w=this.showSunPath?ei(_).map(e=>_.slice(e.startIdx,e.endIdx+1).map(e=>{const t=Et(e.azimuth,e.elevation,o);return{x:t.x*di,y:t.y*di,elev:e.elevation}})):[],x=[122,127,135],$=[245,197,24],k=e=>{const t=Math.sqrt(Math.max(0,Math.min(1,e/90))),o=x.map((e,o)=>Math.round(e+($[o]-e)*t));return`rgb(${o[0]},${o[1]},${o[2]})`},A=this.showSunPath&&this.showSunriseSunset?w.filter(e=>e.length>1).map((e,t)=>{const o=e[0],i=e[e.length-1],s=i.x-o.x,n=i.y-o.y,r=s*s+n*n||1,a=e.filter((t,o)=>o%6==0||o===e.length-1).map(e=>({offset:100*Math.max(0,Math.min(1,((e.x-o.x)*s+(e.y-o.y)*n)/r)),color:k(e.elev)}));return{id:`sun-path-grad-${t}`,x1:o.x,y1:o.y,x2:i.x,y2:i.y,stops:a}}):[],S=e=>this.showSunriseSunset?`url(#sun-path-grad-${e})`:"var(--warning-color, gold)",C=At(0,124,o),E=At(90,124,o),z=At(180,124,o),M=At(270,124,o),I=At(0,di,o),T=At(180,di,o),P=At(90,di,o),O=At(270,di,o),F=ot("compass.sun_tooltip",this.hass,{az:at(n),el:at(r)}),B=null!==g?ot("compass.moon_tooltip",this.hass,{phase:g.phaseName,pct:Math.round(100*g.fraction)}):"",N=ot("compass.sun_path_tooltip",this.hass);return W`
+  `,e([ge({type:Boolean})],Lo.prototype,"on",void 0),e([ge({type:Boolean})],Lo.prototype,"readonly",void 0),e([ge({type:String})],Lo.prototype,"label",void 0),e([ge({type:String})],Lo.prototype,"title",void 0),Lo=e([pe("acp-header-pill")],Lo);const Go=ro(class extends ao{constructor(e){if(super(e),1!==e.type||"class"!==e.name||e.strings?.length>2)throw Error("`classMap()` can only be used in the `class` attribute and must be the only part in the attribute.")}render(e){return" "+Object.keys(e).filter(t=>e[t]).join(" ")+" "}update(e,[t]){if(void 0===this.st){this.st=new Set,void 0!==e.strings&&(this.nt=new Set(e.strings.join(" ").split(/\s/).filter(e=>""!==e)));for(const e in t)t[e]&&!this.nt?.has(e)&&this.st.add(e);return this.render(t)}const o=e.element.classList;for(const e of this.st)e in t||(o.remove(e),this.st.delete(e));for(const e in t){const i=!!t[e];i===this.st.has(e)||this.nt?.has(e)||(i?(o.add(e),this.st.add(e)):(o.remove(e),this.st.delete(e)))}return V}});function Wo(e){return e&&e.__esModule&&Object.prototype.hasOwnProperty.call(e,"default")?e.default:e}var Ho,Uo,Vo={exports:{}},qo=(Ho||(Ho=1,Uo=Vo,function(){var e=Math.PI,t=Math.sin,o=Math.cos,i=Math.tan,s=Math.asin,n=Math.atan2,r=Math.acos,a=e/180,l=864e5,c=2440588,d=2451545;function h(e){return new Date((e+.5-c)*l)}function p(e){return function(e){return e.valueOf()/l-.5+c}(e)-d}var u=23.4397*a;function _(e,s){return n(t(e)*o(u)-i(s)*t(u),o(e))}function g(e,i){return s(t(i)*o(u)+o(i)*t(u)*t(e))}function m(e,s,r){return n(t(e),o(e)*t(s)-i(r)*o(s))}function v(e,i,n){return s(t(i)*t(n)+o(i)*o(n)*o(e))}function f(e,t){return a*(280.16+360.9856235*e)-t}function b(e){return a*(357.5291+.98560028*e)}function y(o){return o+a*(1.9148*t(o)+.02*t(2*o)+3e-4*t(3*o))+102.9372*a+e}function w(e){var t=y(b(e));return{dec:g(t,0),ra:_(t,0)}}var x={getPosition:function(e,t,o){var i=a*-o,s=a*t,n=p(e),r=w(n),l=f(n,i)-r.ra;return{azimuth:m(l,s,r.dec),altitude:v(l,s,r.dec)}}},$=x.times=[[-.833,"sunrise","sunset"],[-.3,"sunriseEnd","sunsetStart"],[-6,"dawn","dusk"],[-12,"nauticalDawn","nauticalDusk"],[-18,"nightEnd","night"],[6,"goldenHourEnd","goldenHour"]];x.addTime=function(e,t,o){$.push([e,t,o])};var k=9e-4;function A(t,o,i){return k+(t+o)/(2*e)+i}function S(e,o,i){return d+e+.0053*t(o)-.0069*t(2*i)}function C(e,i,s,n,a,l,c){var d=function(e,i,s){return r((t(e)-t(i)*t(s))/(o(i)*o(s)))}(e,s,n);return S(A(d,i,a),l,c)}function E(e){var i=a*(134.963+13.064993*e),s=a*(93.272+13.22935*e),n=a*(218.316+13.176396*e)+6.289*a*t(i),r=5.128*a*t(s),l=385001-20905*o(i);return{ra:_(n,r),dec:g(n,r),dist:l}}function z(e,t){return new Date(e.valueOf()+t*l/24)}x.getTimes=function(t,o,i,s){var n,r,l,c,d,u=a*-i,_=a*o,m=function(e){return-2.076*Math.sqrt(e)/60}(s=s||0),v=function(t,o){return Math.round(t-k-o/(2*e))}(p(t),u),f=A(0,u,v),w=b(f),x=y(w),E=g(x,0),z=S(f,w,x),M={solarNoon:h(z),nadir:h(z-.5)};for(n=0,r=$.length;n<r;n+=1)d=z-((c=C(((l=$[n])[0]+m)*a,u,_,E,v,w,x))-z),M[l[1]]=h(d),M[l[2]]=h(c);return M},x.getMoonPosition=function(e,s,r){var l=a*-r,c=a*s,d=p(e),h=E(d),u=f(d,l)-h.ra,_=v(u,c,h.dec),g=n(t(u),i(c)*o(h.dec)-t(h.dec)*o(u));return _+=function(e){return e<0&&(e=0),2967e-7/Math.tan(e+.00312536/(e+.08901179))}(_),{azimuth:m(u,c,h.dec),altitude:_,distance:h.dist,parallacticAngle:g}},x.getMoonIllumination=function(e){var i=p(e||new Date),s=w(i),a=E(i),l=149598e3,c=r(t(s.dec)*t(a.dec)+o(s.dec)*o(a.dec)*o(s.ra-a.ra)),d=n(l*t(c),a.dist-l*o(c)),h=n(o(s.dec)*t(s.ra-a.ra),t(s.dec)*o(a.dec)-o(s.dec)*t(a.dec)*o(s.ra-a.ra));return{fraction:(1+o(d))/2,phase:.5+.5*d*(h<0?-1:1)/Math.PI,angle:h}},x.getMoonTimes=function(e,t,o,i){var s=new Date(e);i?s.setUTCHours(0,0,0,0):s.setHours(0,0,0,0);for(var n,r,l,c,d,h,p,u,_,g,m,v,f,b=.133*a,y=x.getMoonPosition(s,t,o).altitude-b,w=1;w<=24&&(n=x.getMoonPosition(z(s,w),t,o).altitude-b,u=((d=(y+(r=x.getMoonPosition(z(s,w+1),t,o).altitude-b))/2-n)*(p=-(h=(r-y)/2)/(2*d))+h)*p+n,g=0,(_=h*h-4*d*n)>=0&&(m=p-(f=Math.sqrt(_)/(2*Math.abs(d))),v=p+f,Math.abs(m)<=1&&g++,Math.abs(v)<=1&&g++,m<-1&&(m=v)),1===g?y<0?l=w+m:c=w+m:2===g&&(l=w+(u<0?v:m),c=w+(u<0?m:v)),!l||!c);w+=2)y=r;var $={};return l&&($.rise=z(s,l)),c&&($.set=z(s,c)),l||c||($[u>0?"alwaysUp":"alwaysDown"]=!0),$},Uo.exports=x}()),Vo.exports),Yo=Wo(qo);const Qo=new Map;function Zo(e,t,o,i=10){const s=`${e},${t},${o.getTime()},${i}`,n=Qo.get(s);if(n)return Qo.delete(s),Qo.set(s,n),n;const r=[],a=o.getTime()+864e5;for(let s=o.getTime();s<=a;s+=60*i*1e3){const o=new Date(s),i=Yo.getPosition(o,e,t);r.push({t:o,elevation:180*i.altitude/Math.PI,azimuth:((180*i.azimuth/Math.PI+180)%360+360)%360})}if(Qo.set(s,r),Qo.size>4){const e=Qo.keys().next().value;void 0!==e&&Qo.delete(e)}return r}function Xo(e=new Date){const t=new Date(e);return t.setHours(0,0,0,0),t}function Jo(e,t=new Date){if(!e)return Xo(t);const o=new Intl.DateTimeFormat("en-CA",{timeZone:e,year:"numeric",month:"2-digit",day:"2-digit"}).format(t),[i,s,n]=o.split("-").map(Number),r=Date.UTC(i,s-1,n,0,0,0),a=function(e,t){const o=new Intl.DateTimeFormat("en-US",{timeZone:e,year:"numeric",month:"2-digit",day:"2-digit",hour:"2-digit",minute:"2-digit",second:"2-digit",hourCycle:"h23"}).formatToParts(t),i={};for(const e of o)"literal"!==e.type&&(i[e.type]=Number(e.value));return Date.UTC(i.year,i.month-1,i.day,i.hour,i.minute,i.second)-t.getTime()}(e,new Date(r));return new Date(r-a)}function ei(e,t,o,i){const s=((t-o)%360+360)%360;return((e-s)%360+360)%360<=((((t+i)%360+360)%360-s)%360+360)%360}function ti(e,t,o,i){const s=[];let n=-1;for(let r=0;r<e.length;r++){const a=e[r];a.elevation>0&&ei(a.azimuth,t,o,i)?-1===n&&(n=r):-1!==n&&(s.push({startIdx:n,endIdx:r-1}),n=-1)}return-1!==n&&s.push({startIdx:n,endIdx:e.length-1}),s}function oi(e){const t=[];let o=-1;for(let i=0;i<e.length;i++)e[i].elevation>0?-1===o&&(o=i):-1!==o&&(t.push({startIdx:o,endIdx:i-1}),o=-1);return-1!==o&&t.push({startIdx:o,endIdx:e.length-1}),t}function ii(e,t,o=new Date){const i=Yo.getMoonPosition(o,e,t),s=Yo.getMoonIllumination(o);return{azimuth:((180*i.azimuth/Math.PI+180)%360+360)%360,elevation:180*i.altitude/Math.PI,phase:s.phase,fraction:s.fraction,phaseName:si(s.phase)}}function si(e){return e<.0625||e>=.9375?"New Moon":e<.1875?"Waxing Crescent":e<.3125?"First Quarter":e<.4375?"Waxing Gibbous":e<.5625?"Full Moon":e<.6875?"Waning Gibbous":e<.8125?"Last Quarter":"Waning Crescent"}const ni=new Set(["outside_fov","in_fov_not_valid","hitting"]),ri={night:"sun night",hitting:"sun valid",in_fov_not_valid:"sun in-fov",outside_fov:"sun up"};function ai(e){return e.belowHorizon?"night":e.sunState&&ni.has(e.sunState)?e.sunState:e.directSunValid?"hitting":e.inFov?"in_fov_not_valid":"outside_fov"}const li=["#1f77b4","#ff7f0e","#2ca02c","#d62728","#9467bd","#17becf","#e377c2"];function ci(e){const t=li.length;return li[(e%t+t)%t]}function di(e,t){return"string"==typeof e&&e.length>0?{color:e,isOverride:!0}:{color:ci(t),isOverride:!1}}const hi="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAYAAADimHc4AABBS0lEQVR42tW9aaymWX4f9Dvbs7/7e9fqrrV7pmdpezw9nhnjOJETbI+3xEY4sUJEPgRiS5bhS1DAIghLkQgKwQEiJYCI+RCCIWAgibHHtohjj21m72Wmu6eX6aWqbt31XZ/9OQsfzjnPvdXu2ReHklrV03Or7nvP8l9+y/8Q/DH/IoSAANQA1BhjAKir//9wOMR0MknnO/Pd6XS6uzOfz6bT6WSQDQZCCFFVJdq2lVKp7XqzWebb/GK73Z4dPTg6OT4+yZfLJexf2/+ilFJKCNFaa/3H/vP/MS48AcCMMQqAAYAgCLC/tze+cf36ux9//LH3z2az982mkyfGo/EjYRjOGWMp4wyMMnRdB0IItNbQWoNSCq01OOcYDoelUvqiqIp76/XmxTfefPOZl1955TMvPP/C519/441FXdf9x2CUMhCijTFfcjPesoH//90Au+agxhjiT/pwOMD+3v4T+/t7P/iOxx77wTu3b38wy7Idxhjy7RZKK0ipoJSCEAJKKVNVlSGEmK7rQCmFEAKMMZIkCUnTlABAFEUYj8fI0hRRkoALDkLpxdHR0adeePHF3/z4xz/xm5/61Kc/d3Jy4j8e45zDGKO+3IJ/szeDfBsXn7kQo6MowiPXrl07vHbwb4xHoz/PGfvQeDgSo9EQUiq0XWuaplEwAKWUSClJJyXRxpAwCBAGAYIggJQSlFI0TYMgCMAYQzYYgBJigiCA1lrP5nPjvp6NpxMym8+RJgkMoO7dvffJj3/i4//kYx/7g//9M599+o2qKgGAcM7pt2sjyLdh4an7sHo8HuP2rVsfvnZ48FeDMPjJpmnGxhgYY8Apk2VZkrptaBRFhDGGQAjszncgpURelVBKgVIKow1mkwmGwyG22y3quoZSCmVVgVCCKAghhAClFEmSYDqdIo5jDAYDMxqP9SDLTFVV3BgDxhjatt0ePTj+p7//B3/w3/3+H/7h7y6XSwCg7kbob+VGkG9ljDfGUAAqS1PcvnX7+69ff/SvdbL9kaqq4GK+YoxBcE7bpiVlXYESAkop4iTBdDLB4f4B2qYFYRSj4RB1XUNrjSAIUNc1tpstKKOo6xpt20JKibZtEQQBKKVo2xZpmmI4GoEAGI/HGA6HAGC01sYYo9u25aPRCGma4uTs9Lc/9enP/Be/+3u/99HFYglCwBjjWmttvhWbQL6F4UZxIfDOxx//rv39/f9Edt1PFGUBxqhhjGshOOWcE2OAKAqhtca1g0NQQkAIQZKm4JwjS1N0bYsoitBJicVi0Sddn3iVUmjbFuPRCAbA+cUFOOdgjEFrha7tcHZ+Dm00hoMhRsMhxuMxoigC5xxaa5MkiW6ahgIgw+EAZVX/+u//wR/+4u/87u9+vCxLcM7ZlwtLX+8mkG/Vqb927XD8HU8++R83TfPvrVcbQSjRlBLDOWPEnXIpFYwGpJI4PNjD/u4eRCAQiAB1U2M8GqNpGhwdHYExBgMDpTQGWQbGGMIwxDrfwkgFEKBpGuzv7+Pw4BDL5RJd10FwAaUVqqrCcrlE23UQnINzjul0CiklAGAwGCCOY2y3WyWEIMPhkAoh9DbP/8H//Rsf/U8/8clPnrlE/SVvw9ezCeybHOtNGIbmyfe+58fe9cQTv7rZbH50vVozxpiy34tQQgiMMdBKA7Bl5Gw2RZImaLsObdehqipQQgEAz7/4Ak7OzrDNc9RNg9V6DUoolFK4f/8eVus1jDbIywJn5+fIiwLr9RqMMbz40hdwsbhAmiRgjGE6nWI8GqGuKtR1jaqq7GcxBuvNGkopGGNo27ak6zpVliVlhHzwwx/+0E/fvn3n3hdeeulzVVXBJWnzJaq8b/8GEAJuDNT+/l70Xe973y+FQfB3jx+cTLu2k4xxQimljDEwTiE7BYCAcVvLp1mKvf1dUGoXvG1aRGGIJEnwxr27WG82IIT0IUVKidV6g/PzC5R1AwJ7g9ziYTwaAQA2mw2CIMRoNAbn9sdM0xSHh4dYLBfY5jkiWymBc46mbuD7A0opGKVUCEGSNJVlWU7u3L71U0899f7rp2dn/+LBg+OGUsoJIfob3QT2TajrOQD53ve855137tz+Z6vl6iebptGUUiOEYFxwYtyNVVKBEoowEgAMoijEZDJGVVVo2xZJHMPAYLvd4vjkFF0n0dQN2k6h6zp0nYSSGkpq2JtkgyhjdvMYY1BaIxIB2qZF27aomhqMMgyyDNyFnuFgCMY5hBAoyxJd1/WbK5XCerVC3bao6xrGGBoEga7rWu/M50/9xJ/7cz/GRfCHTz/99BEh5BveBPaNLL4xhgsh5FPv/64fGY9Hv3Z+fvFYGAbSNpiUEEKgpD2ZWttFEyEHIYBSCmEY2g9BKZTWtoJpGjw4OUXbdpBK9n/WaBu2/G3QWoMxCgICQolLuBrGGJR1BSY4GGeo6xp104AxijTLQClF13VIkgRSSlRVhdFohK7r0CoJ1dneou5aVFWJxWqJPC+IlJICkEKIgw9+8AN/aTAYvPLZzz79Oa01p5R+3ZvAvpHFj+NYPvX+p35GK/WPV8tVMhqNlDaaN3Xz0AcwxriOlYExCillDyPUTQ0YQHCB5XKN9WZjQwCjAMHlSTcPJznOmU3MxoAQgBB7AxhjoNTmCP99OOdYbzfQSkMIgbquEYYhjDFo2xZlWYIQgjAIsbuzgyiK7OYDkFqjrErkeY66biinVFFKoyff/e6funbtWv7008/8ftu2zH+Wr3UT2Ne7+GmSyg889f5fAPQvNU1jhAhM27asbVpQSh+K25xzcMFA6cOborUGAQEIsNnkaNsWlDEwSkEZBYy7Qdr0OcJu5uVpJ4TY3oFRcM5tHmnbhzbefo39/+M4hupkXwEpZWGOJElAAGRZhiRJwKgNScZhTdoYFGWBuq5pwIUJwkBff/TRj9y6eTN89rnnfruqKsYYxVtT81faBPb1nvzvfN93/I0wFH8TxEjKGJVSUX8ajbFfGwQCXHAYGAQBhzH2lPpE52OyVhpSKnDBIdw/AKBcyPE1/+Wi2pAjuIA2GpSRK3X/lY1xiy8CgYAHaLsW08kUURih7dq+WyaE9CFpsVigaewN1kpBcPs1YRAChKBtG2itifulDg/2/9Rjjz+Wfvozn/3Npmk4pdR8S5KwX/woiuQHnvrAL0Drv9k0raSUsbKoiFLKfw04ZwjCAIQCWitQan9AIUTfOBFCYDRAr2yIb8IoJairFkrZW+K/v2/ALIRAAdjf/Yb4729DFEcQBOCcg1KKNIkRcIHNdgN/SoQQEEKgbVswxhDHMXZ2dgAAcRwjjmNwzpHEMeI4creIYTgcgjFGpJTUAN1oOPi+69evR08/8+xvKSk5eUtO+HK34Gu5AVwIIb/nwx/6GSXlLwkhZNu1rCzt4vsT6k8eYwRKKQyHIxweHqIoCrRt6zaIwxiDrpVQUoJQIAgDGBhobSClBiG0X3QA/e+++6WUggsGwJ72vr/Q2t4KQvvwl6UpwjCChgbc1+3M58iLAkIIEEIQxzEYY4iiCFEU9ZuS57mt0poWbdP0KKsPsXVds7pu5CBN/+SdO48Vn/7MZz72paqjr3sDCCGMEKI+/OEPfSSKwl8BjCKMsHyTkz8SHggFEwyc2xM1HA4RRRGKooCHiT2CSQjABUeSJP2fV1LCaPSb5OM6ZaQvNwHiFoBBSVsd+bCjtd1YEQikaYqmaUAZQ9006KQEJRRN10F1EmVVIgxDzKZTAMB2u0VZlj2453NEURQ2RxCC1EEkUso+nEopiTFGPfHOd3xkMBw+/8wzz36OUsoB6K90C77iBlBKqTFGP/XU+x/b3939aF7kYV01qKqaCiFgjC0zjXFhxIWEJE1w8+ZNfO/3fi+effbZPuwQQlBVle0JGIVWBl0n0bUS2thS1Bi72Iy7asgAjNsQJaWGEBxc2GqKc1tu+vhvN1L38V1rjTC0WFMURdhsNhBCYDAYIAojzKZTdF1nYQ3XQYdhCCll3yMEQYCmaSCCAFEYYrlawgAYDgb+kBAAZLlcmsfv3PlxbfQ/f/mVVx8wxt62Y/6qN8BjO7dv3Qq+88knP3r/6N6tump0VdVsOMiglEJdty7zX8beKA6QJAmUUrh37x7atu1PlK31W9i1IpBSQisDqWyTZrRx3SmDEMxtHGx4UvaWJGkEQuyf9TfDw9qXOJP9XlEUwRiDNE0xn8/RNA2apkErJUaDIRhjqKoKeZ5ju932Ycj/+YvlAk3bgDOO2WyGOAxtz9A2PfoqhMBwOCRlWer7R0fBhz70oT99/+jofzw+Pu7erjz9qjbAJ93xeKR+/Md/9L++e/fun12vt1JJyT2MUNcNKChAAUZZfyUNgK5rsd1usVquQaiN5fYDK7StfOhDMW5Di7CsFZRSYA4+aBsJQm1iVlL34cjnAZ98lVKuObMneDQaIY5je+so6WlMD1sbYyA4w97OHo6Oj/HyKy/j9Owc5xfnMACiMEQYhqjbFkVRuF7E9KUy5wLakkdXN4GenZ1JQsjOO594x/XPfPbpX3WVkf5SYejLbQADoH7wB37gI4Tgvzp+cCK11tyfsKZuQQgAYkBAH0rCAEAoAQEDpTZR2ripoJVGNsgAA1BGITgDdUjnI48eom3txnJuF1YIbsMRY2ibDkEoEAS2ctnZ2cF8Pndhy1Y1cRwjy7I+KY+GI8RhhDiM+jBFCEEURYjjBNsyx73791DVNYIwQCcllusVpFRglEJrhW2eW26h69DKDkkco+vafvM9lMEYQ9d1dLFYyL3dnfft7++/8Nmnn3mO+kX4am+ACz1473vfk73j8cd+/fU33hzKThGpFLFViuqRbEIIOGMghD7cZLnE6OHeKI76/20xHF9CWk43y2xIAwClbQyPosiGLiXBGYfSCpZqVP0NMsb0CzCdTjHIMiRxgk7ZBayqCoILhEEADQPKGIqiQBiGoJTi5OQEeZ73TZsF4lh/spMoRpamUFqDcQ5KLONW1hXKqkQaJ5jNZ33z5/+O8/OFef/73vf92zz/5dffeKNijJG3ywfsbZBNAITFcaz/zJ/5/r+13W4/srhYqqapmdIKBJcNDrHBGbjy3/yHeLgnED0G40+hkgpaGVuPB6IHwyz5biufuq5tmQjSM1z+6/ziN03T9xaj0cguEoAkidG0rY3XXYsojpAlCVarFbQxKMvS8gMuHNV1Cym7h34ObQzKuoZUNiHnRQHq4Imu67DZbtF1LaaTCYzjFNzPTZIkVmenp4Nbd27NX/zCF/6voijp2zVp7Evh+h/+8Ifes7sz/4f3798H44w1dUuM0f7cQxsFGANjQRoQQmGM7kORvx1hZBc/CIK+6ek6hTAMAKD/3dOU/hbEcdQDZZzzPpEHwoYJf3t8pdN1nf1zUeS6VwbK7WY3TYOz83PAALu7uxgMhyiLAlVV9QfFaINAiL7n0B4cdCfbh7lACIyGIxRVCSk7MMqwv7/vuWUEQYDVaoXJZEKbrlOM0vfv7uz+xrPPPXf37UIRfZvESyaTsblz5/Z/Xte1YIyhqRvCGe9xm/7vIBZ6sN2p7jfAnyBj0CdOKSUGAxeb3aJwbhcwDMO+EfLcrJQKWZZhsVj0i0sIgTb6ocUnBOg6G9byPLfAGiUo6wpa2ZDlw0tVV+CEoipKBEHQV1KccwShhTX8AfBNXd80dh1AACEEkiRBFIaWNCIEi9USQggURYHVaoUsy1BVlaNTO/Lkk+/927dv34ZSylw9oH/kBvjE+699z4f+xGg4+M+6rlNVVTEQY+FhqUAcoGZgQTECCs7FQ+EnDENXyVCXRC8rpO02ByEUs9nEQRQprl+/jizLeniaM4bG4fFhGPaLEMdxX+v7/6aUre8Zo33TtM1zZGmKyWiMMLAV0f7OLg7291HVNeqmRlXX2Gw2fVK2+UmDUtI3fxbPsvIXf8t2d3exv7sHzjmKssBsMkNe5FBK49FHHnGfhfl/KOdcBSK4OZvPP/mpT336pSvynIc3wJ/+2XRqPvjdH/jvtTZ3ABhCCG27DnleoK8xYdFFQigMdA8V+03wp8qDZB6/Jz3WAy+yAiEEo9EIbdvaMpJQDLMBNKxkxDZ7pg9jHsTzUPNgMIDW+uFwYgxmkykG2QCTyRjXDg9hjEGe5xgOh1iuVlit16jrGgQUSnm8G67EtP2H32QL8AGysyXx3s6ubda6DvP5HOPRCF3bYjab9TnKN3CDwcBst1sym83uvPnm3X/oBAP9HrC3nH79we/+wFM3b9z4W0mcmG1RsK5tURQ23mltwLnoKT5i8bCHsJhe58MZiDtNk8kEAJAkCbSWqOsWVVljMMiws7Njr7cBuq6DUgrTyRSc254giqKeNHdiq35D/K3y3S3nHGmaYm9vD5PRyIUr1sfz9XqNzWaD9WaD5WLVA4J+MykjPf7keQVjLKAoO9uh11WNpmsQhxEyx7INh0OkSQJyRSTmk3scx9QYY5q6enQwGv3OM888+9rVW8CvnH6kaYo7t2/9PACSF7mq65pa0qJzXShBmiboZAelalDCQK50oT3rJQSE4LbyyLI+dNhrbulFfysAgBGCvb09rDdrrLdbFFWJ8XiMwJ0ySokNfwSWWhQCy+XSbpLb/N3d3f5WAUBeFkijGMvV0pawSqGTHYqyRNt1oIygbTobRgn5I4ir31ytLV9AKAFxZXRRFGiaBmEYIssyaK0hXK7pug6DwQBKqf5Wjsdj/frrr9O9+fzfPzw8/J2jo6NLVNfFbWKM0e9597v3nnjnO/7+tiiCPC9oKAISBAHKskRbt1b60baQnQSl7KHW/yrGH4YhuLAJdTK2cVgbuzn5NgfnHIOBPT1plvZ9hJIK0AadlAjjCMzBxl654GGCqqoRRha7uaIZBee8Z7cmozGKsoSBwcnpKYwBNvnWUpZFaZuuTsEYm0+oC6daayRJ0sMZNs/Y72EAi9Z2EsPREHu7u0jT1JI6RoNRiizLEARBH4odJE6qqgJj9LY25n965ZVXFw5jM9SVXYwxhife+Y6fyotiUNe1CgQnURBAuqsEAigt+yZIa3UleclLqTkhALGNVBAEYIQiiSKMhqMeRqCU9CqG1dJ2nevNBlJJZIMB3vmOx3H98Bp2dndRNw3g/l7GONrOcsU+bFRVhYuLC6xWq55IaZoGy80ay/UKy9UKddPYA2Bsb0H7BpAjjkOX2nSPvvoiQil7W/0Np46rGAxTGJ+kXffNnFTGwyJN01iRgFLIi4JIKZXWJnz3E0/8xTiOoZSi9tDa66f39/eRpslfrOsagnFCtLEVgFKoKyvXMNrTXeaheO8xdR+GPC1YVRW2ZYG261A75QPnwuFCVv9T1zXyPAcjAGdWLHXt8BCj8Riz2QwGBlVVgjFLsPsKoyiKPjH7xHdxftEzWuv1GsvlEufn5yjLEmfn52hl5z6rlb9kgxRpliAIBGSn+q7cw9FXAT5jjLsBtiM2WluZpDGYTqc9FpXnOYqiwO7uLrIsQ1mW4IEAoZRuNhvMZ7OfvnXzJgWgKKXgvoO6cf3Rx9uu/QBjzDBCaSMtXr7Z5mjbru+SLSalQMGu1PsGSkkbRhyqKYTAdpsjSRK0ssPR8QO0bYswDC2hAYIojrDdbu0PBqAoC7z0yssoihyz2Qxnp2c9jtR1dvGapuk3ug8R2vLG69UWlALZwOadq4tX1zWKougBOqU1urYDFxyj8RBSKUjZ9pXPVU75Mk9qF64YGOdYbdbgVxg1IQRWq5X9MwQoisLmEm1ACaGGwBhj3vPe977nO59/4YXPAmDMGMMopfrDH/7gXzLG/CilTGmtGYitSk5OT1yj466hpxAJ7ROJ0qqvhrTWiJMInDNsNznSLEVVVlguV31J6iUp/n8HQQDuTjgIwfnFBY5PTnC+uLChT1kk1Td5Np7azrNtW8A1fBaWMIjCCEo7dNQ1a5ZftnDI7Vu38K53PYG6rnol3nw+eyiHXD39lns20EpBawMhAsxnU1BC0TUW9Y2TpG8YDYDTk9O+kjo5OUEYhoiiSAFgg0F2///9+Cd+V2vNKQAzn8+QZdkPtU2LuqkJ4wxJHOPk9NRWBK7stOSIRT/txbmMjR4ZBACtDJQyyAYpKKU4PT0DAelPX9u2WC6XPQiWJAm021wfh71KrSxL5PnWlo/rNbqug9YaZVlaYkepvtT0IUUErA9LVd2gaTqXPDW00lit1hYhjWNUZQ3Z2b7lhz/yERzs7/e5TEoFJRW6TkJ2ClLaG5AN0r5h7JTEg9MTPDg5Rufq/3t37/ah1VdDnZQYjUZEK43ZZPqDj1y7BmOMYgDM448/Ptzf3/3bm80m2W42ZDKekG2eO9xGuhpY2yrBaBhirCDKbYK/rn4DfLzmnKOqyp4p8yHDg2f+avsFjMIIVVmhaRvH6XK78KstkiQBd0IrrTXaxn42zjiSJEYYBpjNZhgMrKwkTVNEUYi6bno7U9dasE1phYvFha2IygrZIEPXdVgtVxgMh9BaYzAYQEqNsqxgtKVStdYIoxBRFCJNUhRFAWUUNtscSkncuHkTR0dHPXVZliWkUoijCEpKNE1DAE1Go/H8+OTkf3j9jTdyBgDf9b7vfH8QBD/ftp0ZDodESoltnmMymaDrLBndNJ0lymEXjAsOrT0VSUAIXIVkc4VW2glwLWbkQS6P2fuFj+O4T2iDLEMYBCjK0oUYu3haaUjV9d3lcrnCdpPDuA7cwC7YcDi0iVlwJHHibqVr8KTuu+0sS9G2LfKiRJLFGA1HiOIYnep6maTsFPK8wN7erm3EpMWVytKaQEQgUNUVttscjFKMRmPs7+1hs91g5LwIjDG0ssNgOEBdNyjKgmilNaUk6JT67Weffe5VzjnHaDR6SisNxpiijPHXXnsNhFAwzi3q4zSYHv0MQ4u9VLIGiAYItUkYFFEUALAJy5/ygAgoI8EoR1XVPXRcliXKsuwBLsYZmq7tgTYPTw9HGZTSveJNSVuv24WwOSSOYxweHmKz2WC5uMD+7j7KqkJZlkjSBEgskGiMpT+11piMRiDMAmq78zneePNNrFZrGKOx3RTQ2oYrT6f6217kBRacIY5idF0HKSXu378PQggO9/YBWKl8FEXQMLh7717fs+zv7mmlND3c3/uAEOKjfDwaIY3j923yHGEYom0brFZrXDs8xCBNkW+3lhjRCm3XgFGGpq0QhSEIJTCy5xDAGHehRrmumPa1P7S9+oEQaNum52uvlpMnp6cIggC3b9/Gm2++CcYotDZomrYnUOq6RuRqdxEwhGHQh7DtZoOqqhAEIaq6Rte2mIzGSJIEVV1DCN4nyjRJsL+7h052AKWo68aWxVXtum6ruvDd7NUwawn7qj9kbWtzzNGDBzg8OMAgzfoEfO/oPt68e7fvCWazGYqqRBLF79vZ2QENoxBSqXe5xolIqWCMxs2bNzBy8VAqCaMNGLElmi1BLYEeRzEIKAIRuiaovQw9DraWTvC6u7sDpTVGo3GfoHyy9Ak2z3Os12unarAL7NHIS4iYIY5DBEGAruuseqHtsNlsbBJnDKvVCnlVYjabYTQYwmiNIAwxm80cHRljMBwiCiMUeY7FcoE0TSy/4dBWzsVDDeal1JHCKUNQVzYXMcbwyLVrWC6WSNMUOzs7vfyGst7JiXv37tPX33gDlNJ3XDs8JOz6o48mh9cOfiEIgtF2uyWEEDKfzxFFEdbrNVrZucaqgwU+bcyllFsFg7EuFx8eBBcIQ+EALSsBJy5HNC4hDoaDvsWXUvaNj+86xRVixFtRPUlySeTb/OGVCVEcoaprMEIwGY/BuUAUhrh96xYE5+iktB6x4QjDwQCUsT5Op1mGsiqxXm/Q1E3fhPnfgyBAFDkvgWAgznum3EHzHoXBYADOGbTSuHHzJighuHf/Hlary+qtrmvEcUzGoxFdbde/zHd25nuUsnnpmobLK1aCcY4wCCHdDnPG0bZ138RQSiGVje0exCJOKOuVDmEkoJVG07QIQoHJdILFYtEDXk3T9qJd5QiUtm17GHo4HFoZiWt2uq5DFEW9UIrSqzIUBaMV6rrGdDTBcDTE2dkZiqJAlqS4eeMmjGvgfLeutcZ6u3Hls+r1qFd/Htv/cHBuemWHXyerIdXgAbNeBcpwfnZmDSJhgDhO+twhpUTXSrJeraGNng4Hw0POOd9VSiVaaxiAcMogdWe19VXtEEf74QCHdIJAqUvI1vt1ewmhoVBS9wtGQMC5cCfEwg11XfccMWAwm02x3eaI47iHNjximqZpj/H4EnNnZweqk1hvObpOIs8vXE8RW6+BUZeCKqdJJcZgPJ0iDAPcv3f/UqfUdbaI8CwbtawdCIVwPYnaWrKm62Qfkq5uQtO06FrbrddSYrVcuhvcOnOK7hV9ZVWZbZ6z4XC4x9M0mdd1DUKpIVoTxhniJAYBMBoMUVQlGPPyQIrpdIQir1yjZMPRVQxdCIamra+IZ1lfQ9+4cQNFUaCua6xWq76Rs7ShrbUHgwyd7BAFAYJA4Pz8AkmSYDwe9+GpLEucn51hmGXIkgR13fafQUqJ+XSKIAz6Djt0nILgAmlmFQ5pmqKqKjRNAyWl7fCdejuMAld6euEXcyGQPOQ/8EiAMbYvun/vCJRQjBzSG0VRn+u0hkvaGgzUEAPCGN2lXIix20VDKYXsJLTSKCoL2R7s7WMwyCACjigKkKaZVTFw+0GJK+2CIECchDDwBD2gjY3hTdMgjmOcnZ2BEILz83NUVe2qB6tgWK/XIJZEhlEGdd1gsVjAGIPFYoHJaIR3v/MJXH/kUcynU+zv7eHGjRsIRYj5fIa9vT2Mx2PszGaIoxjX9g8tg8Y5RBAgdFWblgqccYRRZD0AWkMq1XMGYRhAdhZyACjapr3s+N0N8ainr4zCMESaJqiqGl987TW0bYeLiwsQQhxQZ28PDHE4lLLDGoAxrapq6CTcJnaCI2W0hXCdnpJQitlshiRJ0DS1UyRbWnE0GmEwSBFGAgcHBxablx2M0X3p2DSNxeCDAMvlEttt3uNJjBFUVW2FukGAVmkEgiEIhCX1nQd4sVpBwSCJYyRxgjAI7c10He5sMsXB/j64I1jatu1FU7WDLPw/VVGgriokaQIhOAaDAXZ3dxHFUV/XK6XtYdTGWWSdH43Thxbf34K6aTAeDzGfz3B6cY6VY9+yLEOaJrZYgf364XDg/9yQvfvd7/reQIiPSCmNMYYqJyHkzMa+siz6+tdXRoSQno6z8KyVgfvmSkoJLji6VqKXRzhf2Gq1gtZWRU0Z7f1iPrFlgwH2d/ZRlAWKokRRFOCcYz6doqnqvkLyUPZ4PLYIptZWVuKk5v0QD0eSeJ6WUooiz7FypS6jDGVZYutwKenMgN6Vc1X9zRmznT+jUFpCcNFXS4NhhoPDfQTOyHGwt29tUFpjm+dYLtdgztlz89YNMxwM6Wa7+T3u3Yk+kXad5YD39/fROEm3pxqvWv+jyJ4Wr2iztKOysbWsoKQBY9yqoKl1yxR5ASkVojBCWdagFNAwPQnetjaR5UWOoiit8KnpIESA9WaDNrmUhCdJgjAMwTjDKBmCrEivnCOEuI49BGMMQRD0Dnsv/LLYkuWQ67pG09pGzKu7CWEQAXN07KWggHHb/9AwBGe8L5WF4Dg7O0cYhijLEscnx0jiGABwsL+P09NTyM4ChqNsYI2JUoE9+sgjTyVJ8qMAjFKKEuelGqXZQ2MAoiBE09QwQE9a+B/WY+GjwRClNTJbH7DsXFNmnKGC91ZTY7TTFD3c5HRS9mT8drvtw11VVYiiCFmaXpV9uN7h0ivsu+VsMICBQV3VTg4vEcUxGOdgjk71Ja+bV4EoiSGVRFVZWJwx6j6rQRAIxEnkyskOYRj0OiVKieNMTB92t9stUndIpJTIBhlGIxui4jAyjezoZrP9Ld517cblAOLxCwszUPu7+yZSK2hjkGXZZdKNIxRFiSzL0DgX+3q1htIah4cH+OKrr/fanapskKSW1LdKBwI4T/BVJJUAGKQptDGIHGjXdR3SJAWjFFIphM7kcX52Csqs8c5z0v5QhGGIqiyRpGlvc/WqCsaYy3N1z0kIIRBnqU3WINhsNla24sphQijKssRkMkGWZTg/P4cQAl0rEcVhD6sPh0NwznF6eor1Zu34Zasv8gyZ1hqcUnDONpwQugrDAHm+te0zIairCjBAGEXQNnk7OpH3BPhkPEbXtRhkAyh96d8NwgBFUWCz2YBQg8P9PaxXGxRFBc4F0ixBFEbY39/Hq6++2ocJT9CcnZ2hccxZ09Rw/Ckm00mvxUmzFFoq1E2NIHB4EiGY7+5eiraUxmA0xGg8BiUE6+Wql4psS6u68CSPMgaz+RyUEEBpRI89houLC9y7dx9FXjgjiW3Mrj/6KLI0w+f18zg9OXNhViPNrJ9ss9n0zpyTs3NMp1PbxBHa61LbtiXCMm8rXhTFuYWQGa3qGmmcIImTPuZXVeUSU9d7riiA6XgCQgle+eKrOD+/QBiEyAZ2h/0PRqnlbpVW7noGiKMYURihLktsNlvAAGmW9MIpIQTarsNqvYZWGovFAnEco2kaTMYjEEOwWq6scS5JnN+gxXg8RlPXvTKDcYYojDCfz3vr03a9AXNSlrIskcQxCKXY391B0zSAAabTKTSs0ODo6AgisOWpCDju3LmD9z75JI6PjzEZT9C1HerGqveSJAXnDBcXC+R57nCtAps8x2gwsNUko1hvNthuczKbTVEUxSnPi+IsTZJKShm3TWO0lOT6I4+AEntNlbb20eVq1cdqIQQuLi5QNTXOzs9R5hVW3QbHx6cw0AiDAGdnZwiDCIxxjMcJZCb70NXJDqv1CsbYuT9VVfWmbcEFzs/PnQulQxhGSJMEbdvi6MExAOD2jZtQSmE+2+m9Zz4ZegmJ5xru371nkdy66SsjSinW6zV4EGB3fw9JkuD87Az5ZotOdlgsFn31BQBSKdy8cQMH+wd45eVXQCnB7s4O0iTB6flZXwldXFz0hYzsLGx+cnKKOIysSE0ISNnh/PycjMcjlRfFCa/K6riu6nOt9aOXBLvGbG8HVVn2KGKSJLg4v3AK5Bjr7RaL1QKNsyj5ephSjq5TSMMAB4e2FNtut716QSmFxWJhdfsunF3Vk3oOwecDzmkfLjbbDSi5lLE3TYMsy6yq4gosst1uMRqNemfmVX0npTaWe/tqWZZW5l43yPMc948f4Pj4uD8UWZZhxDnSNENbVWgdVRonFjnd2dlBWZZ47bXXHF/MXddrDYOLxQK7u3NQ6p39MEkSE631Ks+LI9pJWWiY+65j1UrbUx+GIUAJttuNtZISgvlsBjjOdjQaQXYSSnYPeXl9DG4beakRpRR5bhUSZWlHjw0Gg76+vioF8Z6qIAjABUeel7h77x5aN99hNp0iSZJeE+orNW8vZYxhPp+7sFX3jaAQAtPptK+2sixD2zRYLZbYbDbI8y3Oz87ACUXgbpD3Ng+yDEkSQ2rnqKcUneog3SE4Ojrq+wTvArLGcYq26fDiiy/j/PzclvVdZ3Z2djAcDh/k2+0FdbN5XqS2cjCccywWSywWFzYuwo4LaOum520XywXGY+vB4s7s7BskpRWUklDK9hWr1aq/zuv1um/db9++jclk0oc1f/KbpsFms0VVVlaGThxZUpaIwgjj0ahXRHhq0/sOtNa90XqxWGCz2fbjzezfa0ff3Lh1E9dv3rAYj1QOSkgRhKH9mQlBlg0cWmvFXoxQGIegts435gsFf3BAiIM0NJS6VNXJTlo0wB4+bf9c8/JqvdFMKYXHHrtzM03SjxgYXVUVbZoadVU70rpA13auycowHA2RlwXWmw3yPLennPG+DiYgV/Q4ThzrkNPFYtEvlg8JtjKxfHLjcJcotPCHFYZJTCcTvOdd78Z4NO4bQd97+LDiRVLK/b1+Dmni8ocIAlBCEEYhxpMp8nwLzhkGg4GbqqWhpERdVwijCJ20/HCaphgOBmAO7BtkmZ1R19TW85ANsNlsHPRh5S92Qgx6uDxJIoRRhMVigeFwqGEMXa3Xv/Lsc5/7l1xKifOLi09nNzLU25r1DNV2Y4l3Y+UoYRj1P0ySJNhst3bQkROpWtKEALDEuzYaW/c1nHPked6PACCE9JKUq6a5trWEjMVb0NuPptMpErfoHrKwSmv7PebzOYbjEWTbocgLxIkVA8dx1COkXdeBM4Y4SXDv3l1IBx0zxqAd2JYNB0iyFNv1prcxCcFBDCDc7UgGGcazGbZ5jvVqgZVDVi21SqC1QhAIC+YRgDHiOVtfalOpJE5Pzz7Vtq0V52Zpujk8OPjZpmliKaWhlJIwDFHWNZI4dkOT7OkcZhmatoOBAae0HwmQbwsIwfoGazwZ9ZTh/v5+nwe8G8Y3JLKTqJsao9EIQjBrfaUMSlnSJ01ThFGEJI6glUKaxn3euCpzeeTR6wjDoJeHDwYDBGGIKIl7GCFNU1vFMYG6rdHUjYOfQyRp0hNChBCcnp32c4iUtg0ojMF4MkEgBMqiQBCGOL+4cDZWO2bhcrwCAReX8vrQ2l6NUooKEVQvvfTSf7RcrnIGgAkhqkcfeeRPd7K7QwjRXjgquw6BsJi6MgZRHPW6GsFtTa+cSLdpG3tyKQGIjfN7+/uQzoXuT71XDGuX7KVUgCGoyqqHFYwbDyM4xyOPPmIFs0GA6WRqySFjsNlssNls+h+udoR6kiS98yUIQwyHQ6xXa8RJYrmIpkHdNKjKqid/xpMJ9g8PsTy/QNd2aOoaZVni2uEhlNI4enCEqiwxm00hO4myKDCaTnDv/n3Udd2jpwQUUlroJQh532QaY6ulJIk1ANo0zaeffe7zf7dtW8oA8Kqu9c2b13fjOP4hpZTWWtOeMmztDDdjDBihtos9OICWErLrsFyvoLTFQ5xZ2VYZadorh7052lct3kVvnZANiLE8hIFx/mJ7i4SwamhCCLLEhqAoju0os6a2MkSny/dmaWMMlsulrTgcUa+UgnYVi3EchfctAECSpaAGvSYoLwoEQYCLs/MejLxYWMc8jEESJ67et2ivN4DbIYSqHyIShiEaZ7NK0wRaG00Ioefn57/88suv/gtCCaeEENV1HY6Pj3/d/TvzpSN1LvNNkWO9XmGbb3F+cY6zkxOLghqDwXCIwXCALMsQRVFvWhiOhjg4OEBZljg9PevpRF8OpqmVLXLGrGeY096Rcnn19UOlJmcMWikYrREGIWazKQaj0UMqu+PjYygpEYSBg7uJ8xRYMK9rOzs7dDTqhb6bzQanZ6eI0wSznR0QQvDg+Bh5WeD8wvK7fqQBnLA3CqP+sCVJAhjTj1gTQiAMrcc5CEMrGKhqNE3DCCE4PT39584voRkhxACgjPOzGzeu/1jbtteCIFCEEFpWFRi1wiVQaofhdS3W220/CNVOJwz6crJpGtvOa43ziwucnp4hCARu3LhhS70g6En1zWbjJBteXhj2RgutVT9Z5WBvHzeuXwdxKKOvTjzdaZm8rm+wwjBCmqY9E+Z1pt5T5qWTVgHXIUkTJGmKyWSCxeICxw8eYLFcYuPGIrdt50wXBEVRYu/A2lLv3n0Ty+XSNpBa9s5+b5fane/gzu07tuAAtJSSMsZefPqZ5/6G0xtp7hh7enT0QG+3219J0/S7y7I0HnfPiwKz2cxOHFEKAWeQ7hQqN/QOsBhKFEXWAOFkJEVRglHb/Z6cnGLo5CgA8Njjj4NSajfB8Qxt22KQZYiTBK1TOhsYDAeD3vpjwa4Ek9kUWZpBqw5VVTqyHH3H7UtUb7jwidvN/exhi+F4jKqsHI9Roior1E3zkOkkisLLRd3ZgVEKb7z2GpIo7jlqawG2PUUQBIijCPt7e5jNZlislmjbVksp6dHR0f+6Wq0UpZQbYyRz38QopZCmyZvj8fhntdaBg3RJURSYTqcIg8ASzFIhSxJkgwyFUyj75OqxFv9hN5s12rbBwcEBANOTImmS4pFr1xAlCeIwhJKql5BwxnD9kUcxHo+QpRmuXTvEbD5Hmlktz2A4wNzRozwQeOO111EVJaIkRhRFmM1mvcbf5owILBAgAMqi7OXxPiR6AkVrjaaqcbFY9DnEQx6+r0mSBIeH12zYtPg3wiBAlqbY5FsEIgCBhe/n0yn29/exdspupRQxxsiXX3n1Z8/PLxYOujHsCoTAuq5bX7/+6JMG5klKieKcU84ZNps10iRF6VQEeZGjKAsHAdgfwN8Co7TrEexoL3+CoiiCATAaDLC3s4s4jrG3v9eXbFEYYpBlVtrnEuR8OsV0PsPAjgjrMZgkSdA2NWTbIk5TqxUKQ+wfHCBKE0jnqKcAgsASIpRQbLcb11xaOCTLMjQO8/dCYM44mq5F0zQoXDL2ne/tW7cwHo2wzXMQRnF6dobQhSZf2bVuiEcgAgDGTvqlVEopmVLyoy+88IX/pixLSinVvUnPu+arqjbj8fhoPBr9Fa0Vuk4Sf0rqtgFjHFJ2jgWjjniPEMUx4CCG4XDYn740STCfzW3YSFLcunEDjFJwxt0YgjHCKMRysUAQBBiPx0jTFJPpFNP5HEmWgjuNUJ7nWC2WiJMYQRSBEMtXxEmCqizBOQMXDMOR7T+0M81VVYWmsofGGOO0o8FD9irOuR0QwsXlsKa66oE9i2kx3L55C5QQPPu558AYw96OhbHjNEEgApyenlq4Jo7dZK726jQVcnx88vPPP//Cq9SCYOatPmFjjKFt1949ONj/fiHErSAQqm1bSt2iOY07giCwC++qnoAz2+pTO65skA2cas5WJ6PB0Dohr/h9PblvGzBr6BNhYG/JcAhohSAKIUTQl7ej0QhBGAJOsWBLUadH8oinlKirGsvFAnVd4/z83BIq2iDfbgE3mtKDbWlqWbDDgwMbUssSr7/+BvJenm8PXJokyJIEi+XCfsbRCHlRYLlcQiuN9XqN9Xp9OQKNwA9+UlJKqrX67HOf+/x/uF6viT39bz+qgJZlZfZ2d+8Oh8N/283Xp/60KKWwXq97r5UnZwIRgBCKUAirdnCWgFZ2WG/WKOvKIYpJDxtbVJEgFAFAgGwwQF3XODw8RBiF/aIOh0McHh7aGUAO87k4O0UcJ9YW1DTgrjNVSqEs3Mw3VyBcpTq9koMxhtlshp29PVuuUktBnp6eIs9zSzhNbZI/PDjAaDhCWVUwTvHtGcD1et1P4PKL733DfuOapjFSSrparn7uuec+/wIIaG/Lf5sNMMYYVpblq3u7u3+CMfZYGIaqLEvq5/d496MvA7fb3E4OUQppliEUdtGEEBCcIxACYRTh5OwUIgiAK6LXruswdPW4n+WfJgmEm1aV53n/tkBd11gsFlheLJCkKcLASukZoyjKClxwVKWVsXjBrxCXg/uiMMLB4SGiKASjzMISMCjyAtt8i8XFRa8JmrohfkIIiDDE8clxP9w1zVKcn58jyzJst9sehrg6RuHi4gIDW7kpKSXjnH/iuc99/j9YrpbkrWOO33ZcTVGUZjqZfn48Hv27buogUVISWynZqYEgBAxucqGSPeYurkg1PLYym88gGO9nr40nE4wmY1DYhxrCMAQxwHA0vALs6X7EjTGWvM/z3E7UddMXpVLwk3qLsgTnl3OHPMlT1zXGkwkG46EVGTjf2Wq1QpHnqMoSxGteXUXjlSBSSuR5jsVyiUGW2T5htbRiZc5QlZUV/maZq/TQ+w/ciB0TRRG9++bdf+v5F158/Wrs/3IbYACw9WZztLszPxCCfzCKIkUpoXVtzQ+BO8neHVi7WdGxSz7aESS+RlbGQMoO0/EEaZrC6RYtKcOYUy6onjErygKMMleBWCjc88y+I22qCoPBEGtn0O7aS856MB71dfxkMsFwPIJWCsuLBc7OzpDnOUajUc96+c0KHEMnpV3g1WaNum3w+OOPI4pjbDcbBEJgPB5bA7bjsK9fv957hb1cJ89zxThjlND/+ROf+vR/Wdc1o5Sqr3pkWdM0RHbyD6bT6V9mjA3sCx4gUkqEIkAoBAI3DtIPNfLYTdO1vXOy6zrnLUbPpjWNddqEUWQhb2nlgltLWPcL7U1+vnb3eYgx1mM0xiXhZJABzpsWhSGybIB0OHAzoQk2q3Wv7IjC6OFZFU6W74XDXdehazsYbZBkKaIwhGzsMyqD0RCV66w9M+iZvtVq5dV3xoWl9Ruvv/ETX3zttcKBcuarHdpnCCF0vdmU49Hoi3Ec/fRwOFKEgJal9db6RORBNsu92g0JvLsliuzQjihCXuQg1L6MNJlMbJnohmkvFguAADfu3AZ18ySiOOr1PZd6ffSmD0oI2rpBvt1iPt9BwDnKukYQhVZR13aANjg/O7daUJcTJpMJojjqp2E1TQPlNrJwifzqABM/mMniOyHatkOaJOjcDfMCMd8rOApUcc5Z23Y/+5nPPvOxtm3p1Um6D02M/DJTE40xhm822+fns/lNSsn7hQik1ppeVQp7RUJv2lYKjNqSM3aJtSzK/uQGruT0IBlzuA8XArPZHFwInJ+e2a9xSc3yBm3vSVBOPUcoAeMcZVEg32wguw7b9cZ6xWo7lEkrq7bwrJmHj9u2Rd3UUO6RuKq2w/3i2HbUZekEZ10LAiBK7aJzYbVPnl71+c7xvdBaS0op11r/H5/81Kd/4fzinDPGvuTjP19pcKtp25Zpo39zOBz8JKV0j3OuqqqiQgiMsoFbBNY7TkaDAQi85ND0VtIotCdaw9iBfVqDC4HReAQYg6aqsVouUeQ5tFLggeiTmoeTa/cqxna1Rp7n4ELAKH2ZB1wVMxqNMB6PIYR4aCKiVXc3PcLaNm1vBumkRBRG2Nvb6wFG7ae0EIr5zk7/tVfJIJ/rqqpC13VaSsmEEG+8+OJLP/Laa6+1jLGH3iF760awr+ZlpM1m0w4Hw385HA7+MiFEuJhMDAwoAQhoP3OZC4E4jOzcTXY5UrgsS9hX8MI+zk5ndoa/7CTi1Iqz2qZFmmVu+jpxfHML7QbmMcYQBgESR6bIrgNhtAfAvMzF5x+vpDbG2JLREU29Ks5504jTh3pYJa9KKzjgHJzxPhTFadK/KeCFCK70NVJKo7VWDx4c/8gzzz77CrE2Uf2NDu82APjFxcXxeDz+QhxHf4Expuz4dkUCEVoYgFslcdu2yJLUScTZlXmaViHteYC9g307w3ObO/kgRZTESLMM2iVrX47aAX8cFASNyzVGKxAYLBZLa12NIsRRhJ3dXWw2m94G68FByxHHFsk1GlEQ9okcxjjDxuU86rKuoNoOlBDM5jPsHRxABLbh82MS9GXeME3TqNVqxVer9b/zmc88/WtSSf52Vc/XOz1dK6X4+cXF53d3d/MoCj8ihFAOUQLjHIM0BSEUTdtAwyYvj+1zLtxERdsFTx2RcnZ6hiAKkQ4y61p0Sd2LbH1P4DeDUDscoypKNK4hrGurY63KEuPJBJWrRqjnMRxGNR6P/etIyNIMgdOiWr9xAM5Fr38ihCBwXW0Qhtg/PEAcxTh6cNRrjzz04D6zXCwWQmv9i08/89zf3eZbzhiTbw03b5cHvpYHHHTXdTzP89/f29sN4zj+U1mWdW3bMGMM0jjBaDhEGIV2sd00FT8uwGM6YRgiSzOcOOYqzdK+C27bFmVu3Sv+pvgwVpZ2TJi84s1arzfIczv/U7rxOkVeeCsooihE11qp4Xq9RlVVvZdYOlzL9wudVm4sgoWqeSAQxwnSLMNiucB6vcJ0aqHuu3fvoixL/5Zld3R0JAD8vRde+MJff3B8/LaL/816wsQUZcnLqvqt27dvpQC+L4piCYB0XUdCZ4qLoxiz2RxJErvFsU7yOI4wGI5wcX4OKSXSNEUSJ9BKo6qry4mInexni959/Q0QYt+WjB3qyjjDarXuN6JX5uHKHNAg6DtVf6u8wNiT8UmSWFMGtTeXuIJhW+QglCLkwqK+AAYOXrl//36fJ5bLRXd6eiKU0v/gpZde/bnXXn+dvTXpfqVX9r7mR3woJWaz2bKyqn5zOMgizsWfDIJAcyEIASFBGIJxDumMyT2fKzgm47ErBSuEocWM4KqofGNfOfKLJASDURpcBCAA0ixFuc3R1DU26w1GkzEEF3148tiS3wAPJ3jfgC+XPVzu//FvCwRhiCSOoY0d/LGzswshuC1nqwrnFxe4d+8eLi4uYIwxp6enum07XlXN33v6mWd+7t69e37xzdfyxOHXvAFe8bVYLFjbdL+1M98pKCU/xDknURwpbQytyhKEWo+tlXbbYRp+8CshFHGcQEmFsWvKysJOSNnmue08lcJms0Xj3pTUrvX3vUZTNz0Q5rWefmzYVYd9mqYYDAYYjUY9NtQp2XMCfsKXd/T4A7RZrXFydgpOmR1z6Z5G32w2uigKopSiq9X6F59//sW//uDBgy+5+N/Kh9zMcrXieVF8bGc2f5FS8sNVXYcwRjJKqTIa3MEJQgioTqKTHbLBoDc/CyGQpElvsEiHAzsI2xg0bWsH4UmLzXj5n6+/PbnimyrP9V7O+zT9v191z1gOm/SOmSCwcLjXJBVFgbOzMywdrOAhcLdZsq5rppXu7t2//1c/+alP/9Jyufyyi/+V9uQbfcpQr9dr/uabd58bjUa/MRwOvq9pmr04TRS3b0iSQAR20qFDKI024MJqMQmltgRlDJOpHQG2Wi5R1fbRHI+3XJ3Ie1Wa7k+xV7x5EZSHE/yE3aujZuI47pHNMIpQlCXKqoRsO6zdlEXf2fuNbdvWaK1VVVW8LMtX7987+slnn/vcP+267st2ud+WxzwJIbrtWv7mm3fvR2H4jyaTyTVK6XelaUomk4lsmoZ6elC62XKM2mcF0yy1g7qVncROCcHiYgHZ2fEBnfP6+mmJo9GohxL8Lz+czymO+5N+tY/wIclPXDHGoHLj6/MiR11Wlu/uLkXDHt9pmkbmec601vTiYvG/feELL/3ky6+++gUDwxn90tXOt6QK+nKboLVm9+7fr5fL1f/Zdd1LnPPvCYJglGWZkUpppRXV2jiYgvZ+rSAQ1pN8Zc6mksq9rGSJoziJ+5DlnyD0Md9rfPw03u122wOEvo8Qwjr7tdZo6hr5NsditcLF4gLnFxdou7bngH1FpZRSbmgJq6r6/OjBg59/6aVXfuFicVEyqxBQ34wXtr9p7wk7BJVsNht29+69Z2Un/3EUhWPG2FOd7CghRHPGNBeC1u79RsE5GPHvghGURQmj/XsEjkg0ph81czUM9bV82/Qhp21b27Zz3tOfvsz0Uw83+RZ1W1vewt0cpTWiOPILr40xuus6tlwuyWa9/Uf3Hzz4C1/84hd/p2kb6sKc/mY9b/7N3ICHCJ3z8/Pt/ftH/4xz8f9EYXhdKXVHa02DMNScc13XNSGEEMoo2taaIpSU0I4Q8S4THz7smwJ2brP/b1fHwLRdZ8fruAFPHgNabzZYrdfgzDJYm+0GVdNAKYnxcOSFA4YQot07YjTPc3p2ev6xs7Pzv/LG3bt/5+zsbE0pZV5K8s18W/5b8qa8+4uJtY5R9c53vhN3bt/+s/P57K8Zo7/P25OEEDJJEhqGIdVSomlaJFHUi2MBWFtQmiKJYrRN079s5yGBpmn6mt8/BOpnD0kpEYQhus6OXijK0j7s4ObNqU7q1Wql267j3mIqO/Xx1Wb9d85Oz//JerOGMYYxSrX5Eo/w/Cv1pvyXeAqLAjBCCHN4eIi9vd0feOzO7Z8ZjUY/KoSIKKV+yqDknBOjNQ1FQFrXkHmnzNZBCIwxO//N3w53a/yQJ1+C9hJE2bmBrS1a633QZVkaKSVbLBakLEsoqbumaX5js93+t+vN5teWdtYPofZRZPXNPvXftg14y0YwB82a8XiE97z7PY/v7+39+dF4+G/O5/P3eetRlmUYDAaaEKKbuibGGNK1HVFSEo+7+yTuu2z/uxf+1nWNwupbTde2RkppKGO0VR21CjlL8J8cn34uL4pfzYvif7m4uHj+CkfMvtUL/23dgLfZCANAZ1mGvd1dzOfzD9y6eeOH9/b3/vUkSd4/GAwyr6/J3Rteggs0bWOqsjKAMdQNu6ibGhQEYRyBghCtNVFaEeWM3/k2dy9rVwiCsNxut0/fu3f/ty8Wi19frzefKIpCO5k6pXZ2mvpWhJp/JTbgLQ9bUheepJ9mNd+ZY3dn52A0Hn3HZDL+wCAbfOd8PnuHEOLQGDPpuo774RqEEnRNC6mUraauzJ6WXafarlu2bfugKIqXi7J85vT09FNFXj67WC7vVWUJfbmQ/qU7/e1a9D/2DXjLRhC3Gf70mSsPieLg4ACj0XDOKD24fv36/s58Z77ebKZFsR0QSgNnA+2MMVtjzGK73Z5LKU9W6/WDzWZ7VlWV8aDclZ+ZuTe9vi785pv56/8Dwh2X/Ffkm08AAAAASUVORK5CYII=",pi=110;let ui=0,_i=class extends de{constructor(){super(...arguments),this.discovered_list=[],this.compact=!1,this.showStats=!0,this.showLegend=!0,this.showMoon=!1,this.showCardinals=!0,this.showBlindSpot=!0,this.showSunPath=!0,this.showSunriseSunset=!0,this.showCoverFill=!0,this.showWindowArrow=!0,this.coverColors=[],this.northOffsetDeg=0,this._hiddenEntries=new Set,this._legendMoonMaskId="acp-legend-moon-"+ui++}shouldUpdate(e){return e.size>1||!e.has("hass")||ve(e.get("hass"),this.hass,this._relevantIds())}_relevantIds(){const e=[];for(const t of this.discovered_list){const o=t.entities;e.push(o.sun_sensor,o.target_position_sensor,o.manual_override_binary,o.sun_infront_binary,o.decision_trace_sensor,o.start_sensor,o.end_sensor)}return e}_toggleEntry(e){const t=new Set(this._hiddenEntries);t.has(e)?t.delete(e):t.add(e),this._hiddenEntries=t}_sunFor(e){const t=e.entities.sun_sensor;if(!t)return null;const o=this.hass.states[t];if(!o)return null;const i=parseFloat(o.state);return Number.isNaN(i)?null:{...o.attributes,window_azimuth:o.attributes.window_azimuth}}_sunInfrontFor(e){const t=e.entities.sun_infront_binary;return!!t&&"on"===this.hass.states[t]?.state}_sunDotStateFor(e,t){const o=e.entities.decision_trace_sensor?this.hass.states[e.entities.decision_trace_sensor]?.attributes:void 0;return ai({belowHorizon:t.elevation<=0,sunState:o?.sun_state??null,directSunValid:o?.direct_sun_valid??!1,inFov:!0===t.in_fov})}_readActiveAzimuth(e){if(!e)return null;const t=this.hass.states[e];if(!t)return null;if("unavailable"===t.state||"unknown"===t.state)return null;const o=t.attributes.azimuth;return"number"==typeof o&&Number.isFinite(o)?o:null}_buildOverlays(){const e=[];return this.discovered_list.forEach((t,o)=>{const i=this._sunFor(t);if(!i)return;const s=t.entities.sun_sensor,n=parseFloat(this.hass.states[s]?.state??"0"),{color:r,isOverride:a}=di(this.coverColors?.[o],o);e.push({d:t,sun:i,sunAzi:n,sunInfront:this._sunInfrontFor(t),dotState:this._sunDotStateFor(t,i),coverPos:Zt(this.hass,t),actualPos:Yt(this.hass,t),coverType:t.cover_type,openBlocksSun:kt(t).openBlocksSun,color:r,isOverride:a,index:o})}),e}render(){if(!this.hass)return q;if(!this.discovered_list||0===this.discovered_list.length)return H`<div class="placeholder">${it("compass.placeholder_no_entries",this.hass)}</div>`;const e=this._buildOverlays();if(0===e.length)return H`<div class="placeholder">${it("compass.placeholder_no_sun",this.hass)}</div>`;const t=e.filter(e=>!this._hiddenEntries.has(e.d.entry_id)),o=Tt(this.northOffsetDeg),i=e.length>1,s=e[0],n=s.sunAzi,r=s.sun.elevation,a=Mt(n,r,o),l={night:-1,outside_fov:0,in_fov_not_valid:1,hitting:2},c=r<=0?"night":e.reduce((e,t)=>l[t.dotState]>l[e]?t.dotState:e,"outside_fov"),d=ri[c],{latitude:h,longitude:p,time_zone:u}=this.hass.config,_=void 0!==h&&void 0!==p?Zo(h,p,Jo(u)):[],g=this.showMoon&&void 0!==h&&void 0!==p?ii(h,p):null,m=null!==g&&g.elevation>0,v=g?jt(g.phase,6):0,f=m?Mt(g.azimuth,g.elevation,o):null,b=f?f.x*pi:0,y=f?f.y*pi:0,w=this.showSunPath?oi(_).map(e=>_.slice(e.startIdx,e.endIdx+1).map(e=>{const t=Mt(e.azimuth,e.elevation,o);return{x:t.x*pi,y:t.y*pi,elev:e.elevation}})):[],x=[122,127,135],$=[245,197,24],k=e=>{const t=Math.sqrt(Math.max(0,Math.min(1,e/90))),o=x.map((e,o)=>Math.round(e+($[o]-e)*t));return`rgb(${o[0]},${o[1]},${o[2]})`},A=this.showSunPath&&this.showSunriseSunset?w.filter(e=>e.length>1).map((e,t)=>{const o=e[0],i=e[e.length-1],s=i.x-o.x,n=i.y-o.y,r=s*s+n*n||1,a=e.filter((t,o)=>o%6==0||o===e.length-1).map(e=>({offset:100*Math.max(0,Math.min(1,((e.x-o.x)*s+(e.y-o.y)*n)/r)),color:k(e.elev)}));return{id:`sun-path-grad-${t}`,x1:o.x,y1:o.y,x2:i.x,y2:i.y,stops:a}}):[],S=e=>this.showSunriseSunset?`url(#sun-path-grad-${e})`:"var(--warning-color, gold)",C=Ct(0,124,o),E=Ct(90,124,o),z=Ct(180,124,o),M=Ct(270,124,o),T=Ct(0,pi,o),I=Ct(180,pi,o),P=Ct(90,pi,o),O=Ct(270,pi,o),B=it("compass.sun_tooltip",this.hass,{az:lt(n),el:lt(r)}),F=null!==g?it("compass.moon_tooltip",this.hass,{phase:g.phaseName,pct:Math.round(100*g.fraction)}):"",N=it("compass.sun_path_tooltip",this.hass);return H`
       <div class="compass">
         <svg viewBox="${-140} ${-140} ${280} ${280}">
-          ${H`
+          ${U`
             <defs>
-              ${m?H`
+              ${m?U`
                 <mask id="moon-phase-mask">
                   <circle cx=${b} cy=${y} r=${6} fill="white"></circle>
                   <circle cx=${b+v} cy=${y} r=${6} fill="black"></circle>
                 </mask>
-              `:V}
-              ${A.map(e=>H`
+              `:q}
+              ${A.map(e=>U`
                 <linearGradient id=${e.id} gradientUnits="userSpaceOnUse"
                   x1=${e.x1} y1=${e.y1} x2=${e.x2} y2=${e.y2}>
-                  ${e.stops.map(e=>H`<stop offset="${e.offset}%" stop-color=${e.color}></stop>`)}
+                  ${e.stops.map(e=>U`<stop offset="${e.offset}%" stop-color=${e.color}></stop>`)}
                 </linearGradient>
               `)}
             </defs>
 
-            <circle class="grid" r=${di}></circle>
+            <circle class="grid" r=${pi}></circle>
             <circle class="grid" r=${220/3}></circle>
-            <circle class="grid" r=${di/3}></circle>
-            <line class="grid thin" x1=${I.x} y1=${I.y} x2=${T.x} y2=${T.y}></line>
+            <circle class="grid" r=${pi/3}></circle>
+            <line class="grid thin" x1=${T.x} y1=${T.y} x2=${I.x} y2=${I.y}></line>
             <line class="grid thin" x1=${P.x} y1=${P.y} x2=${O.x} y2=${O.y}></line>
 
             ${t.map(e=>this._renderEntryLayers(e,i,o,_))}
 
-            ${this.showSunPath&&w.length?H`<g ${bo(N)}>${w.filter(e=>e.length>1).flatMap((e,t)=>{const o=e.map(e=>`${e.x},${e.y}`).join(" "),i=H`<polyline class="sun-path-line" points=${o}
-                        style="stroke:${S(t)}"></polyline>`,s=[];for(let t=0;t<e.length;t+=10){const o=e[t],i=e[Math.max(0,t-1)],n=e[Math.min(e.length-1,t+1)],r=180*Math.atan2(n.y-i.y,n.x-i.x)/Math.PI,a=this.showSunriseSunset?k(o.elev):"var(--warning-color, gold)";s.push(H`<path class="sun-path-chevron"
+            ${this.showSunPath&&w.length?U`<g ${wo(N)}>${w.filter(e=>e.length>1).flatMap((e,t)=>{const o=e.map(e=>`${e.x},${e.y}`).join(" "),i=U`<polyline class="sun-path-line" points=${o}
+                        style="stroke:${S(t)}"></polyline>`,s=[];for(let t=0;t<e.length;t+=10){const o=e[t],i=e[Math.max(0,t-1)],n=e[Math.min(e.length-1,t+1)],r=180*Math.atan2(n.y-i.y,n.x-i.x)/Math.PI,a=this.showSunriseSunset?k(o.elev):"var(--warning-color, gold)";s.push(U`<path class="sun-path-chevron"
                           transform=${`translate(${o.x} ${o.y}) rotate(${r})`}
                           d="M -2.4 -3 L 1.8 0 L -2.4 3 L -0.7 0 Z"
-                          style=${`fill:${a}`}></path>`)}return[i,...s]})}</g>`:V}
+                          style=${`fill:${a}`}></path>`)}return[i,...s]})}</g>`:q}
 
-            ${this.showCardinals?H`
+            ${this.showCardinals?U`
               <text class="cardinal" x=${C.x} y=${C.y} text-anchor="middle" dominant-baseline="central">N</text>
               <text class="cardinal" x=${E.x} y=${E.y} text-anchor="middle" dominant-baseline="central">E</text>
               <text class="cardinal" x=${z.x} y=${z.y} text-anchor="middle" dominant-baseline="central">S</text>
               <text class="cardinal" x=${M.x} y=${M.y} text-anchor="middle" dominant-baseline="central">W</text>
-            `:V}
+            `:q}
 
-            ${m?H`
-              <g ${bo(B)}>
+            ${m?U`
+              <g ${wo(F)}>
                 <circle class="moon-outline" cx=${b} cy=${y} r=${6}></circle>
                 <image
                   class="moon-img"
-                  href=${ci}
+                  href=${hi}
                   x=${b-6}
                   y=${y-6}
                   width=${12}
@@ -126,47 +126,47 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
                   mask="url(#moon-phase-mask)"
                 ></image>
               </g>
-            `:V}
+            `:q}
 
-            <g ${bo(F)}>
-              <circle class=${d} cx=${a.x*di} cy=${a.y*di} r="7"></circle>
+            <g ${wo(B)}>
+              <circle class=${d} cx=${a.x*pi} cy=${a.y*pi} r="7"></circle>
             </g>
           `}
         </svg>
-        ${this.showLegend?this._renderLegend(e,i,d,g):V}
-        ${this.showStats?this._renderStats(e,i):V}
+        ${this.showLegend?this._renderLegend(e,i,d,g):q}
+        ${this.showStats?this._renderStats(e,i):q}
       </div>
-    `}_renderEntryLayers(e,t,o=0,i=[]){const s=zt(e.sun.window_azimuth),n=zt(s-e.sun.fov_left),r=zt(s+e.sun.fov_right),a=this._readActiveAzimuth(e.d.entities.start_sensor),l=this._readActiveAzimuth(e.d.entities.end_sensor),c=null!==a&&null!==l;let d,h;if(c)({wedgeStart:d,wedgeEnd:h}=function(e,t,o,i,s){const n=((o-i)%360+360)%360,r=i+s,a=((t-n)%360+360)%360,l=e=>e<=r?e:e-r<360-e?r:0,c=l(((e-n)%360+360)%360),d=l(a);return c===d?{wedgeStart:n,wedgeEnd:((n+r)%360+360)%360}:{wedgeStart:((n+Math.min(c,d))%360+360)%360,wedgeEnd:((n+Math.max(c,d))%360+360)%360}}(zt(a),zt(l),s,e.sun.fov_left,e.sun.fov_right));else{const t=function(e,t,o,i,s){if(void 0===s)return null;const n=zt(t-o),r=o+i,a=e.filter(e=>((e.azimuth-n)%360+360)%360<=r&&e.elevation>s);return 0===a.length?null:{wedgeStart:a[0].azimuth,wedgeEnd:a[a.length-1].azimuth}}(i,s,e.sun.fov_left,e.sun.fov_right,e.sun.min_elevation);d=t?t.wedgeStart:n,h=t?t.wedgeEnd:r}const p=At(s,di,o),{outer:u,inner:_}=(g=e.sun.min_elevation,m=e.sun.max_elevation,v=di,void 0!==g&&void 0!==m&&g>m?{outer:v,inner:0}:{outer:void 0!==g?v*St(g):v,inner:void 0!==m?v*St(m):0});var g,m,v;const f=null!==e.coverPos?Bt(e.coverPos,e.openBlocksSun,di,u):null,b=null!==e.actualPos?Bt(e.actualPos,e.openBlocksSun,di,u):null,y=e.sun.blind_spot_range?[zt((w=s)-(x=e.sun.blind_spot_range)[1]),zt(w-x[0])]:null;var w,x;const $=y?Ct(y[0],y[1],di,0,o):null,k=Ct(d,h,u,_,o),A=c&&(d!==n||h!==r),S=A?Ct(n,r,u,_,o):"",C=null!==f&&f>_?Ct(d,h,f,_,o):"",E=null!==b&&b>_?Ct(d,h,b,_,o):"",z=[];for(const t of Jo(i,s,e.sun.fov_left,e.sun.fov_right)){const s=Mt(i,t.startIdx,t.endIdx,e.sun.min_elevation);s&&!Ot(s.wedgeStart,s.wedgeEnd,d,h)&&z.push({fov:Ct(s.wedgeStart,s.wedgeEnd,u,_,o),cover:this.showCoverFill&&null!==f&&f>_?Ct(s.wedgeStart,s.wedgeEnd,f,_,o):"",actual:this.showCoverFill&&null!==b&&b>_?Ct(s.wedgeStart,s.wedgeEnd,b,_,o):"",from:s.wedgeStart,to:s.wedgeEnd})}const M=t?`${e.d.entry_title}: `:"",I=void 0!==e.sun.min_elevation||void 0!==e.sun.max_elevation?ot("compass.elev_suffix",this.hass,{min:at(e.sun.min_elevation??0),max:at(e.sun.max_elevation??90)}):"",T=c?`${M}${ot("compass.active_sun_arc",this.hass,{from:at(d),to:at(h),elev:I})}`:`${M}${ot("compass.fov_arc",this.hass,{left:at(e.sun.fov_left),right:at(e.sun.fov_right),elev:I})}`,P=`${M}${ot("compass.window_normal_tooltip",this.hass,{bearing:at(s)})}`,O=[];if(null!==e.coverPos){const t=e.openBlocksSun?"compass.cover_position_target_awning":"compass.cover_position_target";O.push(`${M}${ot(t,this.hass,{pct:e.coverPos})}`),null!==e.actualPos&&O.push(ot("compass.cover_position_actual",this.hass,{pct:Math.round(e.actualPos)}))}const F=O.join("\n"),B=y?`${M}${ot("compass.blind_spot",this.hass,{from:at(y[0]),to:at(y[1])})}`:"",N=t||e.isOverride,D=t||e.isOverride,R=N?`fill: ${e.color}; stroke: ${e.color};`:"",j=D?`fill: ${e.color}; stroke: ${e.color};`:"",K=N?`fill: ${e.color}; stroke: ${e.color};`:"",L=N?`stroke: ${e.color};`:"",G=N?`fill: ${e.color};`:"",W=this.showCoverFill&&""!==C,U=this.showBlindSpot&&!!$,q=this.showWindowArrow,Y=`M 0 0 L ${p.x} ${p.y}`,Q=N?`fill: ${e.color}; stroke: ${e.color};`:"",Z=Rt(p.x,p.y,s+o,9,5),X="display: none;",J=`${M}${ot("compass.fov_arc",this.hass,{left:at(e.sun.fov_left),right:at(e.sun.fov_right),elev:I})}`;return H`<g class="entry-overlay">
-      ${A?H`<g ${bo(J)}>
+    `}_renderEntryLayers(e,t,o=0,i=[]){const s=Tt(e.sun.window_azimuth),n=Tt(s-e.sun.fov_left),r=Tt(s+e.sun.fov_right),a=this._readActiveAzimuth(e.d.entities.start_sensor),l=this._readActiveAzimuth(e.d.entities.end_sensor),c=null!==a&&null!==l;let d,h;if(c)({wedgeStart:d,wedgeEnd:h}=function(e,t,o,i,s){const n=((o-i)%360+360)%360,r=i+s,a=((t-n)%360+360)%360,l=e=>e<=r?e:e-r<360-e?r:0,c=l(((e-n)%360+360)%360),d=l(a);return c===d?{wedgeStart:n,wedgeEnd:((n+r)%360+360)%360}:{wedgeStart:((n+Math.min(c,d))%360+360)%360,wedgeEnd:((n+Math.max(c,d))%360+360)%360}}(Tt(a),Tt(l),s,e.sun.fov_left,e.sun.fov_right));else{const t=function(e,t,o,i,s){if(void 0===s)return null;const n=Tt(t-o),r=o+i,a=e.filter(e=>((e.azimuth-n)%360+360)%360<=r&&e.elevation>s);return 0===a.length?null:{wedgeStart:a[0].azimuth,wedgeEnd:a[a.length-1].azimuth}}(i,s,e.sun.fov_left,e.sun.fov_right,e.sun.min_elevation);d=t?t.wedgeStart:n,h=t?t.wedgeEnd:r}const p=Ct(s,pi,o),{outer:u,inner:_}=(g=e.sun.min_elevation,m=e.sun.max_elevation,v=pi,void 0!==g&&void 0!==m&&g>m?{outer:v,inner:0}:{outer:void 0!==g?v*Et(g):v,inner:void 0!==m?v*Et(m):0});var g,m,v;const f=null!==e.coverPos?Dt(e.coverPos,e.openBlocksSun,pi,u):null,b=null!==e.actualPos?Dt(e.actualPos,e.openBlocksSun,pi,u):null,y=e.sun.blind_spot_range?[Tt((w=s)-(x=e.sun.blind_spot_range)[1]),Tt(w-x[0])]:null;var w,x;const $=y?zt(y[0],y[1],pi,0,o):null,k=zt(d,h,u,_,o),A=c&&(d!==n||h!==r),S=A?zt(n,r,u,_,o):"",C=null!==f&&f>_?zt(d,h,f,_,o):"",E=null!==b&&b>_?zt(d,h,b,_,o):"",z=[];for(const t of ti(i,s,e.sun.fov_left,e.sun.fov_right)){const s=It(i,t.startIdx,t.endIdx,e.sun.min_elevation);s&&!Ft(s.wedgeStart,s.wedgeEnd,d,h)&&z.push({fov:zt(s.wedgeStart,s.wedgeEnd,u,_,o),cover:this.showCoverFill&&null!==f&&f>_?zt(s.wedgeStart,s.wedgeEnd,f,_,o):"",actual:this.showCoverFill&&null!==b&&b>_?zt(s.wedgeStart,s.wedgeEnd,b,_,o):"",from:s.wedgeStart,to:s.wedgeEnd})}const M=t?`${e.d.entry_title}: `:"",T=void 0!==e.sun.min_elevation||void 0!==e.sun.max_elevation?it("compass.elev_suffix",this.hass,{min:lt(e.sun.min_elevation??0),max:lt(e.sun.max_elevation??90)}):"",I=c?`${M}${it("compass.active_sun_arc",this.hass,{from:lt(d),to:lt(h),elev:T})}`:`${M}${it("compass.fov_arc",this.hass,{left:lt(e.sun.fov_left),right:lt(e.sun.fov_right),elev:T})}`,P=`${M}${it("compass.window_normal_tooltip",this.hass,{bearing:lt(s)})}`,O=[];if(null!==e.coverPos){const t=e.openBlocksSun?"compass.cover_position_target_awning":"compass.cover_position_target";O.push(`${M}${it(t,this.hass,{pct:e.coverPos})}`),null!==e.actualPos&&O.push(it("compass.cover_position_actual",this.hass,{pct:Math.round(e.actualPos)}))}const B=O.join("\n"),F=y?`${M}${it("compass.blind_spot",this.hass,{from:lt(y[0]),to:lt(y[1])})}`:"",N=t||e.isOverride,D=t||e.isOverride,R=N?`fill: ${e.color}; stroke: ${e.color};`:"",j=D?`fill: ${e.color}; stroke: ${e.color};`:"",K=N?`fill: ${e.color}; stroke: ${e.color};`:"",L=N?`stroke: ${e.color};`:"",G=N?`fill: ${e.color};`:"",W=this.showCoverFill&&""!==C,H=this.showBlindSpot&&!!$,V=this.showWindowArrow,Y=`M 0 0 L ${p.x} ${p.y}`,Q=N?`fill: ${e.color}; stroke: ${e.color};`:"",Z=Kt(p.x,p.y,s+o,9,5),X="display: none;",J=`${M}${it("compass.fov_arc",this.hass,{left:lt(e.sun.fov_left),right:lt(e.sun.fov_right),elev:T})}`;return U`<g class="entry-overlay">
+      ${A?U`<g ${wo(J)}>
               <path class="fov fov-static" style=${R} d=${S}></path>
-            </g>`:V}
-      <g ${bo(T)}>
+            </g>`:q}
+      <g ${wo(I)}>
         <path class="fov" style=${R} d=${k}></path>
       </g>
-      ${z.map(e=>{const t=`${M}${ot("compass.active_sun_arc",this.hass,{from:at(e.from),to:at(e.to),elev:I})}`;return H`<g ${bo(t)}>
+      ${z.map(e=>{const t=`${M}${it("compass.active_sun_arc",this.hass,{from:lt(e.from),to:lt(e.to),elev:T})}`;return U`<g ${wo(t)}>
           <path class="fov-extra" style=${R} d=${e.fov}></path>
-          ${e.cover?H`<path class="cover-fill-extra" style=${j} d=${e.cover}></path>`:V}
-          ${e.actual?H`<path class="cover-actual-extra" style=${j} d=${e.actual}></path>`:V}
+          ${e.cover?U`<path class="cover-fill-extra" style=${j} d=${e.cover}></path>`:q}
+          ${e.actual?U`<path class="cover-actual-extra" style=${j} d=${e.actual}></path>`:q}
         </g>`})}
-      <g class="arrow-group" style=${q?"":X} ${bo(P)}>
+      <g class="arrow-group" style=${V?"":X} ${wo(P)}>
         <path class="window" style=${L} d=${Y}></path>
         <path class="window-head" style=${Q} d=${Z}></path>
         <circle class="window-base" style=${G} cx="0" cy="0" r="4"></circle>
       </g>
-      <g class="cover-group" style=${W?"":X} ${bo(F)}>
+      <g class="cover-group" style=${W?"":X} ${wo(B)}>
         <path class="cover-fill" style=${j} d=${C}></path>
-        ${this.showCoverFill&&E?H`<path class="cover-actual" style=${j} d=${E}></path>`:V}
+        ${this.showCoverFill&&E?U`<path class="cover-actual" style=${j} d=${E}></path>`:q}
       </g>
-      <g class="blind-group" style=${U?"":X} ${bo(B)}>
+      <g class="blind-group" style=${H?"":X} ${wo(F)}>
         <path class="blind-spot" style=${K} d=${$??""}></path>
       </g>
-    </g>`}_legendSunGlyph(e){return W`<span class="glyph"
+    </g>`}_legendSunGlyph(e){return H`<span class="glyph"
       ><svg viewBox="-8 -8 16 16" width="20" height="20">
-        ${H`<circle class=${e} cx="0" cy="0" r="5"></circle>`}
+        ${U`<circle class=${e} cx="0" cy="0" r="5"></circle>`}
       </svg></span
-    >`}_legendMoonGlyph(e){const t=e?Dt(e.phase,4):0,o=this._legendMoonMaskId;return W`<span class="glyph"
+    >`}_legendMoonGlyph(e){const t=e?jt(e.phase,4):0,o=this._legendMoonMaskId;return H`<span class="glyph"
       ><svg viewBox="-5 -5 10 10" width="11" height="11">
-        ${H`
+        ${U`
           <defs>
             <mask id=${o}>
               <circle cx="0" cy="0" r=${4} fill="white"></circle>
@@ -176,7 +176,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
           <circle class="moon-outline" cx="0" cy="0" r=${4}></circle>
           <image
             class="moon-img"
-            href=${ci}
+            href=${hi}
             x=${-4}
             y=${-4}
             width=${8}
@@ -185,21 +185,21 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
           ></image>
         `}
       </svg></span
-    >`}_legendWindowGlyph(e){const t=e?`stroke: ${e};`:"",o=e?`fill: ${e};`:"",i=Rt(5,0,90,4,2);return W`<span class="glyph"
+    >`}_legendWindowGlyph(e){const t=e?`stroke: ${e};`:"",o=e?`fill: ${e};`:"",i=Kt(5,0,90,4,2);return H`<span class="glyph"
       ><svg class="window-glyph" viewBox="-6 -6 12 12" width="13" height="13">
-        ${H`
+        ${U`
           <line class="window" style=${t} x1="-5" y1="0" x2="1.5" y2="0"></line>
           <path class="window-head" style=${o} d=${i}></path>
         `}
       </svg></span
-    >`}_renderLegend(e,t,o,i){const s=e[0]?.isOverride?e[0].color??null:null,n=e[0],r=null!==n?.coverPos&&null!=n?.actualPos&&void 0!==n?.coverPos&&Math.round(n.actualPos)!==Math.round(n.coverPos);return t?W`
+    >`}_renderLegend(e,t,o,i){const s=e[0]?.isOverride?e[0].color??null:null,n=e[0],r=null!==n?.coverPos&&null!=n?.actualPos&&void 0!==n?.coverPos&&Math.round(n.actualPos)!==Math.round(n.coverPos);return t?H`
         <div class="legend">
-          <div>${this._legendSunGlyph(o)} ${ot("compass.sun",this.hass)}</div>
-          ${this.showMoon?W`<div>${this._legendMoonGlyph(i)} ${ot("compass.moon",this.hass)}</div>`:V}
-          ${e.map(e=>W`
+          <div>${this._legendSunGlyph(o)} ${it("compass.sun",this.hass)}</div>
+          ${this.showMoon?H`<div>${this._legendMoonGlyph(i)} ${it("compass.moon",this.hass)}</div>`:q}
+          ${e.map(e=>H`
               <button
                 type="button"
-                class=${Ko({"entry-toggle":!0,hidden:this._hiddenEntries.has(e.d.entry_id)})}
+                class=${Go({"entry-toggle":!0,hidden:this._hiddenEntries.has(e.d.entry_id)})}
                 aria-pressed=${!this._hiddenEntries.has(e.d.entry_id)}
                 @click=${()=>this._toggleEntry(e.d.entry_id)}
               >
@@ -207,13 +207,13 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
                   ><span class="swatch entry" style="background: ${e.color}"></span
                 ></span>
                 ${e.d.entry_title}
-                ${e.sunInfront?W`<span class="status valid">${ot("compass.in_fov_check",this.hass)}</span>`:e.sun.in_fov?W`<span class="status in-fov">${ot("compass.in_fov",this.hass)}</span>`:W`<span class="status">${ot("compass.none",this.hass)}</span>`}
+                ${e.sunInfront?H`<span class="status valid">${it("compass.in_fov_check",this.hass)}</span>`:e.sun.in_fov?H`<span class="status in-fov">${it("compass.in_fov",this.hass)}</span>`:H`<span class="status">${it("compass.none",this.hass)}</span>`}
               </button>
             `)}
         </div>
-      `:W`<div class="legend">
-      <div>${this._legendSunGlyph(o)} ${ot("compass.sun",this.hass)}</div>
-      ${this.showMoon?W`<div>${this._legendMoonGlyph(i)} ${ot("compass.moon",this.hass)}</div>`:V}
+      `:H`<div class="legend">
+      <div>${this._legendSunGlyph(o)} ${it("compass.sun",this.hass)}</div>
+      ${this.showMoon?H`<div>${this._legendMoonGlyph(i)} ${it("compass.moon",this.hass)}</div>`:q}
       <div>
         <span class="licell"
           ><span
@@ -221,61 +221,61 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
             style=${s?`background: ${s}`:""}
           ></span
         ></span>
-        ${ot("compass.window_fov",this.hass)}
+        ${it("compass.window_fov",this.hass)}
       </div>
-      ${this.showCoverFill?W`<div>
+      ${this.showCoverFill?H`<div>
             <span class="licell"
               ><span
                 class="swatch cover-fill-swatch"
                 style=${s?`background: ${s}`:""}
               ></span
             ></span>
-            ${ot("compass.cover_target",this.hass)}
-          </div>`:V}
-      ${this.showCoverFill&&r?W`<div>
+            ${it("compass.cover_target",this.hass)}
+          </div>`:q}
+      ${this.showCoverFill&&r?H`<div>
             <span class="licell"
               ><span
                 class="swatch cover-actual-swatch"
                 style=${s?`border-color: ${s}`:""}
               ></span
             ></span>
-            ${ot("compass.cover_held",this.hass)}
-          </div>`:V}
-      ${this.showWindowArrow?W`<div>
-            ${this._legendWindowGlyph(s)} ${ot("compass.window_normal",this.hass)}
-          </div>`:V}
-    </div>`}_renderStats(e,t){const o=e[0],i=o.sunAzi,s=o.sun.elevation,{latitude:n,longitude:r}=this.hass.config,a=this.showMoon&&void 0!==n&&void 0!==r?ti(n,r):null;return t?W`
+            ${it("compass.cover_held",this.hass)}
+          </div>`:q}
+      ${this.showWindowArrow?H`<div>
+            ${this._legendWindowGlyph(s)} ${it("compass.window_normal",this.hass)}
+          </div>`:q}
+    </div>`}_renderStats(e,t){const o=e[0],i=o.sunAzi,s=o.sun.elevation,{latitude:n,longitude:r}=this.hass.config,a=this.showMoon&&void 0!==n&&void 0!==r?ii(n,r):null;return t?H`
         <div class="stats dim">
           <div class="stats-row">
             <span
-              >${ot("compass.stat_sun",this.hass)}${at(i)} /
-              ${at(s)}</span
+              >${it("compass.stat_sun",this.hass)}${lt(i)} /
+              ${lt(s)}</span
             >
-            ${this.showMoon&&a?W`<span>${a.phaseName} ${Math.round(100*a.fraction)}%</span>`:V}
+            ${this.showMoon&&a?H`<span>${a.phaseName} ${Math.round(100*a.fraction)}%</span>`:q}
           </div>
-          ${e.map(e=>W`
+          ${e.map(e=>H`
               <div class="stats-row entry-row">
                 <span class="swatch entry" style="background: ${e.color}"></span>
                 <span class="entry-name">${e.d.entry_title}</span>
-                <span>∠${at(e.sun.gamma)}</span>
-                <span>W ${at(zt(e.sun.window_azimuth))}</span>
-                ${e.sun.in_fov?W`<span
+                <span>∠${lt(e.sun.gamma)}</span>
+                <span>W ${lt(Tt(e.sun.window_azimuth))}</span>
+                ${e.sun.in_fov?H`<span
                       class="status in-fov"
-                      ${bo(ot("compass.in_fov_tooltip",this.hass))}
+                      ${wo(it("compass.in_fov_tooltip",this.hass))}
                       >✓</span
-                    >`:V}
+                    >`:q}
               </div>
             `)}
         </div>
-      `:W`<div class="stats dim">
-      <span>${ot("compass.stat_azi",this.hass)}${at(i)}</span>
-      <span>${ot("compass.stat_elev",this.hass)}${at(s)}</span>
-      <span>∠: ${at(o.sun.gamma)}</span>
+      `:H`<div class="stats dim">
+      <span>${it("compass.stat_azi",this.hass)}${lt(i)}</span>
+      <span>${it("compass.stat_elev",this.hass)}${lt(s)}</span>
+      <span>∠: ${lt(o.sun.gamma)}</span>
       <span
-        >${ot("compass.stat_window",this.hass)}${at(zt(o.sun.window_azimuth))}</span
+        >${it("compass.stat_window",this.hass)}${lt(Tt(o.sun.window_azimuth))}</span
       >
-      ${this.showMoon&&a?W`<span>${a.phaseName} ${Math.round(100*a.fraction)}%</span>`:V}
-    </div>`}};function ui(e){let t=null,o=null;const i=6e4-Date.now()%6e4;return t=setTimeout(()=>{t=null,e(),o=setInterval(e,6e4)},i),()=>{null!==t&&(clearTimeout(t),t=null),null!==o&&(clearInterval(o),o=null)}}pi.styles=r`
+      ${this.showMoon&&a?H`<span>${a.phaseName} ${Math.round(100*a.fraction)}%</span>`:q}
+    </div>`}};function gi(e){let t=null,o=null;const i=6e4-Date.now()%6e4;return t=setTimeout(()=>{t=null,e(),o=setInterval(e,6e4)},i),()=>{null!==t&&(clearTimeout(t),t=null),null!==o&&(clearInterval(o),o=null)}}_i.styles=a`
     :host {
       display: block;
       width: 100%;
@@ -627,39 +627,39 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
     [data-tooltip][acp-tt-shown] {
       cursor: default;
     }
-  `,e([_e({attribute:!1})],pi.prototype,"hass",void 0),e([_e({attribute:!1})],pi.prototype,"discovered_list",void 0),e([_e({type:Boolean,reflect:!0})],pi.prototype,"compact",void 0),e([_e({attribute:!1})],pi.prototype,"showStats",void 0),e([_e({attribute:!1})],pi.prototype,"showLegend",void 0),e([_e({attribute:!1})],pi.prototype,"showMoon",void 0),e([_e({attribute:!1})],pi.prototype,"showCardinals",void 0),e([_e({attribute:!1})],pi.prototype,"showBlindSpot",void 0),e([_e({attribute:!1})],pi.prototype,"showSunPath",void 0),e([_e({attribute:!1})],pi.prototype,"showSunriseSunset",void 0),e([_e({attribute:!1})],pi.prototype,"showCoverFill",void 0),e([_e({attribute:!1})],pi.prototype,"showWindowArrow",void 0),e([_e({attribute:!1})],pi.prototype,"coverColors",void 0),e([_e({attribute:!1})],pi.prototype,"northOffsetDeg",void 0),e([ge()],pi.prototype,"_hiddenEntries",void 0),pi=e([he("acp-sky-compass")],pi);const _i=32,gi=864e5;function mi(e){if(!e)return null;const t=new Date(e);return Number.isNaN(t.getTime())?null:t}let vi=class extends ce{constructor(){super(...arguments),this.discoveredList=[],this.coverColors=[],this.compact=!1,this._cancelMinuteTimer=null}connectedCallback(){super.connectedCallback(),this._cancelMinuteTimer=ui(()=>this.requestUpdate())}disconnectedCallback(){super.disconnectedCallback(),this._cancelMinuteTimer?.(),this._cancelMinuteTimer=null}shouldUpdate(e){if(e.size>1||!e.has("hass"))return!0;const t=e.get("hass"),o=[];for(const e of this.discoveredList){const t=e.entities;o.push(t.sun_sensor,t.decision_trace_sensor,t.control_status_sensor)}return me(t,this.hass,o)}_sunAttrsFor(e){const t=e.entities.sun_sensor;if(!t)return null;const o=this.hass.states[t];return o?o.attributes:null}_sunDotTraceInputs(){const e=this.discoveredList[0]?.entities.decision_trace_sensor,t=e?this.hass.states[e]?.attributes:void 0;return{sunState:t?.sun_state??null,directSunValid:t?.direct_sun_valid??!1}}_scheduleBounds(){const e=this.discoveredList[0]?.entities.control_status_sensor;if(!e)return null;const t=this.hass.states[e]?.attributes;return t?{start:mi(t.schedule_start),end:mi(t.schedule_end)}:null}render(){if(!this.hass||0===this.discoveredList.length)return V;const e=this._sunAttrsFor(this.discoveredList[0]),{latitude:t,longitude:o,time_zone:i}=this.hass.config??{};if(void 0===t||void 0===o||!e)return W`<div class="placeholder">${ot("elevation.placeholder",this.hass)}</div>`;const s=Zo(i),n=Yo(t,o,s),r=new Date,a=e=>{const t=e.getTime()-s.getTime();return _i+t/864e5*360},l=e=>138-(e- -10)/100*128,c=n.map(e=>`${a(e.t).toFixed(1)},${l(e.elevation).toFixed(1)}`).join(" "),d=l(0),h=a(r),p=this._interpAt(n,r),u=p?l(p.elevation):null,_=!p||p.elevation<=0,g=this._sunDotTraceInputs(),m=si[ni({belowHorizon:_,sunState:g.sunState,directSunValid:g.directSunValid,inFov:!0===e.in_fov})].replace(/^sun /,""),v=e=>138-128*e,f=this.discoveredList.length>1,b=this._scheduleBounds(),y=b?function(e,t,o,i){if(!e&&!t)return{offSchedule:[],bars:[]};const s=e=>(e.getTime()-o)/i,n=e=>Math.max(0,Math.min(1,e)),r=e=>n(e),a=e=>e>1?e-Math.floor(e):n(e),l=e=>e>0&&e<1?[e]:[];if(e&&!t){const t=s(e);return{offSchedule:[{x0:0,x1:r(t)}],bars:l(t)}}if(!e&&t){const e=s(t);return{offSchedule:[{x0:a(e),x1:1}],bars:l(e)}}const c=s(e),d=s(t),h=r(c),p=a(d),u=[...l(c),...l(d)];if(h>p)return{offSchedule:[{x0:p,x1:h}],bars:u};const _=[];return h>0&&_.push({x0:0,x1:h}),p<1&&_.push({x0:p,x1:1}),{offSchedule:_,bars:u}}(b.start,b.end,s.getTime(),gi):{offSchedule:[],bars:[]},w=e=>_i+360*e,x=y.offSchedule.map(e=>({x:w(e.x0),width:w(e.x1)-w(e.x0)})),$=b?.start&&s?(b.start.getTime()-s.getTime())/gi:null,k=y.bars.map(e=>{const t=null!==$&&Math.abs(e-$)<1e-9?b.start.toISOString():b.end.toISOString(),o=null!==$&&Math.abs(e-$)<1e-9,s=w(e);return{x:s,anchor:s>=391?"end":s<=33?"start":"middle",label:lt(t,i),tooltip:ot(o?"elevation.schedule_start_tooltip":"elevation.schedule_end_tooltip",this.hass)}}),A=(()=>{if(!b)return null;const e=b.start?lt(b.start.toISOString(),i):null,t=b.end?lt(b.end.toISOString(),i):null;return e&&t?ot("elevation.schedule",this.hass,{from:e,to:t}):e?ot("elevation.schedule_from",this.hass,{from:e}):t?ot("elevation.schedule_until",this.hass,{to:t}):null})(),S=this.discoveredList.map((e,t)=>{const o=this._sunAttrsFor(e),{color:s,isOverride:r}=li(this.coverColors?.[t],t),l=r;if(!o)return{d:e,runs:[],inPlotBands:[],runBars:[],label:"",color:s,inlineFill:l};const c=Jo(n,o.window_azimuth,o.fov_left,o.fov_right),d="number"==typeof o.min_elevation,h="number"==typeof o.max_elevation,{loFrac:p,hiFrac:u}=function(e,t){if(void 0!==e&&void 0!==t&&e>t)return{loFrac:0,hiFrac:1};const o=e=>Math.max(0,Math.min(1,(e- -10)/100));return{loFrac:void 0!==e?o(e):0,hiFrac:void 0!==t?o(t):1}}(o.min_elevation,o.max_elevation),_=d||h?v(u):10,g=d||h?v(p):138,m=_,b=Math.max(0,g-_),y=c.map(e=>({x0:a(n[e.startIdx].t),x1:a(n[e.endIdx].t),y:m,height:b})),w=c.map(e=>({x0:a(n[e.startIdx].t),x1:a(n[e.endIdx].t),range:`${lt(n[e.startIdx].t.toISOString(),i)} → ${lt(n[e.endIdx].t.toISOString(),i)}`})),x=c.map(e=>`${lt(n[e.startIdx].t.toISOString(),i)} → ${lt(n[e.endIdx].t.toISOString(),i)}`).join(", "),$=[];return f||(d&&$.push(g),h&&$.push(_)),{d:e,runs:c,inPlotBands:y,runBars:w,label:x,color:s,inlineFill:l,limitLines:$}}),C=S.some(e=>e.runs.length>0),E=f?function(e){if(e<=0)return{rows:[],height:0};const t=Array.from({length:e},(e,t)=>({y:0+11*t,height:8}));return{rows:t,height:0+8*e+3*(e-1)+0}}(S.length):{rows:[],height:0},z=138-E.height-3;return W`
+  `,e([ge({attribute:!1})],_i.prototype,"hass",void 0),e([ge({attribute:!1})],_i.prototype,"discovered_list",void 0),e([ge({type:Boolean,reflect:!0})],_i.prototype,"compact",void 0),e([ge({attribute:!1})],_i.prototype,"showStats",void 0),e([ge({attribute:!1})],_i.prototype,"showLegend",void 0),e([ge({attribute:!1})],_i.prototype,"showMoon",void 0),e([ge({attribute:!1})],_i.prototype,"showCardinals",void 0),e([ge({attribute:!1})],_i.prototype,"showBlindSpot",void 0),e([ge({attribute:!1})],_i.prototype,"showSunPath",void 0),e([ge({attribute:!1})],_i.prototype,"showSunriseSunset",void 0),e([ge({attribute:!1})],_i.prototype,"showCoverFill",void 0),e([ge({attribute:!1})],_i.prototype,"showWindowArrow",void 0),e([ge({attribute:!1})],_i.prototype,"coverColors",void 0),e([ge({attribute:!1})],_i.prototype,"northOffsetDeg",void 0),e([me()],_i.prototype,"_hiddenEntries",void 0),_i=e([pe("acp-sky-compass")],_i);const mi=32,vi=864e5;function fi(e){if(!e)return null;const t=new Date(e);return Number.isNaN(t.getTime())?null:t}let bi=class extends de{constructor(){super(...arguments),this.discoveredList=[],this.coverColors=[],this.compact=!1,this._cancelMinuteTimer=null}connectedCallback(){super.connectedCallback(),this._cancelMinuteTimer=gi(()=>this.requestUpdate())}disconnectedCallback(){super.disconnectedCallback(),this._cancelMinuteTimer?.(),this._cancelMinuteTimer=null}shouldUpdate(e){if(e.size>1||!e.has("hass"))return!0;const t=e.get("hass"),o=[];for(const e of this.discoveredList){const t=e.entities;o.push(t.sun_sensor,t.decision_trace_sensor,t.control_status_sensor)}return ve(t,this.hass,o)}_sunAttrsFor(e){const t=e.entities.sun_sensor;if(!t)return null;const o=this.hass.states[t];return o?o.attributes:null}_sunDotTraceInputs(){const e=this.discoveredList[0]?.entities.decision_trace_sensor,t=e?this.hass.states[e]?.attributes:void 0;return{sunState:t?.sun_state??null,directSunValid:t?.direct_sun_valid??!1}}_scheduleBounds(){const e=this.discoveredList[0]?.entities.control_status_sensor;if(!e)return null;const t=this.hass.states[e]?.attributes;return t?{start:fi(t.schedule_start),end:fi(t.schedule_end)}:null}render(){if(!this.hass||0===this.discoveredList.length)return q;const e=this._sunAttrsFor(this.discoveredList[0]),{latitude:t,longitude:o,time_zone:i}=this.hass.config??{};if(void 0===t||void 0===o||!e)return H`<div class="placeholder">${it("elevation.placeholder",this.hass)}</div>`;const s=Jo(i),n=Zo(t,o,s),r=new Date,a=e=>{const t=e.getTime()-s.getTime();return mi+t/864e5*360},l=e=>138-(e- -10)/100*128,c=n.map(e=>`${a(e.t).toFixed(1)},${l(e.elevation).toFixed(1)}`).join(" "),d=l(0),h=a(r),p=this._interpAt(n,r),u=p?l(p.elevation):null,_=!p||p.elevation<=0,g=this._sunDotTraceInputs(),m=ri[ai({belowHorizon:_,sunState:g.sunState,directSunValid:g.directSunValid,inFov:!0===e.in_fov})].replace(/^sun /,""),v=e=>138-128*e,f=this.discoveredList.length>1,b=this._scheduleBounds(),y=b?function(e,t,o,i){if(!e&&!t)return{offSchedule:[],bars:[]};const s=e=>(e.getTime()-o)/i,n=e=>Math.max(0,Math.min(1,e)),r=e=>n(e),a=e=>e>1?e-Math.floor(e):n(e),l=e=>e>0&&e<1?[e]:[];if(e&&!t){const t=s(e);return{offSchedule:[{x0:0,x1:r(t)}],bars:l(t)}}if(!e&&t){const e=s(t);return{offSchedule:[{x0:a(e),x1:1}],bars:l(e)}}const c=s(e),d=s(t),h=r(c),p=a(d),u=[...l(c),...l(d)];if(h>p)return{offSchedule:[{x0:p,x1:h}],bars:u};const _=[];return h>0&&_.push({x0:0,x1:h}),p<1&&_.push({x0:p,x1:1}),{offSchedule:_,bars:u}}(b.start,b.end,s.getTime(),vi):{offSchedule:[],bars:[]},w=e=>mi+360*e,x=y.offSchedule.map(e=>({x:w(e.x0),width:w(e.x1)-w(e.x0)})),$=b?.start&&s?(b.start.getTime()-s.getTime())/vi:null,k=y.bars.map(e=>{const t=null!==$&&Math.abs(e-$)<1e-9?b.start.toISOString():b.end.toISOString(),o=null!==$&&Math.abs(e-$)<1e-9,s=w(e);return{x:s,anchor:s>=391?"end":s<=33?"start":"middle",label:ct(t,i),tooltip:it(o?"elevation.schedule_start_tooltip":"elevation.schedule_end_tooltip",this.hass)}}),A=(()=>{if(!b)return null;const e=b.start?ct(b.start.toISOString(),i):null,t=b.end?ct(b.end.toISOString(),i):null;return e&&t?it("elevation.schedule",this.hass,{from:e,to:t}):e?it("elevation.schedule_from",this.hass,{from:e}):t?it("elevation.schedule_until",this.hass,{to:t}):null})(),S=this.discoveredList.map((e,t)=>{const o=this._sunAttrsFor(e),{color:s,isOverride:r}=di(this.coverColors?.[t],t),l=r;if(!o)return{d:e,runs:[],inPlotBands:[],runBars:[],label:"",color:s,inlineFill:l};const c=ti(n,o.window_azimuth,o.fov_left,o.fov_right),d="number"==typeof o.min_elevation,h="number"==typeof o.max_elevation,{loFrac:p,hiFrac:u}=function(e,t){if(void 0!==e&&void 0!==t&&e>t)return{loFrac:0,hiFrac:1};const o=e=>Math.max(0,Math.min(1,(e- -10)/100));return{loFrac:void 0!==e?o(e):0,hiFrac:void 0!==t?o(t):1}}(o.min_elevation,o.max_elevation),_=d||h?v(u):10,g=d||h?v(p):138,m=_,b=Math.max(0,g-_),y=c.map(e=>({x0:a(n[e.startIdx].t),x1:a(n[e.endIdx].t),y:m,height:b})),w=c.map(e=>({x0:a(n[e.startIdx].t),x1:a(n[e.endIdx].t),range:`${ct(n[e.startIdx].t.toISOString(),i)} → ${ct(n[e.endIdx].t.toISOString(),i)}`})),x=c.map(e=>`${ct(n[e.startIdx].t.toISOString(),i)} → ${ct(n[e.endIdx].t.toISOString(),i)}`).join(", "),$=[];return f||(d&&$.push(g),h&&$.push(_)),{d:e,runs:c,inPlotBands:y,runBars:w,label:x,color:s,inlineFill:l,limitLines:$}}),C=S.some(e=>e.runs.length>0),E=f?function(e){if(e<=0)return{rows:[],height:0};const t=Array.from({length:e},(e,t)=>({y:0+11*t,height:8}));return{rows:t,height:0+8*e+3*(e-1)+0}}(S.length):{rows:[],height:0},z=138-E.height-3;return H`
       <div class="wrap">
         <div class="head">
-          <span class="label">${ot("elevation.title",this.hass)}</span>
+          <span class="label">${it("elevation.title",this.hass)}</span>
           <span class="head-meta">
-            ${f?V:C?W`<span class="dim"
-                      >${ot("elevation.fov_windows",this.hass,{windows:S[0].label})}</span
-                    >`:W`<span class="dim">${ot("elevation.no_fov_today",this.hass)}</span>`}
-            ${A?W`<span class="dim schedule">${A}</span>`:V}
+            ${f?q:C?H`<span class="dim"
+                      >${it("elevation.fov_windows",this.hass,{windows:S[0].label})}</span
+                    >`:H`<span class="dim">${it("elevation.no_fov_today",this.hass)}</span>`}
+            ${A?H`<span class="dim schedule">${A}</span>`:q}
           </span>
         </div>
         <svg viewBox="0 0 ${400} ${160}" preserveAspectRatio="none">
-          ${H`
+          ${U`
             <!-- y-axis gridlines -->
-            ${[0,30,60,90].map(e=>H`
-              <line class="grid" x1=${_i} y1=${l(e)} x2=${392} y2=${l(e)} />
+            ${[0,30,60,90].map(e=>U`
+              <line class="grid" x1=${mi} y1=${l(e)} x2=${392} y2=${l(e)} />
               <text class="tick" x=${28} y=${l(e)+3} text-anchor="end">${e}°</text>
             `)}
 
             <!-- horizon -->
-            <line class="horizon" x1=${_i} y1=${d} x2=${392} y2=${d} />
+            <line class="horizon" x1=${mi} y1=${d} x2=${392} y2=${d} />
 
             <!-- elevation limit gridlines (single-window legacy path only) -->
-            ${S.flatMap(e=>(e.limitLines??[]).map(e=>H`<line class="limit-line" x1=${_i} y1=${e} x2=${392} y2=${e} />`))}
+            ${S.flatMap(e=>(e.limitLines??[]).map(e=>U`<line class="limit-line" x1=${mi} y1=${e} x2=${392} y2=${e} />`))}
 
             <!-- In-plot FOV bands: single-window legacy path only. -->
-            ${f?V:S.flatMap(e=>e.inPlotBands.map(t=>H`<rect
+            ${f?q:S.flatMap(e=>e.inPlotBands.map(t=>U`<rect
                         class="fov-band"
                         x=${t.x0}
                         y=${t.y}
                         width=${t.x1-t.x0}
                         height=${t.height}
-                        style=${e.inlineFill?`fill:${e.color}`:V}
+                        style=${e.inlineFill?`fill:${e.color}`:q}
                       />`))}
 
             <!-- Per-window FOV ribbon (multi-window only): one row per window,
@@ -667,15 +667,15 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
                  sharing the plot's xAt() time scale. Overlaid as a band anchored
                  to the bottom of the plot; drawn BEFORE the curve so the blue
                  curve stays crisp on top. -->
-            ${E.rows.flatMap((e,t)=>{const o=S[t],i=z+e.y,s=o.runs.length?o.d.entry_title:ot("elevation.fov_window_named",this.hass,{name:o.d.entry_title,windows:ot("elevation.no_fov_today",this.hass)}),n=H`<rect
+            ${E.rows.flatMap((e,t)=>{const o=S[t],i=z+e.y,s=o.runs.length?o.d.entry_title:it("elevation.fov_window_named",this.hass,{name:o.d.entry_title,windows:it("elevation.no_fov_today",this.hass)}),n=U`<rect
                 class="ribbon-track"
-                x=${_i}
+                x=${mi}
                 y=${i}
                 width=${360}
                 height=${e.height}
                 rx="2"
-                ${bo(s)}
-              ></rect>`,r=o.runBars.map(t=>H`<rect
+                ${wo(s)}
+              ></rect>`,r=o.runBars.map(t=>U`<rect
                   class="ribbon-bar"
                   x=${t.x0}
                   y=${i}
@@ -683,7 +683,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
                   height=${e.height}
                   rx="2"
                   style=${`fill:${o.color}`}
-                  ${bo(ot("elevation.fov_window_named",this.hass,{name:o.d.entry_title,windows:t.range}))}
+                  ${wo(it("elevation.fov_window_named",this.hass,{name:o.d.entry_title,windows:t.range}))}
                 ></rect>`);return[n,...r]})}
 
             <!-- Schedule window overlay (issue #128): faint off-schedule gray
@@ -691,21 +691,21 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
                  PRE-CURVE so the sun curve and now-line paint on top. The tick
                  label sits slightly higher than the axis ticks (its own class)
                  so it doesn't read as an axis tick. -->
-            ${x.map(e=>H`<rect
+            ${x.map(e=>U`<rect
                 class="off-schedule-zone"
                 x=${e.x}
                 y=${10}
                 width=${e.width}
                 height=${128}
               />`)}
-            ${k.flatMap(e=>[H`<line
+            ${k.flatMap(e=>[U`<line
                 class="schedule-bar"
                 x1=${e.x}
                 y1=${10}
                 x2=${e.x}
                 y2=${138}
-                ${bo(e.tooltip)}
-              ></line>`,H`<text
+                ${wo(e.tooltip)}
+              ></line>`,U`<text
                 class="schedule-tick"
                 x=${e.x}
                 y=${17}
@@ -718,24 +718,24 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
             <!-- current-time cursor + sun dot, drawn last so they sit on top of
                  the curve AND the ribbon bars. A wide transparent hit-line widens
                  the hover target so the thin now-line is easy to tooltip. -->
-            <g class="now-group" ${bo(lt(r.toISOString(),i))}>
+            <g class="now-group" ${wo(ct(r.toISOString(),i))}>
               <line class="now-hit" x1=${h} y1=${10} x2=${h} y2=${138} />
               <line class="now" x1=${h} y1=${10} x2=${h} y2=${138} />
             </g>
-            ${null!==u?H`<circle class="sun-dot ${m}" cx=${h} cy=${u} r="4" />`:V}
+            ${null!==u?U`<circle class="sun-dot ${m}" cx=${h} cy=${u} r="4" />`:q}
 
             <!-- x-axis gridlines + time labels at every 6h, drawn last so the
                  axis sits on the topmost layer (nothing paints over the times).
                  Edge labels anchor inward (start at 00:00, end at 24:00) so they
                  don't clip past the viewBox. -->
-            ${[0,6,12,18,24].map(e=>{const t=new Date(s.getTime()+36e5*e),o=0===e?"start":24===e?"end":"middle";return H`
+            ${[0,6,12,18,24].map(e=>{const t=new Date(s.getTime()+36e5*e),o=0===e?"start":24===e?"end":"middle";return U`
                 <line class="grid faint" x1=${a(t)} y1=${10} x2=${a(t)} y2=${138} />
                 <text class="tick" x=${a(t)} y=${152} text-anchor=${o}>${e.toString().padStart(2,"0")}:00</text>
               `})}
           `}
         </svg>
       </div>
-    `}_interpAt(e,t){if(0===e.length)return null;const o=t.getTime();if(o<=e[0].t.getTime())return e[0];if(o>=e[e.length-1].t.getTime())return e[e.length-1];for(let i=1;i<e.length;i++)if(e[i].t.getTime()>=o){const s=e[i-1],n=e[i],r=(o-s.t.getTime())/(n.t.getTime()-s.t.getTime());return{t:t,elevation:s.elevation+(n.elevation-s.elevation)*r,azimuth:s.azimuth+(n.azimuth-s.azimuth)*r}}return e[e.length-1]}};function fi(e,t){if(!0===e?.custom_position_minimum_mode&&Array.isArray(e.custom_position_slots)&&void 0!==e.custom_position_active_slot){const t=e.custom_position_slots.find(t=>t.slot===e.custom_position_active_slot);if(void 0!==t&&null!==t.position&&void 0!==t.position)return t.position}return t}function bi(e){if(void 0===e?.custom_position_active_slot||!Array.isArray(e.custom_position_slots))return!1;const t=e.custom_position_slots.find(t=>t.slot===e.custom_position_active_slot);return 100===t?.priority}function yi(e){const t=e.replace(/Handler$/,"").replace(/([a-z])([A-Z])/g,"$1_$2").toLowerCase();if(/^custom_position_\d+$/.test(t))return"custom_position";switch(t){case"force_override":return"force";case"weather_override":return"weather";case"manual_override":return"manual";case"motion_timeout":return"motion";case"cloud_suppression":return"cloud";default:return t}}function wi(e,t,o,i=Te,s="Safety"){const n=new Map;for(const t of e){if(!t.matched)continue;const e=yi(t.handler);Ie.includes(e)&&n.set(e,t)}const r=[...Ie].reverse().filter(e=>n.has(e));return 0===r.length?t.reason??"":r.map(e=>function(e,t,o,i,s){const n=i[e]??e,r=t.position,a=null==r?"":` ${it(r)}`;if("custom_position"!==e)return`${n}${a}`.trimEnd();return`${o.custom_position_active_slot_name?`${n} · ${o.custom_position_active_slot_name}`:o.custom_position_active_slot?`${n} #${o.custom_position_active_slot}`:n}${a}${!0===o.custom_position_minimum_mode?" floor":""}${bi(o)?` · ${s}`:""}`}(e,n.get(e),t,i,s)).join(" → ")}vi.styles=r`
+    `}_interpAt(e,t){if(0===e.length)return null;const o=t.getTime();if(o<=e[0].t.getTime())return e[0];if(o>=e[e.length-1].t.getTime())return e[e.length-1];for(let i=1;i<e.length;i++)if(e[i].t.getTime()>=o){const s=e[i-1],n=e[i],r=(o-s.t.getTime())/(n.t.getTime()-s.t.getTime());return{t:t,elevation:s.elevation+(n.elevation-s.elevation)*r,azimuth:s.azimuth+(n.azimuth-s.azimuth)*r}}return e[e.length-1]}};function yi(e,t){if(!0===e?.custom_position_minimum_mode&&Array.isArray(e.custom_position_slots)&&void 0!==e.custom_position_active_slot){const t=e.custom_position_slots.find(t=>t.slot===e.custom_position_active_slot);if(void 0!==t&&null!==t.position&&void 0!==t.position)return t.position}return t}function wi(e){if(void 0===e?.custom_position_active_slot||!Array.isArray(e.custom_position_slots))return!1;const t=e.custom_position_slots.find(t=>t.slot===e.custom_position_active_slot);return 100===t?.priority}function xi(e){const t=e.replace(/Handler$/,"").replace(/([a-z])([A-Z])/g,"$1_$2").toLowerCase();if(/^custom_position_\d+$/.test(t))return"custom_position";switch(t){case"force_override":return"force";case"weather_override":return"weather";case"manual_override":return"manual";case"motion_timeout":return"motion";case"cloud_suppression":return"cloud";default:return t}}function $i(e,t,o,i=Pe,s="Safety"){const n=new Map;for(const t of e){if(!t.matched)continue;const e=xi(t.handler);Ie.includes(e)&&n.set(e,t)}const r=[...Ie].reverse().filter(e=>n.has(e));return 0===r.length?t.reason??"":r.map(e=>function(e,t,o,i,s){const n=i[e]??e,r=t.position,a=null==r?"":` ${st(r)}`;if("custom_position"!==e)return`${n}${a}`.trimEnd();return`${o.custom_position_active_slot_name?`${n} · ${o.custom_position_active_slot_name}`:o.custom_position_active_slot?`${n} #${o.custom_position_active_slot}`:n}${a}${!0===o.custom_position_minimum_mode?" floor":""}${wi(o)?` · ${s}`:""}`}(e,n.get(e),t,i,s)).join(" → ")}bi.styles=a`
     :host {
       display: block;
       width: 100%;
@@ -885,41 +885,41 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
       text-align: center;
       padding: 20px;
     }
-  `,e([_e({attribute:!1})],vi.prototype,"hass",void 0),e([_e({attribute:!1})],vi.prototype,"discoveredList",void 0),e([_e({attribute:!1})],vi.prototype,"coverColors",void 0),e([_e({type:Boolean,reflect:!0})],vi.prototype,"compact",void 0),vi=e([he("acp-elevation-chart")],vi);let xi=class extends ce{constructor(){super(...arguments),this.compact=!1,this.showSummary=!0,this._tick=null,this.hideInactive=!1}disconnectedCallback(){super.disconnectedCallback(),this._syncTimer(!1)}updated(){const e=Boolean(this.hass&&this.discovered&&this._throttleNextAllowedIso());this._syncTimer(e)}_syncTimer(e){e&&null===this._tick?this._tick=setInterval(()=>this.requestUpdate(),1e3):e||null===this._tick||(clearInterval(this._tick),this._tick=null)}shouldUpdate(e){if(e.size>1||!e.has("hass"))return!0;const t=e.get("hass"),o=this.discovered?.entities;return me(t,this.hass,[o?.decision_trace_sensor,o?.last_skipped_sensor])}_throttleNextAllowedIso(){const e=this.discovered.entities.last_skipped_sensor;if(!e)return null;const t=this.hass.states[e];if(!t||"time_delta_too_small"!==t.state)return null;const o=t.attributes,i=function(e,t){if(!e)return null;if(null==t||Number.isNaN(t))return null;const o=new Date(e).getTime();return Number.isNaN(o)?null:new Date(o+6e4*t).toISOString()}(o?.timestamp,o?.time_threshold_minutes);return i?new Date(i).getTime()<=Date.now()?null:i:null}_trace(){const e=this.discovered.entities.decision_trace_sensor;if(!e)return null;const t=this.hass.states[e];if(!t)return null;const o=t.attributes;if(!o?.trace)return null;const i=new Map;for(const e of o.trace)i.set(yi(e.handler),{matched:e.matched,reason:e.reason,position:e.position,held_position:e.held_position});const s={};for(const[e,t]of Object.entries(Pe))s[e]=ot(t,this.hass);return{winner:t.state,reason:o.reason??"",steps:i,enabledHandlers:o.enabled_handlers,summary:wi(o.trace,o,t.state,s),inTimeWindow:o.in_time_window}}render(){if(!this.hass||!this.discovered)return V;const e=this._trace();if(!e)return W`<div class="placeholder">${ot("decision.placeholder",this.hass)}</div>`;const t=this._throttleNextAllowedIso(),o=function(e){if(!e)return new Set;const t=new Set(e);return new Set(Ie.filter(e=>!t.has(e)))}(e.enabledHandlers),i=function(e,t,o,i,s=new Set){return e.filter(e=>e===o||!s.has(e)&&(!i||!0===t.get(e)?.matched))}(Ie,e.steps,e.winner,this.hideInactive,o);return W`
+  `,e([ge({attribute:!1})],bi.prototype,"hass",void 0),e([ge({attribute:!1})],bi.prototype,"discoveredList",void 0),e([ge({attribute:!1})],bi.prototype,"coverColors",void 0),e([ge({type:Boolean,reflect:!0})],bi.prototype,"compact",void 0),bi=e([pe("acp-elevation-chart")],bi);let ki=class extends de{constructor(){super(...arguments),this.compact=!1,this.showSummary=!0,this._tick=null,this.hideInactive=!1}disconnectedCallback(){super.disconnectedCallback(),this._syncTimer(!1)}updated(){const e=Boolean(this.hass&&this.discovered&&this._throttleNextAllowedIso());this._syncTimer(e)}_syncTimer(e){e&&null===this._tick?this._tick=setInterval(()=>this.requestUpdate(),1e3):e||null===this._tick||(clearInterval(this._tick),this._tick=null)}shouldUpdate(e){if(e.size>1||!e.has("hass"))return!0;const t=e.get("hass"),o=this.discovered?.entities;return ve(t,this.hass,[o?.decision_trace_sensor,o?.last_skipped_sensor])}_throttleNextAllowedIso(){const e=this.discovered.entities.last_skipped_sensor;if(!e)return null;const t=this.hass.states[e];if(!t||"time_delta_too_small"!==t.state)return null;const o=t.attributes,i=function(e,t){if(!e)return null;if(null==t||Number.isNaN(t))return null;const o=new Date(e).getTime();return Number.isNaN(o)?null:new Date(o+6e4*t).toISOString()}(o?.timestamp,o?.time_threshold_minutes);return i?new Date(i).getTime()<=Date.now()?null:i:null}_trace(){const e=this.discovered.entities.decision_trace_sensor;if(!e)return null;const t=this.hass.states[e];if(!t)return null;const o=t.attributes;if(!o?.trace)return null;const i=new Map;for(const e of o.trace)i.set(xi(e.handler),{matched:e.matched,reason:e.reason,position:e.position,held_position:e.held_position});const s={};for(const[e,t]of Object.entries(Oe))s[e]=it(t,this.hass);return{winner:t.state,reason:o.reason??"",steps:i,enabledHandlers:o.enabled_handlers,summary:$i(o.trace,o,t.state,s),inTimeWindow:o.in_time_window}}render(){if(!this.hass||!this.discovered)return q;const e=this._trace();if(!e)return H`<div class="placeholder">${it("decision.placeholder",this.hass)}</div>`;const t=this._throttleNextAllowedIso(),o=function(e){if(!e)return new Set;const t=new Set(e);return new Set(Ie.filter(e=>!t.has(e)))}(e.enabledHandlers),i=function(e,t,o,i,s=new Set){return e.filter(e=>e===o||!s.has(e)&&(!i||!0===t.get(e)?.matched))}(Ie,e.steps,e.winner,this.hideInactive,o);return H`
       <div class="wrap">
         <div class="head">
-          <span class="label">${ot("decision.pipeline",this.hass)}</span>
-          <span class="winner">${ot("decision.winner",this.hass,{name:e.winner})}</span>
+          <span class="label">${it("decision.pipeline",this.hass)}</span>
+          <span class="winner">${it("decision.winner",this.hass,{name:e.winner})}</span>
         </div>
-        ${!1===e.inTimeWindow?W`<div
+        ${!1===e.inTimeWindow?H`<div
               class="off-schedule"
-              ${bo(ot("decision.outside_schedule_tooltip",this.hass))}
+              ${wo(it("decision.outside_schedule_tooltip",this.hass))}
             >
-              ${ot("decision.outside_schedule",this.hass)}
-            </div>`:V}
-        ${t?W`<div class="throttle-countdown">
+              ${it("decision.outside_schedule",this.hass)}
+            </div>`:q}
+        ${t?H`<div class="throttle-countdown">
               <ha-icon icon="mdi:timer-sand"></ha-icon>
               <span
-                >${ot("decision.next_change_in",this.hass,{time:ct(t,this.hass)})}</span
+                >${it("decision.next_change_in",this.hass,{time:dt(t,this.hass)})}</span
               >
-            </div>`:V}
-        ${this.showSummary&&e.summary?W`<div class="summary" ${bo(ot("decision.summary_tooltip",this.hass))}>
+            </div>`:q}
+        ${this.showSummary&&e.summary?H`<div class="summary" ${wo(it("decision.summary_tooltip",this.hass))}>
               ${e.summary}
-            </div>`:V}
+            </div>`:q}
         <div class="rows">
           ${i.map(t=>this._row(t,e.steps.get(t),e.winner===t))}
         </div>
         <div class="reason dim">${e.reason}</div>
       </div>
-    `}_row(e,t,o){const i=t?.matched??!1,s=t?.reason??ot("decision.not_evaluated",this.hass),n=t?.position,r=t?.held_position,a=null!=r,l=a?it(r):null!=n?it(n):"",c=a&&null!=n?W` · ${ot("decision.solar_would_be",this.hass,{pct:it(n)})}`:V;return W`
+    `}_row(e,t,o){const i=t?.matched??!1,s=t?.reason??it("decision.not_evaluated",this.hass),n=t?.position,r=t?.held_position,a=null!=r,l=a?st(r):null!=n?st(n):"",c=a&&null!=n?H` · ${it("decision.solar_would_be",this.hass,{pct:st(n)})}`:q;return H`
       <div class="row ${o?"winner":i?"match":"skip"}">
-        <span class="name">${ot(Pe[e],this.hass)}</span>
+        <span class="name">${it(Oe[e],this.hass)}</span>
         <span class="dots" aria-hidden="true">${i?"████":"────"}</span>
         <span class="pos">${l}</span>
         <span class="reason-inline dim">${s}${c}</span>
-        ${o?W`<span class="badge">✓</span>`:V}
+        ${o?H`<span class="badge">✓</span>`:q}
       </div>
-    `}};var $i,ki;xi.styles=r`
+    `}};var Ai,Si;ki.styles=a`
     :host {
       display: block;
     }
@@ -1065,28 +1065,28 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
       padding: 16px;
       text-align: center;
     }
-  `,e([_e({attribute:!1})],xi.prototype,"hass",void 0),e([_e({attribute:!1})],xi.prototype,"discovered",void 0),e([_e({type:Boolean,reflect:!0})],xi.prototype,"compact",void 0),e([_e({type:Boolean,reflect:!0,attribute:"show-summary"})],xi.prototype,"showSummary",void 0),e([_e({type:Boolean,reflect:!0,attribute:"hide-inactive"})],xi.prototype,"hideInactive",void 0),xi=e([he("acp-decision-strip")],xi),function(e){e.language="language",e.system="system",e.comma_decimal="comma_decimal",e.decimal_comma="decimal_comma",e.space_comma="space_comma",e.none="none"}($i||($i={})),function(e){e.language="language",e.system="system",e.am_pm="12",e.twenty_four="24"}(ki||(ki={}));const Ai=["closed","locked","off"],Si=(e,t,o,i)=>{i=i||{},o=null==o?{}:o;const s=new Event(t,{bubbles:void 0===i.bubbles||i.bubbles,cancelable:Boolean(i.cancelable),composed:void 0===i.composed||i.composed});return s.detail=o,e.dispatchEvent(s),s},Ci=e=>{Si(window,"haptic",e)},Ei=(e,t,o,i)=>{let s;"double_tap"===i&&o.double_tap_action?s=o.double_tap_action:"hold"===i&&o.hold_action?s=o.hold_action:"tap"===i&&o.tap_action&&(s=o.tap_action),((e,t,o,i)=>{if(i||(i={action:"more-info"}),!i.confirmation||i.confirmation.exemptions&&i.confirmation.exemptions.some(e=>e.user===t.user.id)||(Ci("warning"),confirm(i.confirmation.text||`Are you sure you want to ${i.action}?`)))switch(i.action){case"more-info":(o.entity||o.camera_image)&&Si(e,"hass-more-info",{entityId:o.entity?o.entity:o.camera_image});break;case"navigate":i.navigation_path&&((e,t,o=!1)=>{o?history.replaceState(null,"",t):history.pushState(null,"",t),Si(window,"location-changed",{replace:o})})(0,i.navigation_path);break;case"url":i.url_path&&window.open(i.url_path);break;case"toggle":o.entity&&(((e,t)=>{((e,t,o=!0)=>{const i=function(e){return e.substr(0,e.indexOf("."))}(t),s="group"===i?"homeassistant":i;let n;switch(i){case"lock":n=o?"unlock":"lock";break;case"cover":n=o?"open_cover":"close_cover";break;default:n=o?"turn_on":"turn_off"}e.callService(s,n,{entity_id:t})})(e,t,Ai.includes(e.states[t].state))})(t,o.entity),Ci("success"));break;case"call-service":{if(!i.service)return void Ci("failure");const[e,o]=i.service.split(".",2);t.callService(e,o,i.service_data,i.target),Ci("success");break}case"fire-dom-event":Si(e,"ll-custom",i)}})(e,t,o,s)};function zi(e){return void 0!==e&&"none"!==e.action}function Mi(e,t){if(null==e)return t.entry_title;if("string"==typeof e)return e;if(Array.isArray(e)){const o=e.map(e=>function(e,t){if(e&&"object"==typeof e)switch(e.type){case"entry":return t.entry_title||void 0;case"area":return t.area_name||void 0;case"text":return e.text||void 0;default:return}}(e,t)).filter(e=>!!e);return o.length>0?o.join(" "):t.entry_title}return"object"==typeof e?t.entry_title:String(e)}function Ii(e){if(!e||"object"!=typeof e)return!1;const t=e.type;return"entry"===t||"area"===t||"text"===t&&"string"==typeof e.text}function Ti(e,t){if(!t)return!1;const o=e.states[t]?.attributes?.supported_features;return"number"==typeof o&&!!(128&o)}function Pi(e,t,o){return e.callService("switch",o?"turn_on":"turn_off",{},{entity_id:t})}const Oi={position:"set_position",tilt:"set_tilt"};function Fi(e,t,o,i){if(function(e){const t=e.services;return!!t?.[Me]?.set_axes}(e)){const i={axes:o};return void e.callService(Me,"set_axes",i,{entity_id:t})}for(const[i,s]of Object.entries(o)){const o=Oi[i];o&&e.callService(Me,o,{[i]:s},{entity_id:t})}}const Bi=3;const Ni=[15,30,60,120];let Di=class extends ce{constructor(){super(...arguments),this.open=!1,this.presets=[],this._onBackdrop=e=>{e.target===e.currentTarget&&this._emitClose()},this._emitClose=()=>{this.dispatchEvent(new CustomEvent("acp-extend-close",{bubbles:!0,composed:!0}))},this._stop=e=>{e.stopPropagation()}}updated(e){e.has("open")&&this.open&&(this._endMs=void 0)}render(){if(!this.open)return V;const e=this._t("dialog.extend.title","Extend manual override");return W`
+  `,e([ge({attribute:!1})],ki.prototype,"hass",void 0),e([ge({attribute:!1})],ki.prototype,"discovered",void 0),e([ge({type:Boolean,reflect:!0})],ki.prototype,"compact",void 0),e([ge({type:Boolean,reflect:!0,attribute:"show-summary"})],ki.prototype,"showSummary",void 0),e([ge({type:Boolean,reflect:!0,attribute:"hide-inactive"})],ki.prototype,"hideInactive",void 0),ki=e([pe("acp-decision-strip")],ki),function(e){e.language="language",e.system="system",e.comma_decimal="comma_decimal",e.decimal_comma="decimal_comma",e.space_comma="space_comma",e.none="none"}(Ai||(Ai={})),function(e){e.language="language",e.system="system",e.am_pm="12",e.twenty_four="24"}(Si||(Si={}));const Ci=["closed","locked","off"],Ei=(e,t,o,i)=>{i=i||{},o=null==o?{}:o;const s=new Event(t,{bubbles:void 0===i.bubbles||i.bubbles,cancelable:Boolean(i.cancelable),composed:void 0===i.composed||i.composed});return s.detail=o,e.dispatchEvent(s),s},zi=e=>{Ei(window,"haptic",e)},Mi=(e,t,o,i)=>{let s;"double_tap"===i&&o.double_tap_action?s=o.double_tap_action:"hold"===i&&o.hold_action?s=o.hold_action:"tap"===i&&o.tap_action&&(s=o.tap_action),((e,t,o,i)=>{if(i||(i={action:"more-info"}),!i.confirmation||i.confirmation.exemptions&&i.confirmation.exemptions.some(e=>e.user===t.user.id)||(zi("warning"),confirm(i.confirmation.text||`Are you sure you want to ${i.action}?`)))switch(i.action){case"more-info":(o.entity||o.camera_image)&&Ei(e,"hass-more-info",{entityId:o.entity?o.entity:o.camera_image});break;case"navigate":i.navigation_path&&((e,t,o=!1)=>{o?history.replaceState(null,"",t):history.pushState(null,"",t),Ei(window,"location-changed",{replace:o})})(0,i.navigation_path);break;case"url":i.url_path&&window.open(i.url_path);break;case"toggle":o.entity&&(((e,t)=>{((e,t,o=!0)=>{const i=function(e){return e.substr(0,e.indexOf("."))}(t),s="group"===i?"homeassistant":i;let n;switch(i){case"lock":n=o?"unlock":"lock";break;case"cover":n=o?"open_cover":"close_cover";break;default:n=o?"turn_on":"turn_off"}e.callService(s,n,{entity_id:t})})(e,t,Ci.includes(e.states[t].state))})(t,o.entity),zi("success"));break;case"call-service":{if(!i.service)return void zi("failure");const[e,o]=i.service.split(".",2);t.callService(e,o,i.service_data,i.target),zi("success");break}case"fire-dom-event":Ei(e,"ll-custom",i)}})(e,t,o,s)};function Ti(e){return void 0!==e&&"none"!==e.action}function Ii(e,t){if(null==e)return t.entry_title;if("string"==typeof e)return e;if(Array.isArray(e)){const o=e.map(e=>function(e,t){if(e&&"object"==typeof e)switch(e.type){case"entry":return t.entry_title||void 0;case"area":return t.area_name||void 0;case"text":return e.text||void 0;default:return}}(e,t)).filter(e=>!!e);return o.length>0?o.join(" "):t.entry_title}return"object"==typeof e?t.entry_title:String(e)}function Pi(e){if(!e||"object"!=typeof e)return!1;const t=e.type;return"entry"===t||"area"===t||"text"===t&&"string"==typeof e.text}function Oi(e,t){if(!t)return!1;const o=e.states[t]?.attributes?.supported_features;return"number"==typeof o&&!!(128&o)}function Bi(e,t,o){return e.callService("switch",o?"turn_on":"turn_off",{},{entity_id:t})}const Fi={position:"set_position",tilt:"set_tilt"};function Ni(e,t,o,i){if(function(e){const t=e.services;return!!t?.[Te]?.set_axes}(e)){const i={axes:o};return void e.callService(Te,"set_axes",i,{entity_id:t})}for(const[i,s]of Object.entries(o)){const o=Fi[i];o&&e.callService(Te,o,{[i]:s},{entity_id:t})}}const Di=3;const Ri=[15,30,60,120];let ji=class extends de{constructor(){super(...arguments),this.open=!1,this.presets=[],this._onBackdrop=e=>{e.target===e.currentTarget&&this._emitClose()},this._emitClose=()=>{this.dispatchEvent(new CustomEvent("acp-extend-close",{bubbles:!0,composed:!0}))},this._stop=e=>{e.stopPropagation()}}updated(e){e.has("open")&&this.open&&(this._endMs=void 0)}render(){if(!this.open)return q;const e=this._t("dialog.extend.title","Extend manual override");return H`
       <div class="backdrop" data-open @click=${this._onBackdrop}>
         <div class="dialog" @click=${this._stop} role="dialog" aria-modal="true">
           <div class="title">${e}</div>
 
-          ${this.presets.length>0?W`<div class="section">
+          ${this.presets.length>0?H`<div class="section">
                 <div class="label">${this._t("dialog.extend.presets_label","Until")}</div>
                 <div class="chips">
-                  ${this.presets.map(e=>W`<button
+                  ${this.presets.map(e=>H`<button
                         class="preset"
                         type="button"
                         @click=${()=>this._pick(Date.parse(e.t))}
                       >
-                        ${this._presetLabel(e)} · ${lt(e.t)}
+                        ${this._presetLabel(e)} · ${ct(e.t)}
                       </button>`)}
                 </div>
-              </div>`:V}
+              </div>`:q}
 
           <div class="section">
             <div class="label">${this._t("dialog.extend.relative_label","Add time")}</div>
             <div class="chips">
-              ${Ni.map(e=>W`<button
+              ${Ri.map(e=>H`<button
                     class="rel"
                     type="button"
                     data-mins=${e}
@@ -1119,7 +1119,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
           </div>
         </div>
       </div>
-    `}_t(e,t){if(!this.hass)return t;const o=ot(e,this.hass);return o===e?t:o}_presetLabel(e){const t=`forecast.event.${e.kind}`,o=this.hass?ot(t,this.hass):t;return o===t?e.label??e.kind:o}_previewText(){if(void 0===this._endMs)return"";const e=new Date(this._endMs).toISOString(),t=lt(e),o=new Date(this._endMs).getDate()!==(new Date).getDate()?this._t("dialog.extend.tomorrow_suffix"," (tomorrow)"):"";return`${this._t("dialog.extend.preview","Override until {time}").replace("{time}",`${t}${o}`)} · ${ct(e,this.hass)}`}_pick(e){this._endMs=e}_addRelative(e){const t=this._endMs??this.currentEndMs??Date.now();this._endMs=t+6e4*e}_onTimeChange(e){const t=e.target.value;if(!t)return;const[o,i]=t.split(":").map(Number);if(Number.isNaN(o)||Number.isNaN(i))return;const s=new Date,n=new Date(s);n.setHours(o,i,0,0),n.getTime()<=s.getTime()&&n.setDate(n.getDate()+1),this._endMs=n.getTime()}_onConfirm(){void 0!==this._endMs&&this.dispatchEvent(new CustomEvent("acp-extend-confirm",{detail:{endMs:this._endMs},bubbles:!0,composed:!0}))}};function Ri(e,t,o){return e.filter(e=>"off"===e||"group"===e||("solar"===e?function(e){return e.solarMatched&&!e.cloudIsWinner}(o)&&!1!==t?.solar:!1!==t?.[e]))}function ji(e){return!!e&&e.some(e=>e.matched&&"solar"===yi(e.handler))}function Ki(e){const t=new Set;if(!e)return t;for(const o of e){if(!o.matched)continue;const e=yi(o.handler);Ie.includes(e)&&t.add(e)}return t}function Li(e){return"cloud"===yi(e)}function Gi(e){if(!1===e.integrationEnabled)return"off";const t=yi(e.winner);return e.manualActive&&"force"!==t&&"custom_position"!==t?"manual":Re[t]??"auto"}function Wi(e,t){return{solarMatched:ji(e),cloudIsWinner:Li(t)}}Di.styles=r`
+    `}_t(e,t){if(!this.hass)return t;const o=it(e,this.hass);return o===e?t:o}_presetLabel(e){const t=`forecast.event.${e.kind}`,o=this.hass?it(t,this.hass):t;return o===t?e.label??e.kind:o}_previewText(){if(void 0===this._endMs)return"";const e=new Date(this._endMs).toISOString(),t=ct(e),o=new Date(this._endMs).getDate()!==(new Date).getDate()?this._t("dialog.extend.tomorrow_suffix"," (tomorrow)"):"";return`${this._t("dialog.extend.preview","Override until {time}").replace("{time}",`${t}${o}`)} · ${dt(e,this.hass)}`}_pick(e){this._endMs=e}_addRelative(e){const t=this._endMs??this.currentEndMs??Date.now();this._endMs=t+6e4*e}_onTimeChange(e){const t=e.target.value;if(!t)return;const[o,i]=t.split(":").map(Number);if(Number.isNaN(o)||Number.isNaN(i))return;const s=new Date,n=new Date(s);n.setHours(o,i,0,0),n.getTime()<=s.getTime()&&n.setDate(n.getDate()+1),this._endMs=n.getTime()}_onConfirm(){void 0!==this._endMs&&this.dispatchEvent(new CustomEvent("acp-extend-confirm",{detail:{endMs:this._endMs},bubbles:!0,composed:!0}))}};function Ki(e){if(null==e||""===e)return null;if("number"!=typeof e&&"string"!=typeof e)return null;const t="number"==typeof e?e:Number(e);return Number.isFinite(t)?Math.max(0,Math.min(100,t)):null}function Li(e,t){if(!e||0===t.length)return[];const o=e.entities;let i=null;const s=()=>{const t=new Map;if(!o)return t;for(const[i,s]of Object.entries(o)){const o=s?.device_id;if(!o)continue;if(!i.startsWith("sensor."))continue;const n=e.states[i];if("battery"!==n?.attributes?.device_class)continue;const r=t.get(o);void 0!==r?null===Ki(e.states[r]?.state)&&null!==Ki(n.state)&&t.set(o,i):t.set(o,i)}return t},n=[];for(const r of t){const t=e.states[r];if(!t)continue;const a=Ki(t.attributes?.battery_level);if(null!==a){n.push({cover_id:r,source_id:r,level:a,charging:!0===t.attributes?.battery_charging});continue}const l=o?.[r]?.device_id;if(!l)continue;i??(i=s());const c=i.get(l);if(!c)continue;const d=e.states[c];n.push({cover_id:r,source_id:c,level:Ki(d?.state),charging:!0===d?.attributes?.battery_charging})}return n}function Gi(e){return!!e&&(null===e.level||e.level<=20)}function Wi(e){let t=null;for(const o of e)t?null===o.level?t=null===t.level?t:o:null!==t.level&&o.level<t.level&&(t=o):t=o;return t}function Hi(e,t=!1){if(null===e)return"mdi:battery-alert-variant-outline";const o=Math.max(0,Math.min(10,Math.floor(e/10)));return 10===o?t?"mdi:battery-charging-100":"mdi:battery":0===o?t?"mdi:battery-charging-10":"mdi:battery-outline":t?"mdi:battery-charging-"+10*o:"mdi:battery-"+10*o}function Ui(e,t,o){return e.filter(e=>"off"===e||"group"===e||("solar"===e?function(e){return e.solarMatched&&!e.cloudIsWinner}(o)&&!1!==t?.solar:!1!==t?.[e]))}function Vi(e){return!!e&&e.some(e=>e.matched&&"solar"===xi(e.handler))}function qi(e){const t=new Set;if(!e)return t;for(const o of e){if(!o.matched)continue;const e=xi(o.handler);Ie.includes(e)&&t.add(e)}return t}function Yi(e){return"cloud"===xi(e)}function Qi(e){if(!1===e.integrationEnabled)return"off";const t=xi(e.winner);return e.manualActive&&"force"!==t&&"custom_position"!==t?"manual":je[t]??"auto"}function Zi(e,t){return{solarMatched:Vi(e),cloudIsWinner:Yi(t)}}ji.styles=a`
     .backdrop {
       position: fixed;
       inset: 0;
@@ -1207,51 +1207,51 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
       opacity: 0.4;
       cursor: default;
     }
-  `,e([_e({attribute:!1})],Di.prototype,"hass",void 0),e([_e({type:Boolean})],Di.prototype,"open",void 0),e([_e({attribute:!1})],Di.prototype,"presets",void 0),e([_e({type:Number,attribute:!1})],Di.prototype,"currentEndMs",void 0),e([ge()],Di.prototype,"_endMs",void 0),Di=e([he("acp-extend-override-dialog")],Di);const Hi=new Set(["group_scene","group_lock","solar","default","motion"]);function Ui(e){if(!e)return[];const t=new Set;for(const o of Object.values(e)){if(!o)continue;const e=yi(o);Hi.has(e)||e in Re&&t.add(e)}return Ie.filter(e=>t.has(e))}let Vi=class extends ce{constructor(){super(...arguments),this.winner="default",this.compact=!1,this.integrationEnabled=!0,this.manualActive=!1,this.safetyActive=!1,this.resumable=!1,this.extendable=!1}render(){const e=this._kind(),t="custom_position"===e&&this.safetyActive,o=t?je.force:je[e],i=this.hass?ot(Ke[e],this.hass):je[e].label,s=t?this.hass?ot("badge.safety",this.hass):"Safety":this._label(e,i),n=t?Le.force:Le[e];if(this.extendable){const t=this.hass?ot("tile.extend_aria",this.hass):"Extend manual override",i=this.hass?ot("tile.resume_aria",this.hass):"Resume automatic control",r=!!n&&!this.compact;return W`<span
+  `,e([ge({attribute:!1})],ji.prototype,"hass",void 0),e([ge({type:Boolean})],ji.prototype,"open",void 0),e([ge({attribute:!1})],ji.prototype,"presets",void 0),e([ge({type:Number,attribute:!1})],ji.prototype,"currentEndMs",void 0),e([me()],ji.prototype,"_endMs",void 0),ji=e([pe("acp-extend-override-dialog")],ji);const Xi=new Set(["group_scene","group_lock","solar","default","motion"]);function Ji(e){if(!e)return[];const t=new Set;for(const o of Object.values(e)){if(!o)continue;const e=xi(o);Xi.has(e)||e in je&&t.add(e)}return Ie.filter(e=>t.has(e))}let es=class extends de{constructor(){super(...arguments),this.winner="default",this.compact=!1,this.integrationEnabled=!0,this.manualActive=!1,this.safetyActive=!1,this.resumable=!1,this.extendable=!1}render(){const e=this._kind(),t="custom_position"===e&&this.safetyActive,o=t?Ke.force:Ke[e],i=this.hass?it(Le[e],this.hass):Ke[e].label,s=t?this.hass?it("badge.safety",this.hass):"Safety":this._label(e,i),n=t?Ge.force:Ge[e];if(this.extendable){const t=this.hass?it("tile.extend_aria",this.hass):"Extend manual override",i=this.hass?it("tile.resume_aria",this.hass):"Resume automatic control",r=!!n&&!this.compact;return H`<span
         class="badge kind-${e} has-actions"
         style="background:${o.bg};color:${o.fg};"
         part="badge"
       >
-        ${r?W`<ha-icon class="badge-icon" icon=${n}></ha-icon>`:V}
+        ${r?H`<ha-icon class="badge-icon" icon=${n}></ha-icon>`:q}
         <span class="badge-label">${s}</span>
         <button
           class="act extend"
           type="button"
-          ${bo(t)}
+          ${wo(t)}
           aria-label=${t}
           @click=${this._onExtendClick}
           @pointerdown=${this._stop}
         >
           <ha-icon icon="mdi:clock-plus-outline"></ha-icon>
         </button>
-        ${this.resumable?W`<button
+        ${this.resumable?H`<button
               class="act resume"
               type="button"
-              ${bo(i)}
+              ${wo(i)}
               aria-label=${i}
               @click=${this._onResumeClick}
               @pointerdown=${this._stop}
             >
               <ha-icon icon="mdi:restore"></ha-icon>
-            </button>`:V}
-      </span>`}const r=W`${n?W`<ha-icon class="badge-icon" icon=${n}></ha-icon>`:V}${s}${this.resumable?W`<ha-icon class="resume-icon" icon="mdi:restore"></ha-icon>`:V}`;if(this.resumable){const t=this.hass?ot("tile.resume_aria",this.hass):"Resume automatic control";return W`<button
+            </button>`:q}
+      </span>`}const r=H`${n?H`<ha-icon class="badge-icon" icon=${n}></ha-icon>`:q}${s}${this.resumable?H`<ha-icon class="resume-icon" icon="mdi:restore"></ha-icon>`:q}`;if(this.resumable){const t=this.hass?it("tile.resume_aria",this.hass):"Resume automatic control";return H`<button
         class="badge kind-${e} resumable"
         style="background:${o.bg};color:${o.fg};"
         part="badge"
         type="button"
-        ${bo(t)}
+        ${wo(t)}
         aria-label=${t}
         @click=${this._onResumeClick}
         @pointerdown=${this._stop}
       >
         ${r}
-      </button>`}const a=this._groupHint(e);return W`<span
+      </button>`}const a=this._groupHint(e);return H`<span
       class="badge kind-${e}"
       style="background:${o.bg};color:${o.fg};"
       part="badge"
-      ${a?bo(a):V}
+      ${a?wo(a):q}
       >${r}</span
-    >`}_groupHint(e){return"group"!==e||void 0===this.groupCount||void 0===this.groupTotal?null:ot("group.who_won",this.hass,{count:this.groupCount,total:this.groupTotal})}_stop(e){e.stopPropagation()}_onResumeClick(e){e.stopPropagation(),this.dispatchEvent(new CustomEvent("acp-resume",{bubbles:!0,composed:!0}))}_onExtendClick(e){e.stopPropagation(),this.dispatchEvent(new CustomEvent("acp-extend",{bubbles:!0,composed:!0}))}_kind(){return this.kindOverride??Gi({winner:this.winner,integrationEnabled:this.integrationEnabled,manualActive:this.manualActive})}_label(e,t){return"manual"===e?this.manualEndIso?lt(this.manualEndIso):t:"custom_position"===e?`${this.slotName?this.slotName:void 0!==this.slotNumber?`${t} #${this.slotNumber}`:t}${void 0!==this.pct&&null!==this.pct?` · ${Math.round(this.pct)}%`:""}${!0===this.minimumMode?this.hass?ot("badge.floor_suffix",this.hass):" ↥":""}`:"group"===e?void 0===this.groupCount||void 0===this.groupTotal?t:`${this.groupCount}/${this.groupTotal}`:t}};Vi.styles=r`
+    >`}_groupHint(e){return"group"!==e||void 0===this.groupCount||void 0===this.groupTotal?null:it("group.who_won",this.hass,{count:this.groupCount,total:this.groupTotal})}_stop(e){e.stopPropagation()}_onResumeClick(e){e.stopPropagation(),this.dispatchEvent(new CustomEvent("acp-resume",{bubbles:!0,composed:!0}))}_onExtendClick(e){e.stopPropagation(),this.dispatchEvent(new CustomEvent("acp-extend",{bubbles:!0,composed:!0}))}_kind(){return this.kindOverride??Qi({winner:this.winner,integrationEnabled:this.integrationEnabled,manualActive:this.manualActive})}_label(e,t){return"manual"===e?this.manualEndIso?ct(this.manualEndIso):t:"custom_position"===e?`${this.slotName?this.slotName:void 0!==this.slotNumber?`${t} #${this.slotNumber}`:t}${void 0!==this.pct&&null!==this.pct?` · ${Math.round(this.pct)}%`:""}${!0===this.minimumMode?this.hass?it("badge.floor_suffix",this.hass):" ↥":""}`:"group"===e?void 0===this.groupCount||void 0===this.groupTotal?t:`${this.groupCount}/${this.groupTotal}`:t}};es.styles=a`
     :host {
       display: inline-flex;
     }
@@ -1373,13 +1373,13 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
     :host([compact]) .badge-icon {
       --mdc-icon-size: 12px;
     }
-  `,e([_e({attribute:!1})],Vi.prototype,"hass",void 0),e([_e()],Vi.prototype,"winner",void 0),e([_e({attribute:"manual-end-iso"})],Vi.prototype,"manualEndIso",void 0),e([_e({type:Number,attribute:"slot-number"})],Vi.prototype,"slotNumber",void 0),e([_e({attribute:"slot-name"})],Vi.prototype,"slotName",void 0),e([_e({type:Number})],Vi.prototype,"pct",void 0),e([_e({type:Boolean,attribute:"minimum-mode"})],Vi.prototype,"minimumMode",void 0),e([_e({type:Boolean,reflect:!0})],Vi.prototype,"compact",void 0),e([_e({type:Boolean,attribute:"integration-enabled"})],Vi.prototype,"integrationEnabled",void 0),e([_e({type:Boolean,attribute:"manual-active"})],Vi.prototype,"manualActive",void 0),e([_e({type:Boolean,attribute:"safety-active"})],Vi.prototype,"safetyActive",void 0),e([_e({attribute:"kind-override"})],Vi.prototype,"kindOverride",void 0),e([_e({type:Number,attribute:"group-count"})],Vi.prototype,"groupCount",void 0),e([_e({type:Number,attribute:"group-total"})],Vi.prototype,"groupTotal",void 0),e([_e({type:Boolean,reflect:!0})],Vi.prototype,"resumable",void 0),e([_e({type:Boolean,reflect:!0})],Vi.prototype,"extendable",void 0),Vi=e([he("acp-tile-badge")],Vi);let qi=class extends ce{constructor(){super(...arguments),this.actual=null,this.target=null,this.coverColor=null,this.compact=!1,this.disabled=!1,this.layout="cover",this.label=null,this.min=0,this.max=100,this.unit="%",this.hintKey=null,this.targetHintKey=null,this._dragValue=null,this.openBlocksSun=!0,this._onPointerDown=e=>{if(this.disabled)return;const t=e.currentTarget;t.setPointerCapture?.(e.pointerId),this._dragValue=this._valueFromEvent(e,t)},this._onPointerMove=e=>{this.disabled||null===this._dragValue||(this._dragValue=this._valueFromEvent(e,e.currentTarget))},this._onPointerEnd=()=>{this._dragValue=null}}_frac(e){if(null==e||Number.isNaN(e))return 0;const t=this.max-this.min;if(0===t)return 0;const o=(e-this.min)/t*100,i=Math.max(0,Math.min(100,o));return this.openBlocksSun?i:100-i}render(){if(!this.hass)return V;const e=null!==this._dragValue,t=this._dragValue??this.actual,o=this._frac(t),i=this._frac(this.target),s=this.label??ot("covers.tilt_title",this.hass);return W`
+  `,e([ge({attribute:!1})],es.prototype,"hass",void 0),e([ge()],es.prototype,"winner",void 0),e([ge({attribute:"manual-end-iso"})],es.prototype,"manualEndIso",void 0),e([ge({type:Number,attribute:"slot-number"})],es.prototype,"slotNumber",void 0),e([ge({attribute:"slot-name"})],es.prototype,"slotName",void 0),e([ge({type:Number})],es.prototype,"pct",void 0),e([ge({type:Boolean,attribute:"minimum-mode"})],es.prototype,"minimumMode",void 0),e([ge({type:Boolean,reflect:!0})],es.prototype,"compact",void 0),e([ge({type:Boolean,attribute:"integration-enabled"})],es.prototype,"integrationEnabled",void 0),e([ge({type:Boolean,attribute:"manual-active"})],es.prototype,"manualActive",void 0),e([ge({type:Boolean,attribute:"safety-active"})],es.prototype,"safetyActive",void 0),e([ge({attribute:"kind-override"})],es.prototype,"kindOverride",void 0),e([ge({type:Number,attribute:"group-count"})],es.prototype,"groupCount",void 0),e([ge({type:Number,attribute:"group-total"})],es.prototype,"groupTotal",void 0),e([ge({type:Boolean,reflect:!0})],es.prototype,"resumable",void 0),e([ge({type:Boolean,reflect:!0})],es.prototype,"extendable",void 0),es=e([pe("acp-tile-badge")],es);let ts=class extends de{constructor(){super(...arguments),this.actual=null,this.target=null,this.coverColor=null,this.compact=!1,this.disabled=!1,this.layout="cover",this.label=null,this.min=0,this.max=100,this.unit="%",this.hintKey=null,this.targetHintKey=null,this._dragValue=null,this.openBlocksSun=!0,this._onPointerDown=e=>{if(this.disabled)return;const t=e.currentTarget;t.setPointerCapture?.(e.pointerId),this._dragValue=this._valueFromEvent(e,t)},this._onPointerMove=e=>{this.disabled||null===this._dragValue||(this._dragValue=this._valueFromEvent(e,e.currentTarget))},this._onPointerEnd=()=>{this._dragValue=null}}_frac(e){if(null==e||Number.isNaN(e))return 0;const t=this.max-this.min;if(0===t)return 0;const o=(e-this.min)/t*100,i=Math.max(0,Math.min(100,o));return this.openBlocksSun?i:100-i}render(){if(!this.hass)return q;const e=null!==this._dragValue,t=this._dragValue??this.actual,o=this._frac(t),i=this._frac(this.target),s=this.label??it("covers.tilt_title",this.hass);return H`
       <div
         class="row ${this.layout}"
-        style=${this.coverColor?`--acp-cover-color:${this.coverColor}`:V}
+        style=${this.coverColor?`--acp-cover-color:${this.coverColor}`:q}
       >
         <span class="label">${s}</span>
-        <span class="num">${it(t)}</span>
+        <span class="num">${st(t)}</span>
         <div
           class="track ${this.disabled?"disabled":""}${e?" dragging":""}"
           role="slider"
@@ -1388,7 +1388,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
           aria-valuemin=${this.min}
           aria-valuemax=${this.max}
           aria-valuenow=${null===t?this.min:this.openBlocksSun?t:this.min+this.max-t}
-          aria-valuetext=${it(t)}
+          aria-valuetext=${st(t)}
           aria-label=${s}
           @click=${this._onClick}
           @pointerdown=${this._onPointerDown}
@@ -1396,18 +1396,18 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
           @pointerup=${this._onPointerEnd}
           @pointercancel=${this._onPointerEnd}
           @keydown=${this._onKeydown}
-          ${bo(ot(this.hintKey??"covers.tilt_click_to_set",this.hass))}
+          ${wo(it(this.hintKey??"covers.tilt_click_to_set",this.hass))}
         >
           <div class="fill" style="width:${o}%"></div>
           <div class="fill-closed" style="width:${100-o}%"></div>
-          ${null!==this.target?W`<div
+          ${null!==this.target?H`<div
                 class="marker"
                 style="left:clamp(1px, ${i}%, calc(100% - 1px))"
-                ${bo(ot(this.targetHintKey??"covers.tilt_target_tooltip",this.hass,{pct:this.target}))}
-              ></div>`:V}
+                ${wo(it(this.targetHintKey??"covers.tilt_target_tooltip",this.hass,{pct:this.target}))}
+              ></div>`:q}
         </div>
       </div>
-    `}_valueFromEvent(e,t){const o=t.getBoundingClientRect(),i=(e.clientX-o.left)/o.width,s=this.openBlocksSun?i:1-i,n=this.min+s*(this.max-this.min);return this._clamp(n)}_clamp(e){return Math.max(this.min,Math.min(this.max,Math.round(e)))}_commit(e){this.dispatchEvent(new CustomEvent("acp-tilt-set",{detail:e,bubbles:!0,composed:!0}))}_onClick(e){this.disabled||this._commit(this._valueFromEvent(e,e.currentTarget))}_onKeydown(e){if(this.disabled)return;const t=this.openBlocksSun?1:-1,o=this.openBlocksSun?this.min:this.max,i=this.openBlocksSun?this.max:this.min,s=this.actual??o;let n;switch(e.key){case"ArrowRight":case"ArrowUp":n=s+t;break;case"ArrowLeft":case"ArrowDown":n=s-t;break;case"PageUp":n=s+10*t;break;case"PageDown":n=s-10*t;break;case"Home":n=o;break;case"End":n=i;break;default:return}e.preventDefault(),this._commit(this._clamp(n))}};qi.styles=r`
+    `}_valueFromEvent(e,t){const o=t.getBoundingClientRect(),i=(e.clientX-o.left)/o.width,s=this.openBlocksSun?i:1-i,n=this.min+s*(this.max-this.min);return this._clamp(n)}_clamp(e){return Math.max(this.min,Math.min(this.max,Math.round(e)))}_commit(e){this.dispatchEvent(new CustomEvent("acp-tilt-set",{detail:e,bubbles:!0,composed:!0}))}_onClick(e){this.disabled||this._commit(this._valueFromEvent(e,e.currentTarget))}_onKeydown(e){if(this.disabled)return;const t=this.openBlocksSun?1:-1,o=this.openBlocksSun?this.min:this.max,i=this.openBlocksSun?this.max:this.min,s=this.actual??o;let n;switch(e.key){case"ArrowRight":case"ArrowUp":n=s+t;break;case"ArrowLeft":case"ArrowDown":n=s-t;break;case"PageUp":n=s+10*t;break;case"PageDown":n=s-10*t;break;case"Home":n=o;break;case"End":n=i;break;default:return}e.preventDefault(),this._commit(this._clamp(n))}};ts.styles=a`
     :host {
       display: block;
     }
@@ -1504,21 +1504,21 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
       transform: translateX(-50%);
       transition: left 0.3s ease;
     }
-  `,e([_e({attribute:!1})],qi.prototype,"hass",void 0),e([_e({attribute:!1})],qi.prototype,"actual",void 0),e([_e({attribute:!1})],qi.prototype,"target",void 0),e([_e({attribute:!1})],qi.prototype,"coverColor",void 0),e([_e({type:Boolean,reflect:!0})],qi.prototype,"compact",void 0),e([_e({type:Boolean,reflect:!0})],qi.prototype,"disabled",void 0),e([_e({reflect:!0})],qi.prototype,"layout",void 0),e([_e({attribute:!1})],qi.prototype,"label",void 0),e([_e({type:Number})],qi.prototype,"min",void 0),e([_e({type:Number})],qi.prototype,"max",void 0),e([_e()],qi.prototype,"unit",void 0),e([_e({attribute:!1})],qi.prototype,"hintKey",void 0),e([_e({attribute:!1})],qi.prototype,"targetHintKey",void 0),e([ge()],qi.prototype,"_dragValue",void 0),e([_e({type:Boolean})],qi.prototype,"openBlocksSun",void 0),qi=e([he("acp-axis-bar")],qi),customElements.get("acp-tilt-bar")||customElements.define("acp-tilt-bar",class extends qi{});const Yi={status:"unknown",on:0,total:0};let Qi=null,Zi=null;function Xi(e,t,o){if(!t||0===o.length)return Yi;const i=function(e){if(Qi===e&&Zi)return Zi;const t=new Map;for(const o of e){if(o.platform!==Me)continue;const e=o.config_entry_id;if(!e)continue;const i=`${e}_`;if(!o.unique_id.startsWith(i))continue;const s=o.unique_id.slice(i.length),n=o.entity_id.split(".")[0],r=Xe[`${n}:${s}`];if("target_position_sensor"!==r&&"automatic_control_switch"!==r&&"integration_enabled_switch"!==r)continue;const a=t.get(e)??{};"target_position_sensor"===r?a.positionSensor=o.entity_id:"automatic_control_switch"===r?a.automaticControl=o.entity_id:a.integrationEnabled=o.entity_id,t.set(e,a)}return Qi=e,Zi=t,t}(t),s=new Map;for(const[t,o]of i){if(!o.positionSensor)continue;const i=e.states[o.positionSensor]?.attributes?.actual_positions;if(i)for(const e of Object.keys(i))s.set(e,t)}const n=new Map;let r=0,a=0;for(const t of new Set(o)){const o=s.get(t);if(!o)continue;let l=n.get(o);void 0===l&&(l=Ji(e,i.get(o)),n.set(o,l)),null!==l&&(a++,l&&r++)}return 0===a?Yi:{status:r===a?"all":0===r?"none":"some",on:r,total:a}}function Ji(e,t){if(!t?.automaticControl)return null;const o=e.states[t.automaticControl];if(!o)return null;const i=!t.integrationEnabled||"off"!==e.states[t.integrationEnabled]?.state;return"on"===o.state&&i}const es=["auto","all_open","all_closed","privacy"],ts=["open","closed","mixed","unknown"];function os(e,t){const o=t.entities,i=o.group_position_sensor?e.states[o.group_position_sensor]:void 0,s=i?parseFloat(i.state):NaN,n=i?.attributes?.member_positions??{},r=o.group_who_won_sensor?e.states[o.group_who_won_sensor]:void 0,a=r?.attributes?.member_winners,l=o.group_state_sensor?e.states[o.group_state_sensor]?.state??"unknown":"unknown",c=o.group_scene_select?e.states[o.group_scene_select]:void 0,d=c?.attributes?.current_option??c?.state??"auto",h=new Set;for(const t of Object.keys(n)){const o=e.states[t]?.attributes?.device_class;o&&h.add(o)}const p=o.group_cover,u=Ti(e,p);return{position:Number.isNaN(s)?null:s,memberPositions:n,rosterTotal:Object.keys(n).length,whoWonCount:r?parseInt(r.state,10):NaN,memberWinners:a,aggregate:ts.includes(l)?l:"unknown",scene:es.includes(d)?d:"auto",locked:!!o.group_lock_switch&&"on"===e.states[o.group_lock_switch]?.state,automationOn:!o.group_automation_switch||"on"===e.states[o.group_automation_switch]?.state,memberAutomation:Xi(e,zo(),Object.keys(a??{})),lockId:o.group_lock_switch,automationId:o.group_automation_switch,clearId:o.group_clear_overrides_button,target:p??o.group_position_sensor,deviceClass:1===h.size?[...h][0]:void 0,tilt:p&&u?{entityId:p,value:e.states[p]?.attributes?.current_tilt_position??null}:void 0}}function is(e,t){return ht({deviceClass:e.deviceClass,coverType:"",position:t})}const ss=new Set(["force","weather","group_scene","manual","group_lock","custom_position"]);function ns(e,t,o){t.target&&function(e,t,o){const i={position:o};e.callService(Me,"group_set_position",i,{entity_id:t})}(e,t.target,o)}function rs(e,t,o){o.target&&function(e,t,o=[]){const i=e.services;i?.[Me]?.group_stop?e.callService(Me,"group_stop",{},{entity_id:t}):0!==o.length&&e.callService("cover","stop_cover",{},{entity_id:o})}(e,o.target,t.managed_covers??[])}function as(e,t,o){t.tilt&&function(e,t,o){e.callService("cover","set_cover_tilt_position",{tilt_position:o},{entity_id:t})}(e,t.tilt.entityId,o)}let ls=class extends ce{constructor(){super(...arguments),this.position=null,this.enabled=!0,this.labels="tile",this.compact=!1,this.fill=!1}render(){const e=null!==this.position&&this.position>=100,t=null!==this.position&&this.position<=0;return W`
+  `,e([ge({attribute:!1})],ts.prototype,"hass",void 0),e([ge({attribute:!1})],ts.prototype,"actual",void 0),e([ge({attribute:!1})],ts.prototype,"target",void 0),e([ge({attribute:!1})],ts.prototype,"coverColor",void 0),e([ge({type:Boolean,reflect:!0})],ts.prototype,"compact",void 0),e([ge({type:Boolean,reflect:!0})],ts.prototype,"disabled",void 0),e([ge({reflect:!0})],ts.prototype,"layout",void 0),e([ge({attribute:!1})],ts.prototype,"label",void 0),e([ge({type:Number})],ts.prototype,"min",void 0),e([ge({type:Number})],ts.prototype,"max",void 0),e([ge()],ts.prototype,"unit",void 0),e([ge({attribute:!1})],ts.prototype,"hintKey",void 0),e([ge({attribute:!1})],ts.prototype,"targetHintKey",void 0),e([me()],ts.prototype,"_dragValue",void 0),e([ge({type:Boolean})],ts.prototype,"openBlocksSun",void 0),ts=e([pe("acp-axis-bar")],ts),customElements.get("acp-tilt-bar")||customElements.define("acp-tilt-bar",class extends ts{});const os={status:"unknown",on:0,total:0};let is=null,ss=null;function ns(e,t,o){if(!t||0===o.length)return os;const i=function(e){if(is===e&&ss)return ss;const t=new Map;for(const o of e){if(o.platform!==Te)continue;const e=o.config_entry_id;if(!e)continue;const i=`${e}_`;if(!o.unique_id.startsWith(i))continue;const s=o.unique_id.slice(i.length),n=o.entity_id.split(".")[0],r=Je[`${n}:${s}`];if("target_position_sensor"!==r&&"automatic_control_switch"!==r&&"integration_enabled_switch"!==r)continue;const a=t.get(e)??{};"target_position_sensor"===r?a.positionSensor=o.entity_id:"automatic_control_switch"===r?a.automaticControl=o.entity_id:a.integrationEnabled=o.entity_id,t.set(e,a)}return is=e,ss=t,t}(t),s=new Map;for(const[t,o]of i){if(!o.positionSensor)continue;const i=e.states[o.positionSensor]?.attributes?.actual_positions;if(i)for(const e of Object.keys(i))s.set(e,t)}const n=new Map;let r=0,a=0;for(const t of new Set(o)){const o=s.get(t);if(!o)continue;let l=n.get(o);void 0===l&&(l=rs(e,i.get(o)),n.set(o,l)),null!==l&&(a++,l&&r++)}return 0===a?os:{status:r===a?"all":0===r?"none":"some",on:r,total:a}}function rs(e,t){if(!t?.automaticControl)return null;const o=e.states[t.automaticControl];if(!o)return null;const i=!t.integrationEnabled||"off"!==e.states[t.integrationEnabled]?.state;return"on"===o.state&&i}const as=["auto","all_open","all_closed","privacy"],ls=["open","closed","mixed","unknown"];function cs(e,t){const o=t.entities,i=o.group_position_sensor?e.states[o.group_position_sensor]:void 0,s=i?parseFloat(i.state):NaN,n=i?.attributes?.member_positions??{},r=o.group_who_won_sensor?e.states[o.group_who_won_sensor]:void 0,a=r?.attributes?.member_winners,l=o.group_state_sensor?e.states[o.group_state_sensor]?.state??"unknown":"unknown",c=o.group_scene_select?e.states[o.group_scene_select]:void 0,d=c?.attributes?.current_option??c?.state??"auto",h=new Set;for(const t of Object.keys(n)){const o=e.states[t]?.attributes?.device_class;o&&h.add(o)}const p=o.group_cover,u=Oi(e,p);return{position:Number.isNaN(s)?null:s,memberPositions:n,rosterTotal:Object.keys(n).length,whoWonCount:r?parseInt(r.state,10):NaN,memberWinners:a,aggregate:ls.includes(l)?l:"unknown",scene:as.includes(d)?d:"auto",locked:!!o.group_lock_switch&&"on"===e.states[o.group_lock_switch]?.state,automationOn:!o.group_automation_switch||"on"===e.states[o.group_automation_switch]?.state,memberAutomation:ns(e,To(),Object.keys(a??{})),lockId:o.group_lock_switch,automationId:o.group_automation_switch,clearId:o.group_clear_overrides_button,target:p??o.group_position_sensor,deviceClass:1===h.size?[...h][0]:void 0,tilt:p&&u?{entityId:p,value:e.states[p]?.attributes?.current_tilt_position??null}:void 0}}function ds(e,t){return pt({deviceClass:e.deviceClass,coverType:"",position:t})}const hs=new Set(["force","weather","group_scene","manual","group_lock","custom_position"]);function ps(e,t,o){t.target&&function(e,t,o){const i={position:o};e.callService(Te,"group_set_position",i,{entity_id:t})}(e,t.target,o)}function us(e,t,o){o.target&&function(e,t,o=[]){const i=e.services;i?.[Te]?.group_stop?e.callService(Te,"group_stop",{},{entity_id:t}):0!==o.length&&e.callService("cover","stop_cover",{},{entity_id:o})}(e,o.target,t.managed_covers??[])}function _s(e,t,o){t.tilt&&function(e,t,o){e.callService("cover","set_cover_tilt_position",{tilt_position:o},{entity_id:t})}(e,t.tilt.entityId,o)}let gs=class extends de{constructor(){super(...arguments),this.position=null,this.enabled=!0,this.labels="tile",this.compact=!1,this.fill=!1}render(){const e=null!==this.position&&this.position>=100,t=null!==this.position&&this.position<=0;return H`
       <div class="move-buttons">
         <button
           class="up"
           type="button"
-          aria-label=${ot(`${this.labels}.open`,this.hass)}
+          aria-label=${it(`${this.labels}.open`,this.hass)}
           ?disabled=${!this.enabled||e}
           @click=${()=>this._emit("open")}
         >
-          <ha-icon icon=${pt(this.deviceClass)}></ha-icon>
+          <ha-icon icon=${ut(this.deviceClass)}></ha-icon>
         </button>
         <button
           class="stop"
           type="button"
-          aria-label=${ot(`${this.labels}.stop`,this.hass)}
+          aria-label=${it(`${this.labels}.stop`,this.hass)}
           ?disabled=${!this.enabled}
           @click=${()=>this._emit("stop")}
         >
@@ -1527,14 +1527,14 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
         <button
           class="down"
           type="button"
-          aria-label=${ot(`${this.labels}.close`,this.hass)}
+          aria-label=${it(`${this.labels}.close`,this.hass)}
           ?disabled=${!this.enabled||t}
           @click=${()=>this._emit("close")}
         >
-          <ha-icon icon=${ut(this.deviceClass)}></ha-icon>
+          <ha-icon icon=${_t(this.deviceClass)}></ha-icon>
         </button>
       </div>
-    `}_emit(e){this.dispatchEvent(new CustomEvent("acp-move",{detail:e,bubbles:!0,composed:!0}))}};ls.styles=r`
+    `}_emit(e){this.dispatchEvent(new CustomEvent("acp-move",{detail:e,bubbles:!0,composed:!0}))}};gs.styles=a`
     :host {
       display: contents;
     }
@@ -1603,49 +1603,49 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
       opacity: 0.4;
       cursor: not-allowed;
     }
-  `,e([_e({attribute:!1})],ls.prototype,"hass",void 0),e([_e({attribute:!1})],ls.prototype,"position",void 0),e([_e({attribute:!1})],ls.prototype,"deviceClass",void 0),e([_e({type:Boolean})],ls.prototype,"enabled",void 0),e([_e()],ls.prototype,"labels",void 0),e([_e({type:Boolean,reflect:!0})],ls.prototype,"compact",void 0),e([_e({type:Boolean,reflect:!0})],ls.prototype,"fill",void 0),ls=e([he("acp-cover-move-buttons")],ls);const cs={all:"mdi:robot",some:"mdi:robot-outline",none:"mdi:robot-off"};let ds=class extends ce{constructor(){super(...arguments),this.showSceneSelect=!0,this.showLock=!0,this.showAutomation=!0,this.showClearOverrides=!0}render(){if(!this.hass||!this.discovered||!this.snapshot)return V;const e=this.snapshot,t=this.showClearOverrides?e.clearId:void 0,o=this.showLock&&!!e.lockId,i=this.showAutomation&&!!e.automationId,s=this.showSceneSelect&&!!this.discovered.entities.group_scene_select;if(!(s||o||i||t))return V;const n=function(e){if(!e)return!0;const t=Object.values(e);return 0!==t.length&&t.some(e=>!e||ss.has(yi(e)))}(e.memberWinners);return W`
+  `,e([ge({attribute:!1})],gs.prototype,"hass",void 0),e([ge({attribute:!1})],gs.prototype,"position",void 0),e([ge({attribute:!1})],gs.prototype,"deviceClass",void 0),e([ge({type:Boolean})],gs.prototype,"enabled",void 0),e([ge()],gs.prototype,"labels",void 0),e([ge({type:Boolean,reflect:!0})],gs.prototype,"compact",void 0),e([ge({type:Boolean,reflect:!0})],gs.prototype,"fill",void 0),gs=e([pe("acp-cover-move-buttons")],gs);const ms={all:"mdi:robot",some:"mdi:robot-outline",none:"mdi:robot-off"};let vs=class extends de{constructor(){super(...arguments),this.showSceneSelect=!0,this.showLock=!0,this.showAutomation=!0,this.showClearOverrides=!0}render(){if(!this.hass||!this.discovered||!this.snapshot)return q;const e=this.snapshot,t=this.showClearOverrides?e.clearId:void 0,o=this.showLock&&!!e.lockId,i=this.showAutomation&&!!e.automationId,s=this.showSceneSelect&&!!this.discovered.entities.group_scene_select;if(!(s||o||i||t))return q;const n=function(e){if(!e)return!0;const t=Object.values(e);return 0!==t.length&&t.some(e=>!e||hs.has(xi(e)))}(e.memberWinners);return H`
       <div class="group-row" @click=${this._stop} @pointerdown=${this._stop} @keydown=${this._stop}>
-        ${s?W`<select
+        ${s?H`<select
               class="scene-select"
-              aria-label=${ot("group.scene",this.hass)}
+              aria-label=${it("group.scene",this.hass)}
               @change=${this._onSceneChange}
             >
-              ${es.map(t=>W`<option value=${t} ?selected=${t===e.scene}>
-                    ${ot(`group.scene_${t}`,this.hass)}
+              ${as.map(t=>H`<option value=${t} ?selected=${t===e.scene}>
+                    ${it(`group.scene_${t}`,this.hass)}
                   </option>`)}
-            </select>`:V}
-        ${o?W`<button
+            </select>`:q}
+        ${o?H`<button
               class="ctrl lock-toggle ${e.locked?"active":""}"
               type="button"
               aria-pressed=${e.locked?"true":"false"}
-              aria-label=${ot(e.locked?"group.unlock":"group.lock",this.hass)}
-              ${bo(ot(e.locked?"group.unlock":"group.lock",this.hass))}
-              @click=${()=>function(e,t,o){const i=t.entities.group_lock_switch;i&&Pi(e,i,!o)}(this.hass,this.discovered,e.locked)}
+              aria-label=${it(e.locked?"group.unlock":"group.lock",this.hass)}
+              ${wo(it(e.locked?"group.unlock":"group.lock",this.hass))}
+              @click=${()=>function(e,t,o){const i=t.entities.group_lock_switch;i&&Bi(e,i,!o)}(this.hass,this.discovered,e.locked)}
             >
               <ha-icon icon=${e.locked?"mdi:lock":"mdi:lock-open-variant"}></ha-icon>
-            </button>`:V}
-        ${i?this._automationButton(this._automationView(e)):V}
-        ${t?W`<button
+            </button>`:q}
+        ${i?this._automationButton(this._automationView(e)):q}
+        ${t?H`<button
               class="ctrl clear-overrides"
               type="button"
-              aria-label=${ot("group.clear_overrides",this.hass)}
+              aria-label=${it("group.clear_overrides",this.hass)}
               ?disabled=${!n}
-              ${bo(ot(n?"group.clear_overrides":"group.clear_overrides_none",this.hass))}
+              ${wo(it(n?"group.clear_overrides":"group.clear_overrides_none",this.hass))}
               @click=${()=>{return e=this.hass,o=t,void e.callService("button","press",{},{entity_id:o});var e,o}}
             >
               <ha-icon icon="mdi:backup-restore"></ha-icon>
-            </button>`:V}
+            </button>`:q}
       </div>
-    `}_automationView(e){const t=ot("group.automation",this.hass),o=e.memberAutomation.status;if("unknown"===o)return{cls:e.automationOn?"active":"",icon:e.automationOn?cs.all:cs.none,ariaPressed:e.automationOn?"true":"false",label:t,on:e.automationOn};const i="all"===o,s=ot("group.automation_count",this.hass,{count:e.memberAutomation.on,total:e.memberAutomation.total});return{cls:`auto-${o}`,icon:cs[o],ariaPressed:"some"===o?"mixed":i?"true":"false",label:`${t} — ${s}`,on:i}}_automationButton(e){return W`<button
+    `}_automationView(e){const t=it("group.automation",this.hass),o=e.memberAutomation.status;if("unknown"===o)return{cls:e.automationOn?"active":"",icon:e.automationOn?ms.all:ms.none,ariaPressed:e.automationOn?"true":"false",label:t,on:e.automationOn};const i="all"===o,s=it("group.automation_count",this.hass,{count:e.memberAutomation.on,total:e.memberAutomation.total});return{cls:`auto-${o}`,icon:ms[o],ariaPressed:"some"===o?"mixed":i?"true":"false",label:`${t} — ${s}`,on:i}}_automationButton(e){return H`<button
       class="ctrl automation-toggle ${e.cls}"
       type="button"
       aria-pressed=${e.ariaPressed}
       aria-label=${e.label}
-      ${bo(e.label)}
-      @click=${()=>function(e,t,o){const i=t.entities.group_automation_switch;i&&Pi(e,i,!o)}(this.hass,this.discovered,e.on)}
+      ${wo(e.label)}
+      @click=${()=>function(e,t,o){const i=t.entities.group_automation_switch;i&&Bi(e,i,!o)}(this.hass,this.discovered,e.on)}
     >
       <ha-icon icon=${e.icon}></ha-icon>
-    </button>`}_onSceneChange(e){!function(e,t,o){const i=t.entities.group_scene_select;i&&function(e,t,o){e.callService("select","select_option",{option:o},{entity_id:t})}(e,i,o)}(this.hass,this.discovered,e.target.value)}_stop(e){e.stopPropagation()}};ds.styles=r`
+    </button>`}_onSceneChange(e){!function(e,t,o){const i=t.entities.group_scene_select;i&&function(e,t,o){e.callService("select","select_option",{option:o},{entity_id:t})}(e,i,o)}(this.hass,this.discovered,e.target.value)}_stop(e){e.stopPropagation()}};vs.styles=a`
     :host {
       display: block;
     }
@@ -1727,7 +1727,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
     .ctrl ha-icon {
       --mdc-icon-size: 20px;
     }
-  `,e([_e({attribute:!1})],ds.prototype,"hass",void 0),e([_e({attribute:!1})],ds.prototype,"discovered",void 0),e([_e({attribute:!1})],ds.prototype,"snapshot",void 0),e([_e({type:Boolean})],ds.prototype,"showSceneSelect",void 0),e([_e({type:Boolean})],ds.prototype,"showLock",void 0),e([_e({type:Boolean})],ds.prototype,"showAutomation",void 0),e([_e({type:Boolean})],ds.prototype,"showClearOverrides",void 0),ds=e([he("acp-group-controls-row")],ds);let hs=class extends ce{constructor(){super(...arguments),this.showControls=!0,this.showPositionBar=!0,this.showTilt=!0,this.showSceneSelect=!0,this.showLock=!0,this.showAutomation=!0,this.showClearOverrides=!0,this.showMemberBadges=!0,this.stateColor=!0,this.iconInteractive=!1,this._posDrag=null,this._openMoreInfo=()=>{this.dispatchEvent(new CustomEvent("acp-open-more-info",{bubbles:!0,composed:!0}))},this._onIconClick=e=>{this.iconInteractive&&(e.stopPropagation(),this.dispatchEvent(new CustomEvent("acp-icon-action",{bubbles:!0,composed:!0})))},this._onIconKeydown=e=>{this.iconInteractive&&("Enter"!==e.key&&" "!==e.key||(e.preventDefault(),this._onIconClick(e)))},this._onBodyKeydown=e=>{e.target===e.currentTarget&&("Enter"!==e.key&&" "!==e.key||(e.preventDefault(),this._openMoreInfo()))},this._onPosPointerMove=e=>{null!==this._posDrag&&(e.stopPropagation(),this._posDrag=gt(this._pctFromEvent(e,e.currentTarget),xt(this.discovered)))},this._onPosPointerEnd=e=>{e.stopPropagation(),this._posDrag=null}}render(){if(!this.hass||!this.discovered)return V;const e=os(this.hass,this.discovered),t=ot(`group.state_${e.aggregate}`,this.hass),o=this._posDrag??e.position,i=xt(this.discovered),s=null===o?0:gt(o,i),n=this.stateColor?_t(e.aggregate):"",r=!!e.target,a=this.showMemberBadges?Ui(e.memberWinners):[];return W`
+  `,e([ge({attribute:!1})],vs.prototype,"hass",void 0),e([ge({attribute:!1})],vs.prototype,"discovered",void 0),e([ge({attribute:!1})],vs.prototype,"snapshot",void 0),e([ge({type:Boolean})],vs.prototype,"showSceneSelect",void 0),e([ge({type:Boolean})],vs.prototype,"showLock",void 0),e([ge({type:Boolean})],vs.prototype,"showAutomation",void 0),e([ge({type:Boolean})],vs.prototype,"showClearOverrides",void 0),vs=e([pe("acp-group-controls-row")],vs);let fs=class extends de{constructor(){super(...arguments),this.showControls=!0,this.showPositionBar=!0,this.showTilt=!0,this.showSceneSelect=!0,this.showLock=!0,this.showAutomation=!0,this.showClearOverrides=!0,this.showMemberBadges=!0,this.stateColor=!0,this.iconInteractive=!1,this._posDrag=null,this._openMoreInfo=()=>{this.dispatchEvent(new CustomEvent("acp-open-more-info",{bubbles:!0,composed:!0}))},this._onIconClick=e=>{this.iconInteractive&&(e.stopPropagation(),this.dispatchEvent(new CustomEvent("acp-icon-action",{bubbles:!0,composed:!0})))},this._onIconKeydown=e=>{this.iconInteractive&&("Enter"!==e.key&&" "!==e.key||(e.preventDefault(),this._onIconClick(e)))},this._onBodyKeydown=e=>{e.target===e.currentTarget&&("Enter"!==e.key&&" "!==e.key||(e.preventDefault(),this._openMoreInfo()))},this._onPosPointerMove=e=>{null!==this._posDrag&&(e.stopPropagation(),this._posDrag=vt(this._pctFromEvent(e,e.currentTarget),kt(this.discovered)))},this._onPosPointerEnd=e=>{e.stopPropagation(),this._posDrag=null}}render(){if(!this.hass||!this.discovered)return q;const e=cs(this.hass,this.discovered),t=it(`group.state_${e.aggregate}`,this.hass),o=this._posDrag??e.position,i=kt(this.discovered),s=null===o?0:vt(o,i),n=this.stateColor?mt(e.aggregate):"",r=!!e.target,a=this.showMemberBadges?Ji(e.memberWinners):[];return H`
       <div
         class=${"group-tile"+(this.showControls?" has-controls":"")}
         role="button"
@@ -1737,26 +1737,26 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
       >
         <div
           class=${"cover-icon-wrap"+(this.iconInteractive?" background":"")}
-          role=${this.iconInteractive?"button":V}
-          tabindex=${this.iconInteractive?0:V}
-          aria-label=${this.iconInteractive?ot("tile.icon_action_label",this.hass):V}
-          style=${n?`--acp-tile-icon-color: ${n}`:V}
+          role=${this.iconInteractive?"button":q}
+          tabindex=${this.iconInteractive?0:q}
+          aria-label=${this.iconInteractive?it("tile.icon_action_label",this.hass):q}
+          style=${n?`--acp-tile-icon-color: ${n}`:q}
           @click=${this._onIconClick}
           @keydown=${this._onIconKeydown}
         >
           <ha-icon
             class="cover-icon"
-            icon=${this.icon??is(e,o)}
+            icon=${this.icon??ds(e,o)}
             style=${n?`color: ${n}`:""}
           ></ha-icon>
         </div>
 
         <div class="label">
           <div class="title">${this.name??this.discovered.entry_title}</div>
-          <div class="state">${t} · ${it(o)}</div>
+          <div class="state">${t} · ${st(o)}</div>
         </div>
 
-        ${this.showControls?W`<div
+        ${this.showControls?H`<div
               class="controls"
               @click=${this._stop}
               @pointerdown=${this._stop}
@@ -1771,17 +1771,17 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
                 .enabled=${r}
                 @acp-move=${t=>this._move(t,e)}
               ></acp-cover-move-buttons>
-            </div>`:V}
+            </div>`:q}
 
         <div class="chrome-line">
-          ${Number.isNaN(e.whoWonCount)?V:W`<acp-tile-badge
+          ${Number.isNaN(e.whoWonCount)?q:H`<acp-tile-badge
                 .hass=${this.hass}
                 kind-override="group"
                 .groupCount=${e.whoWonCount}
                 .groupTotal=${e.rosterTotal}
               ></acp-tile-badge>`}
-          ${a.map(e=>W`<acp-tile-badge .hass=${this.hass} .winner=${e}></acp-tile-badge>`)}
-          ${this.showPositionBar?W`<div
+          ${a.map(e=>H`<acp-tile-badge .hass=${this.hass} .winner=${e}></acp-tile-badge>`)}
+          ${this.showPositionBar?H`<div
                 class="pos-slider${null!==this._posDrag?" dragging":""}${r?"":" disabled"}"
                 role="slider"
                 tabindex=${r?0:-1}
@@ -1789,9 +1789,9 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
                 aria-valuemin="0"
                 aria-valuemax="100"
                 aria-valuenow=${s}
-                aria-valuetext=${ot("covers.position_open_value",this.hass,{pct:it(o)})}
-                aria-label=${ot("group.position_slider_label",this.hass)}
-                ${bo(ot("covers.click_to_set",this.hass))}
+                aria-valuetext=${it("covers.position_open_value",this.hass,{pct:st(o)})}
+                aria-label=${it("group.position_slider_label",this.hass)}
+                ${wo(it("covers.click_to_set",this.hass))}
                 @click=${t=>this._onPosClick(t,e)}
                 @pointerdown=${e=>this._onPosPointerDown(e,r)}
                 @pointermove=${this._onPosPointerMove}
@@ -1800,15 +1800,12 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
                 @keydown=${t=>this._onPosKeydown(t,e)}
               >
                 <div class="pos-bar">
-                  <div
-                    class="pos-fill"
-                    style=${`width:${s}%;background:${n||"var(--primary-color)"}`}
-                  ></div>
+                  <div class="pos-fill" style=${`width:${s}%`}></div>
                 </div>
-              </div>`:V}
+              </div>`:q}
         </div>
 
-        ${this.showTilt&&e.tilt?W`<div
+        ${this.showTilt&&e.tilt?H`<div
               class="tilt-line"
               @click=${this._stop}
               @pointerdown=${this._stop}
@@ -1817,12 +1814,12 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
               <acp-axis-bar
                 layout="tile"
                 .hass=${this.hass}
-                .label=${ot("covers.tilt_title",this.hass)}
+                .label=${it("covers.tilt_title",this.hass)}
                 .actual=${e.tilt.value}
                 .openBlocksSun=${!1}
-                @acp-tilt-set=${t=>as(this.hass,e,t.detail)}
+                @acp-tilt-set=${t=>_s(this.hass,e,t.detail)}
               ></acp-axis-bar>
-            </div>`:V}
+            </div>`:q}
 
         <acp-group-controls-row
           .hass=${this.hass}
@@ -1834,7 +1831,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
           .showClearOverrides=${this.showClearOverrides}
         ></acp-group-controls-row>
       </div>
-    `}_move(e,t){"stop"===e.detail?rs(this.hass,this.discovered,t):ns(this.hass,t,"open"===e.detail?100:0)}_pctFromEvent(e,t){const o=t.getBoundingClientRect(),i=Math.round((e.clientX-o.left)/o.width*100);return Math.max(0,Math.min(100,i))}_onPosPointerDown(e,t){if(e.stopPropagation(),!t)return;const o=e.currentTarget;o.setPointerCapture?.(e.pointerId),this._posDrag=gt(this._pctFromEvent(e,o),xt(this.discovered))}_onPosClick(e,t){e.stopPropagation(),t.target&&ns(this.hass,t,gt(this._pctFromEvent(e,e.currentTarget),xt(this.discovered)))}_onPosKeydown(e,t){const o=xt(this.discovered),i=null===t.position?0:gt(t.position,o);let s;switch(e.key){case"ArrowRight":case"ArrowUp":s=i+1;break;case"ArrowLeft":case"ArrowDown":s=i-1;break;case"PageUp":s=i+10;break;case"PageDown":s=i-10;break;case"Home":s=0;break;case"End":s=100;break;default:return}e.preventDefault(),e.stopPropagation(),t.target&&ns(this.hass,t,gt(Math.max(0,Math.min(100,s)),o))}_stop(e){e.stopPropagation()}};hs.styles=r`
+    `}_move(e,t){"stop"===e.detail?us(this.hass,this.discovered,t):ps(this.hass,t,"open"===e.detail?100:0)}_pctFromEvent(e,t){const o=t.getBoundingClientRect(),i=Math.round((e.clientX-o.left)/o.width*100);return Math.max(0,Math.min(100,i))}_onPosPointerDown(e,t){if(e.stopPropagation(),!t)return;const o=e.currentTarget;o.setPointerCapture?.(e.pointerId),this._posDrag=vt(this._pctFromEvent(e,o),kt(this.discovered))}_onPosClick(e,t){e.stopPropagation(),t.target&&ps(this.hass,t,vt(this._pctFromEvent(e,e.currentTarget),kt(this.discovered)))}_onPosKeydown(e,t){const o=kt(this.discovered),i=null===t.position?0:vt(t.position,o);let s;switch(e.key){case"ArrowRight":case"ArrowUp":s=i+1;break;case"ArrowLeft":case"ArrowDown":s=i-1;break;case"PageUp":s=i+10;break;case"PageDown":s=i-10;break;case"Home":s=0;break;case"End":s=100;break;default:return}e.preventDefault(),e.stopPropagation(),t.target&&ps(this.hass,t,vt(Math.max(0,Math.min(100,s)),o))}_stop(e){e.stopPropagation()}};fs.styles=a`
     :host {
       display: block;
     }
@@ -2017,6 +2014,10 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
     .pos-fill {
       position: absolute;
       inset: 0 auto 0 0;
+      /* One constant color for every rail, never the cover's state color: a rail
+         that changed hue as it crossed open/closed read as a status light rather
+         than a measurement. Overridable per-theme via --acp-pos-fill-color. */
+      background: var(--acp-pos-fill-color, ${r(gt)});
       opacity: 0.55;
       border-radius: 6px;
       transition: width 0.3s ease;
@@ -2034,18 +2035,18 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
       grid-area: group;
       margin-top: 4px;
     }
-  `,e([_e({attribute:!1})],hs.prototype,"hass",void 0),e([_e({attribute:!1})],hs.prototype,"discovered",void 0),e([_e({type:Boolean})],hs.prototype,"showControls",void 0),e([_e({type:Boolean})],hs.prototype,"showPositionBar",void 0),e([_e({type:Boolean})],hs.prototype,"showTilt",void 0),e([_e({type:Boolean})],hs.prototype,"showSceneSelect",void 0),e([_e({type:Boolean})],hs.prototype,"showLock",void 0),e([_e({type:Boolean})],hs.prototype,"showAutomation",void 0),e([_e({type:Boolean})],hs.prototype,"showClearOverrides",void 0),e([_e({type:Boolean})],hs.prototype,"showMemberBadges",void 0),e([_e({type:Boolean})],hs.prototype,"stateColor",void 0),e([_e({type:Boolean})],hs.prototype,"iconInteractive",void 0),e([_e({attribute:!1})],hs.prototype,"name",void 0),e([_e({attribute:!1})],hs.prototype,"icon",void 0),e([ge()],hs.prototype,"_posDrag",void 0),hs=e([he("acp-group-tile")],hs);const ps=(e,t,o)=>{const i=new Map;for(let s=t;s<=o;s++)i.set(e[s],s);return i},us=so(class extends no{constructor(e){if(super(e),2!==e.type)throw Error("repeat() can only be used in text expressions")}dt(e,t,o){let i;void 0===o?o=t:void 0!==t&&(i=t);const s=[],n=[];let r=0;for(const t of e)s[r]=i?i(t,r):r,n[r]=o(t,r),r++;return{values:n,keys:s}}render(e,t,o){return this.dt(e,t,o).values}update(e,[t,o,i]){const s=(e=>e._$AH)(e),{values:n,keys:r}=this.dt(t,o,i);if(!Array.isArray(s))return this.ut=r,n;const a=this.ut??=[],l=[];let c,d,h=0,p=s.length-1,u=0,_=n.length-1;for(;h<=p&&u<=_;)if(null===s[h])h++;else if(null===s[p])p--;else if(a[h]===r[u])l[u]=eo(s[h],n[u]),h++,u++;else if(a[p]===r[_])l[_]=eo(s[p],n[_]),p--,_--;else if(a[h]===r[_])l[_]=eo(s[h],n[_]),Jt(e,l[_+1],s[h]),h++,_--;else if(a[p]===r[u])l[u]=eo(s[p],n[u]),Jt(e,s[h],s[p]),p--,u++;else if(void 0===c&&(c=ps(r,u,_),d=ps(a,h,p)),c.has(a[h]))if(c.has(a[p])){const t=d.get(r[u]),o=void 0!==t?s[t]:null;if(null===o){const t=Jt(e,s[h]);eo(t,n[u]),l[u]=t}else l[u]=eo(o,n[u]),Jt(e,s[h],o),s[t]=null;u++}else io(s[p]),p--;else io(s[h]),h++;for(;u<=_;){const t=Jt(e,l[_+1]);eo(t,n[u]),l[u++]=t}for(;h<=p;){const e=s[h++];null!==e&&io(e)}return this.ut=r,oo(e,l),U}}),_s=["acp-dialog-close","acp-tile-tap","acp-open-more-info","acp-resume","acp-extend","acp-extend-confirm","acp-extend-close","acp-tilt-set"];let gs=0;const ms=new WeakMap;let vs=class extends ce{constructor(){super(...arguments),this.position=null,this.winner=null,this.acpManaged=!1,this.showTilt=!0,this.openBlocksSun=!0,this.compact=!1,this._entryId=null,this._tile=null,this._tileKey=null,this._resolveKey=null,this._onMove=e=>{var t,o;"stop"===e.detail?(t=this.hass,o=this.entityId,this.acpManaged?t.callService(Me,"stop",{},{entity_id:o}):t.callService("cover","stop_cover",{},{entity_id:o})):this._set("position","open"===e.detail?100:0)}}willUpdate(e){if(!this.hass||!this.entityId)return;e.has("entityId")&&(this._entryId=null,this._tile=null,this._tileKey=null,this._resolveKey=null);const t=zo();if(!t)return;const o=`${this.entityId}|${function(e){let t=ms.get(e);return void 0===t&&(t=++gs,ms.set(e,t)),t}(t)}`;if(this._resolveKey===o)return;this._resolveKey=o;const i=function(e,t){if(!t.startsWith("cover."))return null;const o=zo();if(!o)return null;const i=Po(o);if(i.get(t)?.platform===Me)return null;for(const[o,s]of Object.entries(e.states)){const e=s?.attributes?.actual_positions;if(!e||!(t in e))continue;const n=i.get(o);if(n?.platform===Me)return n.config_entry_id}return null}(this.hass,this.entityId);i&&(this._entryId=i)}updated(){this._tile&&this.hass&&(this._tile.hass=this.hass)}_tileCard(e){const t=`${e}|${this.entityId}|${this.showTilt}`;if(this._tile&&this._tileKey===t)return this._tile.hass=this.hass,this._tile;if(!customElements.get(xe))return null;const o=document.createElement(xe);o.setConfig({type:`custom:${xe}`,entry_id:e,cover:this.entityId,show_tilt:this.showTilt});for(const e of _s)o.addEventListener(e,e=>e.stopPropagation());return o.hass=this.hass,this._tile=o,this._tileKey=t,o}render(){if(!this.hass||!this.entityId)return V;if(this._entryId){const e=this._tileCard(this._entryId);if(e)return W`<div class="tile-host">${e}</div>`}return this._fallbackRow()}_fallbackRow(){const e=this.hass.states[this.entityId],t=e?.attributes?.friendly_name??this.entityId,o=nt(e?.state),i=this.showTilt&&Ti(this.hass,this.entityId),s=i?e?.attributes?.current_tilt_position??null:null;return W`
+  `,e([ge({attribute:!1})],fs.prototype,"hass",void 0),e([ge({attribute:!1})],fs.prototype,"discovered",void 0),e([ge({type:Boolean})],fs.prototype,"showControls",void 0),e([ge({type:Boolean})],fs.prototype,"showPositionBar",void 0),e([ge({type:Boolean})],fs.prototype,"showTilt",void 0),e([ge({type:Boolean})],fs.prototype,"showSceneSelect",void 0),e([ge({type:Boolean})],fs.prototype,"showLock",void 0),e([ge({type:Boolean})],fs.prototype,"showAutomation",void 0),e([ge({type:Boolean})],fs.prototype,"showClearOverrides",void 0),e([ge({type:Boolean})],fs.prototype,"showMemberBadges",void 0),e([ge({type:Boolean})],fs.prototype,"stateColor",void 0),e([ge({type:Boolean})],fs.prototype,"iconInteractive",void 0),e([ge({attribute:!1})],fs.prototype,"name",void 0),e([ge({attribute:!1})],fs.prototype,"icon",void 0),e([me()],fs.prototype,"_posDrag",void 0),fs=e([pe("acp-group-tile")],fs);const bs=(e,t,o)=>{const i=new Map;for(let s=t;s<=o;s++)i.set(e[s],s);return i},ys=ro(class extends ao{constructor(e){if(super(e),2!==e.type)throw Error("repeat() can only be used in text expressions")}dt(e,t,o){let i;void 0===o?o=t:void 0!==t&&(i=t);const s=[],n=[];let r=0;for(const t of e)s[r]=i?i(t,r):r,n[r]=o(t,r),r++;return{values:n,keys:s}}render(e,t,o){return this.dt(e,t,o).values}update(e,[t,o,i]){const s=(e=>e._$AH)(e),{values:n,keys:r}=this.dt(t,o,i);if(!Array.isArray(s))return this.ut=r,n;const a=this.ut??=[],l=[];let c,d,h=0,p=s.length-1,u=0,_=n.length-1;for(;h<=p&&u<=_;)if(null===s[h])h++;else if(null===s[p])p--;else if(a[h]===r[u])l[u]=oo(s[h],n[u]),h++,u++;else if(a[p]===r[_])l[_]=oo(s[p],n[_]),p--,_--;else if(a[h]===r[_])l[_]=oo(s[h],n[_]),to(e,l[_+1],s[h]),h++,_--;else if(a[p]===r[u])l[u]=oo(s[p],n[u]),to(e,s[h],s[p]),p--,u++;else if(void 0===c&&(c=bs(r,u,_),d=bs(a,h,p)),c.has(a[h]))if(c.has(a[p])){const t=d.get(r[u]),o=void 0!==t?s[t]:null;if(null===o){const t=to(e,s[h]);oo(t,n[u]),l[u]=t}else l[u]=oo(o,n[u]),to(e,s[h],o),s[t]=null;u++}else no(s[p]),p--;else no(s[h]),h++;for(;u<=_;){const t=to(e,l[_+1]);oo(t,n[u]),l[u++]=t}for(;h<=p;){const e=s[h++];null!==e&&no(e)}return this.ut=r,so(e,l),V}}),ws=["acp-dialog-close","acp-tile-tap","acp-open-more-info","acp-resume","acp-extend","acp-extend-confirm","acp-extend-close","acp-tilt-set"];let xs=0;const $s=new WeakMap;let ks=class extends de{constructor(){super(...arguments),this.position=null,this.winner=null,this.acpManaged=!1,this.showTilt=!0,this.openBlocksSun=!0,this.compact=!1,this._entryId=null,this._tile=null,this._tileKey=null,this._resolveKey=null,this._onMove=e=>{var t,o;"stop"===e.detail?(t=this.hass,o=this.entityId,this.acpManaged?t.callService(Te,"stop",{},{entity_id:o}):t.callService("cover","stop_cover",{},{entity_id:o})):this._set("position","open"===e.detail?100:0)}}willUpdate(e){if(!this.hass||!this.entityId)return;e.has("entityId")&&(this._entryId=null,this._tile=null,this._tileKey=null,this._resolveKey=null);const t=To();if(!t)return;const o=`${this.entityId}|${function(e){let t=$s.get(e);return void 0===t&&(t=++xs,$s.set(e,t)),t}(t)}`;if(this._resolveKey===o)return;this._resolveKey=o;const i=function(e,t){if(!t.startsWith("cover."))return null;const o=To();if(!o)return null;const i=Bo(o);if(i.get(t)?.platform===Te)return null;for(const[o,s]of Object.entries(e.states)){const e=s?.attributes?.actual_positions;if(!e||!(t in e))continue;const n=i.get(o);if(n?.platform===Te)return n.config_entry_id}return null}(this.hass,this.entityId);i&&(this._entryId=i)}updated(){this._tile&&this.hass&&(this._tile.hass=this.hass)}_tileCard(e){const t=`${e}|${this.entityId}|${this.showTilt}`;if(this._tile&&this._tileKey===t)return this._tile.hass=this.hass,this._tile;if(!customElements.get($e))return null;const o=document.createElement($e);o.setConfig({type:`custom:${$e}`,entry_id:e,cover:this.entityId,show_tilt:this.showTilt});for(const e of ws)o.addEventListener(e,e=>e.stopPropagation());return o.hass=this.hass,this._tile=o,this._tileKey=t,o}render(){if(!this.hass||!this.entityId)return q;if(this._entryId){const e=this._tileCard(this._entryId);if(e)return H`<div class="tile-host">${e}</div>`}return this._fallbackRow()}_fallbackRow(){const e=this.hass.states[this.entityId],t=e?.attributes?.friendly_name??this.entityId,o=rt(e?.state),i=this.showTilt&&Oi(this.hass,this.entityId),s=i?e?.attributes?.current_tilt_position??null:null;return H`
       <div class="member ${o?"unavailable":""}">
         <div class="head">
-          <div class="name" ${bo(this.entityId)}>${t}</div>
-          ${this.winner?W`<acp-tile-badge .hass=${this.hass} .winner=${this.winner}></acp-tile-badge>`:V}
+          <div class="name" ${wo(this.entityId)}>${t}</div>
+          ${this.winner?H`<acp-tile-badge .hass=${this.hass} .winner=${this.winner}></acp-tile-badge>`:q}
         </div>
         <div class="body">
           <div class="tracks">
             <acp-axis-bar
               layout="cover"
               .hass=${this.hass}
-              .label=${ot("group.position",this.hass)}
+              .label=${it("group.position",this.hass)}
               .hintKey=${"covers.click_to_set"}
               .targetHintKey=${"covers.target_tooltip"}
               .actual=${this.position}
@@ -2054,16 +2055,16 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
               .compact=${this.compact}
               @acp-tilt-set=${e=>this._set("position",e.detail)}
             ></acp-axis-bar>
-            ${i?W`<acp-axis-bar
+            ${i?H`<acp-axis-bar
                     layout="cover"
                     .hass=${this.hass}
-                    .label=${ot("covers.tilt_title",this.hass)}
+                    .label=${it("covers.tilt_title",this.hass)}
                     .actual=${s}
                     .openBlocksSun=${!1}
                     .disabled=${o}
                     .compact=${this.compact}
                     @acp-tilt-set=${e=>this._set("tilt",e.detail)}
-                  ></acp-axis-bar>`:V}
+                  ></acp-axis-bar>`:q}
           </div>
           <acp-cover-move-buttons
             compact
@@ -2077,7 +2078,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
           </div>
         </div>
       </div>
-    `}_set(e,t){!function(e,t,o,i,s){s?Fi(e,t,{[o]:i}):"tilt"!==o?e.callService("cover","set_cover_position",{position:i},{entity_id:t}):e.callService("cover","set_cover_tilt_position",{tilt_position:i},{entity_id:t})}(this.hass,this.entityId,e,t,this.acpManaged)}};vs.styles=r`
+    `}_set(e,t){!function(e,t,o,i,s){s?Ni(e,t,{[o]:i}):"tilt"!==o?e.callService("cover","set_cover_position",{position:i},{entity_id:t}):e.callService("cover","set_cover_tilt_position",{tilt_position:i},{entity_id:t})}(this.hass,this.entityId,e,t,this.acpManaged)}};ks.styles=a`
     :host {
       display: block;
     }
@@ -2167,52 +2168,52 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
       opacity: 0.4;
       cursor: default;
     }
-  `,e([_e({attribute:!1})],vs.prototype,"hass",void 0),e([_e({attribute:!1})],vs.prototype,"entityId",void 0),e([_e({attribute:!1})],vs.prototype,"position",void 0),e([_e({attribute:!1})],vs.prototype,"winner",void 0),e([_e({type:Boolean})],vs.prototype,"acpManaged",void 0),e([_e({type:Boolean})],vs.prototype,"showTilt",void 0),e([_e({type:Boolean})],vs.prototype,"openBlocksSun",void 0),e([_e({type:Boolean,reflect:!0})],vs.prototype,"compact",void 0),e([ge()],vs.prototype,"_entryId",void 0),vs=e([he("acp-group-member-row")],vs);let fs=class extends ce{constructor(){super(...arguments),this.open=!1,this.showTilt=!0,this.showSceneSelect=!0,this.showLock=!0,this.showAutomation=!0,this.showClearOverrides=!0,this.showMemberBadges=!0,this.stateColor=!0,this._onBackdrop=e=>{e.target===e.currentTarget&&this._emitClose()},this._emitClose=()=>{this.dispatchEvent(new CustomEvent("acp-dialog-close",{bubbles:!0,composed:!0}))},this._stop=e=>{e.stopPropagation()}}render(){if(!this.open||!this.hass||!this.discovered)return V;const e=os(this.hass,this.discovered),t=this.stateColor?_t(e.aggregate):"",o=Object.entries(e.memberPositions),i=!!e.target,s=this.showMemberBadges?Ui(e.memberWinners):[],n=ot("dialog.close",this.hass);return W`
+  `,e([ge({attribute:!1})],ks.prototype,"hass",void 0),e([ge({attribute:!1})],ks.prototype,"entityId",void 0),e([ge({attribute:!1})],ks.prototype,"position",void 0),e([ge({attribute:!1})],ks.prototype,"winner",void 0),e([ge({type:Boolean})],ks.prototype,"acpManaged",void 0),e([ge({type:Boolean})],ks.prototype,"showTilt",void 0),e([ge({type:Boolean})],ks.prototype,"openBlocksSun",void 0),e([ge({type:Boolean,reflect:!0})],ks.prototype,"compact",void 0),e([me()],ks.prototype,"_entryId",void 0),ks=e([pe("acp-group-member-row")],ks);let As=class extends de{constructor(){super(...arguments),this.open=!1,this.showTilt=!0,this.showSceneSelect=!0,this.showLock=!0,this.showAutomation=!0,this.showClearOverrides=!0,this.showMemberBadges=!0,this.stateColor=!0,this._onBackdrop=e=>{e.target===e.currentTarget&&this._emitClose()},this._emitClose=()=>{this.dispatchEvent(new CustomEvent("acp-dialog-close",{bubbles:!0,composed:!0}))},this._stop=e=>{e.stopPropagation()}}render(){if(!this.open||!this.hass||!this.discovered)return q;const e=cs(this.hass,this.discovered),t=this.stateColor?mt(e.aggregate):"",o=Object.entries(e.memberPositions),i=!!e.target,s=this.showMemberBadges?Ji(e.memberWinners):[],n=it("dialog.close",this.hass);return H`
       <div class="backdrop" data-open @click=${this._onBackdrop}>
         <div class="dialog" @click=${this._stop} role="dialog" aria-modal="true">
           <div class="header">
             <ha-icon
               class="cover-icon"
-              icon=${this.icon??is(e,e.position)}
+              icon=${this.icon??ds(e,e.position)}
               style=${t?`color: ${t}`:""}
             ></ha-icon>
             <div class="title">${this.name??this.discovered.entry_title}</div>
-            ${Number.isNaN(e.whoWonCount)?V:W`<acp-tile-badge
+            ${Number.isNaN(e.whoWonCount)?q:H`<acp-tile-badge
                   .hass=${this.hass}
                   kind-override="group"
                   .groupCount=${e.whoWonCount}
                   .groupTotal=${e.rosterTotal}
                 ></acp-tile-badge>`}
-            ${s.map(e=>W`<acp-tile-badge .hass=${this.hass} .winner=${e}></acp-tile-badge>`)}
+            ${s.map(e=>H`<acp-tile-badge .hass=${this.hass} .winner=${e}></acp-tile-badge>`)}
             <button class="close" type="button" aria-label=${n} @click=${this._emitClose}>
               ✕
             </button>
           </div>
 
           <div class="summary">
-            <span class="agg-state">${ot(`group.state_${e.aggregate}`,this.hass)}</span>
-            <span class="agg-position">${it(e.position)}</span>
+            <span class="agg-state">${it(`group.state_${e.aggregate}`,this.hass)}</span>
+            <span class="agg-position">${st(e.position)}</span>
           </div>
 
           <acp-axis-bar
             layout="cover"
             .hass=${this.hass}
-            .label=${ot("group.position",this.hass)}
+            .label=${it("group.position",this.hass)}
             .hintKey=${"covers.click_to_set"}
             .targetHintKey=${"covers.target_tooltip"}
             .actual=${e.position}
-            .openBlocksSun=${xt(this.discovered).openBlocksSun}
+            .openBlocksSun=${kt(this.discovered).openBlocksSun}
             .disabled=${!i}
-            @acp-tilt-set=${t=>ns(this.hass,e,t.detail)}
+            @acp-tilt-set=${t=>ps(this.hass,e,t.detail)}
           ></acp-axis-bar>
-          ${this.showTilt&&e.tilt?W`<acp-axis-bar
+          ${this.showTilt&&e.tilt?H`<acp-axis-bar
                 layout="cover"
                 .hass=${this.hass}
-                .label=${ot("covers.tilt_title",this.hass)}
+                .label=${it("covers.tilt_title",this.hass)}
                 .actual=${e.tilt.value}
                 .openBlocksSun=${!1}
-                @acp-tilt-set=${t=>as(this.hass,e,t.detail)}
-              ></acp-axis-bar>`:V}
+                @acp-tilt-set=${t=>_s(this.hass,e,t.detail)}
+              ></acp-axis-bar>`:q}
 
           <div class="controls">
             <acp-cover-move-buttons
@@ -2236,22 +2237,22 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
           ></acp-group-controls-row>
 
           <div class="members">
-            <div class="members-head">${ot("group.members",this.hass)}</div>
-            ${0===o.length?W`<div class="member-placeholder">
-                  ${ot("group.member_placeholder",this.hass)}
-                </div>`:us(o,([e])=>e,([t,o])=>W`<acp-group-member-row
+            <div class="members-head">${it("group.members",this.hass)}</div>
+            ${0===o.length?H`<div class="member-placeholder">
+                  ${it("group.member_placeholder",this.hass)}
+                </div>`:ys(o,([e])=>e,([t,o])=>H`<acp-group-member-row
                       .hass=${this.hass}
                       .entityId=${t}
                       .position=${o}
                       .winner=${e.memberWinners?.[t]}
-                      .openBlocksSun=${xt(this.discovered).openBlocksSun}
+                      .openBlocksSun=${kt(this.discovered).openBlocksSun}
                       .acpManaged=${!!e.memberWinners&&t in e.memberWinners}
                       .showTilt=${this.showTilt}
                     ></acp-group-member-row>`)}
           </div>
         </div>
       </div>
-    `}_move(e,t){"stop"===e.detail?rs(this.hass,this.discovered,t):ns(this.hass,t,"open"===e.detail?100:0)}};function bs(e){if("number"==typeof e.lu)return 1e3*e.lu;if("number"==typeof e.lc)return 1e3*e.lc;const t=e.last_updated??e.last_changed;if("string"==typeof t){const e=Date.parse(t);if(!Number.isNaN(e))return e}return null}fs.styles=r`
+    `}_move(e,t){"stop"===e.detail?us(this.hass,this.discovered,t):ps(this.hass,t,"open"===e.detail?100:0)}};function Ss(e){if("number"==typeof e.lu)return 1e3*e.lu;if("number"==typeof e.lc)return 1e3*e.lc;const t=e.last_updated??e.last_changed;if("string"==typeof t){const e=Date.parse(t);if(!Number.isNaN(e))return e}return null}As.styles=a`
     :host {
       display: contents;
     }
@@ -2344,37 +2345,37 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
       text-align: center;
       padding: 12px;
     }
-  `,e([_e({attribute:!1})],fs.prototype,"hass",void 0),e([_e({attribute:!1})],fs.prototype,"discovered",void 0),e([_e({type:Boolean,reflect:!0})],fs.prototype,"open",void 0),e([_e({type:Boolean})],fs.prototype,"showTilt",void 0),e([_e({type:Boolean})],fs.prototype,"showSceneSelect",void 0),e([_e({type:Boolean})],fs.prototype,"showLock",void 0),e([_e({type:Boolean})],fs.prototype,"showAutomation",void 0),e([_e({type:Boolean})],fs.prototype,"showClearOverrides",void 0),e([_e({type:Boolean})],fs.prototype,"showMemberBadges",void 0),e([_e({type:Boolean})],fs.prototype,"stateColor",void 0),e([_e({attribute:!1})],fs.prototype,"name",void 0),e([_e({attribute:!1})],fs.prototype,"icon",void 0),fs=e([he("acp-group-dialog")],fs);const ys="current_position";function ws(e,t=ys){const o=e.a??e.attributes,i=o?.[t];return"number"!=typeof i||Number.isNaN(i)?null:i}function xs(e,t=ys){const o=[];let i=null;for(const s of e){const e=bs(s),n=ws(s,t);null!==n&&(i=n),null!==e&&null!==i&&o.push({t:e,position:i})}return o}function $s(e){const t=Object.keys(e).filter(t=>e[t].length>0);if(0===t.length)return[];const o={},i=new Set;for(const s of t){const t=[...e[s]].sort((e,t)=>e.t-t.t);o[s]=t;for(const e of t)i.add(e.t)}const s=[...i].sort((e,t)=>e-t),n={},r={};for(const e of t)n[e]=0,r[e]=null;const a=[];for(const e of s){for(const i of t){const t=o[i];for(;n[i]<t.length&&t[n[i]].t<=e;)r[i]=t[n[i]].position,n[i]++}const i=Ft(r);null!==i&&a.push({t:new Date(e).toISOString(),position:i})}return a}async function ks(e,t,o,i,s={}){const n={position:{},tilt:{}},r=t.filter(e=>"string"==typeof e&&e.length>0);if(0===r.length)return n;let a;try{a=await e.callWS({type:"history/history_during_period",start_time:new Date(o).toISOString(),end_time:new Date(i).toISOString(),entity_ids:r,minimal_response:!1,no_attributes:!1,significant_changes_only:!1})}catch{return n}if(!a||"object"!=typeof a)return n;const l={position:{},tilt:{}};for(const e of r){const t=a[e];if(!Array.isArray(t))continue;const o=As(t,ys,!!s.inverted,i);if(o&&(l.position[e]=o),s.wantTilt){const o=As(t,"current_tilt_position",!!s.tiltInverted,i);o&&(l.tilt[e]=o)}}return l}function As(e,t,o,i){const s=xs(e,t);if(0===s.length)return null;const n=s.sort((e,t)=>e.t-t.t).map(e=>({t:new Date(e.t).toISOString(),position:o?100-e.position:e.position})),r=n[n.length-1];return Date.parse(r.t)<i&&n.push({t:new Date(i).toISOString(),position:r.position}),n}let Ss=class extends ce{constructor(){super(...arguments),this.compact=!1,this.resetEnabled=!0,this._tick=null}disconnectedCallback(){super.disconnectedCallback(),this._syncTimer(!1)}shouldUpdate(e){if(e.size>1||!e.has("hass"))return!0;const t=e.get("hass"),o=this.discovered?.entities;return me(t,this.hass,[o?.manual_override_binary,o?.manual_override_end_sensor,o?.motion_status_sensor,o?.reset_override_button])}updated(){if(!this.hass||!this.discovered)return void this._syncTimer(!1);const e=!this.compact&&(null!==this._manualEndIso()||null!=this._motionStatus()?.endIso);this._syncTimer(e)}_syncTimer(e){e&&null===this._tick?this._tick=setInterval(()=>this.requestUpdate(),1e3):e||null===this._tick||(clearInterval(this._tick),this._tick=null)}_manualActive(){const e=this.discovered.entities.manual_override_binary;return!!e&&"on"===this.hass.states[e]?.state}_manualEndIso(){const e=this.discovered.entities.manual_override_end_sensor;if(!e)return null;const t=this.hass.states[e];return t&&"unknown"!==t.state&&"unavailable"!==t.state?t.state:null}_motionStatus(){const e=this.discovered.entities.motion_status_sensor;if(!e)return null;const t=this.hass.states[e];if(!t)return null;const o=t.attributes.motion_timeout_end_time;return{state:t.state,endIso:o??null}}_resetManual(){const e=this.discovered.entities.reset_override_button;e&&this.hass.callService("button","press",{entity_id:e})}_motionStateLabel(e,t){if(e){const t=this.hass.states[e],o=this.hass.formatEntityState;if(t&&"function"==typeof o){const e=o(t);if(e)return e}}return t.replace(/_/g," ")}render(){if(!this.hass||!this.discovered)return V;const e=this._manualActive(),t=this._manualEndIso(),o=this._motionStatus(),i=this.discovered.entities.motion_status_sensor,s=this.discovered.entities.reset_override_button,n=ot("overrides.reset_manual",this.hass);return W`
+  `,e([ge({attribute:!1})],As.prototype,"hass",void 0),e([ge({attribute:!1})],As.prototype,"discovered",void 0),e([ge({type:Boolean,reflect:!0})],As.prototype,"open",void 0),e([ge({type:Boolean})],As.prototype,"showTilt",void 0),e([ge({type:Boolean})],As.prototype,"showSceneSelect",void 0),e([ge({type:Boolean})],As.prototype,"showLock",void 0),e([ge({type:Boolean})],As.prototype,"showAutomation",void 0),e([ge({type:Boolean})],As.prototype,"showClearOverrides",void 0),e([ge({type:Boolean})],As.prototype,"showMemberBadges",void 0),e([ge({type:Boolean})],As.prototype,"stateColor",void 0),e([ge({attribute:!1})],As.prototype,"name",void 0),e([ge({attribute:!1})],As.prototype,"icon",void 0),As=e([pe("acp-group-dialog")],As);const Cs="current_position";function Es(e,t=Cs){const o=e.a??e.attributes,i=o?.[t];return"number"!=typeof i||Number.isNaN(i)?null:i}function zs(e,t=Cs){const o=[];let i=null;for(const s of e){const e=Ss(s),n=Es(s,t);null!==n&&(i=n),null!==e&&null!==i&&o.push({t:e,position:i})}return o}function Ms(e){const t=Object.keys(e).filter(t=>e[t].length>0);if(0===t.length)return[];const o={},i=new Set;for(const s of t){const t=[...e[s]].sort((e,t)=>e.t-t.t);o[s]=t;for(const e of t)i.add(e.t)}const s=[...i].sort((e,t)=>e-t),n={},r={};for(const e of t)n[e]=0,r[e]=null;const a=[];for(const e of s){for(const i of t){const t=o[i];for(;n[i]<t.length&&t[n[i]].t<=e;)r[i]=t[n[i]].position,n[i]++}const i=Nt(r);null!==i&&a.push({t:new Date(e).toISOString(),position:i})}return a}async function Ts(e,t,o,i,s={}){const n={position:{},tilt:{}},r=t.filter(e=>"string"==typeof e&&e.length>0);if(0===r.length)return n;let a;try{a=await e.callWS({type:"history/history_during_period",start_time:new Date(o).toISOString(),end_time:new Date(i).toISOString(),entity_ids:r,minimal_response:!1,no_attributes:!1,significant_changes_only:!1})}catch{return n}if(!a||"object"!=typeof a)return n;const l={position:{},tilt:{}};for(const e of r){const t=a[e];if(!Array.isArray(t))continue;const o=Is(t,Cs,!!s.inverted,i);if(o&&(l.position[e]=o),s.wantTilt){const o=Is(t,"current_tilt_position",!!s.tiltInverted,i);o&&(l.tilt[e]=o)}}return l}function Is(e,t,o,i){const s=zs(e,t);if(0===s.length)return null;const n=s.sort((e,t)=>e.t-t.t).map(e=>({t:new Date(e.t).toISOString(),position:o?100-e.position:e.position})),r=n[n.length-1];return Date.parse(r.t)<i&&n.push({t:new Date(i).toISOString(),position:r.position}),n}let Ps=class extends de{constructor(){super(...arguments),this.compact=!1,this.resetEnabled=!0,this._tick=null}disconnectedCallback(){super.disconnectedCallback(),this._syncTimer(!1)}shouldUpdate(e){if(e.size>1||!e.has("hass"))return!0;const t=e.get("hass"),o=this.discovered?.entities;return ve(t,this.hass,[o?.manual_override_binary,o?.manual_override_end_sensor,o?.motion_status_sensor,o?.reset_override_button])}updated(){if(!this.hass||!this.discovered)return void this._syncTimer(!1);const e=!this.compact&&(null!==this._manualEndIso()||null!=this._motionStatus()?.endIso);this._syncTimer(e)}_syncTimer(e){e&&null===this._tick?this._tick=setInterval(()=>this.requestUpdate(),1e3):e||null===this._tick||(clearInterval(this._tick),this._tick=null)}_manualActive(){const e=this.discovered.entities.manual_override_binary;return!!e&&"on"===this.hass.states[e]?.state}_manualEndIso(){const e=this.discovered.entities.manual_override_end_sensor;if(!e)return null;const t=this.hass.states[e];return t&&"unknown"!==t.state&&"unavailable"!==t.state?t.state:null}_motionStatus(){const e=this.discovered.entities.motion_status_sensor;if(!e)return null;const t=this.hass.states[e];if(!t)return null;const o=t.attributes.motion_timeout_end_time;return{state:t.state,endIso:o??null}}_resetManual(){const e=this.discovered.entities.reset_override_button;e&&this.hass.callService("button","press",{entity_id:e})}_motionStateLabel(e,t){if(e){const t=this.hass.states[e],o=this.hass.formatEntityState;if(t&&"function"==typeof o){const e=o(t);if(e)return e}}return t.replace(/_/g," ")}render(){if(!this.hass||!this.discovered)return q;const e=this._manualActive(),t=this._manualEndIso(),o=this._motionStatus(),i=this.discovered.entities.motion_status_sensor,s=this.discovered.entities.reset_override_button,n=it("overrides.reset_manual",this.hass);return H`
       <div class="wrap">
-        <div class="label dim">${ot("overrides.title",this.hass)}</div>
+        <div class="label dim">${it("overrides.title",this.hass)}</div>
         <div class="grid">
           <div class="tile ${e?"active":""}">
-            <div class="tile-label">${ot("overrides.manual",this.hass)}</div>
+            <div class="tile-label">${it("overrides.manual",this.hass)}</div>
             <div class="tile-value">
-              ${ot(e?"overrides.active":"overrides.off",this.hass)}
+              ${it(e?"overrides.active":"overrides.off",this.hass)}
             </div>
-            ${t?W`<div class="tile-sub dim">
-                  ${ot("overrides.ends_in",this.hass,{time:ct(t,this.hass)})}
-                </div>`:V}
+            ${t?H`<div class="tile-sub dim">
+                  ${it("overrides.ends_in",this.hass,{time:dt(t,this.hass)})}
+                </div>`:q}
           </div>
 
-          ${o?W`<div class="tile ${"motion_detected"===o.state?"active":""}">
-                <div class="tile-label">${ot("overrides.motion",this.hass)}</div>
+          ${o?H`<div class="tile ${"motion_detected"===o.state?"active":""}">
+                <div class="tile-label">${it("overrides.motion",this.hass)}</div>
                 <div class="tile-value">${this._motionStateLabel(i,o.state)}</div>
-                ${o.endIso?W`<div class="tile-sub dim">
-                      ${ot("overrides.timeout",this.hass,{time:ct(o.endIso,this.hass)})}
-                    </div>`:V}
-              </div>`:V}
-          ${s?this.resetEnabled?W`<button class="tile action" @click=${this._resetManual}>
+                ${o.endIso?H`<div class="tile-sub dim">
+                      ${it("overrides.timeout",this.hass,{time:dt(o.endIso,this.hass)})}
+                    </div>`:q}
+              </div>`:q}
+          ${s?this.resetEnabled?H`<button class="tile action" @click=${this._resetManual}>
                   <ha-icon icon="mdi:restore"></ha-icon>
                   <div class="tile-value">${n}</div>
-                </button>`:W`<button class="tile action readonly" aria-disabled="true" tabindex="-1">
+                </button>`:H`<button class="tile action readonly" aria-disabled="true" tabindex="-1">
                   <ha-icon icon="mdi:restore"></ha-icon>
                   <div class="tile-value">${n}</div>
-                </button>`:V}
+                </button>`:q}
         </div>
       </div>
-    `}};Ss.styles=r`
+    `}};Ps.styles=a`
     :host {
       display: block;
     }
@@ -2458,51 +2459,51 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
     ha-icon {
       --mdc-icon-size: 18px;
     }
-  `,e([_e({attribute:!1})],Ss.prototype,"hass",void 0),e([_e({attribute:!1})],Ss.prototype,"discovered",void 0),e([_e({type:Boolean,reflect:!0})],Ss.prototype,"compact",void 0),e([_e({type:Boolean,attribute:"reset-enabled"})],Ss.prototype,"resetEnabled",void 0),Ss=e([he("acp-overrides-panel")],Ss);const Cs=new Set(["mode_off","active"]),Es={summer_mode:"mdi:weather-sunny",winter_mode:"mdi:snowflake",intermediate:"mdi:weather-partly-cloudy"};let zs=class extends ce{constructor(){super(...arguments),this.compact=!1}shouldUpdate(e){if(e.size>1||!e.has("hass"))return!0;const t=e.get("hass"),o=this.discovered?.entities;return me(t,this.hass,[o?.climate_status_sensor,o?.climate_mode_switch])}render(){if(!this.hass||!this.discovered)return V;const e=this.discovered.entities.climate_status_sensor;if(!e)return V;const t=this.hass.states[e];if(!t||"unavailable"===t.state)return V;if("unknown"===t.state||""===t.state){const e=this.discovered.entities.climate_mode_switch,o=!!e&&"off"===this.hass.states[e]?.state,i=ot(o?"climate.mode_off":"climate.standby",this.hass),s=o?"mdi:power-off":"mdi:thermostat",n=t.attributes?.inactive_reason;return this._renderStandby(s,i,n)}const o=t.state,i=t.attributes??{},s=Es[o]??"mdi:thermostat",n=this.hass.formatEntityState,r="function"==typeof n?n(t)??o:o,a=i.temperature_unit??"°",l=!0===i.temp_switch,c=(e,t)=>null==t||Number.isNaN(t)?null:`${ot(e,this.hass)} ${t.toFixed(1)}${a}`,d=l?null:[c("climate.threshold_low",i.temp_low),c("climate.threshold_high",i.temp_high)].filter(e=>null!==e).join(" ")||null,h=[...l?[c("climate.threshold_low",i.temp_low),c("climate.threshold_high",i.temp_high)]:[],c("climate.threshold_summer_outside",i.temp_summer_outside)].filter(e=>null!==e).join(" ")||null,p=[void 0!==i.indoor_temperature?{label:ot("climate.indoor",this.hass),value:i.indoor_temperature,unit:a,threshold:d}:null,void 0!==i.outdoor_temperature?{label:ot("climate.outdoor",this.hass),value:i.outdoor_temperature,unit:a,threshold:h}:null].filter(e=>null!==e);if(null!=(u=i.inactive_reason)&&"active"!==u)return this._renderStandby(s,r,i.inactive_reason,p);var u;const _=void 0!==i.active_temperature?`${i.active_temperature.toFixed(1)}${a}`:"—",g=[{label:ot("climate.presence",this.hass),value:i.is_presence,icon:"mdi:account-check"},{label:ot("climate.sunny",this.hass),value:i.is_sunny,icon:"mdi:white-balance-sunny"},{label:ot("climate.lux",this.hass),value:i.lux_active,icon:"mdi:brightness-7"},{label:ot("climate.irradiance",this.hass),value:i.irradiance_active,icon:"mdi:solar-power"}].filter(e=>void 0!==e.value);return W`
+  `,e([ge({attribute:!1})],Ps.prototype,"hass",void 0),e([ge({attribute:!1})],Ps.prototype,"discovered",void 0),e([ge({type:Boolean,reflect:!0})],Ps.prototype,"compact",void 0),e([ge({type:Boolean,attribute:"reset-enabled"})],Ps.prototype,"resetEnabled",void 0),Ps=e([pe("acp-overrides-panel")],Ps);const Os=new Set(["mode_off","active"]),Bs={summer_mode:"mdi:weather-sunny",winter_mode:"mdi:snowflake",intermediate:"mdi:weather-partly-cloudy"};let Fs=class extends de{constructor(){super(...arguments),this.compact=!1}shouldUpdate(e){if(e.size>1||!e.has("hass"))return!0;const t=e.get("hass"),o=this.discovered?.entities;return ve(t,this.hass,[o?.climate_status_sensor,o?.climate_mode_switch])}render(){if(!this.hass||!this.discovered)return q;const e=this.discovered.entities.climate_status_sensor;if(!e)return q;const t=this.hass.states[e];if(!t||"unavailable"===t.state)return q;if("unknown"===t.state||""===t.state){const e=this.discovered.entities.climate_mode_switch,o=!!e&&"off"===this.hass.states[e]?.state,i=it(o?"climate.mode_off":"climate.standby",this.hass),s=o?"mdi:power-off":"mdi:thermostat",n=t.attributes?.inactive_reason;return this._renderStandby(s,i,n)}const o=t.state,i=t.attributes??{},s=Bs[o]??"mdi:thermostat",n=this.hass.formatEntityState,r="function"==typeof n?n(t)??o:o,a=i.temperature_unit??"°",l=!0===i.temp_switch,c=(e,t)=>null==t||Number.isNaN(t)?null:`${it(e,this.hass)} ${t.toFixed(1)}${a}`,d=l?null:[c("climate.threshold_low",i.temp_low),c("climate.threshold_high",i.temp_high)].filter(e=>null!==e).join(" ")||null,h=[...l?[c("climate.threshold_low",i.temp_low),c("climate.threshold_high",i.temp_high)]:[],c("climate.threshold_summer_outside",i.temp_summer_outside)].filter(e=>null!==e).join(" ")||null,p=[void 0!==i.indoor_temperature?{label:it("climate.indoor",this.hass),value:i.indoor_temperature,unit:a,threshold:d}:null,void 0!==i.outdoor_temperature?{label:it("climate.outdoor",this.hass),value:i.outdoor_temperature,unit:a,threshold:h}:null].filter(e=>null!==e);if(null!=(u=i.inactive_reason)&&"active"!==u)return this._renderStandby(s,r,i.inactive_reason,p);var u;const _=void 0!==i.active_temperature?`${i.active_temperature.toFixed(1)}${a}`:"—",g=[{label:it("climate.presence",this.hass),value:i.is_presence,icon:"mdi:account-check"},{label:it("climate.sunny",this.hass),value:i.is_sunny,icon:"mdi:white-balance-sunny"},{label:it("climate.lux",this.hass),value:i.lux_active,icon:"mdi:brightness-7"},{label:it("climate.irradiance",this.hass),value:i.irradiance_active,icon:"mdi:solar-power"}].filter(e=>void 0!==e.value);return H`
       <div class="wrap">
         <div class="head">
-          <span class="label">${ot("climate.title",this.hass)}</span>
-          <span class="dim">${ot("climate.active",this.hass,{strategy:_})}</span>
+          <span class="label">${it("climate.title",this.hass)}</span>
+          <span class="dim">${it("climate.active",this.hass,{strategy:_})}</span>
         </div>
         <div class="strategy">
           <ha-icon icon=${s}></ha-icon>
           <span class="strategy-name">${r}</span>
         </div>
         ${this._renderTemps(p)}
-        ${g.length?W`
+        ${g.length?H`
               <div class="conditions">
-                ${g.map(e=>W`
-                    <div class="chip ${e.value?"on":"off"}" ${bo(e.label)}>
+                ${g.map(e=>H`
+                    <div class="chip ${e.value?"on":"off"}" ${wo(e.label)}>
                       <ha-icon icon=${e.icon}></ha-icon>
                       <span>${e.label}</span>
                     </div>
                   `)}
               </div>
-            `:V}
+            `:q}
       </div>
-    `}_renderStandby(e,t,o,i=[]){const s=o&&!Cs.has(o)?ot(`climate.reason.${o}`,this.hass):void 0;return W`
+    `}_renderStandby(e,t,o,i=[]){const s=o&&!Os.has(o)?it(`climate.reason.${o}`,this.hass):void 0;return H`
       <div class="wrap">
         <div class="head">
-          <span class="label">${ot("climate.title",this.hass)}</span>
+          <span class="label">${it("climate.title",this.hass)}</span>
         </div>
         <div class="strategy standby">
           <ha-icon icon=${e}></ha-icon>
           <span class="strategy-name dim">${t}</span>
         </div>
-        ${s?W`<div class="standby-reason dim">${s}</div>`:V}
+        ${s?H`<div class="standby-reason dim">${s}</div>`:q}
         ${this._renderTemps(i)}
       </div>
-    `}_renderTemps(e){return e.length?W`
+    `}_renderTemps(e){return e.length?H`
       <div class="temps">
-        ${e.map(e=>W`
+        ${e.map(e=>H`
             <div class="temp">
               <span class="temp-label dim">${e.label}</span>
               <span class="temp-value">${e.value.toFixed(1)}${e.unit}</span>
-              ${e.threshold?W`<span class="temp-threshold dim">${e.threshold}</span>`:V}
+              ${e.threshold?H`<span class="temp-threshold dim">${e.threshold}</span>`:q}
             </div>
           `)}
       </div>
-    `:V}};zs.styles=r`
+    `:q}};Fs.styles=a`
     :host {
       display: block;
     }
@@ -2609,25 +2610,25 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
     .dim {
       color: var(--secondary-text-color);
     }
-  `,e([_e({attribute:!1})],zs.prototype,"hass",void 0),e([_e({attribute:!1})],zs.prototype,"discovered",void 0),e([_e({type:Boolean,reflect:!0})],zs.prototype,"compact",void 0),zs=e([he("acp-climate-panel")],zs);let Ms=class extends ce{constructor(){super(...arguments),this.compact=!1,this.coverColor=null,this._dragPreview=null,this._openMoreInfo=()=>{this.dispatchEvent(new CustomEvent("acp-open-more-info",{bubbles:!0,composed:!0}))},this._onNameKeydown=e=>{"Enter"!==e.key&&" "!==e.key||(e.preventDefault(),this._openMoreInfo())},this._onTrackPointerDown=(e,t,o)=>{const i=e.currentTarget;i.setPointerCapture?.(e.pointerId),this._dragPreview={entityId:t,pct:gt(this._pctFromEvent(e,i),o)}},this._onTrackPointerMove=(e,t,o)=>{if(this._dragPreview?.entityId!==t)return;const i=e.currentTarget;this._dragPreview={entityId:t,pct:gt(this._pctFromEvent(e,i),o)}},this._onTrackPointerEnd=e=>{this._dragPreview?.entityId===e&&(this._dragPreview=null)}}shouldUpdate(e){if(e.size>1||!e.has("hass"))return!0;const t=e.get("hass"),o=this.discovered?.entities,i=this.discovered?wt(this.discovered).map(e=>e.targetRole?o?.[e.targetRole]:void 0).filter(e=>!!e):[];return me(t,this.hass,[...i,o?.position_mismatch_binary,o?.manual_override_binary,...this.discovered?.managed_covers??[]])}_target(){const e=this.discovered.entities.target_position_sensor;return e&&this.hass.states[e]?{target:Yt(this.hass,this.discovered),covers:Wt(this.hass,this.discovered)}:{target:null,covers:{}}}_transit(){const e=this.discovered.entities.target_position_sensor;if(!e)return{};const t=this.hass.states[e];if(!t)return{};const o=t.attributes;return o?.transit_states??{}}_mismatched(){const e=this.discovered.entities.position_mismatch_binary;if(!e)return new Set;const t=this.hass.states[e];if("on"!==t?.state)return new Set;const o=t.attributes.entities;return o?new Set(Object.entries(o).filter(([,e])=>e.mismatch).map(([e])=>e)):new Set}_setAxis(e,t,o){Fi(this.hass,e,{[t]:o})}_axisTarget(e){const t=e.targetRole;if(!t)return null;const o=this.discovered.entities[t];if(!o)return null;const i=parseFloat(this.hass.states[o]?.state??"");return Number.isNaN(i)?null:i}_axisActual(e,t){return Ut(this.hass,e,t)}_motorDivergence(){return function(e,t){const o=Kt(e,t),i=jt(e,t);return null===o||null===i||o===i||$t(t)&&i===100-o?null:i}(this.hass,this.discovered)}_axisLabel(e){const t=He[e.id];return t?ot(t,this.hass):e.label}_axisTargetLabel(e,t){return"tilt"===e.id?ot("covers.tilt_target",this.hass,{pct:it(t)}):`${this._axisLabel(e)}: ${it(t)}`}render(){if(!this.hass||!this.discovered)return V;const{target:e,covers:t}=this._target(),o=this._mismatched(),i=(l=this.hass,c=this.discovered,null!==Nt(qt(l,c),Gt(l,c),Lt(l,c))),s=this._motorDivergence(),n=this._transit(),r=this.coverOrder?.length?this.coverOrder.filter(e=>e in t).map(e=>[e,t[e]]):[],a=r.length>0?r:Object.entries(t);var l,c;if(0===a.length)return W`<div class="placeholder">${ot("covers.placeholder",this.hass)}</div>`;const d=wt(this.discovered).filter(e=>"position"!==e.id),h=xt(this.discovered),p=new Map(d.map(e=>[e.id,this._axisTarget(e)]));return W`
-      <div class="wrap" style=${this.coverColor?`--acp-cover-color:${this.coverColor}`:V}>
+  `,e([ge({attribute:!1})],Fs.prototype,"hass",void 0),e([ge({attribute:!1})],Fs.prototype,"discovered",void 0),e([ge({type:Boolean,reflect:!0})],Fs.prototype,"compact",void 0),Fs=e([pe("acp-climate-panel")],Fs);let Ns=class extends de{constructor(){super(...arguments),this.compact=!1,this.coverColor=null,this._dragPreview=null,this._openMoreInfo=()=>{this.dispatchEvent(new CustomEvent("acp-open-more-info",{bubbles:!0,composed:!0}))},this._onNameKeydown=e=>{"Enter"!==e.key&&" "!==e.key||(e.preventDefault(),this._openMoreInfo())},this._onTrackPointerDown=(e,t,o)=>{const i=e.currentTarget;i.setPointerCapture?.(e.pointerId),this._dragPreview={entityId:t,pct:vt(this._pctFromEvent(e,i),o)}},this._onTrackPointerMove=(e,t,o)=>{if(this._dragPreview?.entityId!==t)return;const i=e.currentTarget;this._dragPreview={entityId:t,pct:vt(this._pctFromEvent(e,i),o)}},this._onTrackPointerEnd=e=>{this._dragPreview?.entityId===e&&(this._dragPreview=null)}}shouldUpdate(e){if(e.size>1||!e.has("hass"))return!0;const t=e.get("hass"),o=this.discovered?.entities,i=this.discovered?$t(this.discovered).map(e=>e.targetRole?o?.[e.targetRole]:void 0).filter(e=>!!e):[];return ve(t,this.hass,[...i,o?.position_mismatch_binary,o?.manual_override_binary,...this.discovered?.managed_covers??[]])}_target(){const e=this.discovered.entities.target_position_sensor;return e&&this.hass.states[e]?{target:Zt(this.hass,this.discovered),covers:Ut(this.hass,this.discovered)}:{target:null,covers:{}}}_transit(){const e=this.discovered.entities.target_position_sensor;if(!e)return{};const t=this.hass.states[e];if(!t)return{};const o=t.attributes;return o?.transit_states??{}}_mismatched(){const e=this.discovered.entities.position_mismatch_binary;if(!e)return new Set;const t=this.hass.states[e];if("on"!==t?.state)return new Set;const o=t.attributes.entities;return o?new Set(Object.entries(o).filter(([,e])=>e.mismatch).map(([e])=>e)):new Set}_setAxis(e,t,o){Ni(this.hass,e,{[t]:o})}_axisTarget(e){const t=e.targetRole;if(!t)return null;const o=this.discovered.entities[t];if(!o)return null;const i=parseFloat(this.hass.states[o]?.state??"");return Number.isNaN(i)?null:i}_axisActual(e,t){return qt(this.hass,e,t)}_motorDivergence(){return function(e,t){const o=Gt(e,t),i=Lt(e,t);return null===o||null===i||o===i||At(t)&&i===100-o?null:i}(this.hass,this.discovered)}_axisLabel(e){const t=Ue[e.id];return t?it(t,this.hass):e.label}_axisTargetLabel(e,t){return"tilt"===e.id?it("covers.tilt_target",this.hass,{pct:st(t)}):`${this._axisLabel(e)}: ${st(t)}`}render(){if(!this.hass||!this.discovered)return q;const{target:e,covers:t}=this._target(),o=this._mismatched(),i=(l=this.hass,c=this.discovered,null!==Rt(Qt(l,c),Ht(l,c),Wt(l,c))),s=this._motorDivergence(),n=this._transit(),r=this.coverOrder?.length?this.coverOrder.filter(e=>e in t).map(e=>[e,t[e]]):[],a=r.length>0?r:Object.entries(t);var l,c;if(0===a.length)return H`<div class="placeholder">${it("covers.placeholder",this.hass)}</div>`;const d=$t(this.discovered).filter(e=>"position"!==e.id),h=kt(this.discovered),p=new Map(d.map(e=>[e.id,this._axisTarget(e)]));return H`
+      <div class="wrap" style=${this.coverColor?`--acp-cover-color:${this.coverColor}`:q}>
         <div class="head">
-          <span class="label">${ot("covers.title",this.hass)}</span>
+          <span class="label">${it("covers.title",this.hass)}</span>
           <span class="targets">
             <span
               class="target"
-              ${null!==s?bo(ot("covers.target_tooltip_motor",this.hass,{pct:s})):V}
-              >${ot(i?"covers.target_solar":"covers.target",this.hass,{pct:it(e)})}</span
+              ${null!==s?wo(it("covers.target_tooltip_motor",this.hass,{pct:s})):q}
+              >${it(i?"covers.target_solar":"covers.target",this.hass,{pct:st(e)})}</span
             >
-            ${d.map(e=>W`<span class="target"
+            ${d.map(e=>H`<span class="target"
                   >${this._axisTargetLabel(e,p.get(e.id)??null)}</span
                 >`)}
           </span>
         </div>
-        ${a.map(([t,s])=>W`
+        ${a.map(([t,s])=>H`
             <div class="cover-group">
               ${this._bar(t,s,e,o.has(t),i,n[t]??null,h)}
-              ${d.map(e=>W`<acp-tilt-bar
+              ${d.map(e=>H`<acp-tilt-bar
                     .hass=${this.hass}
                     .label=${this._axisLabel(e)}
                     .min=${e.min}
@@ -2643,7 +2644,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
             </div>
           `)}
       </div>
-    `}_bar(e,t,o,i,s,n,r){const a=this.hass.states[e]?.attributes?.friendly_name??e,l=o??0,c=this._dragPreview?.entityId===e?this._dragPreview.pct:null,d=it(null!==c?c:t),h=c??t,p=null===h?0:gt(h,r),u=gt(l,r),_=rt(this.hass,e,n??void 0);return W`
+    `}_bar(e,t,o,i,s,n,r){const a=this.hass.states[e]?.attributes?.friendly_name??e,l=o??0,c=this._dragPreview?.entityId===e?this._dragPreview.pct:null,d=st(null!==c?c:t),h=c??t,p=null===h?0:vt(h,r),u=vt(l,r),_=at(this.hass,e,n??void 0);return H`
       <div class="cover ${i?"mismatch":""}">
         <div
           class="name"
@@ -2651,16 +2652,16 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
           tabindex="0"
           @click=${this._openMoreInfo}
           @keydown=${this._onNameKeydown}
-          ${bo(e)}
+          ${wo(e)}
         >
           ${a}
         </div>
         <div class="num">
-          ${n&&!_?W`<ha-icon
+          ${n&&!_?H`<ha-icon
                 class="transit transit-${n}"
                 icon=${"opening"===n?"mdi:arrow-up-thin":"mdi:arrow-down-thin"}
-                ${bo(ot("covers."+n,this.hass))}
-              ></ha-icon>`:V}${_?W`<span class="num-state">${_}</span><span class="num-sep"> · </span>`:V}<span class="num-pct">${d}</span>
+                ${wo(it("covers."+n,this.hass))}
+              ></ha-icon>`:q}${_?H`<span class="num-state">${_}</span><span class="num-sep"> · </span>`:q}<span class="num-pct">${d}</span>
         </div>
         <div
           class="track"
@@ -2669,27 +2670,27 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
           aria-valuemin="0"
           aria-valuemax="100"
           aria-valuenow=${p}
-          aria-valuetext=${ot("covers.position_open_value",this.hass,{pct:d})}
-          aria-label=${ot("covers.position_slider_label",this.hass)}
+          aria-valuetext=${it("covers.position_open_value",this.hass,{pct:d})}
+          aria-label=${it("covers.position_slider_label",this.hass)}
           @click=${t=>this._handleTrackClick(t,e,r)}
           @pointerdown=${t=>this._onTrackPointerDown(t,e,r)}
           @pointermove=${t=>this._onTrackPointerMove(t,e,r)}
           @pointerup=${()=>this._onTrackPointerEnd(e)}
           @pointercancel=${()=>this._onTrackPointerEnd(e)}
           @keydown=${t=>this._onTrackKeydown(t,e,p,r)}
-          ${bo(ot("covers.click_to_set",this.hass))}
+          ${wo(it("covers.click_to_set",this.hass))}
         >
           <div class="fill" style="width:${p}%"></div>
           <div class="fill-closed" style="width:${100-p}%"></div>
-          ${null!==o?W`<div
+          ${null!==o?H`<div
                 class="marker"
                 style="left:clamp(1px, ${u}%, calc(100% - 1px))"
-                ${bo(ot(s?"covers.target_tooltip_override":"covers.target_tooltip",this.hass,{pct:l}))}
-              ></div>`:V}
+                ${wo(it(s?"covers.target_tooltip_override":"covers.target_tooltip",this.hass,{pct:l}))}
+              ></div>`:q}
         </div>
-        ${i&&!s?W`<ha-icon class="warn" icon="mdi:alert-circle-outline"></ha-icon>`:V}
+        ${i&&!s?H`<ha-icon class="warn" icon="mdi:alert-circle-outline"></ha-icon>`:q}
       </div>
-    `}_pctFromEvent(e,t){const o=t.getBoundingClientRect(),i=Math.round((e.clientX-o.left)/o.width*100);return Math.max(0,Math.min(100,i))}_handleTrackClick(e,t,o){const i=e.currentTarget,s=this._pctFromEvent(e,i);this._setAxis(t,"position",gt(s,o))}_onTrackKeydown(e,t,o,i){let s;switch(e.key){case"ArrowRight":case"ArrowUp":s=o+1;break;case"ArrowLeft":case"ArrowDown":s=o-1;break;case"PageUp":s=o+10;break;case"PageDown":s=o-10;break;case"Home":s=0;break;case"End":s=100;break;default:return}e.preventDefault();const n=Math.max(0,Math.min(100,s));this._setAxis(t,"position",gt(n,i))}};function Is(e){if("number"==typeof e.lu)return 1e3*e.lu;if("number"==typeof e.lc)return 1e3*e.lc;const t=e.last_updated??e.last_changed;if("string"==typeof t){const e=Date.parse(t);if(!Number.isNaN(e))return e}return null}function Ts(e){if(!Array.isArray(e))return[];const t=[];for(const o of e){if(!o||"object"!=typeof o)continue;const e=Is(o),i=o.s??o.state;null!==e&&"string"==typeof i&&t.push({t:e,state:i,attributes:o.a??o.attributes??{}})}return t.sort((e,t)=>e.t-t.t),t}function Ps(e,t,o){if(0===e.length||o<=t)return[];let i=null;const s=[];for(const n of e){if(n.t>=o)break;n.t<=t?i=n:s.push(n)}const n=i?[{...i,t:t},...s]:[...s];if(0===n.length)return[];const r=[];for(const e of n){const t=r[r.length-1];t&&t.state===e.state||(t&&(t.end=e.t),r.push({start:e.t,end:o,state:e.state,attributes:e.attributes}))}return r.filter(e=>e.end>e.start)}function Os(e,t={}){const o=[];for(const i of e){const e=t.preferAttribute?i.attributes[t.preferAttribute]:void 0;if("number"==typeof e&&Number.isFinite(e)){o.push({t:i.t,value:e});continue}const s=parseFloat(i.state);Number.isNaN(s)||o.push({t:i.t,value:t.inverted?100-s:s})}return o}function Fs(e){return e.map(e=>({t:Date.parse(e.t),value:e.position})).filter(e=>!Number.isNaN(e.t))}function Bs(e,t){if(0===e.length)return[];const o=[e[0]];for(let t=1;t<e.length;t++){const i=e[t-1],s=e[t];s.value!==i.value&&o.push({t:s.t,value:i.value}),o.push(s)}const i=o[o.length-1];return i.t<t&&o.push({t:t,value:i.value}),o}function Ns(e,t){let o=null,i=Number.NEGATIVE_INFINITY;for(const s of e)Number.isNaN(s.t)||s.t<=t&&s.t>=i&&(i=s.t,o=s.value);return o}async function Ds(e,t,o,i){const s=t.filter(e=>"string"==typeof e&&e.length>0);if(0===s.length)return{};let n;try{n=await e.callWS({type:"history/history_during_period",start_time:new Date(o).toISOString(),end_time:new Date(i).toISOString(),entity_ids:s,minimal_response:!1,no_attributes:!1,significant_changes_only:!1})}catch{return{}}if(!n||"object"!=typeof n)return{};const r={};for(const e of s){const t=Ts(n[e]);t.length>0&&(r[e]=t)}return r}var Rs;Ms.styles=r`
+    `}_pctFromEvent(e,t){const o=t.getBoundingClientRect(),i=Math.round((e.clientX-o.left)/o.width*100);return Math.max(0,Math.min(100,i))}_handleTrackClick(e,t,o){const i=e.currentTarget,s=this._pctFromEvent(e,i);this._setAxis(t,"position",vt(s,o))}_onTrackKeydown(e,t,o,i){let s;switch(e.key){case"ArrowRight":case"ArrowUp":s=o+1;break;case"ArrowLeft":case"ArrowDown":s=o-1;break;case"PageUp":s=o+10;break;case"PageDown":s=o-10;break;case"Home":s=0;break;case"End":s=100;break;default:return}e.preventDefault();const n=Math.max(0,Math.min(100,s));this._setAxis(t,"position",vt(n,i))}};function Ds(e){if("number"==typeof e.lu)return 1e3*e.lu;if("number"==typeof e.lc)return 1e3*e.lc;const t=e.last_updated??e.last_changed;if("string"==typeof t){const e=Date.parse(t);if(!Number.isNaN(e))return e}return null}function Rs(e){if(!Array.isArray(e))return[];const t=[];for(const o of e){if(!o||"object"!=typeof o)continue;const e=Ds(o),i=o.s??o.state;null!==e&&"string"==typeof i&&t.push({t:e,state:i,attributes:o.a??o.attributes??{}})}return t.sort((e,t)=>e.t-t.t),t}function js(e,t,o){if(0===e.length||o<=t)return[];let i=null;const s=[];for(const n of e){if(n.t>=o)break;n.t<=t?i=n:s.push(n)}const n=i?[{...i,t:t},...s]:[...s];if(0===n.length)return[];const r=[];for(const e of n){const t=r[r.length-1];t&&t.state===e.state||(t&&(t.end=e.t),r.push({start:e.t,end:o,state:e.state,attributes:e.attributes}))}return r.filter(e=>e.end>e.start)}function Ks(e,t={}){const o=[];for(const i of e){const e=t.preferAttribute?i.attributes[t.preferAttribute]:void 0;if("number"==typeof e&&Number.isFinite(e)){o.push({t:i.t,value:e});continue}const s=parseFloat(i.state);Number.isNaN(s)||o.push({t:i.t,value:t.inverted?100-s:s})}return o}function Ls(e){return e.map(e=>({t:Date.parse(e.t),value:e.position})).filter(e=>!Number.isNaN(e.t))}function Gs(e,t){if(0===e.length)return[];const o=[e[0]];for(let t=1;t<e.length;t++){const i=e[t-1],s=e[t];s.value!==i.value&&o.push({t:s.t,value:i.value}),o.push(s)}const i=o[o.length-1];return i.t<t&&o.push({t:t,value:i.value}),o}function Ws(e,t){let o=null,i=Number.NEGATIVE_INFINITY;for(const s of e)Number.isNaN(s.t)||s.t<=t&&s.t>=i&&(i=s.t,o=s.value);return o}async function Hs(e,t,o,i){const s=t.filter(e=>"string"==typeof e&&e.length>0);if(0===s.length)return{};let n;try{n=await e.callWS({type:"history/history_during_period",start_time:new Date(o).toISOString(),end_time:new Date(i).toISOString(),entity_ids:s,minimal_response:!1,no_attributes:!1,significant_changes_only:!1})}catch{return{}}if(!n||"object"!=typeof n)return{};const r={};for(const e of s){const t=Rs(n[e]);t.length>0&&(r[e]=t)}return r}var Us;Ns.styles=a`
     :host {
       display: block;
     }
@@ -2874,7 +2875,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
       text-align: center;
       padding: 16px;
     }
-  `,e([_e({attribute:!1})],Ms.prototype,"hass",void 0),e([_e({attribute:!1})],Ms.prototype,"discovered",void 0),e([_e({type:Boolean,reflect:!0})],Ms.prototype,"compact",void 0),e([_e({attribute:!1})],Ms.prototype,"coverColor",void 0),e([_e({attribute:!1})],Ms.prototype,"coverOrder",void 0),e([ge()],Ms.prototype,"_dragPreview",void 0),Ms=e([he("acp-cover-bar")],Ms);const js=864e5;let Ks=Rs=class extends ce{constructor(){super(...arguments),this.samples=[],this.events=[],this.history=[],this.now=Date.now(),this._hoverIdx=null,this._onPointerMove=e=>{const t=e.currentTarget.getBoundingClientRect();if(t.width<=0)return;const o=(e.clientX-t.left)/t.width,i=Math.max(0,Math.min(1,o))*Rs.VIEW_W;this._hoverIdx=this._nearestSampleIdx(i)},this._onPointerLeave=()=>{this._hoverIdx=null}}render(){const e=this.samples&&this.samples.length>0,t=this.history&&this.history.length>0;if(!e&&!t)return V;const{VIEW_W:o,VIEW_H:i,TOP_PAD:s,EVENT_HIT_W:n}=Rs,r=i-s,a=Qo(new Date(this.now)).getTime(),l=a+js,c=e=>It(e,a,o),d=e=>Tt(e,s,r),h=this.samples.map(e=>{const t=Date.parse(e.t);return{t:t,x:c(t),y:d(e.position),sample:e,inDay:!Number.isNaN(t)&&t>=a&&t<=l}}),p=h.filter(e=>e.inDay).map(e=>`${e.x.toFixed(1)},${e.y.toFixed(1)}`).join(" "),u=function(e,t,o){if(0===e.length||!(o>t))return[];const i=[...e].sort((e,t)=>e.t-t.t);let s=null;const n=[];for(const e of i){if(e.t>o)break;e.t<=t?s=e:n.push(e)}return s?[{t:t,value:s.value},...n]:n}(Fs(this.history??[]),a,this.now),_=Bs(u,this.now).map(e=>`${c(e.t).toFixed(1)},${d(e.value).toFixed(1)}`).join(" "),g=function(e){for(const t of e)for(const e of Object.keys(t))if(!Gs.has(e)&&"number"==typeof t[e])return e;return null}(this.samples),m=[];if(null!==g){let e=[];for(const t of h){if(!t.inDay)continue;const o=t.sample[g];if("number"==typeof o){const i=Tt(o,s,r);e.push(`${t.x.toFixed(1)},${i.toFixed(1)}`)}else e.length>0&&(m.push(e.join(" ")),e=[])}e.length>0&&m.push(e.join(" "))}const v=m.map(e=>H`<polyline class="curve-secondary" points=${e} fill="none"></polyline>`),f=(this.events??[]).map(e=>{const t=Date.parse(e.t);if(Number.isNaN(t)||t<a||t>l)return null;const o=c(t),r=`evt-${e.kind}`,d=function(e,t){const o=`forecast.event.${e.kind}`,i=ot(o,t),s=i===o?e.label??e.kind:i,n=lt(e.t);return"—"===n?s:`${s} — ${n}`}(e,this.hass);return H`<g class="event-group" ${bo(d)}>
+  `,e([ge({attribute:!1})],Ns.prototype,"hass",void 0),e([ge({attribute:!1})],Ns.prototype,"discovered",void 0),e([ge({type:Boolean,reflect:!0})],Ns.prototype,"compact",void 0),e([ge({attribute:!1})],Ns.prototype,"coverColor",void 0),e([ge({attribute:!1})],Ns.prototype,"coverOrder",void 0),e([me()],Ns.prototype,"_dragPreview",void 0),Ns=e([pe("acp-cover-bar")],Ns);const Vs=864e5;let qs=Us=class extends de{constructor(){super(...arguments),this.samples=[],this.events=[],this.history=[],this.now=Date.now(),this._hoverIdx=null,this._onPointerMove=e=>{const t=e.currentTarget.getBoundingClientRect();if(t.width<=0)return;const o=(e.clientX-t.left)/t.width,i=Math.max(0,Math.min(1,o))*Us.VIEW_W;this._hoverIdx=this._nearestSampleIdx(i)},this._onPointerLeave=()=>{this._hoverIdx=null}}render(){const e=this.samples&&this.samples.length>0,t=this.history&&this.history.length>0;if(!e&&!t)return q;const{VIEW_W:o,VIEW_H:i,TOP_PAD:s,EVENT_HIT_W:n}=Us,r=i-s,a=Xo(new Date(this.now)).getTime(),l=a+Vs,c=e=>Pt(e,a,o),d=e=>Ot(e,s,r),h=this.samples.map(e=>{const t=Date.parse(e.t);return{t:t,x:c(t),y:d(e.position),sample:e,inDay:!Number.isNaN(t)&&t>=a&&t<=l}}),p=h.filter(e=>e.inDay).map(e=>`${e.x.toFixed(1)},${e.y.toFixed(1)}`).join(" "),u=function(e,t,o){if(0===e.length||!(o>t))return[];const i=[...e].sort((e,t)=>e.t-t.t);let s=null;const n=[];for(const e of i){if(e.t>o)break;e.t<=t?s=e:n.push(e)}return s?[{t:t,value:s.value},...n]:n}(Ls(this.history??[]),a,this.now),_=Gs(u,this.now).map(e=>`${c(e.t).toFixed(1)},${d(e.value).toFixed(1)}`).join(" "),g=function(e){for(const t of e)for(const e of Object.keys(t))if(!Qs.has(e)&&"number"==typeof t[e])return e;return null}(this.samples),m=[];if(null!==g){let e=[];for(const t of h){if(!t.inDay)continue;const o=t.sample[g];if("number"==typeof o){const i=Ot(o,s,r);e.push(`${t.x.toFixed(1)},${i.toFixed(1)}`)}else e.length>0&&(m.push(e.join(" ")),e=[])}e.length>0&&m.push(e.join(" "))}const v=m.map(e=>U`<polyline class="curve-secondary" points=${e} fill="none"></polyline>`),f=(this.events??[]).map(e=>{const t=Date.parse(e.t);if(Number.isNaN(t)||t<a||t>l)return null;const o=c(t),r=`evt-${e.kind}`,d=function(e,t){const o=`forecast.event.${e.kind}`,i=it(o,t),s=i===o?e.label??e.kind:i,n=ct(e.t);return"—"===n?s:`${s} — ${n}`}(e,this.hass);return U`<g class="event-group" ${wo(d)}>
           <line
             class="event-hit"
             x1=${o.toFixed(1)}
@@ -2890,20 +2891,20 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
             y1=${s}
             y2=${i}
           ></line>
-        </g>`}).filter(e=>null!==e),b=null!==this._hoverIdx&&this._hoverIdx>=0&&this._hoverIdx<h.length?h[this._hoverIdx]:null,y=b?H`<g class="hover-guide" pointer-events="none">
+        </g>`}).filter(e=>null!==e),b=null!==this._hoverIdx&&this._hoverIdx>=0&&this._hoverIdx<h.length?h[this._hoverIdx]:null,y=b?U`<g class="hover-guide" pointer-events="none">
           <line class="hover-line"
             x1=${b.x.toFixed(1)} x2=${b.x.toFixed(1)}
             y1=${s} y2=${i}></line>
           <circle class="hover-dot" cx=${b.x.toFixed(1)} cy=${b.y.toFixed(1)} r="3"></circle>
-        </g>`:V,w=!b||b.t>this.now?null:Ns(u,b.t),x=b?W`<div class="hover-label" style=${`left: ${(b.x/o*100).toFixed(2)}%`}>
-          ${function(e,t,o,i){const s=lt(e.t),n=`${Math.round(Ls(e.position))}%`,r=e.handler?`${s} · ${n} · ${e.handler}`:`${s} · ${n}`;if(null===t)return r;const a=e[t];if("number"!=typeof a)return r;const l=function(e,t,o){const i=Ws[e];if(i)return ot(i,t);const s=o?.[e];return s||e.charAt(0).toUpperCase()+e.slice(1)}(t,o,i);return`${r} · ${l}: ${`${Math.round(Ls(a))}%`}`}(b.sample,g,this.hass,this.axisLabels)}${null!==w?` · ${ot("forecast.legend_actual",this.hass)} ${Math.round(Ls(w))}%`:""}
-        </div>`:V,$=[0,6,12,18,24].map(e=>{const t=c(a+36e5*e);return H`
+        </g>`:q,w=!b||b.t>this.now?null:Ws(u,b.t),x=b?H`<div class="hover-label" style=${`left: ${(b.x/o*100).toFixed(2)}%`}>
+          ${function(e,t,o,i){const s=ct(e.t),n=`${Math.round(Ys(e.position))}%`,r=e.handler?`${s} · ${n} · ${e.handler}`:`${s} · ${n}`;if(null===t)return r;const a=e[t];if("number"!=typeof a)return r;const l=function(e,t,o){const i=Zs[e];if(i)return it(i,t);const s=o?.[e];return s||e.charAt(0).toUpperCase()+e.slice(1)}(t,o,i);return`${r} · ${l}: ${`${Math.round(Ys(a))}%`}`}(b.sample,g,this.hass,this.axisLabels)}${null!==w?` · ${it("forecast.legend_actual",this.hass)} ${Math.round(Ys(w))}%`:""}
+        </div>`:q,$=[0,6,12,18,24].map(e=>{const t=c(a+36e5*e);return U`
         <line class="grid faint" x1=${t} y1=${s} x2=${t} y2=${i-.5} />
         <text class="axis-label tick-time" x=${t} y=${i-3} text-anchor="middle">${e.toString().padStart(2,"0")}:00</text>
-      `}),k=this.now,A=c(k),S=k>=a&&k<=l?H`<g class="now-group" ${bo(lt(new Date(k).toISOString()))}>
+      `}),k=this.now,A=c(k),S=k>=a&&k<=l?U`<g class="now-group" ${wo(ct(new Date(k).toISOString()))}>
           <line class="now-hit" x1=${A.toFixed(1)} y1=${s} x2=${A.toFixed(1)} y2=${i-.5}></line>
           <line class="now" x1=${A.toFixed(1)} y1=${s} x2=${A.toFixed(1)} y2=${i-.5}></line>
-        </g>`:V;return W`
+        </g>`:q;return H`
       <div class="wrap">
         <svg
           viewBox="0 0 ${o} ${i}"
@@ -2916,19 +2917,19 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
           <text class="axis-label" x="4" y=${s+8} text-anchor="start">100%</text>
           ${$}
           <polyline class="curve" points=${p} fill="none"></polyline>
-          ${_?H`<polyline class="actual-curve" points=${_} fill="none"></polyline>`:V}
+          ${_?U`<polyline class="actual-curve" points=${_} fill="none"></polyline>`:q}
           ${v} ${f} ${y} ${S}
         </svg>
-        ${t?this._renderLegend():V} ${x}
+        ${t?this._renderLegend():q} ${x}
       </div>
-    `}_renderLegend(){return W`<div class="legend">
+    `}_renderLegend(){return H`<div class="legend">
       <span class="legend-item"
-        ><span class="swatch swatch-forecast"></span>${ot("forecast.legend_forecast",this.hass)}</span
+        ><span class="swatch swatch-forecast"></span>${it("forecast.legend_forecast",this.hass)}</span
       >
       <span class="legend-item"
-        ><span class="swatch swatch-actual"></span>${ot("forecast.legend_actual",this.hass)}</span
+        ><span class="swatch swatch-actual"></span>${it("forecast.legend_actual",this.hass)}</span
       >
-    </div>`}_nearestSampleIdx(e){const t=Qo(new Date(this.now)).getTime(),o=t+js;let i=-1,s=Number.POSITIVE_INFINITY;for(let n=0;n<this.samples.length;n++){const r=Date.parse(this.samples[n].t);if(Number.isNaN(r)||r<t||r>o)continue;const a=It(r,t,Rs.VIEW_W),l=Math.abs(a-e);l<s&&(s=l,i=n)}return i>=0?i:null}};function Ls(e){return Number.isNaN(e)||e<0?0:e>100?100:e}Ks.VIEW_W=600,Ks.VIEW_H=80,Ks.TOP_PAD=10,Ks.EVENT_HIT_W=12,Ks.styles=r`
+    </div>`}_nearestSampleIdx(e){const t=Xo(new Date(this.now)).getTime(),o=t+Vs;let i=-1,s=Number.POSITIVE_INFINITY;for(let n=0;n<this.samples.length;n++){const r=Date.parse(this.samples[n].t);if(Number.isNaN(r)||r<t||r>o)continue;const a=Pt(r,t,Us.VIEW_W),l=Math.abs(a-e);l<s&&(s=l,i=n)}return i>=0?i:null}};function Ys(e){return Number.isNaN(e)||e<0?0:e>100?100:e}qs.VIEW_W=600,qs.VIEW_H=80,qs.TOP_PAD=10,qs.EVENT_HIT_W=12,qs.styles=a`
     :host {
       display: block;
     }
@@ -3070,40 +3071,40 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
       stroke: transparent;
       stroke-width: 10;
     }
-  `,e([_e({attribute:!1})],Ks.prototype,"hass",void 0),e([_e({attribute:!1})],Ks.prototype,"samples",void 0),e([_e({attribute:!1})],Ks.prototype,"events",void 0),e([_e({attribute:!1})],Ks.prototype,"history",void 0),e([_e({attribute:!1})],Ks.prototype,"now",void 0),e([_e({attribute:!1})],Ks.prototype,"axisLabels",void 0),e([ge()],Ks.prototype,"_hoverIdx",void 0),Ks=Rs=e([he("acp-forecast-strip")],Ks);const Gs=new Set(["t","position","handler"]),Ws={tilt:"covers.tilt_title"},Hs=["sol_elev_deg","gamma_deg"],Us=["position_pct"],Vs=new Set([...Hs,...Us,"status","cover_type","tilt"]),qs={cover_blind:["effective_distance_m","adjusted_height_m","safety_margin"],cover_awning:["awn_angle_deg","vertical_position_m","length_m"],cover_tilt:["slat_angle_raw_deg","tilt_mode","max_degrees"]},Ys=new Set([...Hs,...Us,...Object.values(qs).flat()]);function Qs(e,t){return null==t?"—":"boolean"==typeof t?t?"✓":"✗":Array.isArray(t)?t.length?t.join(", "):"—":"number"==typeof t?Number.isNaN(t)?"—":"position_pct"===e||e.endsWith("_pct")?`${Math.round(t)}%`:e.endsWith("_deg")?`${t.toFixed(1)}°`:e.endsWith("_m")?`${t.toFixed(3)} m`:e.endsWith("_rad")?`${t.toFixed(3)} rad`:t.toFixed(3):String(t)}function Zs(e,t,o){const i=[];for(const o of t)o in e&&i.push({key:o,value:Qs(o,e[o]),curated:Ys.has(o)});return i}function Xs(e,t,o){const i=Zs(e,Hs),s=Zs(e,Us);let n;if(o){const o=qs[t]??[],i=Object.keys(e).filter(e=>!Vs.has(e)&&!o.includes(e));n=[...o.filter(t=>t in e),...i]}else n=(qs[t]??[]).filter(t=>t in e);const r=Zs(e,n),a=e.position_pct;return{status:"string"==typeof e.status?e.status:void 0,hasTarget:"number"==typeof a&&!Number.isNaN(a),inputs:i,intermediates:r,output:s}}function Js(e,t){const o="string"==typeof e.cover_type?e.cover_type:"",i=Xs(e,o,t);let s;if("cover_venetian"===o){const o=e.tilt;o&&"object"==typeof o&&(s=Xs(o,"cover_tilt",t))}return{coverType:o,position:i,tilt:s}}let en=class extends ce{constructor(){super(...arguments),this.compact=!1,this._showAll=!1,this._toggleShowAll=()=>{this._showAll=!this._showAll}}shouldUpdate(e){return e.size>1||!e.has("hass")||me(e.get("hass"),this.hass,[this.discovered?.entities.solar_calculation_sensor])}render(){if(!this.hass||!this.discovered)return V;const e=this.discovered.entities.solar_calculation_sensor;if(!e)return V;const t=this.hass.states[e];if(!t||"unavailable"===t.state)return V;const o=t.attributes,i=Js(o,this._showAll),s=function(e){const t=Js(e,!0),o=Js(e,!1),i=e=>e.position.intermediates.length+(e.tilt?.intermediates.length??0);return Math.max(0,i(t)-i(o))}(o);return W`
+  `,e([ge({attribute:!1})],qs.prototype,"hass",void 0),e([ge({attribute:!1})],qs.prototype,"samples",void 0),e([ge({attribute:!1})],qs.prototype,"events",void 0),e([ge({attribute:!1})],qs.prototype,"history",void 0),e([ge({attribute:!1})],qs.prototype,"now",void 0),e([ge({attribute:!1})],qs.prototype,"axisLabels",void 0),e([me()],qs.prototype,"_hoverIdx",void 0),qs=Us=e([pe("acp-forecast-strip")],qs);const Qs=new Set(["t","position","handler"]),Zs={tilt:"covers.tilt_title"},Xs=["sol_elev_deg","gamma_deg"],Js=["position_pct"],en=new Set([...Xs,...Js,"status","cover_type","tilt"]),tn={cover_blind:["effective_distance_m","adjusted_height_m","safety_margin"],cover_awning:["awn_angle_deg","vertical_position_m","length_m"],cover_tilt:["slat_angle_raw_deg","tilt_mode","max_degrees"]},on=new Set([...Xs,...Js,...Object.values(tn).flat()]);function sn(e,t){return null==t?"—":"boolean"==typeof t?t?"✓":"✗":Array.isArray(t)?t.length?t.join(", "):"—":"number"==typeof t?Number.isNaN(t)?"—":"position_pct"===e||e.endsWith("_pct")?`${Math.round(t)}%`:e.endsWith("_deg")?`${t.toFixed(1)}°`:e.endsWith("_m")?`${t.toFixed(3)} m`:e.endsWith("_rad")?`${t.toFixed(3)} rad`:t.toFixed(3):String(t)}function nn(e,t,o){const i=[];for(const o of t)o in e&&i.push({key:o,value:sn(o,e[o]),curated:on.has(o)});return i}function rn(e,t,o){const i=nn(e,Xs),s=nn(e,Js);let n;if(o){const o=tn[t]??[],i=Object.keys(e).filter(e=>!en.has(e)&&!o.includes(e));n=[...o.filter(t=>t in e),...i]}else n=(tn[t]??[]).filter(t=>t in e);const r=nn(e,n),a=e.position_pct;return{status:"string"==typeof e.status?e.status:void 0,hasTarget:"number"==typeof a&&!Number.isNaN(a),inputs:i,intermediates:r,output:s}}function an(e,t){const o="string"==typeof e.cover_type?e.cover_type:"",i=rn(e,o,t);let s;if("cover_venetian"===o){const o=e.tilt;o&&"object"==typeof o&&(s=rn(o,"cover_tilt",t))}return{coverType:o,position:i,tilt:s}}let ln=class extends de{constructor(){super(...arguments),this.compact=!1,this._showAll=!1,this._toggleShowAll=()=>{this._showAll=!this._showAll}}shouldUpdate(e){return e.size>1||!e.has("hass")||ve(e.get("hass"),this.hass,[this.discovered?.entities.solar_calculation_sensor])}render(){if(!this.hass||!this.discovered)return q;const e=this.discovered.entities.solar_calculation_sensor;if(!e)return q;const t=this.hass.states[e];if(!t||"unavailable"===t.state)return q;const o=t.attributes,i=an(o,this._showAll),s=function(e){const t=an(e,!0),o=an(e,!1),i=e=>e.position.intermediates.length+(e.tilt?.intermediates.length??0);return Math.max(0,i(t)-i(o))}(o);return H`
       <div class="wrap">
         <div class="head">
-          <span class="label">${ot("solar.title",this.hass)}</span>
+          <span class="label">${it("solar.title",this.hass)}</span>
           ${this._statusChip(i.position.status)}
         </div>
-        ${this._axis(i.position,i.tilt?ot("solar.axis_position",this.hass):void 0)}
-        ${i.tilt?this._axis(i.tilt,ot("solar.axis_tilt",this.hass)):V}
-        ${s>0?W`<button class="show-all" type="button" @click=${this._toggleShowAll}>
-              ${this._showAll?ot("solar.show_less",this.hass):ot("solar.show_all",this.hass,{count:s})}
-            </button>`:V}
+        ${this._axis(i.position,i.tilt?it("solar.axis_position",this.hass):void 0)}
+        ${i.tilt?this._axis(i.tilt,it("solar.axis_tilt",this.hass)):q}
+        ${s>0?H`<button class="show-all" type="button" @click=${this._toggleShowAll}>
+              ${this._showAll?it("solar.show_less",this.hass):it("solar.show_all",this.hass,{count:s})}
+            </button>`:q}
       </div>
-    `}_statusChip(e){if(!e)return V;const t=e.startsWith("Direct"),o=this._statusSlug(e),i="_unknown"===o?e:ot(`solar.status.${o}`,this.hass);return W`<span class="status-chip ${t?"direct":"default"}">${i}</span>`}_statusSlug(e){return{"Direct Sun":"direct_sun","Default: FOV Exit":"fov_exit","Default: Elevation Limit":"elevation_limit","Default: Sunset Offset":"sunset_offset","Default: Blind Spot":"blind_spot",Default:"default"}[e]??"_unknown"}_axis(e,t){return W`
+    `}_statusChip(e){if(!e)return q;const t=e.startsWith("Direct"),o=this._statusSlug(e),i="_unknown"===o?e:it(`solar.status.${o}`,this.hass);return H`<span class="status-chip ${t?"direct":"default"}">${i}</span>`}_statusSlug(e){return{"Direct Sun":"direct_sun","Default: FOV Exit":"fov_exit","Default: Elevation Limit":"elevation_limit","Default: Sunset Offset":"sunset_offset","Default: Blind Spot":"blind_spot",Default:"default"}[e]??"_unknown"}_axis(e,t){return H`
       <div class="axis">
-        ${t?W`<div class="axis-title dim">${t}</div>`:V}
-        ${this._group(ot("solar.group_inputs",this.hass),e.inputs)}
-        ${this._group(ot("solar.group_intermediates",this.hass),e.intermediates)}
-        ${e.hasTarget?this._group(ot("solar.group_output",this.hass),e.output):W`<div class="no-target dim">
-              ${ot("solar.no_target",this.hass,{status:e.status??"—"})}
+        ${t?H`<div class="axis-title dim">${t}</div>`:q}
+        ${this._group(it("solar.group_inputs",this.hass),e.inputs)}
+        ${this._group(it("solar.group_intermediates",this.hass),e.intermediates)}
+        ${e.hasTarget?this._group(it("solar.group_output",this.hass),e.output):H`<div class="no-target dim">
+              ${it("solar.no_target",this.hass,{status:e.status??"—"})}
             </div>`}
       </div>
-    `}_group(e,t){return 0===t.length?V:W`
+    `}_group(e,t){return 0===t.length?q:H`
       <div class="group">
         <div class="group-label dim">${e}</div>
         <div class="rows">
-          ${t.map(e=>W`<div class="row">
+          ${t.map(e=>H`<div class="row">
                 <span class="key ${e.curated?"":"raw"}"
-                  >${e.curated?ot(`solar.field.${e.key}`,this.hass):e.key}</span
+                  >${e.curated?it(`solar.field.${e.key}`,this.hass):e.key}</span
                 >
                 <span class="value">${e.value}</span>
               </div>`)}
         </div>
       </div>
-    `}};function tn(e){const t=new Map;let o=0;for(const i of e){const e=Math.max(0,i.end-i.start);0!==e&&(t.set(i.state,(t.get(i.state)??0)+e),o+=e)}return 0===o?[]:[...t.entries()].map(([e,t])=>({handler:e,ms:t,fraction:t/o})).sort((e,t)=>t.ms-e.ms)}function on(e,t){let o=0;for(const i of e)t(i.state)&&(o+=Math.max(0,i.end-i.start));return o}function sn(e){const t=Math.round(e/6e4);if(t<1)return"<1m";const o=Math.floor(t/60),i=t%60;return 0===o?`${i}m`:0===i?`${o}h`:`${o}h ${i}m`}function nn(e){const t=e.services;return!!t?.[Me]?.get_diagnostics}function rn(e){if(!e||"object"!=typeof e||Array.isArray(e))return null;const t=e,o="string"==typeof t.ts?t.ts:null,i="string"==typeof t.event?t.event:null;if(null===o||null===i)return null;const s=Date.parse(o);if(Number.isNaN(s))return null;const n={};for(const[e,o]of Object.entries(t))"ts"!==e&&"event"!==e&&(n[e]=o);return{ts:o,t:s,event:i,fields:n}}async function an(e,t){const o={events:[],window:null,bufferSize:null,available:!1,raw:null};if(!nn(e))return o;const i=e.callService;let s;try{s=await i(Me,"get_diagnostics",{config_entry_id:[t]},void 0,!1,!0)}catch{return o}return function(e,t){const o={events:[],window:null,bufferSize:null,available:!1,raw:null};if(!e||"object"!=typeof e)return o;const i=e.entries;if(!i||"object"!=typeof i)return o;const s=i[t];if(!s||"object"!=typeof s)return o;const n=s.diagnostics;if(!n||"object"!=typeof n)return o;if("error"in n)return o;const r=Array.isArray(n.event_timeline)?n.event_timeline:[],a=[];for(const e of r){const t=rn(e);t&&a.push(t)}a.sort((e,t)=>e.t-t.t);const l=n.data_window,c=l&&"object"==typeof l?{start:"string"==typeof l.start?l.start:null,end:"string"==typeof l.end?l.end:null,capturedAt:"string"==typeof l.captured_at?l.captured_at:null}:null,d=n.debug_config?.debug_event_buffer_size;return{events:a,window:c,bufferSize:"number"==typeof d?d:null,available:!0,raw:e}}(s&&"object"==typeof s&&"response"in s?s.response:s,t)}function ln(e){return"string"==typeof e&&e.length>0?e:null}function cn(e){if(!e||"object"!=typeof e||Array.isArray(e))return null;const t=e,o=t.when;return"number"==typeof o&&Number.isFinite(o)?{t:1e3*o,entityId:ln(t.entity_id),name:ln(t.name)??ln(t.entity_id)??"",state:ln(t.state),message:ln(t.message),icon:ln(t.icon),contextUserId:ln(t.context_user_id),contextName:ln(t.context_name),contextDomain:ln(t.context_domain),contextService:ln(t.context_service)}:null}async function dn(e,t,o,i){const s=t.filter(e=>"string"==typeof e&&e.length>0);if(0===s.length)return[];try{return function(e){if(!Array.isArray(e))return[];const t=[];for(const o of e){const e=cn(o);e&&t.push(e)}return t.sort((e,t)=>t.t-e.t),t}(await e.callWS({type:"logbook/get_events",start_time:new Date(o).toISOString(),end_time:new Date(i).toISOString(),entity_ids:s}))}catch{return[]}}function hn(e,t){if(e.contextName)return e.contextName;const o=e.contextUserId;return o?t.get(o)??null:null}en.styles=r`
+    `}};function cn(e){const t=new Map;let o=0;for(const i of e){const e=Math.max(0,i.end-i.start);0!==e&&(t.set(i.state,(t.get(i.state)??0)+e),o+=e)}return 0===o?[]:[...t.entries()].map(([e,t])=>({handler:e,ms:t,fraction:t/o})).sort((e,t)=>t.ms-e.ms)}function dn(e,t){let o=0;for(const i of e)t(i.state)&&(o+=Math.max(0,i.end-i.start));return o}function hn(e){const t=Math.round(e/6e4);if(t<1)return"<1m";const o=Math.floor(t/60),i=t%60;return 0===o?`${i}m`:0===i?`${o}h`:`${o}h ${i}m`}function pn(e){const t=e.services;return!!t?.[Te]?.get_diagnostics}function un(e){if(!e||"object"!=typeof e||Array.isArray(e))return null;const t=e,o="string"==typeof t.ts?t.ts:null,i="string"==typeof t.event?t.event:null;if(null===o||null===i)return null;const s=Date.parse(o);if(Number.isNaN(s))return null;const n={};for(const[e,o]of Object.entries(t))"ts"!==e&&"event"!==e&&(n[e]=o);return{ts:o,t:s,event:i,fields:n}}async function _n(e,t){const o={events:[],window:null,bufferSize:null,available:!1,raw:null};if(!pn(e))return o;const i=e.callService;let s;try{s=await i(Te,"get_diagnostics",{config_entry_id:[t]},void 0,!1,!0)}catch{return o}return function(e,t){const o={events:[],window:null,bufferSize:null,available:!1,raw:null};if(!e||"object"!=typeof e)return o;const i=e.entries;if(!i||"object"!=typeof i)return o;const s=i[t];if(!s||"object"!=typeof s)return o;const n=s.diagnostics;if(!n||"object"!=typeof n)return o;if("error"in n)return o;const r=Array.isArray(n.event_timeline)?n.event_timeline:[],a=[];for(const e of r){const t=un(e);t&&a.push(t)}a.sort((e,t)=>e.t-t.t);const l=n.data_window,c=l&&"object"==typeof l?{start:"string"==typeof l.start?l.start:null,end:"string"==typeof l.end?l.end:null,capturedAt:"string"==typeof l.captured_at?l.captured_at:null}:null,d=n.debug_config?.debug_event_buffer_size;return{events:a,window:c,bufferSize:"number"==typeof d?d:null,available:!0,raw:e}}(s&&"object"==typeof s&&"response"in s?s.response:s,t)}function gn(e){return"string"==typeof e&&e.length>0?e:null}function mn(e){if(!e||"object"!=typeof e||Array.isArray(e))return null;const t=e,o=t.when;return"number"==typeof o&&Number.isFinite(o)?{t:1e3*o,entityId:gn(t.entity_id),name:gn(t.name)??gn(t.entity_id)??"",state:gn(t.state),message:gn(t.message),icon:gn(t.icon),contextUserId:gn(t.context_user_id),contextName:gn(t.context_name),contextDomain:gn(t.context_domain),contextService:gn(t.context_service)}:null}async function vn(e,t,o,i){const s=t.filter(e=>"string"==typeof e&&e.length>0);if(0===s.length)return[];try{return function(e){if(!Array.isArray(e))return[];const t=[];for(const o of e){const e=mn(o);e&&t.push(e)}return t.sort((e,t)=>t.t-e.t),t}(await e.callWS({type:"logbook/get_events",start_time:new Date(o).toISOString(),end_time:new Date(i).toISOString(),entity_ids:s}))}catch{return[]}}function fn(e,t){if(e.contextName)return e.contextName;const o=e.contextUserId;return o?t.get(o)??null:null}ln.styles=a`
     :host {
       display: block;
     }
@@ -3206,16 +3207,16 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
     [data-tooltip][acp-tt-shown] {
       cursor: default;
     }
-  `,e([_e({attribute:!1})],en.prototype,"hass",void 0),e([_e({attribute:!1})],en.prototype,"discovered",void 0),e([_e({type:Boolean,reflect:!0})],en.prototype,"compact",void 0),e([ge()],en.prototype,"_showAll",void 0),en=e([he("acp-solar-calc")],en);const pn={cover_command_sent:{skipped:!1},end_time_default_sent:{skipped:!1},reconcile_gave_up:{skipped:!0},reconcile_skipped_in_transit:{skipped:!0}},un=["position","target_position","to"];function _n(e,t){return t?100-e:e}function gn(e,t=!1){const o=[],i=new Set(["entity_id","service","entity_ids"]);for(const s of un){const n=e[s];if("number"==typeof n&&Number.isFinite(n)){o.push(`${s} ${Math.round(_n(n,t))}%`),i.add(s);break}}for(const[t,s]of Object.entries(e))i.has(t)||null!=s&&""!==s&&"object"!=typeof s&&o.push(`${t} ${String(s)}`);return o.length>0?o.join(" · "):null}var mn;const vn=36e5,fn=864e5;let bn=mn=class extends ce{constructor(){super(...arguments),this.hours=24,this.advancedOpen=!1,this.hideAdvanced=!1,this.showWindowPicker=!0,this.active=!0,this._target=[],this._actual=[],this._perCover={},this._tiltTarget=[],this._tiltActual={},this._copied=!1,this._whoWon=[],this._controlStatus=[],this._stateBands={},this._activity=[],this._loading=!1,this._loaded=!1,this._timeline=null,this._eventFilter="",this._advanced=!1,this._maximized=null,this._hoverT=null,this._now=Date.now(),this._cancelMinuteTimer=null,this._minutesSinceFetch=0,this._fetchKey=null,this._onPointerMove=e=>{const t=this.renderRoot.querySelector(".track-plot");if(!t)return;const o=t.getBoundingClientRect();if(o.width<=0)return;const i=Math.max(0,Math.min(1,(e.clientX-o.left)/o.width));this._hoverT=this._start+i*(this._now-this._start)},this._onPointerLeave=()=>{this._hoverT=null}}get _posH(){return"tracks"===this._maximized?mn.POS_H_MAX:mn.POS_H}connectedCallback(){super.connectedCallback(),this._advanced=this.advancedOpen}disconnectedCallback(){super.disconnectedCallback(),this._stopMinuteTimer()}updated(e){e.has("advancedOpen")&&(this._advanced=this.advancedOpen),e.has("_maximized")&&this.toggleAttribute("maximized",null!==this._maximized),e.has("active")&&!this.active&&(this._fetchKey=null,this._minutesSinceFetch=0,null!==this._maximized&&(this._maximized=null,this.dispatchEvent(new CustomEvent("acp-history-expand",{detail:{expanded:!1,section:null},bubbles:!0,composed:!0})))),this._syncMinuteTimer(),this._maybeFetch()}shouldUpdate(e){return e.size>1||!e.has("hass")}get _entryId(){return this.discovered?.entry_id??null}_syncMinuteTimer(){this.active&&null===this._cancelMinuteTimer?this._cancelMinuteTimer=ui(()=>{this._minutesSinceFetch+=1,this._minutesSinceFetch>=5?(this._fetchKey=null,this._maybeFetch()):this.requestUpdate()}):this.active||this._stopMinuteTimer()}_stopMinuteTimer(){null!==this._cancelMinuteTimer&&(this._cancelMinuteTimer(),this._cancelMinuteTimer=null)}_maybeFetch(){if(!this.active||!this.hass||!this.discovered)return;const e=this._entryId;if(!e)return;const t=`${e}|${this.hours}|${$t(this.discovered)}`;t!==this._fetchKey&&(this._fetchKey=t,this._minutesSinceFetch=0,this._fetch(t))}async _fetch(e){const t=this.hass,o=this.discovered,i=Date.now(),s=i-this.hours*vn;this._loading=!0,this._now=i;const n=o.entities,r=o.managed_covers??[],a=$t(o),l=wt(o).find(e=>"tilt"===e.id),c=l?.inverted??!1,d=!!l,h=[];n.target_position_sensor&&h.push(n.target_position_sensor),d&&n.target_tilt_sensor&&h.push(n.target_tilt_sensor),n.control_status_sensor&&h.push(n.control_status_sensor),n.decision_trace_sensor&&h.push(n.decision_trace_sensor);for(const e of Ye){const t=n[e.role];t&&h.push(t)}const p=[...r];for(const e of Ye){const t=n[e.role];t&&p.push(t)}n.control_status_sensor&&p.push(n.control_status_sensor),n.decision_trace_sensor&&p.push(n.decision_trace_sensor),n.last_action_sensor&&p.push(n.last_action_sensor);const u=this._show("actions"),_=this._show("position")&&r.length>0,[g,m,v,f]=await Promise.all([_?ks(t,r,s,i,{inverted:a,tiltInverted:c,wantTilt:d}):Promise.resolve({position:{},tilt:{}}),Ds(t,h,s,i),u?dn(t,p,s,i):Promise.resolve([]),u||this._advanced?an(t,this._entryId??""):Promise.resolve(null)]);if(this._fetchKey!==e)return;this._actual=function(e){const t={};for(const[o,i]of Object.entries(e)){const e=i.map(e=>({t:Date.parse(e.t),position:e.position})).filter(e=>!Number.isNaN(e.t));e.length>0&&(t[o]=e)}return $s(t)}(g.position),this._perCover=r.length>1?g.position:{},this._tiltActual=g.tilt,this._tiltTarget=d&&n.target_tilt_sensor?Os(m[n.target_tilt_sensor]??[]):[],this._target=n.target_position_sensor?Os(m[n.target_position_sensor]??[],{preferAttribute:"linear_position",inverted:a}):[],this._whoWon=n.decision_trace_sensor?Ps(m[n.decision_trace_sensor]??[],s,i):[],this._controlStatus=n.control_status_sensor?Ps(m[n.control_status_sensor]??[],s,i):[];const b={};for(const e of Ye){const t=n[e.role];t&&(b[e.role]=Ps(m[t]??[],s,i))}this._stateBands=b,f&&(this._timeline=f),this._activity=u?function(e,t,o,i){const s=o.filter(e=>e.t>=i.startMs&&e.t<=i.endMs).map(e=>function(e,t=!1){const o=pn[e.event];if(!o)return null;const i="string"==typeof e.fields.service?e.fields.service:null,s="string"==typeof e.fields.entity_id?e.fields.entity_id:null;return{t:e.t,source:"command",title:i??e.event,name:null,entityId:s&&s.length>0?s:null,detail:gn(e.fields,t),service:i,triggeredBy:null,skipped:o.skipped}}(e,i.inverted)).filter(e=>null!==e),n=[...t].sort((e,t)=>e.t-t.t),r=new Set;for(const e of s)if(e.entityId)for(const t of n)if(!r.has(t)&&t.entityId===e.entityId&&!(t.t<e.t||t.t-e.t>5e3||t.contextUserId||t.contextName)){r.add(t);break}const a=function(e){const t=new Map;for(const o of Object.values(e.states??{})){if(!o.entity_id.startsWith("person."))continue;const e=o.attributes.user_id,i=o.attributes.friendly_name;"string"==typeof e&&"string"==typeof i&&i.length>0&&t.set(e,i)}const o=e.user;return o?.id&&o.name&&!t.has(o.id)&&t.set(o.id,o.name),t}(e),l=[...s,...t.filter(e=>!r.has(e)).map(t=>function(e,t,o){const i=e.entityId?o.states?.[e.entityId]?.attributes?.friendly_name:void 0;return{t:e.t,source:"logbook",title:e.state??e.message??"",name:i||e.name||null,entityId:e.entityId,detail:null,service:null,triggeredBy:hn(e,t),skipped:!1}}(t,a,e))];return l.sort((e,t)=>t.t-e.t),l}(t,v,f?.events??[],{startMs:s,endMs:i,inverted:a}):[],this._loading=!1,this._loaded=!0}_show(e){return!1!==this.tracks?.[e]}_setHours(e){e!==this.hours&&(this.hours=e,this.dispatchEvent(new CustomEvent("acp-history-hours",{detail:{hours:e},bubbles:!0,composed:!0})))}_refresh(){this._fetchKey=null,this._timeline=null,this._maybeFetch()}_toggleMaximize(e){this._maximized=this._maximized===e?null:e,"events"===this._maximized&&null===this._timeline&&an(this.hass,this._entryId??"").then(e=>{this._timeline=e}),this.dispatchEvent(new CustomEvent("acp-history-expand",{detail:{expanded:null!==this._maximized,section:this._maximized},bubbles:!0,composed:!0}))}_maximizeButton(e){const t=this._maximized===e,o=ot(t?"history.collapse":"history.expand",this.hass);return W`<button
+  `,e([ge({attribute:!1})],ln.prototype,"hass",void 0),e([ge({attribute:!1})],ln.prototype,"discovered",void 0),e([ge({type:Boolean,reflect:!0})],ln.prototype,"compact",void 0),e([me()],ln.prototype,"_showAll",void 0),ln=e([pe("acp-solar-calc")],ln);const bn={cover_command_sent:{skipped:!1},end_time_default_sent:{skipped:!1},reconcile_gave_up:{skipped:!0},reconcile_skipped_in_transit:{skipped:!0}},yn=["position","target_position","to"];function wn(e,t){return t?100-e:e}function xn(e,t=!1){const o=[],i=new Set(["entity_id","service","entity_ids"]);for(const s of yn){const n=e[s];if("number"==typeof n&&Number.isFinite(n)){o.push(`${s} ${Math.round(wn(n,t))}%`),i.add(s);break}}for(const[t,s]of Object.entries(e))i.has(t)||null!=s&&""!==s&&"object"!=typeof s&&o.push(`${t} ${String(s)}`);return o.length>0?o.join(" · "):null}var $n;const kn=36e5,An=864e5;let Sn=$n=class extends de{constructor(){super(...arguments),this.hours=24,this.advancedOpen=!1,this.hideAdvanced=!1,this.showWindowPicker=!0,this.active=!0,this._target=[],this._actual=[],this._perCover={},this._tiltTarget=[],this._tiltActual={},this._copied=!1,this._whoWon=[],this._controlStatus=[],this._stateBands={},this._activity=[],this._loading=!1,this._loaded=!1,this._timeline=null,this._eventFilter="",this._advanced=!1,this._maximized=null,this._hoverT=null,this._now=Date.now(),this._cancelMinuteTimer=null,this._minutesSinceFetch=0,this._fetchKey=null,this._onPointerMove=e=>{const t=this.renderRoot.querySelector(".track-plot");if(!t)return;const o=t.getBoundingClientRect();if(o.width<=0)return;const i=Math.max(0,Math.min(1,(e.clientX-o.left)/o.width));this._hoverT=this._start+i*(this._now-this._start)},this._onPointerLeave=()=>{this._hoverT=null}}get _posH(){return"tracks"===this._maximized?$n.POS_H_MAX:$n.POS_H}connectedCallback(){super.connectedCallback(),this._advanced=this.advancedOpen}disconnectedCallback(){super.disconnectedCallback(),this._stopMinuteTimer()}updated(e){e.has("advancedOpen")&&(this._advanced=this.advancedOpen),e.has("_maximized")&&this.toggleAttribute("maximized",null!==this._maximized),e.has("active")&&!this.active&&(this._fetchKey=null,this._minutesSinceFetch=0,null!==this._maximized&&(this._maximized=null,this.dispatchEvent(new CustomEvent("acp-history-expand",{detail:{expanded:!1,section:null},bubbles:!0,composed:!0})))),this._syncMinuteTimer(),this._maybeFetch()}shouldUpdate(e){return e.size>1||!e.has("hass")}get _entryId(){return this.discovered?.entry_id??null}_syncMinuteTimer(){this.active&&null===this._cancelMinuteTimer?this._cancelMinuteTimer=gi(()=>{this._minutesSinceFetch+=1,this._minutesSinceFetch>=5?(this._fetchKey=null,this._maybeFetch()):this.requestUpdate()}):this.active||this._stopMinuteTimer()}_stopMinuteTimer(){null!==this._cancelMinuteTimer&&(this._cancelMinuteTimer(),this._cancelMinuteTimer=null)}_maybeFetch(){if(!this.active||!this.hass||!this.discovered)return;const e=this._entryId;if(!e)return;const t=`${e}|${this.hours}|${At(this.discovered)}`;t!==this._fetchKey&&(this._fetchKey=t,this._minutesSinceFetch=0,this._fetch(t))}async _fetch(e){const t=this.hass,o=this.discovered,i=Date.now(),s=i-this.hours*kn;this._loading=!0,this._now=i;const n=o.entities,r=o.managed_covers??[],a=At(o),l=$t(o).find(e=>"tilt"===e.id),c=l?.inverted??!1,d=!!l,h=[];n.target_position_sensor&&h.push(n.target_position_sensor),d&&n.target_tilt_sensor&&h.push(n.target_tilt_sensor),n.control_status_sensor&&h.push(n.control_status_sensor),n.decision_trace_sensor&&h.push(n.decision_trace_sensor);for(const e of Qe){const t=n[e.role];t&&h.push(t)}const p=[...r];for(const e of Qe){const t=n[e.role];t&&p.push(t)}n.control_status_sensor&&p.push(n.control_status_sensor),n.decision_trace_sensor&&p.push(n.decision_trace_sensor),n.last_action_sensor&&p.push(n.last_action_sensor);const u=this._show("actions"),_=this._show("position")&&r.length>0,[g,m,v,f]=await Promise.all([_?Ts(t,r,s,i,{inverted:a,tiltInverted:c,wantTilt:d}):Promise.resolve({position:{},tilt:{}}),Hs(t,h,s,i),u?vn(t,p,s,i):Promise.resolve([]),u||this._advanced?_n(t,this._entryId??""):Promise.resolve(null)]);if(this._fetchKey!==e)return;this._actual=function(e){const t={};for(const[o,i]of Object.entries(e)){const e=i.map(e=>({t:Date.parse(e.t),position:e.position})).filter(e=>!Number.isNaN(e.t));e.length>0&&(t[o]=e)}return Ms(t)}(g.position),this._perCover=r.length>1?g.position:{},this._tiltActual=g.tilt,this._tiltTarget=d&&n.target_tilt_sensor?Ks(m[n.target_tilt_sensor]??[]):[],this._target=n.target_position_sensor?Ks(m[n.target_position_sensor]??[],{preferAttribute:"linear_position",inverted:a}):[],this._whoWon=n.decision_trace_sensor?js(m[n.decision_trace_sensor]??[],s,i):[],this._controlStatus=n.control_status_sensor?js(m[n.control_status_sensor]??[],s,i):[];const b={};for(const e of Qe){const t=n[e.role];t&&(b[e.role]=js(m[t]??[],s,i))}this._stateBands=b,f&&(this._timeline=f),this._activity=u?function(e,t,o,i){const s=o.filter(e=>e.t>=i.startMs&&e.t<=i.endMs).map(e=>function(e,t=!1){const o=bn[e.event];if(!o)return null;const i="string"==typeof e.fields.service?e.fields.service:null,s="string"==typeof e.fields.entity_id?e.fields.entity_id:null;return{t:e.t,source:"command",title:i??e.event,name:null,entityId:s&&s.length>0?s:null,detail:xn(e.fields,t),service:i,triggeredBy:null,skipped:o.skipped}}(e,i.inverted)).filter(e=>null!==e),n=[...t].sort((e,t)=>e.t-t.t),r=new Set;for(const e of s)if(e.entityId)for(const t of n)if(!r.has(t)&&t.entityId===e.entityId&&!(t.t<e.t||t.t-e.t>5e3||t.contextUserId||t.contextName)){r.add(t);break}const a=function(e){const t=new Map;for(const o of Object.values(e.states??{})){if(!o.entity_id.startsWith("person."))continue;const e=o.attributes.user_id,i=o.attributes.friendly_name;"string"==typeof e&&"string"==typeof i&&i.length>0&&t.set(e,i)}const o=e.user;return o?.id&&o.name&&!t.has(o.id)&&t.set(o.id,o.name),t}(e),l=[...s,...t.filter(e=>!r.has(e)).map(t=>function(e,t,o){const i=e.entityId?o.states?.[e.entityId]?.attributes?.friendly_name:void 0;return{t:e.t,source:"logbook",title:e.state??e.message??"",name:i||e.name||null,entityId:e.entityId,detail:null,service:null,triggeredBy:fn(e,t),skipped:!1}}(t,a,e))];return l.sort((e,t)=>t.t-e.t),l}(t,v,f?.events??[],{startMs:s,endMs:i,inverted:a}):[],this._loading=!1,this._loaded=!0}_show(e){return!1!==this.tracks?.[e]}_setHours(e){e!==this.hours&&(this.hours=e,this.dispatchEvent(new CustomEvent("acp-history-hours",{detail:{hours:e},bubbles:!0,composed:!0})))}_refresh(){this._fetchKey=null,this._timeline=null,this._maybeFetch()}_toggleMaximize(e){this._maximized=this._maximized===e?null:e,"events"===this._maximized&&null===this._timeline&&_n(this.hass,this._entryId??"").then(e=>{this._timeline=e}),this.dispatchEvent(new CustomEvent("acp-history-expand",{detail:{expanded:null!==this._maximized,section:this._maximized},bubbles:!0,composed:!0}))}_maximizeButton(e){const t=this._maximized===e,o=it(t?"history.collapse":"history.expand",this.hass);return H`<button
       type="button"
       class="icon-btn"
       @click=${()=>this._toggleMaximize(e)}
-      ${bo(o)}
+      ${wo(o)}
       aria-label=${o}
       aria-pressed=${t?"true":"false"}
     >
       <ha-icon icon=${t?"mdi:arrow-collapse":"mdi:arrow-expand"}></ha-icon>
-    </button>`}_toggleAdvanced(){this._advanced=!this._advanced,this._advanced&&null===this._timeline&&an(this.hass,this._entryId??"").then(e=>{this._timeline=e})}async _copyDiagnostics(){const e=this._timeline?.raw;if(null!=e)try{await navigator.clipboard.writeText(JSON.stringify(e,null,2)),this._copied=!0,setTimeout(()=>{this._copied=!1},2e3)}catch{}}_showMore(e,t){const o=new URLSearchParams;t.length>0&&o.set("entity_id",t.join(",")),o.set("start_date",new Date(this._start).toISOString()),o.set("end_date",new Date(this._now).toISOString());const i=`/${e}?${o.toString()}`;history.pushState(null,"",i),window.dispatchEvent(new CustomEvent("location-changed",{detail:{replace:!1}})),this.dispatchEvent(new CustomEvent("acp-history-closed",{bubbles:!0,composed:!0}))}get _start(){return this._now-this.hours*vn}_pct(e){const t=this._now-this._start;return t>0?Math.max(0,Math.min(100,(e-this._start)/t*100)):0}_x(e){return function(e,t,o,i){const s=o-t;if(!(s>0))return 0;const n=(e-t)/s;return Math.max(0,Math.min(i,n*i))}(e,this._start,this._now,mn.VIEW_W)}_stepPoints(e,t){return Bs(e,this._now).map(e=>`${this._x(e.t).toFixed(1)},${t(e.value).toFixed(1)}`).join(" ")}render(){return this.hass&&this.discovered?null!==this._maximized?this._renderMaximized():W`
+    </button>`}_toggleAdvanced(){this._advanced=!this._advanced,this._advanced&&null===this._timeline&&_n(this.hass,this._entryId??"").then(e=>{this._timeline=e})}async _copyDiagnostics(){const e=this._timeline?.raw;if(null!=e)try{await navigator.clipboard.writeText(JSON.stringify(e,null,2)),this._copied=!0,setTimeout(()=>{this._copied=!1},2e3)}catch{}}_showMore(e,t){const o=new URLSearchParams;t.length>0&&o.set("entity_id",t.join(",")),o.set("start_date",new Date(this._start).toISOString()),o.set("end_date",new Date(this._now).toISOString());const i=`/${e}?${o.toString()}`;history.pushState(null,"",i),window.dispatchEvent(new CustomEvent("location-changed",{detail:{replace:!1}})),this.dispatchEvent(new CustomEvent("acp-history-closed",{bubbles:!0,composed:!0}))}get _start(){return this._now-this.hours*kn}_pct(e){const t=this._now-this._start;return t>0?Math.max(0,Math.min(100,(e-this._start)/t*100)):0}_x(e){return function(e,t,o,i){const s=o-t;if(!(s>0))return 0;const n=(e-t)/s;return Math.max(0,Math.min(i,n*i))}(e,this._start,this._now,$n.VIEW_W)}_stepPoints(e,t){return Gs(e,this._now).map(e=>`${this._x(e.t).toFixed(1)},${t(e.value).toFixed(1)}`).join(" ")}render(){return this.hass&&this.discovered?null!==this._maximized?this._renderMaximized():H`
       <div class="history">
         ${this._renderToolbar()} ${this._renderStats()} ${this._renderReadout()}
         <div
@@ -3223,52 +3224,52 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
           @pointermove=${this._onPointerMove}
           @pointerleave=${this._onPointerLeave}
         >
-          ${this._show("position")?this._renderPositionTrack():V}
-          ${this._show("position")?this._renderTiltTrack():V}
-          ${this._show("who_won")?this._renderWhoWonTrack():V}
-          ${this._show("who_won")?this._renderControlStatusTrack():V}
-          ${this._show("context")?this._renderStateTracks():V} ${this._renderAxis()}
+          ${this._show("position")?this._renderPositionTrack():q}
+          ${this._show("position")?this._renderTiltTrack():q}
+          ${this._show("who_won")?this._renderWhoWonTrack():q}
+          ${this._show("who_won")?this._renderControlStatusTrack():q}
+          ${this._show("context")?this._renderStateTracks():q} ${this._renderAxis()}
         </div>
-        ${this._loading&&!this._loaded?W`<p class="dim">${ot("history.loading",this.hass)}</p>`:V}
-        ${this._show("actions")?this._renderActivity():V} ${this._renderAdvanced()}
+        ${this._loading&&!this._loaded?H`<p class="dim">${it("history.loading",this.hass)}</p>`:q}
+        ${this._show("actions")?this._renderActivity():q} ${this._renderAdvanced()}
       </div>
-    `:V}_renderToolbar(){return this.showWindowPicker?W`
+    `:q}_renderToolbar(){return this.showWindowPicker?H`
       <div class="toolbar">
-        <div class="windows" role="group" aria-label=${ot("history.window_label",this.hass)}>
-          ${Qe.map(e=>W`
+        <div class="windows" role="group" aria-label=${it("history.window_label",this.hass)}>
+          ${Ze.map(e=>H`
               <button
                 type="button"
                 class="chip ${e===this.hours?"on":""}"
                 aria-pressed=${e===this.hours?"true":"false"}
                 @click=${()=>this._setHours(e)}
               >
-                ${ot("history.window_hours",this.hass,{hours:e})}
+                ${it("history.window_hours",this.hass,{hours:e})}
               </button>
             `)}
         </div>
         <div class="toolbar-right">
-          ${null===this._maximized?W`<button
+          ${null===this._maximized?H`<button
                   type="button"
                   class="link"
                   @click=${()=>this._showMore("history",this._allEntityIds())}
                 >
-                  ${ot("history.show_more",this.hass)}
-                </button>`:V}
+                  ${it("history.show_more",this.hass)}
+                </button>`:q}
           <button
             type="button"
             class="icon-btn"
             @click=${this._refresh}
-            ${bo(ot("history.refresh",this.hass))}
-            aria-label=${ot("history.refresh",this.hass)}
+            ${wo(it("history.refresh",this.hass))}
+            aria-label=${it("history.refresh",this.hass)}
           >
             <ha-icon icon="mdi:refresh" class=${this._loading?"spin":""}></ha-icon>
           </button>
-          ${null===this._maximized?this._maximizeButton("tracks"):V}
+          ${null===this._maximized?this._maximizeButton("tracks"):q}
         </div>
       </div>
-    `:V}_allEntityIds(){const e=this.discovered.entities,t=[...this.discovered.managed_covers??[]];e.target_position_sensor&&t.push(e.target_position_sensor),e.control_status_sensor&&t.push(e.control_status_sensor),e.decision_trace_sensor&&t.push(e.decision_trace_sensor);for(const o of Ye){const i=e[o.role];i&&t.push(i)}return t}_renderReadout(){const e=this._hoverT;if(null===e)return W`<div class="readout dim">${this._renderRangeLabel()}</div>`;const t=[$n(e)],o=Ns(this._target,e);null!==o&&t.push(`${ot("history.legend_target",this.hass)} ${Math.round(o)}%`);const i=Ns(Fs(this._actual),e);null!==i&&t.push(`${ot("history.legend_actual",this.hass)} ${Math.round(i)}%`);const s=xn(this._whoWon,e);s&&t.push(this._handlerLabel(s.state));const n=xn(this._controlStatus,e);n&&!qe.has(n.state)&&t.push(this._controlStatusLabel(n.state));for(const o of Ye){const i=xn(this._stateBands[o.role]??[],e);i&&wn(i.state)&&t.push(ot(o.key,this.hass))}return W`<div class="readout">${t.join(" · ")}</div>`}_renderRangeLabel(){const e=this._now-this._start>fn,t=t=>e?`${kn(t)} ${$n(t)}`:$n(t);return`${t(this._start)} → ${t(this._now)}`}_renderPositionTrack(){const{VIEW_W:e,POS_TOP_PAD:t}=mn,o=this._posH,i=o-t,s=e=>Tt(e,t,i),n=this._stepPoints(this._target,s),r=this._stepPoints(Fs(this._actual),s),a=Object.entries(this._perCover).map(([e,t])=>({id:e,points:this._stepPoints(Fs(t),s)})),l=!n&&!r;return W`
+    `:q}_allEntityIds(){const e=this.discovered.entities,t=[...this.discovered.managed_covers??[]];e.target_position_sensor&&t.push(e.target_position_sensor),e.control_status_sensor&&t.push(e.control_status_sensor),e.decision_trace_sensor&&t.push(e.decision_trace_sensor);for(const o of Qe){const i=e[o.role];i&&t.push(i)}return t}_renderReadout(){const e=this._hoverT;if(null===e)return H`<div class="readout dim">${this._renderRangeLabel()}</div>`;const t=[Mn(e)],o=Ws(this._target,e);null!==o&&t.push(`${it("history.legend_target",this.hass)} ${Math.round(o)}%`);const i=Ws(Ls(this._actual),e);null!==i&&t.push(`${it("history.legend_actual",this.hass)} ${Math.round(i)}%`);const s=zn(this._whoWon,e);s&&t.push(this._handlerLabel(s.state));const n=zn(this._controlStatus,e);n&&!Ye.has(n.state)&&t.push(this._controlStatusLabel(n.state));for(const o of Qe){const i=zn(this._stateBands[o.role]??[],e);i&&En(i.state)&&t.push(it(o.key,this.hass))}return H`<div class="readout">${t.join(" · ")}</div>`}_renderRangeLabel(){const e=this._now-this._start>An,t=t=>e?`${Tn(t)} ${Mn(t)}`:Mn(t);return`${t(this._start)} → ${t(this._now)}`}_renderPositionTrack(){const{VIEW_W:e,POS_TOP_PAD:t}=$n,o=this._posH,i=o-t,s=e=>Ot(e,t,i),n=this._stepPoints(this._target,s),r=this._stepPoints(Ls(this._actual),s),a=Object.entries(this._perCover).map(([e,t])=>({id:e,points:this._stepPoints(Ls(t),s)})),l=!n&&!r;return H`
       <div class="track">
-        <div class="track-label">${ot("history.track_position",this.hass)}</div>
+        <div class="track-label">${it("history.track_position",this.hass)}</div>
         <div class="track-plot">
           <svg
             viewBox="0 0 ${e} ${o}"
@@ -3278,19 +3279,19 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
           >
             ${this._sunShading(t,o)} ${this._gridLines(t,o)}
             <line class="baseline" x1="0" y1=${o-.5} x2=${e} y2=${o-.5}></line>
-            ${a.map(e=>e.points?H`<polyline class="cover-curve" points=${e.points} fill="none"></polyline>`:V)}
-            ${n?H`<polyline class="target-curve" points=${n} fill="none"></polyline>`:V}
-            ${r?H`<polyline class="actual-curve" points=${r} fill="none"></polyline>`:V}
+            ${a.map(e=>e.points?U`<polyline class="cover-curve" points=${e.points} fill="none"></polyline>`:q)}
+            ${n?U`<polyline class="target-curve" points=${n} fill="none"></polyline>`:q}
+            ${r?U`<polyline class="actual-curve" points=${r} fill="none"></polyline>`:q}
             ${this._hoverLine(t,o)}
           </svg>
-          ${l?this._renderEmptyNote(this.discovered.managed_covers?.[0]):V}
+          ${l?this._renderEmptyNote(this.discovered.managed_covers?.[0]):q}
           <span class="y-max">100%</span>
         </div>
       </div>
-      ${l?V:this._renderPositionLegend(a.length>0)}
-    `}_renderTiltTrack(){const{VIEW_W:e,POS_TOP_PAD:t}=mn,o=this._posH,i=Object.values(this._tiltActual);if(0===this._tiltTarget.length&&0===i.length)return V;const s=o-t,n=e=>Tt(e,t,s),r=this._stepPoints(this._tiltTarget,n),a=i.map(e=>this._stepPoints(Fs(e),n));return W`
+      ${l?q:this._renderPositionLegend(a.length>0)}
+    `}_renderTiltTrack(){const{VIEW_W:e,POS_TOP_PAD:t}=$n,o=this._posH,i=Object.values(this._tiltActual);if(0===this._tiltTarget.length&&0===i.length)return q;const s=o-t,n=e=>Ot(e,t,s),r=this._stepPoints(this._tiltTarget,n),a=i.map(e=>this._stepPoints(Ls(e),n));return H`
       <div class="track">
-        <div class="track-label">${ot("covers.tilt_title",this.hass)}</div>
+        <div class="track-label">${it("covers.tilt_title",this.hass)}</div>
         <div class="track-plot">
           <svg
             viewBox="0 0 ${e} ${o}"
@@ -3300,161 +3301,161 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
           >
             ${this._sunShading(t,o)} ${this._gridLines(t,o)}
             <line class="baseline" x1="0" y1=${o-.5} x2=${e} y2=${o-.5}></line>
-            ${a.map(e=>e?H`<polyline class="actual-curve" points=${e} fill="none"></polyline>`:V)}
-            ${r?H`<polyline class="target-curve" points=${r} fill="none"></polyline>`:V}
+            ${a.map(e=>e?U`<polyline class="actual-curve" points=${e} fill="none"></polyline>`:q)}
+            ${r?U`<polyline class="target-curve" points=${r} fill="none"></polyline>`:q}
             ${this._hoverLine(t,o)}
           </svg>
           <span class="y-max">100%</span>
         </div>
       </div>
-    `}_sunShading(e,t){const o=[],i=t-e;for(const t of this._nightSegments()){const s=this._x(t.start),n=this._x(t.end)-s;n<=0||o.push(H`<rect class="night" x=${s.toFixed(1)} y=${e} width=${n.toFixed(1)} height=${i}></rect>`)}for(const t of this._stateBands.sun_infront_binary??[]){if(!wn(t.state))continue;const s=this._x(t.start),n=this._x(t.end)-s;n<=0||o.push(H`<rect class="saa" x=${s.toFixed(1)} y=${e} width=${n.toFixed(1)} height=${i}></rect>`)}return o}_nightSegments(){const e=this.hass?.config?.latitude,t=this.hass?.config?.longitude;if("number"!=typeof e||"number"!=typeof t)return[];const o=[];let i=Qo(new Date(this._start)).getTime();for(let s=0;s<8&&i<this._now;s++){const s=Yo(e,t,new Date(i));if(0===s.length)continue;const n=ei(s);let r=s[0].t.getTime();for(const e of n){const t=s[e.startIdx].t.getTime();t>r&&o.push({start:r,end:t}),r=s[e.endIdx].t.getTime()}const a=s[s.length-1].t.getTime();r<a&&o.push({start:r,end:a});const l=Qo(new Date(i+fn+432e5)).getTime();i=l>i?l:i+fn}return o.map(e=>({start:Math.max(e.start,this._start),end:Math.min(e.end,this._now)})).filter(e=>e.end>e.start)}_renderEmptyNote(e){const t=!!e&&!!this.hass.states?.[e];return W`<span class="empty-note"
-      >${ot(t?"history.no_recorder_data":"history.no_data",this.hass)}</span
-    >`}_renderPositionLegend(e){return W`
+    `}_sunShading(e,t){const o=[],i=t-e;for(const t of this._nightSegments()){const s=this._x(t.start),n=this._x(t.end)-s;n<=0||o.push(U`<rect class="night" x=${s.toFixed(1)} y=${e} width=${n.toFixed(1)} height=${i}></rect>`)}for(const t of this._stateBands.sun_infront_binary??[]){if(!En(t.state))continue;const s=this._x(t.start),n=this._x(t.end)-s;n<=0||o.push(U`<rect class="saa" x=${s.toFixed(1)} y=${e} width=${n.toFixed(1)} height=${i}></rect>`)}return o}_nightSegments(){const e=this.hass?.config?.latitude,t=this.hass?.config?.longitude;if("number"!=typeof e||"number"!=typeof t)return[];const o=[];let i=Xo(new Date(this._start)).getTime();for(let s=0;s<8&&i<this._now;s++){const s=Zo(e,t,new Date(i));if(0===s.length)continue;const n=oi(s);let r=s[0].t.getTime();for(const e of n){const t=s[e.startIdx].t.getTime();t>r&&o.push({start:r,end:t}),r=s[e.endIdx].t.getTime()}const a=s[s.length-1].t.getTime();r<a&&o.push({start:r,end:a});const l=Xo(new Date(i+An+432e5)).getTime();i=l>i?l:i+An}return o.map(e=>({start:Math.max(e.start,this._start),end:Math.min(e.end,this._now)})).filter(e=>e.end>e.start)}_renderEmptyNote(e){const t=!!e&&!!this.hass.states?.[e];return H`<span class="empty-note"
+      >${it(t?"history.no_recorder_data":"history.no_data",this.hass)}</span
+    >`}_renderPositionLegend(e){return H`
       <div class="track">
         <div class="track-label"></div>
         <div class="legend">
           <span class="legend-item"
-            ><span class="line-swatch target"></span>${ot("history.legend_target",this.hass)}</span
+            ><span class="line-swatch target"></span>${it("history.legend_target",this.hass)}</span
           >
           <span class="legend-item"
-            ><span class="line-swatch actual"></span>${ot("history.legend_actual",this.hass)}</span
+            ><span class="line-swatch actual"></span>${it("history.legend_actual",this.hass)}</span
           >
-          ${e?W`<span class="legend-item"
-                ><span class="line-swatch cover"></span>${ot("history.legend_per_cover",this.hass)}</span
-              >`:V}
+          ${e?H`<span class="legend-item"
+                ><span class="line-swatch cover"></span>${it("history.legend_per_cover",this.hass)}</span
+              >`:q}
           <span class="legend-item"
-            ><span class="swatch saa-swatch"></span>${ot("history.legend_saa",this.hass)}</span
+            ><span class="swatch saa-swatch"></span>${it("history.legend_saa",this.hass)}</span
           >
           <span class="legend-item"
-            ><span class="swatch night-swatch"></span>${ot("history.legend_night",this.hass)}</span
+            ><span class="swatch night-swatch"></span>${it("history.legend_night",this.hass)}</span
           >
         </div>
       </div>
-    `}_renderStats(){if(!this._loaded)return V;const e=function(e){const{moves:t,travel:o}=function(e){let t=0,o=0,i=null;for(const s of e)Number.isFinite(s.position)&&(null!==i&&s.position!==i&&(t+=1,o+=Math.abs(s.position-i)),i=s.position);return{moves:t,travel:Math.round(o)}}(e.actual);return{moves:t,travel:o,handlers:tn(e.whoWon),activeMs:on(e.overrideBands,e.isActive)}}({actual:this._actual,whoWon:this._whoWon,overrideBands:this._stateBands.manual_override_binary??[],isActive:wn});return 0===e.moves&&0===e.handlers.length?V:W`
+    `}_renderStats(){if(!this._loaded)return q;const e=function(e){const{moves:t,travel:o}=function(e){let t=0,o=0,i=null;for(const s of e)Number.isFinite(s.position)&&(null!==i&&s.position!==i&&(t+=1,o+=Math.abs(s.position-i)),i=s.position);return{moves:t,travel:Math.round(o)}}(e.actual);return{moves:t,travel:o,handlers:cn(e.whoWon),activeMs:dn(e.overrideBands,e.isActive)}}({actual:this._actual,whoWon:this._whoWon,overrideBands:this._stateBands.manual_override_binary??[],isActive:En});return 0===e.moves&&0===e.handlers.length?q:H`
       <div class="stats">
         <span class="stat"
-          ><strong>${e.moves}</strong> ${ot("history.stat_moves",this.hass)}</span
+          ><strong>${e.moves}</strong> ${it("history.stat_moves",this.hass)}</span
         >
         <span class="stat"
-          ><strong>${e.travel}</strong> ${ot("history.stat_travel",this.hass)}</span
+          ><strong>${e.travel}</strong> ${it("history.stat_travel",this.hass)}</span
         >
-        ${e.activeMs>0?W`<span class="stat"
-              ><strong>${sn(e.activeMs)}</strong> ${ot("history.stat_override",this.hass)}</span
-            >`:V}
-        ${e.handlers.slice(0,3).map(e=>{const t=je[this._badgeKind(e.handler)];return W`<span class="stat handler-stat">
+        ${e.activeMs>0?H`<span class="stat"
+              ><strong>${hn(e.activeMs)}</strong> ${it("history.stat_override",this.hass)}</span
+            >`:q}
+        ${e.handlers.slice(0,3).map(e=>{const t=Ke[this._badgeKind(e.handler)];return H`<span class="stat handler-stat">
             <span class="swatch" style="background:${t.bg};border-color:${t.fg}"></span>
-            ${this._handlerLabel(e.handler)} ${sn(e.ms)}
+            ${this._handlerLabel(e.handler)} ${hn(e.ms)}
           </span>`})}
       </div>
-    `}_renderWhoWonTrack(){const e=this._whoWon.map(e=>{const t=this._pct(e.start),o=Math.max(.2,this._pct(e.end)-t),i=je[this._badgeKind(e.state)],s=this._handlerLabel(e.state);return W`<div
+    `}_renderWhoWonTrack(){const e=this._whoWon.map(e=>{const t=this._pct(e.start),o=Math.max(.2,this._pct(e.end)-t),i=Ke[this._badgeKind(e.state)],s=this._handlerLabel(e.state);return H`<div
         class="band"
         style=${`left:${t.toFixed(2)}%;width:${o.toFixed(2)}%;background:${i.bg};color:${i.fg};box-shadow:inset 0 0 0 1px ${i.fg}`}
-        ${bo(`${s} — ${$n(e.start)} → ${$n(e.end)}`)}
+        ${wo(`${s} — ${Mn(e.start)} → ${Mn(e.end)}`)}
       >
         ${o>=6?s:""}
-      </div>`});return W`
+      </div>`});return H`
       <div class="track">
-        <div class="track-label">${ot("history.track_who_won",this.hass)}</div>
+        <div class="track-label">${it("history.track_who_won",this.hass)}</div>
         <div class="track-plot">
           <div class="bar">
             ${e}${this._hoverMarker()}
-            ${0===e.length?W`<span class="empty-note">${ot("history.no_data",this.hass)}</span>`:V}
+            ${0===e.length?H`<span class="empty-note">${it("history.no_data",this.hass)}</span>`:q}
           </div>
         </div>
       </div>
       ${this._renderWhoWonLegend()}
-    `}_renderWhoWonLegend(){const e=new Map;for(const t of this._whoWon)e.set(this._badgeKind(t.state),t.state);return 0===e.size?V:W`
+    `}_renderWhoWonLegend(){const e=new Map;for(const t of this._whoWon)e.set(this._badgeKind(t.state),t.state);return 0===e.size?q:H`
       <div class="track">
         <div class="track-label"></div>
         <div class="legend">
-          ${[...e.entries()].map(([e,t])=>{const o=je[e];return W`<span class="legend-item">
+          ${[...e.entries()].map(([e,t])=>{const o=Ke[e];return H`<span class="legend-item">
               <span class="swatch" style="background:${o.bg};border-color:${o.fg}"></span>
-              <ha-icon icon=${Le[e]} style="color:${o.fg}"></ha-icon>
+              <ha-icon icon=${Ge[e]} style="color:${o.fg}"></ha-icon>
               ${this._handlerLabel(t)}
             </span>`})}
         </div>
       </div>
-    `}_renderControlStatusTrack(){if(0===this._controlStatus.length)return V;const e=ot("history.track_control_status",this.hass);return W`
+    `}_renderControlStatusTrack(){if(0===this._controlStatus.length)return q;const e=it("history.track_control_status",this.hass);return H`
       <div class="track">
-        <div class="track-label" ${bo(e)}>${e}</div>
+        <div class="track-label" ${wo(e)}>${e}</div>
         <div class="track-plot">
           <div class="bar">
-            ${this._controlStatus.map(e=>{const t=this._pct(e.start),o=Math.max(.2,this._pct(e.end)-t),i=this._controlStatusLabel(e.state),s=qe.has(e.state);return W`<div
+            ${this._controlStatus.map(e=>{const t=this._pct(e.start),o=Math.max(.2,this._pct(e.end)-t),i=this._controlStatusLabel(e.state),s=Ye.has(e.state);return H`<div
                 class=${"band status "+(s?"active":"idle")}
                 style=${`left:${t.toFixed(2)}%;width:${o.toFixed(2)}%`}
-                ${bo(`${i} — ${$n(e.start)} → ${$n(e.end)}`)}
+                ${wo(`${i} — ${Mn(e.start)} → ${Mn(e.end)}`)}
               >
                 ${o>=6?i:""}
               </div>`})}${this._hoverMarker()}
           </div>
         </div>
       </div>
-    `}_renderStateTracks(){return Ye.filter(e=>this.discovered.entities[e.role]).map(e=>{const t=this._stateBands[e.role]??[],o=ot(e.key,this.hass);return W`
+    `}_renderStateTracks(){return Qe.filter(e=>this.discovered.entities[e.role]).map(e=>{const t=this._stateBands[e.role]??[],o=it(e.key,this.hass);return H`
         <div class="track">
-          <div class="track-label" ${bo(o)}>${o}</div>
+          <div class="track-label" ${wo(o)}>${o}</div>
           <div class="track-plot">
             <div class="bar">
-              ${t.map(t=>{const i=this._pct(t.start),s=Math.max(.2,this._pct(t.end)-i),n=wn(t.state),r=this._stateLabel(t.state);return W`<div
+              ${t.map(t=>{const i=this._pct(t.start),s=Math.max(.2,this._pct(t.end)-i),n=En(t.state),r=this._stateLabel(t.state);return H`<div
                   class=${`band state ${n?"on":"off"} ${e.cls}`}
                   style=${`left:${i.toFixed(2)}%;width:${s.toFixed(2)}%`}
-                  ${bo(`${o}: ${r} — ${$n(t.start)} → ${$n(t.end)}`)}
+                  ${wo(`${o}: ${r} — ${Mn(t.start)} → ${Mn(t.end)}`)}
                 >
                   ${s>=6?r:""}
                 </div>`})}${this._hoverMarker()}
-              ${0===t.length?W`<span class="empty-note">${ot("history.no_data",this.hass)}</span>`:V}
+              ${0===t.length?H`<span class="empty-note">${it("history.no_data",this.hass)}</span>`:q}
             </div>
           </div>
         </div>
-      `})}_renderAxis(){const e=this._axisTicks();return W`
+      `})}_renderAxis(){const e=this._axisTicks();return H`
       <div class="track axis">
         <div class="track-label"></div>
         <div class="track-plot">
           <div class="axis-row">
-            ${e.map((e,t)=>{return W`<span
+            ${e.map((e,t)=>{return H`<span
                   class=${"axis-tick"+(0===t?" first":"")}
                   style="left:${this._pct(e).toFixed(2)}%"
-                  >${0===t||(o=e,0===new Date(o).getHours())?kn(e):$n(e)}</span
+                  >${0===t||(o=e,0===new Date(o).getHours())?Tn(e):Mn(e)}</span
                 >`;var o})}
           </div>
         </div>
       </div>
-    `}_axisTicks(){const e=(this._now-this._start)/4,t=[];for(let o=0;o<=4;o++)t.push(Math.round((this._start+o*e)/vn)*vn);return t}_gridLines(e,t){return this._axisTicks().map(o=>{const i=this._x(o).toFixed(1);return H`<line class="grid" x1=${i} y1=${e} x2=${i} y2=${t}></line>`})}_hoverLine(e,t){if(null===this._hoverT)return V;const o=this._x(this._hoverT).toFixed(1);return H`<line class="hover-line" x1=${o} y1=${e} x2=${o} y2=${t}></line>`}_hoverMarker(){return null===this._hoverT?V:W`<div
+    `}_axisTicks(){const e=(this._now-this._start)/4,t=[];for(let o=0;o<=4;o++)t.push(Math.round((this._start+o*e)/kn)*kn);return t}_gridLines(e,t){return this._axisTicks().map(o=>{const i=this._x(o).toFixed(1);return U`<line class="grid" x1=${i} y1=${e} x2=${i} y2=${t}></line>`})}_hoverLine(e,t){if(null===this._hoverT)return q;const o=this._x(this._hoverT).toFixed(1);return U`<line class="hover-line" x1=${o} y1=${e} x2=${o} y2=${t}></line>`}_hoverMarker(){return null===this._hoverT?q:H`<div
       class="hover-marker"
       style="left:${this._pct(this._hoverT).toFixed(2)}%"
-    ></div>`}_renderActivity(){const e=function(e){const t=new Map;for(const o of e){const e=new Date(o.t);e.setHours(0,0,0,0);const i=e.getTime(),s=t.get(i);s?s.push(o):t.set(i,[o])}return[...t.entries()].sort((e,t)=>t[0]-e[0]).map(([e,t])=>({dayMs:e,entries:[...t].sort((e,t)=>t.t-e.t)}))}(this._activity);return W`
+    ></div>`}_renderActivity(){const e=function(e){const t=new Map;for(const o of e){const e=new Date(o.t);e.setHours(0,0,0,0);const i=e.getTime(),s=t.get(i);s?s.push(o):t.set(i,[o])}return[...t.entries()].sort((e,t)=>t[0]-e[0]).map(([e,t])=>({dayMs:e,entries:[...t].sort((e,t)=>t.t-e.t)}))}(this._activity);return H`
       <div class="section">
-        ${"activity"===this._maximized?V:W`<div class="section-head">
-              <h4>${ot("history.activity_title",this.hass)}</h4>
+        ${"activity"===this._maximized?q:H`<div class="section-head">
+              <h4>${it("history.activity_title",this.hass)}</h4>
               <span class="head-actions">
                 <button
                   type="button"
                   class="link"
                   @click=${()=>this._showMore("logbook",this._allEntityIds())}
                 >
-                  ${ot("history.show_more",this.hass)}
+                  ${it("history.show_more",this.hass)}
                 </button>
                 ${this._maximizeButton("activity")}
               </span>
             </div>`}
-        ${0===this._activity.length?W`<p class="dim">${ot("history.activity_empty",this.hass)}</p>`:W`<div class="activity">
-              ${e.map(e=>W`
-                  <div class="day-head">${function(e,t,o){const i=new Date(t);i.setHours(0,0,0,0);const s=Math.round((i.getTime()-e)/fn),n=new Date(e).toLocaleDateString([],{year:"numeric",month:"long",day:"numeric"});return 0===s?`${ot("history.today",o)} · ${n}`:1===s?`${ot("history.yesterday",o)} · ${n}`:n}(e.dayMs,this._now,this.hass)}</div>
+        ${0===this._activity.length?H`<p class="dim">${it("history.activity_empty",this.hass)}</p>`:H`<div class="activity">
+              ${e.map(e=>H`
+                  <div class="day-head">${function(e,t,o){const i=new Date(t);i.setHours(0,0,0,0);const s=Math.round((i.getTime()-e)/An),n=new Date(e).toLocaleDateString([],{year:"numeric",month:"long",day:"numeric"});return 0===s?`${it("history.today",o)} · ${n}`:1===s?`${it("history.yesterday",o)} · ${n}`:n}(e.dayMs,this._now,this.hass)}</div>
                   <ul class="log">
                     ${e.entries.map(e=>this._renderActivityRow(e))}
                   </ul>
                 `)}
             </div>`}
       </div>
-    `}_renderActivityRow(e){const t=e.triggeredBy;return W`<li class=${`evt-row ${e.source}${e.skipped?" skipped":""}`}>
+    `}_renderActivityRow(e){const t=e.triggeredBy;return H`<li class=${`evt-row ${e.source}${e.skipped?" skipped":""}`}>
       <span class="dot"></span>
       <span class="evt-main">
         <span class="evt-title">${e.title}</span>
-        ${e.detail?W`<span class="evt-detail">${e.detail}</span>`:V}
-        ${e.name&&"logbook"===e.source?W`<span class="evt-entity">${e.name}</span>`:V}
+        ${e.detail?H`<span class="evt-detail">${e.detail}</span>`:q}
+        ${e.name&&"logbook"===e.source?H`<span class="evt-entity">${e.name}</span>`:q}
       </span>
-      ${t?W`<span class="who" ${bo(t)}>${function(e){const t=e.trim().split(/\s+/).filter(Boolean);return 0===t.length?"?":1===t.length?t[0].slice(0,2).toUpperCase():(t[0][0]+t[t.length-1][0]).toUpperCase()}(t)}</span>`:V}
-      <span class="evt-time">${$n(e.t)}</span>
-    </li>`}_renderMaximized(){const e=this._maximized,t={tracks:ot("history.section_tracks",this.hass),activity:ot("history.activity_title",this.hass),events:ot("history.advanced",this.hass)},o="tracks"===e?"history":"activity"===e?"logbook":null;return W`
+      ${t?H`<span class="who" ${wo(t)}>${function(e){const t=e.trim().split(/\s+/).filter(Boolean);return 0===t.length?"?":1===t.length?t[0].slice(0,2).toUpperCase():(t[0][0]+t[t.length-1][0]).toUpperCase()}(t)}</span>`:q}
+      <span class="evt-time">${Mn(e.t)}</span>
+    </li>`}_renderMaximized(){const e=this._maximized,t={tracks:it("history.section_tracks",this.hass),activity:it("history.activity_title",this.hass),events:it("history.advanced",this.hass)},o="tracks"===e?"history":"activity"===e?"logbook":null;return H`
       <div class=${`history full full-${e}`}>
         <div class="full-head">
           <button type="button" class="disclosure" @click=${()=>this._toggleMaximize(e)}>
@@ -3462,35 +3463,35 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
             ${t[e]}
           </button>
           <span class="head-actions">
-            ${o?W`<button
+            ${o?H`<button
                   type="button"
                   class="link"
                   @click=${()=>this._showMore(o,this._allEntityIds())}
                 >
-                  ${ot("history.show_more",this.hass)}
-                </button>`:V}
+                  ${it("history.show_more",this.hass)}
+                </button>`:q}
             ${this._maximizeButton(e)}
           </span>
         </div>
-        ${"events"===e?V:this._renderToolbar()}
-        ${"tracks"===e?W`
+        ${"events"===e?q:this._renderToolbar()}
+        ${"tracks"===e?H`
               ${this._renderStats()} ${this._renderReadout()}
               <div
                 class="tracks"
                 @pointermove=${this._onPointerMove}
                 @pointerleave=${this._onPointerLeave}
               >
-                ${this._show("position")?this._renderPositionTrack():V}
-                ${this._show("position")?this._renderTiltTrack():V}
-                ${this._show("who_won")?this._renderWhoWonTrack():V}
-                ${this._show("who_won")?this._renderControlStatusTrack():V}
-                ${this._show("context")?this._renderStateTracks():V} ${this._renderAxis()}
+                ${this._show("position")?this._renderPositionTrack():q}
+                ${this._show("position")?this._renderTiltTrack():q}
+                ${this._show("who_won")?this._renderWhoWonTrack():q}
+                ${this._show("who_won")?this._renderControlStatusTrack():q}
+                ${this._show("context")?this._renderStateTracks():q} ${this._renderAxis()}
               </div>
-            `:V}
-        ${"activity"===e?this._renderActivity():V}
-        ${"events"===e?this._renderEventBuffer():V}
+            `:q}
+        ${"activity"===e?this._renderActivity():q}
+        ${"events"===e?this._renderEventBuffer():q}
       </div>
-    `}_renderAdvanced(){return this.hideAdvanced?V:nn(this.hass)?W`
+    `}_renderAdvanced(){return this.hideAdvanced?q:pn(this.hass)?H`
       <div class="section advanced">
         <div class="section-head">
           <button
@@ -3500,45 +3501,45 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
             @click=${this._toggleAdvanced}
           >
             <ha-icon icon=${this._advanced?"mdi:chevron-down":"mdi:chevron-right"}></ha-icon>
-            ${ot("history.advanced",this.hass)}
+            ${it("history.advanced",this.hass)}
           </button>
           ${this._maximizeButton("events")}
         </div>
-        <div class="advanced-body">${this._advanced?this._renderEventBuffer():V}</div>
+        <div class="advanced-body">${this._advanced?this._renderEventBuffer():q}</div>
       </div>
-    `:V}_renderEventBuffer(){const e=this._timeline;if(null===e)return W`<p class="dim">${ot("history.loading",this.hass)}</p>`;if(!e.available)return W`<p class="dim">${ot("history.events_unavailable",this.hass)}</p>`;const t=this._eventFilter.trim().toLowerCase(),o=t?e.events.filter(e=>function(e){return`${e.event} ${An(e.fields)}`.toLowerCase()}(e).includes(t)):e.events;return W`
+    `:q}_renderEventBuffer(){const e=this._timeline;if(null===e)return H`<p class="dim">${it("history.loading",this.hass)}</p>`;if(!e.available)return H`<p class="dim">${it("history.events_unavailable",this.hass)}</p>`;const t=this._eventFilter.trim().toLowerCase(),o=t?e.events.filter(e=>function(e){return`${e.event} ${In(e.fields)}`.toLowerCase()}(e).includes(t)):e.events;return H`
       <div class="events">
         <div class="events-meta">
           <span
-            >${ot("history.events_count",this.hass,{shown:o.length,total:e.events.length})}</span
+            >${it("history.events_count",this.hass,{shown:o.length,total:e.events.length})}</span
           >
-          ${null!==e.bufferSize?W`<span
-                >${ot("history.buffer_size",this.hass,{size:e.bufferSize})}</span
-              >`:V}
-          ${e.window?.start?W`<span
-                >${ot("history.data_window",this.hass,{from:lt(e.window.start),to:lt(e.window.end??e.window.start)})}</span
-              >`:V}
-          ${null!==e.raw&&void 0!==e.raw?W`<button type="button" class="link" @click=${()=>{this._copyDiagnostics()}}>
-                ${this._copied?ot("history.copied",this.hass):ot("history.copy_diagnostics",this.hass)}
-              </button>`:V}
+          ${null!==e.bufferSize?H`<span
+                >${it("history.buffer_size",this.hass,{size:e.bufferSize})}</span
+              >`:q}
+          ${e.window?.start?H`<span
+                >${it("history.data_window",this.hass,{from:ct(e.window.start),to:ct(e.window.end??e.window.start)})}</span
+              >`:q}
+          ${null!==e.raw&&void 0!==e.raw?H`<button type="button" class="link" @click=${()=>{this._copyDiagnostics()}}>
+                ${this._copied?it("history.copied",this.hass):it("history.copy_diagnostics",this.hass)}
+              </button>`:q}
         </div>
         <input
           class="events-search"
           type="search"
           .value=${this._eventFilter}
-          placeholder=${ot("history.events_search",this.hass)}
-          aria-label=${ot("history.events_search",this.hass)}
+          placeholder=${it("history.events_search",this.hass)}
+          aria-label=${it("history.events_search",this.hass)}
           @input=${e=>{this._eventFilter=e.target.value}}
         />
-        ${0===o.length?W`<p class="dim">${ot("history.events_empty",this.hass)}</p>`:W`<ul class="event-list">
-              ${[...o].reverse().map(e=>W`<li class="evt sev-${Ze[e.event]??"info"}">
-                    <span class="evt-time">${lt(e.ts)}</span>
+        ${0===o.length?H`<p class="dim">${it("history.events_empty",this.hass)}</p>`:H`<ul class="event-list">
+              ${[...o].reverse().map(e=>H`<li class="evt sev-${Xe[e.event]??"info"}">
+                    <span class="evt-time">${ct(e.ts)}</span>
                     <span class="evt-name">${e.event}</span>
-                    <span class="evt-fields">${An(e.fields)}</span>
+                    <span class="evt-fields">${In(e.fields)}</span>
                   </li>`)}
             </ul>`}
       </div>
-    `}_badgeKind(e){return Re[e]??"auto"}_handlerLabel(e){const t=Pe[e];if(t)return ot(t,this.hass);const o=Ke[e];return o?ot(o,this.hass):yn(e)}_controlStatusLabel(e){const t=Ve[e];return t?ot(t,this.hass):yn(e)}_stateLabel(e){return"on"===e?ot("dialog.on",this.hass):"off"===e?ot("dialog.off",this.hass):e}};function yn(e){if(!e)return e;const t=e.replace(/_/g," ");return t.charAt(0).toUpperCase()+t.slice(1)}function wn(e){return"off"!==e&&"unavailable"!==e&&"unknown"!==e}function xn(e,t){for(const o of e)if(t>=o.start&&t<o.end)return o;return null}function $n(e){const t=new Date(e);return Number.isNaN(t.getTime())?"—":t.toLocaleTimeString([],{hour:"2-digit",minute:"2-digit"})}function kn(e){return new Date(e).toLocaleDateString([],{month:"short",day:"numeric"})}function An(e){const t=[];for(const[o,i]of Object.entries(e))null!=i&&""!==i&&t.push(`${o}=${"object"==typeof i?JSON.stringify(i):String(i)}`);return t.join("  ")}bn.VIEW_W=600,bn.POS_H=96,bn.POS_H_MAX=220,bn.POS_TOP_PAD=8,bn.styles=r`
+    `}_badgeKind(e){return je[e]??"auto"}_handlerLabel(e){const t=Oe[e];if(t)return it(t,this.hass);const o=Le[e];return o?it(o,this.hass):Cn(e)}_controlStatusLabel(e){const t=qe[e];return t?it(t,this.hass):Cn(e)}_stateLabel(e){return"on"===e?it("dialog.on",this.hass):"off"===e?it("dialog.off",this.hass):e}};function Cn(e){if(!e)return e;const t=e.replace(/_/g," ");return t.charAt(0).toUpperCase()+t.slice(1)}function En(e){return"off"!==e&&"unavailable"!==e&&"unknown"!==e}function zn(e,t){for(const o of e)if(t>=o.start&&t<o.end)return o;return null}function Mn(e){const t=new Date(e);return Number.isNaN(t.getTime())?"—":t.toLocaleTimeString([],{hour:"2-digit",minute:"2-digit"})}function Tn(e){return new Date(e).toLocaleDateString([],{month:"short",day:"numeric"})}function In(e){const t=[];for(const[o,i]of Object.entries(e))null!=i&&""!==i&&t.push(`${o}=${"object"==typeof i?JSON.stringify(i):String(i)}`);return t.join("  ")}Sn.VIEW_W=600,Sn.POS_H=96,Sn.POS_H_MAX=220,Sn.POS_TOP_PAD=8,Sn.styles=a`
     :host {
       display: block;
     }
@@ -4115,12 +4116,12 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
     [data-tooltip][acp-tt-shown] {
       cursor: default;
     }
-  `,e([_e({attribute:!1})],bn.prototype,"hass",void 0),e([_e({attribute:!1})],bn.prototype,"discovered",void 0),e([_e({type:Number})],bn.prototype,"hours",void 0),e([_e({attribute:!1})],bn.prototype,"tracks",void 0),e([_e({type:Boolean})],bn.prototype,"advancedOpen",void 0),e([_e({type:Boolean})],bn.prototype,"hideAdvanced",void 0),e([_e({type:Boolean})],bn.prototype,"showWindowPicker",void 0),e([_e({type:Boolean})],bn.prototype,"active",void 0),e([ge()],bn.prototype,"_target",void 0),e([ge()],bn.prototype,"_actual",void 0),e([ge()],bn.prototype,"_perCover",void 0),e([ge()],bn.prototype,"_tiltTarget",void 0),e([ge()],bn.prototype,"_tiltActual",void 0),e([ge()],bn.prototype,"_copied",void 0),e([ge()],bn.prototype,"_whoWon",void 0),e([ge()],bn.prototype,"_controlStatus",void 0),e([ge()],bn.prototype,"_stateBands",void 0),e([ge()],bn.prototype,"_activity",void 0),e([ge()],bn.prototype,"_loading",void 0),e([ge()],bn.prototype,"_loaded",void 0),e([ge()],bn.prototype,"_timeline",void 0),e([ge()],bn.prototype,"_eventFilter",void 0),e([ge()],bn.prototype,"_advanced",void 0),e([ge()],bn.prototype,"_maximized",void 0),e([ge()],bn.prototype,"_hoverT",void 0),e([ge()],bn.prototype,"_now",void 0),bn=mn=e([he("acp-history-view")],bn);let Sn=class extends ce{constructor(){super(...arguments),this.open=!1,this.hours=24,this._expanded=null,this._onKeyDown=e=>{this.open&&"Escape"===e.key&&this._close()},this._close=()=>{this.open=!1,this._expanded=null,this.dispatchEvent(new CustomEvent("acp-history-closed",{bubbles:!0,composed:!0}))},this._onBackdrop=e=>{e.target===e.currentTarget&&this._close()}}connectedCallback(){super.connectedCallback(),window.addEventListener("keydown",this._onKeyDown)}disconnectedCallback(){super.disconnectedCallback(),window.removeEventListener("keydown",this._onKeyDown)}render(){if(!this.hass||!this.discovered)return V;const e=this.discovered.entry_title||ot("history.title",this.hass);return W`
+  `,e([ge({attribute:!1})],Sn.prototype,"hass",void 0),e([ge({attribute:!1})],Sn.prototype,"discovered",void 0),e([ge({type:Number})],Sn.prototype,"hours",void 0),e([ge({attribute:!1})],Sn.prototype,"tracks",void 0),e([ge({type:Boolean})],Sn.prototype,"advancedOpen",void 0),e([ge({type:Boolean})],Sn.prototype,"hideAdvanced",void 0),e([ge({type:Boolean})],Sn.prototype,"showWindowPicker",void 0),e([ge({type:Boolean})],Sn.prototype,"active",void 0),e([me()],Sn.prototype,"_target",void 0),e([me()],Sn.prototype,"_actual",void 0),e([me()],Sn.prototype,"_perCover",void 0),e([me()],Sn.prototype,"_tiltTarget",void 0),e([me()],Sn.prototype,"_tiltActual",void 0),e([me()],Sn.prototype,"_copied",void 0),e([me()],Sn.prototype,"_whoWon",void 0),e([me()],Sn.prototype,"_controlStatus",void 0),e([me()],Sn.prototype,"_stateBands",void 0),e([me()],Sn.prototype,"_activity",void 0),e([me()],Sn.prototype,"_loading",void 0),e([me()],Sn.prototype,"_loaded",void 0),e([me()],Sn.prototype,"_timeline",void 0),e([me()],Sn.prototype,"_eventFilter",void 0),e([me()],Sn.prototype,"_advanced",void 0),e([me()],Sn.prototype,"_maximized",void 0),e([me()],Sn.prototype,"_hoverT",void 0),e([me()],Sn.prototype,"_now",void 0),Sn=$n=e([pe("acp-history-view")],Sn);let Pn=class extends de{constructor(){super(...arguments),this.open=!1,this.hours=24,this._expanded=null,this._onKeyDown=e=>{this.open&&"Escape"===e.key&&this._close()},this._close=()=>{this.open=!1,this._expanded=null,this.dispatchEvent(new CustomEvent("acp-history-closed",{bubbles:!0,composed:!0}))},this._onBackdrop=e=>{e.target===e.currentTarget&&this._close()}}connectedCallback(){super.connectedCallback(),window.addEventListener("keydown",this._onKeyDown)}disconnectedCallback(){super.disconnectedCallback(),window.removeEventListener("keydown",this._onKeyDown)}render(){if(!this.hass||!this.discovered)return q;const e=this.discovered.entry_title||it("history.title",this.hass);return H`
       <div
         class="backdrop"
         role="dialog"
         aria-modal="true"
-        aria-label=${ot("history.title",this.hass)}
+        aria-label=${it("history.title",this.hass)}
         @click=${this._onBackdrop}
       >
         <div
@@ -4129,13 +4130,13 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
           <header>
             <div class="titles">
               <span class="title">${e}</span>
-              <span class="subtitle">${ot("history.title",this.hass)}</span>
+              <span class="subtitle">${it("history.title",this.hass)}</span>
             </div>
             <button
               type="button"
               class="close"
               @click=${this._close}
-              aria-label=${ot("history.close",this.hass)}
+              aria-label=${it("history.close",this.hass)}
             >
               <ha-icon icon="mdi:close"></ha-icon>
             </button>
@@ -4153,7 +4154,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
           </div>
         </div>
       </div>
-    `}};Sn.styles=r`
+    `}};Pn.styles=a`
     :host {
       display: none;
     }
@@ -4241,7 +4242,14 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
       padding: 12px 14px 14px;
       overflow-y: auto;
     }
-  `,e([_e({attribute:!1})],Sn.prototype,"hass",void 0),e([_e({attribute:!1})],Sn.prototype,"discovered",void 0),e([_e({type:Boolean,reflect:!0})],Sn.prototype,"open",void 0),e([_e({type:Number})],Sn.prototype,"hours",void 0),e([_e({attribute:!1})],Sn.prototype,"tracks",void 0),e([ge()],Sn.prototype,"_expanded",void 0),Sn=e([he("acp-history-dialog")],Sn);let Cn=class extends ce{constructor(){super(...arguments),this.open=!1,this.advancedOpen=!1,this.showCompass=!0,this.showElevationChart=!0,this.showSolarCalc=!0,this.stateColor=!0,this._cancelMinuteTimer=null,this._positionHistory=[],this._historyKey=null,this._historyOpen=!1,this._listSource=null,this._list=[],this._openHistory=e=>{e.stopPropagation(),this._historyOpen=!0},this._onResume=()=>{const e=this.discovered.entities.reset_override_button;e&&this.hass.callService("button","press",{entity_id:e})},this._toggleAdvanced=()=>{this.advancedOpen=!this.advancedOpen},this._openDevicePage=()=>{const e=this.discovered.device_id;e&&this._navigate(`/config/devices/device/${e}`)},this._openIntegrationPage=()=>{this._navigate(`/config/integrations/integration/${Me}`)},this._onBackdrop=e=>{e.target===e.currentTarget&&this._emitClose()},this._emitClose=()=>{this.dispatchEvent(new CustomEvent("acp-dialog-close",{bubbles:!0,composed:!0}))},this._stop=e=>{e.stopPropagation()}}updated(){this._syncMinuteTimer(this.open),this._maybeFetchHistory()}_maybeFetchHistory(){if(!this.open||!this.hass||!this.discovered)return;const e=this.discovered.managed_covers??[];if(0===e.length)return this._historyKey=null,void(this._positionHistory.length>0&&(this._positionHistory=[]));const t=Date.now(),o=Qo(new Date(t)).getTime(),i=$t(this.discovered),s=`${e.join(",")}|${o}|${i}`;s!==this._historyKey&&(this._historyKey=s,async function(e,t,o,i,s=!1){if(0===t.length)return[];let n;try{n=await e.callWS({type:"history/history_during_period",start_time:new Date(o).toISOString(),end_time:new Date(i).toISOString(),entity_ids:t,minimal_response:!1,no_attributes:!1,significant_changes_only:!1})}catch{return[]}if(!n||"object"!=typeof n)return[];const r={};for(const e of t){const t=n[e];if(!Array.isArray(t))continue;const o=xs(t);o.length>0&&(r[e]=o)}const a=$s(r);if(a.length>0){const e=a[a.length-1];Date.parse(e.t)<i&&a.push({t:new Date(i).toISOString(),position:e.position})}return s?a.map(e=>({t:e.t,position:100-e.position})):a}(this.hass,e,o,t,i).then(e=>{this._historyKey===s&&(this._positionHistory=e)}))}disconnectedCallback(){super.disconnectedCallback(),this._syncMinuteTimer(!1)}_syncMinuteTimer(e){e&&null===this._cancelMinuteTimer?this._cancelMinuteTimer=ui(()=>this.requestUpdate()):e||null===this._cancelMinuteTimer||(this._cancelMinuteTimer(),this._cancelMinuteTimer=null)}get _discoveredList(){return this.discovered!==this._listSource&&(this._listSource=this.discovered,this._list=this.discovered?[this.discovered]:[]),this._list}_buildHandlerLabels(){const e={};for(const[t,o]of Object.entries(Pe))e[t]=ot(o,this.hass);return e}_headerIcon(){const e=this.discovered.managed_covers?.[0],t=e?this.hass.states[e]:void 0;return ht({explicitIcon:t?.attributes?.icon,deviceClass:t?.attributes?.device_class,coverType:this.discovered.cover_type,position:Ht(this.hass,this.discovered,e)})}_headerColor(){if(!this.stateColor)return null;const e=this.discovered.managed_covers?.[0],t=e?this.hass.states[e]:void 0;return _t(t?.state)}render(){if(!this.open||!this.hass||!this.discovered)return V;const e=this._winner(),t=this._traceAttrs(),o=this._matchedHandlers(t,e),i=bi(t),s=t?wi(t.trace??[],t,0,this._buildHandlerLabels(),ot("badge.safety",this.hass)):"",n=this._target(),r=this._shouldShowResume(),a=this._switchOn("integration_enabled_switch"),l=this._switchOn("automatic_control_switch"),c=ot("dialog.configure_integration",this.hass),d=ot("dialog.open_device_page",this.hass),h=ot("dialog.close",this.hass),p=ot("history.open",this.hass),u=this._headerColor();return W`
+  `,e([ge({attribute:!1})],Pn.prototype,"hass",void 0),e([ge({attribute:!1})],Pn.prototype,"discovered",void 0),e([ge({type:Boolean,reflect:!0})],Pn.prototype,"open",void 0),e([ge({type:Number})],Pn.prototype,"hours",void 0),e([ge({attribute:!1})],Pn.prototype,"tracks",void 0),e([me()],Pn.prototype,"_expanded",void 0),Pn=e([pe("acp-history-dialog")],Pn);let On=class extends de{constructor(){super(...arguments),this.open=!1,this.advancedOpen=!1,this.showCompass=!0,this.showElevationChart=!0,this.showSolarCalc=!0,this.stateColor=!0,this._cancelMinuteTimer=null,this._positionHistory=[],this._historyKey=null,this._historyOpen=!1,this._listSource=null,this._list=[],this._openHistory=e=>{e.stopPropagation(),this._historyOpen=!0},this._onResume=()=>{const e=this.discovered.entities.reset_override_button;e&&this.hass.callService("button","press",{entity_id:e})},this._toggleAdvanced=()=>{this.advancedOpen=!this.advancedOpen},this._openDevicePage=()=>{const e=this.discovered.device_id;e&&this._navigate(`/config/devices/device/${e}`)},this._openIntegrationPage=()=>{this._navigate(`/config/integrations/integration/${Te}`)},this._onBackdrop=e=>{e.target===e.currentTarget&&this._emitClose()},this._emitClose=()=>{this.dispatchEvent(new CustomEvent("acp-dialog-close",{bubbles:!0,composed:!0}))},this._stop=e=>{e.stopPropagation()}}updated(){this._syncMinuteTimer(this.open),this._maybeFetchHistory()}_maybeFetchHistory(){if(!this.open||!this.hass||!this.discovered)return;const e=this.discovered.managed_covers??[];if(0===e.length)return this._historyKey=null,void(this._positionHistory.length>0&&(this._positionHistory=[]));const t=Date.now(),o=Xo(new Date(t)).getTime(),i=At(this.discovered),s=`${e.join(",")}|${o}|${i}`;s!==this._historyKey&&(this._historyKey=s,async function(e,t,o,i,s=!1){if(0===t.length)return[];let n;try{n=await e.callWS({type:"history/history_during_period",start_time:new Date(o).toISOString(),end_time:new Date(i).toISOString(),entity_ids:t,minimal_response:!1,no_attributes:!1,significant_changes_only:!1})}catch{return[]}if(!n||"object"!=typeof n)return[];const r={};for(const e of t){const t=n[e];if(!Array.isArray(t))continue;const o=zs(t);o.length>0&&(r[e]=o)}const a=Ms(r);if(a.length>0){const e=a[a.length-1];Date.parse(e.t)<i&&a.push({t:new Date(i).toISOString(),position:e.position})}return s?a.map(e=>({t:e.t,position:100-e.position})):a}(this.hass,e,o,t,i).then(e=>{this._historyKey===s&&(this._positionHistory=e)}))}disconnectedCallback(){super.disconnectedCallback(),this._syncMinuteTimer(!1)}_syncMinuteTimer(e){e&&null===this._cancelMinuteTimer?this._cancelMinuteTimer=gi(()=>this.requestUpdate()):e||null===this._cancelMinuteTimer||(this._cancelMinuteTimer(),this._cancelMinuteTimer=null)}get _discoveredList(){return this.discovered!==this._listSource&&(this._listSource=this.discovered,this._list=this.discovered?[this.discovered]:[]),this._list}_buildHandlerLabels(){const e={};for(const[t,o]of Object.entries(Oe))e[t]=it(o,this.hass);return e}_headerIcon(){const e=this.discovered.managed_covers?.[0],t=e?this.hass.states[e]:void 0;return pt({explicitIcon:t?.attributes?.icon,deviceClass:t?.attributes?.device_class,coverType:this.discovered.cover_type,position:Vt(this.hass,this.discovered,e)})}_headerColor(){if(!this.stateColor)return null;const e=this.discovered.managed_covers?.[0],t=e?this.hass.states[e]:void 0;return mt(t?.state)}_batteryTpl(){const e=this.coverOrder??this.discovered?.managed_covers??[],t=Li(this.hass,e),o=Wi(t);if(!o)return q;const i=1===t.length?null===o.level?it("dialog.battery_unknown",this.hass):it("dialog.battery",this.hass,{level:o.level}):t.map(e=>it("dialog.battery_named",this.hass,{name:this._coverName(e.cover_id),level:null===e.level?"—":e.level})).join(" · ");return H`<div
+      class="icon-btn battery${Gi(o)?" low":""}"
+      role="img"
+      aria-label=${i}
+      ${wo(i)}
+    >
+      <ha-icon icon=${Hi(o.level,o.charging)}></ha-icon>
+    </div>`}_coverName(e){return this.hass?.states[e]?.attributes?.friendly_name??e}render(){if(!this.open||!this.hass||!this.discovered)return q;const e=this._winner(),t=this._traceAttrs(),o=this._matchedHandlers(t,e),i=wi(t),s=t?$i(t.trace??[],t,0,this._buildHandlerLabels(),it("badge.safety",this.hass)):"",n=this._target(),r=this._shouldShowResume(),a=this._switchOn("integration_enabled_switch"),l=this._switchOn("automatic_control_switch"),c=it("dialog.configure_integration",this.hass),d=it("dialog.open_device_page",this.hass),h=it("dialog.close",this.hass),p=it("history.open",this.hass),u=this._headerColor();return H`
       <div class="backdrop" data-open @click=${this._onBackdrop}>
         <div class="dialog" @click=${this._stop} role="dialog" aria-modal="true">
           <div class="header">
@@ -4252,57 +4260,58 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
             ></ha-icon>
             <div class="title">${this.discovered.entry_title}</div>
             <div class="badges">
-              ${a?l?o.map(e=>W`<acp-tile-badge
+              ${a?l?o.map(e=>H`<acp-tile-badge
                           .hass=${this.hass}
                           .winner=${e}
                           .slotNumber=${"custom_position"===e?t?.custom_position_active_slot:void 0}
                           .slotName=${"custom_position"===e?t?.custom_position_active_slot_name:void 0}
-                          .pct=${"custom_position"===e?fi(t,n)??void 0:void 0}
+                          .pct=${"custom_position"===e?yi(t,n)??void 0:void 0}
                           .minimumMode=${"custom_position"===e?t?.custom_position_minimum_mode:void 0}
                           .safetyActive=${"custom_position"===e&&i}
-                        ></acp-tile-badge>`):V:W`<acp-tile-badge
+                        ></acp-tile-badge>`):q:H`<acp-tile-badge
                     .hass=${this.hass}
                     .integrationEnabled=${!1}
                   ></acp-tile-badge>`}
             </div>
+            ${this._batteryTpl()}
             <button
               class="icon-btn history-link"
               type="button"
               aria-label=${p}
-              ${bo(p)}
+              ${wo(p)}
               @click=${this._openHistory}
             >
-              <ha-icon icon=${Ue}></ha-icon>
+              <ha-icon icon=${Ve}></ha-icon>
             </button>
             <button
               class="icon-btn options-link"
               type="button"
               aria-label=${c}
-              ${bo(c)}
+              ${wo(c)}
               @click=${this._openIntegrationPage}
             >
               <ha-icon icon="mdi:tune-variant"></ha-icon>
             </button>
-            ${this.discovered.device_id?W`<button
+            ${this.discovered.device_id?H`<button
                   class="icon-btn device-link"
                   type="button"
                   aria-label=${d}
-                  ${bo(d)}
+                  ${wo(d)}
                   @click=${this._openDevicePage}
                 >
                   <ha-icon icon="mdi:cog"></ha-icon>
-                </button>`:V}
+                </button>`:q}
             <button class="close" type="button" aria-label=${h} @click=${this._emitClose}>
               ✕
             </button>
           </div>
 
-          ${s?W`<div class="summary">${s}</div>`:V}
+          ${s?H`<div class="summary">${s}</div>`:q}
 
           <div class="position-block">
-            <div class="position-label">${ot("dialog.target",this.hass)}</div>
-            <div class="position-value">${it(n)}</div>
-            ${this._mismatchActive()?W`<ha-icon class="warn" icon="mdi:alert-circle-outline"></ha-icon>`:V}
+            <div class="position-label">${it("dialog.target",this.hass)}</div>
+            <div class="position-value">${st(n)}</div>
+            ${this._mismatchActive()?H`<ha-icon class="warn" icon="mdi:alert-circle-outline"></ha-icon>`:q}
           </div>
 
           <acp-cover-bar
@@ -4312,17 +4321,17 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
           ></acp-cover-bar>
 
           ${this._renderForecastStrip()} ${this._renderControls()}
-          ${r?W`<div class="actions">
+          ${r?H`<div class="actions">
                 <button class="resume" type="button" @click=${this._onResume}>
-                  ${ot("dialog.resume_auto",this.hass)}
+                  ${it("dialog.resume_auto",this.hass)}
                 </button>
-              </div>`:V}
+              </div>`:q}
 
           <button class="advanced-toggle" type="button" @click=${this._toggleAdvanced}>
-            ${this.advancedOpen?ot("dialog.hide_advanced",this.hass):ot("dialog.show_advanced",this.hass)}
+            ${this.advancedOpen?it("dialog.hide_advanced",this.hass):it("dialog.show_advanced",this.hass)}
           </button>
-          ${this.advancedOpen?W`<div class="advanced">
-                ${this.showCompass?W`<div class="advanced-compass">
+          ${this.advancedOpen?H`<div class="advanced">
+                ${this.showCompass?H`<div class="advanced-compass">
                       <acp-sky-compass
                         .hass=${this.hass}
                         .discovered_list=${this._discoveredList}
@@ -4330,21 +4339,21 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
                         .showLegend=${!1}
                         .showStats=${!0}
                       ></acp-sky-compass>
-                    </div>`:V}
-                ${this.showElevationChart?W`<acp-elevation-chart
+                    </div>`:q}
+                ${this.showElevationChart?H`<acp-elevation-chart
                       .hass=${this.hass}
                       .discoveredList=${this._discoveredList}
                       ?compact=${!0}
-                    ></acp-elevation-chart>`:V}
+                    ></acp-elevation-chart>`:q}
                 ${this._renderSlots(t?.custom_position_slots)}
                 <acp-decision-strip
                   .hass=${this.hass}
                   .discovered=${this.discovered}
                 ></acp-decision-strip>
-                ${this.showSolarCalc?W`<acp-solar-calc
+                ${this.showSolarCalc?H`<acp-solar-calc
                       .hass=${this.hass}
                       .discovered=${this.discovered}
-                    ></acp-solar-calc>`:V}
+                    ></acp-solar-calc>`:q}
                 <acp-overrides-panel
                   .hass=${this.hass}
                   .discovered=${this.discovered}
@@ -4353,7 +4362,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
                   .hass=${this.hass}
                   .discovered=${this.discovered}
                 ></acp-climate-panel>
-              </div>`:V}
+              </div>`:q}
         </div>
       </div>
       <acp-history-dialog
@@ -4362,46 +4371,46 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
         .open=${this._historyOpen}
         @acp-history-closed=${()=>{this._historyOpen=!1}}
       ></acp-history-dialog>
-    `}_winner(){const e=this.discovered.entities.decision_trace_sensor;return e?this.hass.states[e]?.state??"default":"default"}_traceAttrs(){const e=this.discovered.entities.decision_trace_sensor;if(e)return this.hass.states[e]?.attributes}_matchedHandlers(e,t){if(!e?.trace)return[];const o=Ki(e.trace),i=Ie.filter(e=>o.has(e)).map(e=>Re[e]).filter(e=>void 0!==e),s=Wi(e.trace,t);return Ri(i,this.badges,s)}_target(){return Lt(this.hass,this.discovered)}_mismatchActive(){const e=this.discovered.entities.position_mismatch_binary;return!!e&&"on"===this.hass.states[e]?.state}_manualOverrideOn(){const e=this.discovered.entities.manual_override_binary;return!!e&&"on"===this.hass.states[e]?.state}_switchOn(e){const t=this.discovered.entities[e];return!t||"off"!==this.hass.states[t]?.state}_shouldShowResume(){return!!this.discovered.entities.reset_override_button&&this._manualOverrideOn()}_renderSlots(e){if(!e)return V;const t=e.filter(e=>null!==e.sensor);return 0===t.length?V:W`<div class="slots-section">
-      <div class="slots-label">${ot("dialog.custom_positions",this.hass)}</div>
+    `}_winner(){const e=this.discovered.entities.decision_trace_sensor;return e?this.hass.states[e]?.state??"default":"default"}_traceAttrs(){const e=this.discovered.entities.decision_trace_sensor;if(e)return this.hass.states[e]?.attributes}_matchedHandlers(e,t){if(!e?.trace)return[];const o=qi(e.trace),i=Ie.filter(e=>o.has(e)).map(e=>je[e]).filter(e=>void 0!==e),s=Zi(e.trace,t);return Ui(i,this.badges,s)}_target(){return Wt(this.hass,this.discovered)}_mismatchActive(){const e=this.discovered.entities.position_mismatch_binary;return!!e&&"on"===this.hass.states[e]?.state}_manualOverrideOn(){const e=this.discovered.entities.manual_override_binary;return!!e&&"on"===this.hass.states[e]?.state}_switchOn(e){const t=this.discovered.entities[e];return!t||"off"!==this.hass.states[t]?.state}_shouldShowResume(){return!!this.discovered.entities.reset_override_button&&this._manualOverrideOn()}_renderSlots(e){if(!e)return q;const t=e.filter(e=>null!==e.sensor);return 0===t.length?q:H`<div class="slots-section">
+      <div class="slots-label">${it("dialog.custom_positions",this.hass)}</div>
       ${t.map(e=>this._renderSlotRow(e))}
-    </div>`}_renderSlotRow(e){const t=e.sensor_name??`#${e.slot}`,o=e.sensors?.length??0,i=!0===e.template?W`<span
+    </div>`}_renderSlotRow(e){const t=e.sensor_name??`#${e.slot}`,o=e.sensors?.length??0,i=!0===e.template?H`<span
             class="slot-template"
-            ${bo("Template"+(o>0?` · ${o} sensors${e.template_mode?` (${e.template_mode})`:""}`:""))}
+            ${wo("Template"+(o>0?` · ${o} sensors${e.template_mode?` (${e.template_mode})`:""}`:""))}
           >
             <ha-icon icon="mdi:code-braces"></ha-icon>
-          </span>`:V;return W`<div class="slot-row" data-slot=${e.slot}>
+          </span>`:q;return H`<div class="slot-row" data-slot=${e.slot}>
       <span class="slot-label">${t}</span>
       ${i}
-      <span class="slot-position">${it(e.position)}</span>
-      ${!0===e.min_mode?W`<span
+      <span class="slot-position">${st(e.position)}</span>
+      ${!0===e.min_mode?H`<span
             class="slot-min-mode${null!=e.priority&&e.priority>80?"":" is-bypassable"}"
-            ${bo(ot("dialog.floor_tooltip",this.hass))}
+            ${wo(it("dialog.floor_tooltip",this.hass))}
           >
-            ${ot("dialog.floor",this.hass)}
-          </span>`:V}
+            ${it("dialog.floor",this.hass)}
+          </span>`:q}
       <button
         class="slot-toggle ${e.enabled?"on":"off"}"
         type="button"
-        aria-label=${e.enabled?ot("dialog.disable_slot",this.hass,{slot:e.slot}):ot("dialog.enable_slot",this.hass,{slot:e.slot})}
+        aria-label=${e.enabled?it("dialog.disable_slot",this.hass,{slot:e.slot}):it("dialog.enable_slot",this.hass,{slot:e.slot})}
         @click=${()=>this._toggleSlot(e)}
       >
-        ${e.enabled?ot("dialog.on",this.hass):ot("dialog.off",this.hass)}
+        ${e.enabled?it("dialog.on",this.hass):it("dialog.off",this.hass)}
       </button>
-    </div>`}_renderControls(){const e=[{role:"automatic_control_switch",label:ot("dialog.automatic",this.hass)},{role:"climate_mode_switch",label:ot("dialog.climate",this.hass)},{role:"motion_control_switch",label:ot("dialog.motion",this.hass)}].filter(e=>!!this.discovered.entities[e.role]);return 0===e.length?V:W`<div class="controls-block">
-      <div class="controls-label">${ot("dialog.controls",this.hass)}</div>
+    </div>`}_renderControls(){const e=[{role:"automatic_control_switch",label:it("dialog.automatic",this.hass)},{role:"climate_mode_switch",label:it("dialog.climate",this.hass)},{role:"motion_control_switch",label:it("dialog.motion",this.hass)}].filter(e=>!!this.discovered.entities[e.role]);return 0===e.length?q:H`<div class="controls-block">
+      <div class="controls-label">${it("dialog.controls",this.hass)}</div>
       <div class="controls-row">${e.map(e=>this._renderSwitchChip(e.role,e.label))}</div>
-    </div>`}_renderSwitchChip(e,t){const o=this.discovered.entities[e],i="on"===this.hass.states[o]?.state,s=ot(i?"dialog.state_on":"dialog.state_off",this.hass),n=ot(i?"dialog.on":"dialog.off",this.hass);return W`<button
+    </div>`}_renderSwitchChip(e,t){const o=this.discovered.entities[e],i="on"===this.hass.states[o]?.state,s=it(i?"dialog.state_on":"dialog.state_off",this.hass),n=it(i?"dialog.on":"dialog.off",this.hass);return H`<button
       class="ctrl-toggle ${i?"on":"off"}"
       type="button"
       aria-pressed=${i}
-      aria-label=${ot("dialog.toggle_hint",this.hass,{label:t,state:s})}
+      aria-label=${it("dialog.toggle_hint",this.hass,{label:t,state:s})}
       @click=${()=>this._toggleSwitch(o,i)}
     >
       <span class="ctrl-label">${t}</span>
       <span class="ctrl-state">${n}</span>
-    </button>`}_toggleSwitch(e,t){this.hass.callService("switch",t?"turn_off":"turn_on",{entity_id:e})}_renderForecastStrip(){const e=this.discovered.entities.position_forecast_sensor,t=e?this.hass.states[e]?.attributes:void 0,o=t?.forecast??[],i=t?.events??[],s=this._positionHistory;if(0===o.length&&0===s.length)return V;const n={};for(const e of wt(this.discovered))n[e.id]=e.label;return W`<div class="forecast-block">
-      <div class="forecast-label">${ot("dialog.todays_forecast",this.hass)}</div>
+    </button>`}_toggleSwitch(e,t){this.hass.callService("switch",t?"turn_off":"turn_on",{entity_id:e})}_renderForecastStrip(){const e=this.discovered.entities.position_forecast_sensor,t=e?this.hass.states[e]?.attributes:void 0,o=t?.forecast??[],i=t?.events??[],s=this._positionHistory;if(0===o.length&&0===s.length)return q;const n={};for(const e of $t(this.discovered))n[e.id]=e.label;return H`<div class="forecast-block">
+      <div class="forecast-label">${it("dialog.todays_forecast",this.hass)}</div>
       <acp-forecast-strip
         .hass=${this.hass}
         .samples=${o}
@@ -4410,20 +4419,20 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
         .now=${Date.now()}
         .axisLabels=${n}
       ></acp-forecast-strip>
-      <div class="forecast-note">${ot("forecast.solar_only_note",this.hass)}</div>
-    </div>`}_toggleSlot(e){const t=this.discovered.managed_covers[0];t&&this.hass.callService(Me,"set_custom_position",{entity_id:t,slot:e.slot,enabled:!e.enabled})}_navigate(e){history.pushState(null,"",e),window.dispatchEvent(new CustomEvent("location-changed",{detail:{replace:!1}})),this._emitClose()}};function En(e){return W`
+      <div class="forecast-note">${it("forecast.solar_only_note",this.hass)}</div>
+    </div>`}_toggleSlot(e){const t=this.discovered.managed_covers[0];t&&this.hass.callService(Te,"set_custom_position",{entity_id:t,slot:e.slot,enabled:!e.enabled})}_navigate(e){history.pushState(null,"",e),window.dispatchEvent(new CustomEvent("location-changed",{detail:{replace:!1}})),this._emitClose()}};function Bn(e){return H`
     <div
       class="editor-footer"
       style="display:flex;align-items:center;justify-content:space-between;gap:8px;"
     >
       <a href=${"https://www.buymeacoffee.com/jrhubott"} target="_blank" rel="noopener noreferrer">
-        <img src=${"https://img.shields.io/badge/Buy%20me%20a%20coffee-FFDD00?style=for-the-badge&logo=buy-me-a-coffee&logoColor=black"} alt=${ot("editor.common.support_alt",e)} height="20" />
+        <img src=${"https://img.shields.io/badge/Buy%20me%20a%20coffee-FFDD00?style=for-the-badge&logo=buy-me-a-coffee&logoColor=black"} alt=${it("editor.common.support_alt",e)} height="20" />
       </a>
       <span class="version-footer dim">
-        ${ot("root.footer_version",e,{version:ve})}
+        ${it("root.footer_version",e,{version:fe})}
       </span>
     </div>
-  `}Cn.styles=r`
+  `}On.styles=a`
     :host {
       display: contents;
     }
@@ -4492,6 +4501,14 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
       display: inline-flex;
       align-items: center;
       --mdc-icon-size: 18px;
+    }
+    /* The battery shares .icon-btn's metrics so it lines up with the buttons
+       beside it, but it is a readout, not a control — no pointer affordance. */
+    .icon-btn.battery {
+      cursor: default;
+    }
+    .icon-btn.battery.low {
+      color: var(--error-color, #db4437);
     }
     .icon-btn:hover {
       color: var(--primary-text-color);
@@ -4694,25 +4711,25 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
     .ctrl-toggle:hover {
       background: rgba(var(--rgb-primary-color, 33, 150, 243), 0.08);
     }
-  `,e([_e({attribute:!1})],Cn.prototype,"hass",void 0),e([_e({attribute:!1})],Cn.prototype,"discovered",void 0),e([_e({type:Boolean,reflect:!0})],Cn.prototype,"open",void 0),e([_e({type:Boolean})],Cn.prototype,"advancedOpen",void 0),e([_e({type:Boolean})],Cn.prototype,"showCompass",void 0),e([_e({type:Boolean})],Cn.prototype,"showElevationChart",void 0),e([_e({type:Boolean})],Cn.prototype,"showSolarCalc",void 0),e([_e({type:Boolean})],Cn.prototype,"stateColor",void 0),e([_e({attribute:!1})],Cn.prototype,"badges",void 0),e([_e({attribute:!1})],Cn.prototype,"coverOrder",void 0),e([ge()],Cn.prototype,"_positionHistory",void 0),e([ge()],Cn.prototype,"_historyOpen",void 0),Cn=e([he("acp-more-info-dialog")],Cn);const zn=["auto","solar","force","weather","manual","custom_position","motion","climate","glare_zone","cloud"],Mn={show_position:!0,show_state:!0,show_decision_summary:!1,show_controls:!0,show_badge:!0,show_position_bar:!0,show_tilt:!0,show_compass:!0,show_elevation_chart:!0,show_solar_calc:!0,show_motion_icon:!0,state_color:!0,layout:"detailed",badge_auto:!0,badge_solar:!0,badge_force:!0,badge_weather:!0,badge_manual:!0,badge_custom_position:!0,badge_motion:!0,badge_climate:!0,badge_glare_zone:!0,badge_cloud:!0,show_scene_select:!0,show_lock:!0,show_automation:!0,show_clear_overrides:!0,show_member_badges:!0},In={entry_id:"editor.common.entry_id",name:"editor.tile.name",icon:"editor.tile.icon",cover:"editor.tile.cover",layout:"editor.tile.layout",show_position:"editor.tile.show_position",show_state:"editor.tile.show_state",show_decision_summary:"editor.tile.show_decision_summary",show_controls:"editor.tile.show_controls",controls_cover:"editor.tile.controls_cover",controls_axis:"editor.tile.controls_axis",show_badge:"editor.tile.show_badge",show_position_bar:"editor.tile.show_position_bar",show_tilt:"editor.tile.show_tilt",badge_section:"editor.tile.badge_section",badge_auto:"editor.tile.badge_auto",badge_solar:"editor.tile.badge_solar",badge_force:"editor.tile.badge_force",badge_weather:"editor.tile.badge_weather",badge_manual:"editor.tile.badge_manual",badge_custom_position:"editor.tile.badge_custom_position",badge_motion:"editor.tile.badge_motion",badge_climate:"editor.tile.badge_climate",badge_glare_zone:"editor.tile.badge_glare_zone",badge_cloud:"editor.tile.badge_cloud",show_compass:"editor.tile.show_compass",show_elevation_chart:"editor.tile.show_elevation_chart",show_solar_calc:"editor.tile.show_solar_calc",show_motion_icon:"editor.tile.show_motion_icon",state_color:"editor.tile.state_color",tap_action:"editor.tile.tap_action",icon_tap_action:"editor.tile.icon_tap_action",hold_action:"editor.tile.hold_action",double_tap_action:"editor.tile.double_tap_action",interactions_section:"editor.tile.interactions_section",content_section:"editor.tile.content_section",controls_section:"editor.tile.controls_section",dialog_section:"editor.tile.dialog_section",group_row_section:"editor.tile.group_row_section",show_scene_select:"editor.tile.show_scene_select",show_lock:"editor.tile.show_lock",show_automation:"editor.tile.show_automation",show_clear_overrides:"editor.tile.show_clear_overrides",show_member_badges:"editor.tile.show_member_badges"};let Tn=class extends ce{constructor(){super(...arguments),this._entries=null,this._entriesError=null,this._registry=null,this._managedCovers=[],this._entriesFetchInFlight=!1,this._registryFetchInFlight=!1,this._unsubRegistry=null,this._isGroupEntry=!1,this._computeLabel=e=>{const t=In[e.name];return t?ot(t,this.hass):e.name},this._valueChanged=e=>{e.stopPropagation();const t={...e.detail.value};this._nameIsComposed()&&!t.name&&delete t.name;for(const[e,o]of Object.entries(Mn))e.startsWith("badge_")?t[e]===o&&delete t[e]:this._config&&Object.prototype.hasOwnProperty.call(this._config,e)||t[e]!==o||delete t[e];const o={};for(const e of zn){const i=`badge_${e}`;!1===t[i]&&(o[e]=!1),delete t[i]}const i={...this._config??{type:"",entry_id:""},...t};this._config?.entry_id&&i.entry_id!==this._config.entry_id&&(delete i.cover,delete i.covers,delete i.controls_cover,delete i.controls_axis),Object.keys(o).length>0?i.badges=o:delete i.badges,this._emit(i)},this._dragFrom=null}setConfig(e){this._config={...e}}disconnectedCallback(){super.disconnectedCallback(),this._unsubRegistry&&(this._unsubRegistry(),this._unsubRegistry=null)}updated(e){e.has("hass")&&this.hass&&(this._ensureEntries(),this._ensureRegistry()),(e.has("_registry")||e.has("_config"))&&null!==this._registry&&this._refreshManagedCovers()}_ensureEntries(){this._entries||this._entriesFetchInFlight||(this._entriesFetchInFlight=!0,Fo(this.hass).then(e=>{this._entries=e,this._entriesError=null,this._config?.entry_id||1!==e.length||this._emit({...this._config??{type:"",entry_id:""},entry_id:e[0].entry_id}),this._refreshManagedCovers()}).catch(e=>{this._entriesError=e?.message??"failed to load config entries"}).finally(()=>{this._entriesFetchInFlight=!1}))}_ensureRegistry(){null!==this._registry||this._registryFetchInFlight||(this._registryFetchInFlight=!0,Ao(this.hass).then(e=>{this._registry=e,this._refreshManagedCovers()}).catch(()=>{this._registry=[]}).finally(()=>{this._registryFetchInFlight=!1})),this._unsubRegistry||(this._unsubRegistry=So(this.hass,()=>{this._registryFetchInFlight=!0,Ao(this.hass).then(e=>{this._registry=e}).catch(()=>{}).finally(()=>{this._registryFetchInFlight=!1})}))}_emit(e){this._config=e,this.dispatchEvent(new CustomEvent("config-changed",{detail:{config:e},bubbles:!0,composed:!0}))}_refreshManagedCovers(){if(!this._config?.entry_id||!this._registry||!this.hass)return;const e=ko(this.hass,{type:this._config.type,entry_id:this._config.entry_id},this._registry);this._managedCovers=e?.managed_covers??[],this._isGroupEntry=!!e?.is_group}_nameIsComposed(){return Array.isArray(this._config?.name)}render(){if(!this._config)return V;if(this._entriesError&&!this._entries)return W`
+  `,e([ge({attribute:!1})],On.prototype,"hass",void 0),e([ge({attribute:!1})],On.prototype,"discovered",void 0),e([ge({type:Boolean,reflect:!0})],On.prototype,"open",void 0),e([ge({type:Boolean})],On.prototype,"advancedOpen",void 0),e([ge({type:Boolean})],On.prototype,"showCompass",void 0),e([ge({type:Boolean})],On.prototype,"showElevationChart",void 0),e([ge({type:Boolean})],On.prototype,"showSolarCalc",void 0),e([ge({type:Boolean})],On.prototype,"stateColor",void 0),e([ge({attribute:!1})],On.prototype,"badges",void 0),e([ge({attribute:!1})],On.prototype,"coverOrder",void 0),e([me()],On.prototype,"_positionHistory",void 0),e([me()],On.prototype,"_historyOpen",void 0),On=e([pe("acp-more-info-dialog")],On);const Fn=["auto","solar","force","weather","manual","custom_position","motion","climate","glare_zone","cloud"],Nn={show_position:!0,show_state:!0,show_decision_summary:!1,show_controls:!0,show_badge:!0,show_position_bar:!0,show_tilt:!0,show_compass:!0,show_elevation_chart:!0,show_solar_calc:!0,show_motion_icon:!0,state_color:!0,layout:"detailed",badge_auto:!0,badge_solar:!0,badge_force:!0,badge_weather:!0,badge_manual:!0,badge_custom_position:!0,badge_motion:!0,badge_climate:!0,badge_glare_zone:!0,badge_cloud:!0,show_scene_select:!0,show_lock:!0,show_automation:!0,show_clear_overrides:!0,show_member_badges:!0},Dn={entry_id:"editor.common.entry_id",name:"editor.tile.name",icon:"editor.tile.icon",cover:"editor.tile.cover",layout:"editor.tile.layout",show_position:"editor.tile.show_position",show_state:"editor.tile.show_state",show_decision_summary:"editor.tile.show_decision_summary",show_controls:"editor.tile.show_controls",controls_cover:"editor.tile.controls_cover",controls_axis:"editor.tile.controls_axis",show_badge:"editor.tile.show_badge",show_position_bar:"editor.tile.show_position_bar",show_tilt:"editor.tile.show_tilt",badge_section:"editor.tile.badge_section",badge_auto:"editor.tile.badge_auto",badge_solar:"editor.tile.badge_solar",badge_force:"editor.tile.badge_force",badge_weather:"editor.tile.badge_weather",badge_manual:"editor.tile.badge_manual",badge_custom_position:"editor.tile.badge_custom_position",badge_motion:"editor.tile.badge_motion",badge_climate:"editor.tile.badge_climate",badge_glare_zone:"editor.tile.badge_glare_zone",badge_cloud:"editor.tile.badge_cloud",show_compass:"editor.tile.show_compass",show_elevation_chart:"editor.tile.show_elevation_chart",show_solar_calc:"editor.tile.show_solar_calc",show_motion_icon:"editor.tile.show_motion_icon",state_color:"editor.tile.state_color",tap_action:"editor.tile.tap_action",icon_tap_action:"editor.tile.icon_tap_action",hold_action:"editor.tile.hold_action",double_tap_action:"editor.tile.double_tap_action",interactions_section:"editor.tile.interactions_section",content_section:"editor.tile.content_section",controls_section:"editor.tile.controls_section",dialog_section:"editor.tile.dialog_section",group_row_section:"editor.tile.group_row_section",show_scene_select:"editor.tile.show_scene_select",show_lock:"editor.tile.show_lock",show_automation:"editor.tile.show_automation",show_clear_overrides:"editor.tile.show_clear_overrides",show_member_badges:"editor.tile.show_member_badges"};let Rn=class extends de{constructor(){super(...arguments),this._entries=null,this._entriesError=null,this._registry=null,this._managedCovers=[],this._entriesFetchInFlight=!1,this._registryFetchInFlight=!1,this._unsubRegistry=null,this._isGroupEntry=!1,this._computeLabel=e=>{const t=Dn[e.name];return t?it(t,this.hass):e.name},this._valueChanged=e=>{e.stopPropagation();const t={...e.detail.value};this._nameIsComposed()&&!t.name&&delete t.name;for(const[e,o]of Object.entries(Nn))e.startsWith("badge_")?t[e]===o&&delete t[e]:this._config&&Object.prototype.hasOwnProperty.call(this._config,e)||t[e]!==o||delete t[e];const o={};for(const e of Fn){const i=`badge_${e}`;!1===t[i]&&(o[e]=!1),delete t[i]}const i={...this._config??{type:"",entry_id:""},...t};this._config?.entry_id&&i.entry_id!==this._config.entry_id&&(delete i.cover,delete i.covers,delete i.controls_cover,delete i.controls_axis),Object.keys(o).length>0?i.badges=o:delete i.badges,this._emit(i)},this._dragFrom=null}setConfig(e){this._config={...e}}disconnectedCallback(){super.disconnectedCallback(),this._unsubRegistry&&(this._unsubRegistry(),this._unsubRegistry=null)}updated(e){e.has("hass")&&this.hass&&(this._ensureEntries(),this._ensureRegistry()),(e.has("_registry")||e.has("_config"))&&null!==this._registry&&this._refreshManagedCovers()}_ensureEntries(){this._entries||this._entriesFetchInFlight||(this._entriesFetchInFlight=!0,No(this.hass).then(e=>{this._entries=e,this._entriesError=null,this._config?.entry_id||1!==e.length||this._emit({...this._config??{type:"",entry_id:""},entry_id:e[0].entry_id}),this._refreshManagedCovers()}).catch(e=>{this._entriesError=e?.message??"failed to load config entries"}).finally(()=>{this._entriesFetchInFlight=!1}))}_ensureRegistry(){null!==this._registry||this._registryFetchInFlight||(this._registryFetchInFlight=!0,Co(this.hass).then(e=>{this._registry=e,this._refreshManagedCovers()}).catch(()=>{this._registry=[]}).finally(()=>{this._registryFetchInFlight=!1})),this._unsubRegistry||(this._unsubRegistry=Eo(this.hass,()=>{this._registryFetchInFlight=!0,Co(this.hass).then(e=>{this._registry=e}).catch(()=>{}).finally(()=>{this._registryFetchInFlight=!1})}))}_emit(e){this._config=e,this.dispatchEvent(new CustomEvent("config-changed",{detail:{config:e},bubbles:!0,composed:!0}))}_refreshManagedCovers(){if(!this._config?.entry_id||!this._registry||!this.hass)return;const e=So(this.hass,{type:this._config.type,entry_id:this._config.entry_id},this._registry);this._managedCovers=e?.managed_covers??[],this._isGroupEntry=!!e?.is_group}_nameIsComposed(){return Array.isArray(this._config?.name)}render(){if(!this._config)return q;if(this._entriesError&&!this._entries)return H`
         <div class="form">
           <div class="error">
-            ${ot("editor.common.load_failed",this.hass,{error:this._entriesError})}
+            ${it("editor.common.load_failed",this.hass,{error:this._entriesError})}
           </div>
           <label class="field-label" for="entry-id-fallback"
-            >${ot("editor.common.entry_id_fallback_label",this.hass)}</label
+            >${it("editor.common.entry_id_fallback_label",this.hass)}</label
           >
           <input
             id="entry-id-fallback"
             type="text"
             class="text-input"
             .value=${this._config.entry_id??""}
-            placeholder=${ot("editor.common.entry_id_manual_placeholder",this.hass)}
+            placeholder=${it("editor.common.entry_id_manual_placeholder",this.hass)}
             @change=${e=>{const t={...this._config??{type:"",entry_id:""},entry_id:e.target.value};this._config?.entry_id&&t.entry_id!==this._config.entry_id&&(delete t.cover,delete t.covers,delete t.controls_cover,delete t.controls_axis),this._emit(t)}}
           />
-          ${En(this.hass)}
+          ${Bn(this.hass)}
         </div>
-      `;const e=this._schema(),{badges:t,...o}=this._config,i={};for(const e of zn)t&&!1===t[e]&&(i[`badge_${e}`]=!1);const s=this._nameIsComposed(),n={...Mn,...o,...s?{name:""}:{},...i};return W`
+      `;const e=this._schema(),{badges:t,...o}=this._config,i={};for(const e of Fn)t&&!1===t[e]&&(i[`badge_${e}`]=!1);const s=this._nameIsComposed(),n={...Nn,...o,...s?{name:""}:{},...i};return H`
       <div class="form">
         <ha-form
           .hass=${this.hass}
@@ -4721,16 +4738,16 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
           .computeLabel=${this._computeLabel}
           @value-changed=${this._valueChanged}
         ></ha-form>
-        ${s?W`<div class="hint">${ot("editor.tile.name_composed_hint",this.hass)}</div>`:V}
-        ${this._managedCovers.length>1&&!this._config?.cover?W`<div class="hint">${ot("editor.tile.cover_blank_hint",this.hass)}</div>`:V}
-        ${this._renderRailOrder()} ${En(this.hass)}
+        ${s?H`<div class="hint">${it("editor.tile.name_composed_hint",this.hass)}</div>`:q}
+        ${this._managedCovers.length>1&&!this._config?.cover?H`<div class="hint">${it("editor.tile.cover_blank_hint",this.hass)}</div>`:q}
+        ${this._renderRailOrder()} ${Bn(this.hass)}
       </div>
-    `}_railRows(){const e=this._managedCovers,t=(this._config?.covers??[]).filter(t=>e.includes(t)),o=e.filter(e=>!t.includes(e)),i=t.length>0?[...t.map(e=>({id:e,shown:!0})),...o.map(e=>({id:e,shown:!1}))]:e.map(e=>({id:e,shown:this._defaultShows(e)}));return[...i.filter(e=>e.shown),...i.filter(e=>!e.shown)]}_defaultShows(e){return!this._config?.cover||e===this._config.cover}_coverName(e){return this.hass?.states[e]?.attributes?.friendly_name??e}_emitRails(e){if(!this._config)return;const t=e.filter(e=>e.shown).map(e=>e.id),o=this._managedCovers.filter(e=>this._defaultShows(e)),i=t.length===o.length&&t.every((e,t)=>e===o[t]),{covers:s,...n}=this._config;this._emit(i?n:{...n,covers:t})}_moveRail(e,t){const o=this._railRows(),i=o.filter(e=>e.shown).length;if(t<0||t>=i||e>=i||e===t)return;const s=[...o],[n]=s.splice(e,1);s.splice(t,0,n),this._emitRails(s)}_toggleRail(e){const t=this._railRows();if(t[e].shown&&1===t.filter(e=>e.shown).length)return;const o=t[e];if(o.shown)return void this._emitRails(t.map((t,o)=>o===e?{...t,shown:!1}:t));const i=t.filter(e=>e.shown),s=this._managedCovers.indexOf(o.id),n=i.filter(e=>this._managedCovers.indexOf(e.id)<s).length,r=[...i];r.splice(n,0,{...o,shown:!0}),this._emitRails(r)}_renderRailOrder(){if(this._isGroupEntry||this._managedCovers.length<2)return V;const e=this._railRows(),t=e.filter(e=>e.shown).length;return W`
+    `}_railRows(){const e=this._managedCovers,t=(this._config?.covers??[]).filter(t=>e.includes(t)),o=e.filter(e=>!t.includes(e)),i=t.length>0?[...t.map(e=>({id:e,shown:!0})),...o.map(e=>({id:e,shown:!1}))]:e.map(e=>({id:e,shown:this._defaultShows(e)}));return[...i.filter(e=>e.shown),...i.filter(e=>!e.shown)]}_defaultShows(e){return!this._config?.cover||e===this._config.cover}_coverName(e){return this.hass?.states[e]?.attributes?.friendly_name??e}_emitRails(e){if(!this._config)return;const t=e.filter(e=>e.shown).map(e=>e.id),o=this._managedCovers.filter(e=>this._defaultShows(e)),i=t.length===o.length&&t.every((e,t)=>e===o[t]),{covers:s,...n}=this._config;this._emit(i?n:{...n,covers:t})}_moveRail(e,t){const o=this._railRows(),i=o.filter(e=>e.shown).length;if(t<0||t>=i||e>=i||e===t)return;const s=[...o],[n]=s.splice(e,1);s.splice(t,0,n),this._emitRails(s)}_toggleRail(e){const t=this._railRows();if(t[e].shown&&1===t.filter(e=>e.shown).length)return;const o=t[e];if(o.shown)return void this._emitRails(t.map((t,o)=>o===e?{...t,shown:!1}:t));const i=t.filter(e=>e.shown),s=this._managedCovers.indexOf(o.id),n=i.filter(e=>this._managedCovers.indexOf(e.id)<s).length,r=[...i];r.splice(n,0,{...o,shown:!0}),this._emitRails(r)}_renderRailOrder(){if(this._isGroupEntry||this._managedCovers.length<2)return q;const e=this._railRows(),t=e.filter(e=>e.shown).length;return H`
       <div class="rail-order">
-        <div class="rail-order-title">${ot("editor.tile.covers",this.hass)}</div>
-        <div class="hint">${ot("editor.tile.covers_hint",this.hass)}</div>
+        <div class="rail-order-title">${it("editor.tile.covers",this.hass)}</div>
+        <div class="hint">${it("editor.tile.covers_hint",this.hass)}</div>
         <ul>
-          ${e.map((e,o)=>W`
+          ${e.map((e,o)=>H`
               <li
                 class=${`rail${e.shown?"":" hidden-rail"}${this._dragFrom===o?" dragging":""}`}
                 draggable=${e.shown?"true":"false"}
@@ -4744,7 +4761,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
                 <button
                   type="button"
                   class="rail-btn"
-                  aria-label=${ot("editor.tile.covers_move_up",this.hass)}
+                  aria-label=${it("editor.tile.covers_move_up",this.hass)}
                   ?disabled=${!e.shown||0===o}
                   @click=${()=>this._moveRail(o,o-1)}
                 >
@@ -4753,7 +4770,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
                 <button
                   type="button"
                   class="rail-btn"
-                  aria-label=${ot("editor.tile.covers_move_down",this.hass)}
+                  aria-label=${it("editor.tile.covers_move_down",this.hass)}
                   ?disabled=${!e.shown||o>=t-1}
                   @click=${()=>this._moveRail(o,o+1)}
                 >
@@ -4762,7 +4779,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
                 <button
                   type="button"
                   class="rail-btn"
-                  aria-label=${ot(e.shown?"editor.tile.covers_hide":"editor.tile.covers_show",this.hass)}
+                  aria-label=${it(e.shown?"editor.tile.covers_hide":"editor.tile.covers_show",this.hass)}
                   aria-pressed=${e.shown?"true":"false"}
                   ?disabled=${e.shown&&1===t}
                   @click=${()=>this._toggleRail(o)}
@@ -4773,7 +4790,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
             `)}
         </ul>
       </div>
-    `}_schema(){const e=this._entries?.map(e=>({value:e.entry_id,label:e.title}))??[],t=[{value:"one-line",label:ot("editor.tile.layout_option_one_line",this.hass)},{value:"detailed",label:ot("editor.tile.layout_option_detailed",this.hass)}];let o={entity:{domain:"cover"}},i=!1,s=0,n=[];if(this._registry&&this._config?.entry_id){const e=ko(this.hass,{type:this._config.type,entry_id:this._config.entry_id},this._registry);i=!!e?.is_group,s=e?.managed_covers.length??0,e&&!i&&e.managed_covers.length>0&&(o={entity:{domain:"cover",include_entities:e.managed_covers}}),e&&!i&&(n=wt(e).map(e=>({value:e.id,label:He[e.id]?ot(He[e.id],this.hass):e.label})))}return i?[{name:"entry_id",required:!0,selector:{select:{options:e,mode:"dropdown"}}},this._section("content_section","mdi:format-text",!0,[{name:"name",selector:{text:{}}},{name:"icon",selector:{icon:{}}},this._grid([{name:"state_color",selector:{boolean:{}}}])]),this._section("controls_section","mdi:arrow-up-down",!1,[this._grid([{name:"show_controls",selector:{boolean:{}}},{name:"show_position_bar",selector:{boolean:{}}},{name:"show_tilt",selector:{boolean:{}}}])]),this._section("group_row_section","mdi:window-shutter-cog",!1,[this._grid([{name:"show_scene_select",selector:{boolean:{}}},{name:"show_lock",selector:{boolean:{}}},{name:"show_automation",selector:{boolean:{}}},{name:"show_clear_overrides",selector:{boolean:{}}},{name:"show_member_badges",selector:{boolean:{}}}])]),this._interactionsSection()]:[{name:"entry_id",required:!0,selector:{select:{options:e,mode:"dropdown"}}},...s>1||this._config?.cover?[{name:"cover",selector:o}]:[],this._section("content_section","mdi:format-text",!0,[{name:"name",selector:{text:{}}},{name:"icon",selector:{icon:{}}},{name:"layout",selector:{select:{mode:"list",options:t}}},this._grid([{name:"show_position",selector:{boolean:{}}},{name:"show_state",selector:{boolean:{}}},{name:"show_decision_summary",selector:{boolean:{}}},{name:"state_color",selector:{boolean:{}}},{name:"show_motion_icon",selector:{boolean:{}}}])]),this._section("controls_section","mdi:arrow-up-down",!1,[this._grid([{name:"show_controls",selector:{boolean:{}}},{name:"show_position_bar",selector:{boolean:{}}},{name:"show_tilt",selector:{boolean:{}}}]),...s>1||this._config?.controls_cover?[{name:"controls_cover",selector:o}]:[],...n.length>1||this._config?.controls_axis?[{name:"controls_axis",selector:{select:{options:n,mode:"dropdown"}}}]:[]]),this._section("badge_section","mdi:label-multiple-outline",!1,[{name:"show_badge",selector:{boolean:{}}},this._grid(zn.map(e=>({name:`badge_${e}`,selector:{boolean:{}}})))]),this._section("dialog_section","mdi:card-text-outline",!1,[this._grid([{name:"show_compass",selector:{boolean:{}}},{name:"show_elevation_chart",selector:{boolean:{}}},{name:"show_solar_calc",selector:{boolean:{}}}])]),this._interactionsSection()]}_section(e,t,o,i){return{type:"expandable",name:"",title:ot(`editor.tile.${e}`,this.hass),icon:t,expanded:o,schema:i}}_grid(e){return{type:"grid",name:"",schema:e}}_interactionsSection(){return this._section("interactions_section","mdi:gesture-tap",!1,[{name:"tap_action",selector:{ui_action:{}}},{name:"icon_tap_action",selector:{ui_action:{default_action:"none"}}},{name:"hold_action",selector:{ui_action:{}}},{name:"double_tap_action",selector:{ui_action:{}}}])}};Tn.styles=r`
+    `}_schema(){const e=this._entries?.map(e=>({value:e.entry_id,label:e.title}))??[],t=[{value:"one-line",label:it("editor.tile.layout_option_one_line",this.hass)},{value:"detailed",label:it("editor.tile.layout_option_detailed",this.hass)}];let o={entity:{domain:"cover"}},i=!1,s=0,n=[];if(this._registry&&this._config?.entry_id){const e=So(this.hass,{type:this._config.type,entry_id:this._config.entry_id},this._registry);i=!!e?.is_group,s=e?.managed_covers.length??0,e&&!i&&e.managed_covers.length>0&&(o={entity:{domain:"cover",include_entities:e.managed_covers}}),e&&!i&&(n=$t(e).map(e=>({value:e.id,label:Ue[e.id]?it(Ue[e.id],this.hass):e.label})))}return i?[{name:"entry_id",required:!0,selector:{select:{options:e,mode:"dropdown"}}},this._section("content_section","mdi:format-text",!0,[{name:"name",selector:{text:{}}},{name:"icon",selector:{icon:{}}},this._grid([{name:"state_color",selector:{boolean:{}}}])]),this._section("controls_section","mdi:arrow-up-down",!1,[this._grid([{name:"show_controls",selector:{boolean:{}}},{name:"show_position_bar",selector:{boolean:{}}},{name:"show_tilt",selector:{boolean:{}}}])]),this._section("group_row_section","mdi:window-shutter-cog",!1,[this._grid([{name:"show_scene_select",selector:{boolean:{}}},{name:"show_lock",selector:{boolean:{}}},{name:"show_automation",selector:{boolean:{}}},{name:"show_clear_overrides",selector:{boolean:{}}},{name:"show_member_badges",selector:{boolean:{}}}])]),this._interactionsSection()]:[{name:"entry_id",required:!0,selector:{select:{options:e,mode:"dropdown"}}},...s>1||this._config?.cover?[{name:"cover",selector:o}]:[],this._section("content_section","mdi:format-text",!0,[{name:"name",selector:{text:{}}},{name:"icon",selector:{icon:{}}},{name:"layout",selector:{select:{mode:"list",options:t}}},this._grid([{name:"show_position",selector:{boolean:{}}},{name:"show_state",selector:{boolean:{}}},{name:"show_decision_summary",selector:{boolean:{}}},{name:"state_color",selector:{boolean:{}}},{name:"show_motion_icon",selector:{boolean:{}}}])]),this._section("controls_section","mdi:arrow-up-down",!1,[this._grid([{name:"show_controls",selector:{boolean:{}}},{name:"show_position_bar",selector:{boolean:{}}},{name:"show_tilt",selector:{boolean:{}}}]),...s>1||this._config?.controls_cover?[{name:"controls_cover",selector:o}]:[],...n.length>1||this._config?.controls_axis?[{name:"controls_axis",selector:{select:{options:n,mode:"dropdown"}}}]:[]]),this._section("badge_section","mdi:label-multiple-outline",!1,[{name:"show_badge",selector:{boolean:{}}},this._grid(Fn.map(e=>({name:`badge_${e}`,selector:{boolean:{}}})))]),this._section("dialog_section","mdi:card-text-outline",!1,[this._grid([{name:"show_compass",selector:{boolean:{}}},{name:"show_elevation_chart",selector:{boolean:{}}},{name:"show_solar_calc",selector:{boolean:{}}}])]),this._interactionsSection()]}_section(e,t,o,i){return{type:"expandable",name:"",title:it(`editor.tile.${e}`,this.hass),icon:t,expanded:o,schema:i}}_grid(e){return{type:"grid",name:"",schema:e}}_interactionsSection(){return this._section("interactions_section","mdi:gesture-tap",!1,[{name:"tap_action",selector:{ui_action:{}}},{name:"icon_tap_action",selector:{ui_action:{default_action:"none"}}},{name:"hold_action",selector:{ui_action:{}}},{name:"double_tap_action",selector:{ui_action:{}}}])}};Rn.styles=a`
     :host {
       display: block;
     }
@@ -4884,19 +4901,19 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
     .dim {
       color: var(--secondary-text-color);
     }
-  `,e([_e({attribute:!1})],Tn.prototype,"hass",void 0),e([ge()],Tn.prototype,"_config",void 0),e([ge()],Tn.prototype,"_entries",void 0),e([ge()],Tn.prototype,"_entriesError",void 0),e([ge()],Tn.prototype,"_registry",void 0),e([ge()],Tn.prototype,"_managedCovers",void 0),e([ge()],Tn.prototype,"_isGroupEntry",void 0),e([ge()],Tn.prototype,"_dragFrom",void 0),Tn=e([he($e)],Tn);let Pn=class extends ce{constructor(){super(...arguments),this._registry=null,this._registryError=null,this._dialogOpen=!1,this._posDrag=null,this._extendOpen=!1,this._unsubRegistry=null,this._fetchInFlight=!1,this._memo=yo(),this._discovered=null,this._fetchGen=0,this._closeDialog=()=>{this._dialogOpen=!1},this._onPosPointerDown=(e,t,o)=>{e.stopPropagation();const i=e.currentTarget;i.setPointerCapture?.(e.pointerId),this._posDrag={id:t,pct:gt(this._posPctFromEvent(e,i),o)}},this._onPosPointerMove=(e,t,o)=>{this._posDrag?.id===t&&(e.stopPropagation(),this._posDrag={id:t,pct:gt(this._posPctFromEvent(e,e.currentTarget),o)})},this._onPosPointerEnd=e=>{e.stopPropagation(),this._posDrag=null},this._holdTimer=null,this._pendingTapTimer=null,this._holdFired=!1,this._onPointerDown=()=>{this._holdFired=!1,null!=this._holdTimer&&clearTimeout(this._holdTimer),zi(this._config?.hold_action)&&(this._holdTimer=setTimeout(()=>{this._holdFired=!0,this._holdTimer=null,this._fireAction("hold")},500))},this._onPointerUp=()=>{null!=this._holdTimer&&(clearTimeout(this._holdTimer),this._holdTimer=null)},this._onPointerCancel=()=>{null!=this._holdTimer&&(clearTimeout(this._holdTimer),this._holdTimer=null)},this._onClick=()=>{if(!this._holdFired)return zi(this._config?.double_tap_action)?null!=this._pendingTapTimer?(clearTimeout(this._pendingTapTimer),this._pendingTapTimer=null,void this._fireAction("double_tap")):void(this._pendingTapTimer=setTimeout(()=>{this._pendingTapTimer=null,this._fireAction("tap")},250)):void this._fireAction("tap");this._holdFired=!1},this._onIconClick=e=>{this._hasIconAction()&&(e.stopPropagation(),this._config&&this.hass&&Ei(this,this.hass,{entity:this._actionEntity(),tap_action:this._config.icon_tap_action},"tap"))},this._onIconKeydown=e=>{this._hasIconAction()&&("Enter"!==e.key&&" "!==e.key||(e.preventDefault(),this._onIconClick(e)))}}setConfig(e){if(!e||"string"!=typeof e.entry_id||0===e.entry_id.length)throw new Error(`${xe}: \`entry_id\` is required and must be a non-empty string`);if(null!=(t=e.name)&&"string"!=typeof t&&!(Array.isArray(t)?t.every(Ii):"object"!=typeof t))throw new Error(`${xe}: \`name\` must be a string or an array of {type: 'entry'|'area'} or {type: 'text', text: string} parts`);var t;let o={...e};if("string"==typeof o.tap_action&&(o={...o,tap_action:"none"===o.tap_action?{action:"none"}:void 0}),this._config=o,o.tooltips&&mo(o.tooltips),null===this._registry){const e=No.get(o.entry_id);e&&(this._registry=e.entries)}}getCardSize(){return 1}getGridOptions(){return{columns:"full",rows:"auto",min_columns:3,min_rows:"one-line"!==this._config?.layout?2:1}}static async getStubConfig(e){let t="";try{const o=await Fo(e);t=o[0]?.entry_id??""}catch{}return{type:`custom:${xe}`,entry_id:t}}static async getConfigElement(){return document.createElement($e)}connectedCallback(){if(super.connectedCallback(),null===this._registry){const e=zo();e&&(this._registry=e)}this.hass&&this._ensureRegistry()}disconnectedCallback(){super.disconnectedCallback(),this._unsubRegistry&&(this._unsubRegistry(),this._unsubRegistry=null)}updated(e){e.has("hass")&&this.hass&&this._ensureRegistry()}shouldUpdate(e){return e.size>1||!e.has("hass")||(!this._discovered||(!!this._discovered.is_group||me(e.get("hass"),this.hass,Object.values(this._discovered.entities))))}willUpdate(e){this._config&&this.hass&&null!==this._registry&&(e.has("hass")||e.has("_registry")||e.has("_config"))&&(this._discovered=this._memo(this.hass,{type:this._config.type,entry_id:this._config.entry_id},this._registry))}_ensureRegistry(){this._fetchRegistry(),this._unsubRegistry||(this._unsubRegistry=So(this.hass,()=>{this._fetchRegistry(!0)}))}_fetchRegistry(e=!1){if(this._fetchInFlight)return;this._fetchInFlight=!0;const t=++this._fetchGen;Mo(this.hass,e).then(e=>{t===this._fetchGen&&e!==this._registry&&(this._registry=e,this._registryError=null,this._config&&No.set(this._config.entry_id,Ro(e,this._config.entry_id)))}).catch(e=>{t===this._fetchGen&&(this._registryError=e?.message??"entity registry fetch failed")}).finally(()=>{t===this._fetchGen&&(this._fetchInFlight=!1)})}render(){if(!this._config||!this.hass)return V;if(null===this._registry)return W`<ha-card>
+  `,e([ge({attribute:!1})],Rn.prototype,"hass",void 0),e([me()],Rn.prototype,"_config",void 0),e([me()],Rn.prototype,"_entries",void 0),e([me()],Rn.prototype,"_entriesError",void 0),e([me()],Rn.prototype,"_registry",void 0),e([me()],Rn.prototype,"_managedCovers",void 0),e([me()],Rn.prototype,"_isGroupEntry",void 0),e([me()],Rn.prototype,"_dragFrom",void 0),Rn=e([pe(ke)],Rn);let jn=class extends de{constructor(){super(...arguments),this._registry=null,this._registryError=null,this._dialogOpen=!1,this._posDrag=null,this._extendOpen=!1,this._unsubRegistry=null,this._fetchInFlight=!1,this._memo=xo(),this._discovered=null,this._fetchGen=0,this._closeDialog=()=>{this._dialogOpen=!1},this._onPosPointerDown=(e,t,o)=>{e.stopPropagation();const i=e.currentTarget;i.setPointerCapture?.(e.pointerId),this._posDrag={id:t,pct:vt(this._posPctFromEvent(e,i),o)}},this._onPosPointerMove=(e,t,o)=>{this._posDrag?.id===t&&(e.stopPropagation(),this._posDrag={id:t,pct:vt(this._posPctFromEvent(e,e.currentTarget),o)})},this._onPosPointerEnd=e=>{e.stopPropagation(),this._posDrag=null},this._holdTimer=null,this._pendingTapTimer=null,this._holdFired=!1,this._onPointerDown=()=>{this._holdFired=!1,null!=this._holdTimer&&clearTimeout(this._holdTimer),Ti(this._config?.hold_action)&&(this._holdTimer=setTimeout(()=>{this._holdFired=!0,this._holdTimer=null,this._fireAction("hold")},500))},this._onPointerUp=()=>{null!=this._holdTimer&&(clearTimeout(this._holdTimer),this._holdTimer=null)},this._onPointerCancel=()=>{null!=this._holdTimer&&(clearTimeout(this._holdTimer),this._holdTimer=null)},this._onClick=()=>{if(!this._holdFired)return Ti(this._config?.double_tap_action)?null!=this._pendingTapTimer?(clearTimeout(this._pendingTapTimer),this._pendingTapTimer=null,void this._fireAction("double_tap")):void(this._pendingTapTimer=setTimeout(()=>{this._pendingTapTimer=null,this._fireAction("tap")},250)):void this._fireAction("tap");this._holdFired=!1},this._onIconClick=e=>{this._hasIconAction()&&(e.stopPropagation(),this._config&&this.hass&&Mi(this,this.hass,{entity:this._actionEntity(),tap_action:this._config.icon_tap_action},"tap"))},this._onIconKeydown=e=>{this._hasIconAction()&&("Enter"!==e.key&&" "!==e.key||(e.preventDefault(),this._onIconClick(e)))}}setConfig(e){if(!e||"string"!=typeof e.entry_id||0===e.entry_id.length)throw new Error(`${$e}: \`entry_id\` is required and must be a non-empty string`);if(null!=(t=e.name)&&"string"!=typeof t&&!(Array.isArray(t)?t.every(Pi):"object"!=typeof t))throw new Error(`${$e}: \`name\` must be a string or an array of {type: 'entry'|'area'} or {type: 'text', text: string} parts`);var t;let o={...e};if("string"==typeof o.tap_action&&(o={...o,tap_action:"none"===o.tap_action?{action:"none"}:void 0}),this._config=o,o.tooltips&&fo(o.tooltips),null===this._registry){const e=Ro.get(o.entry_id);e&&(this._registry=e.entries)}}getCardSize(){return 1}getGridOptions(){return{columns:"full",rows:"auto",min_columns:3,min_rows:"one-line"!==this._config?.layout?2:1}}static async getStubConfig(e){let t="";try{const o=await No(e);t=o[0]?.entry_id??""}catch{}return{type:`custom:${$e}`,entry_id:t}}static async getConfigElement(){return document.createElement(ke)}connectedCallback(){if(super.connectedCallback(),null===this._registry){const e=To();e&&(this._registry=e)}this.hass&&this._ensureRegistry()}disconnectedCallback(){super.disconnectedCallback(),this._unsubRegistry&&(this._unsubRegistry(),this._unsubRegistry=null)}updated(e){e.has("hass")&&this.hass&&this._ensureRegistry()}shouldUpdate(e){return e.size>1||!e.has("hass")||(!this._discovered||(!!this._discovered.is_group||ve(e.get("hass"),this.hass,Object.values(this._discovered.entities))))}willUpdate(e){this._config&&this.hass&&null!==this._registry&&(e.has("hass")||e.has("_registry")||e.has("_config"))&&(this._discovered=this._memo(this.hass,{type:this._config.type,entry_id:this._config.entry_id},this._registry))}_ensureRegistry(){this._fetchRegistry(),this._unsubRegistry||(this._unsubRegistry=Eo(this.hass,()=>{this._fetchRegistry(!0)}))}_fetchRegistry(e=!1){if(this._fetchInFlight)return;this._fetchInFlight=!0;const t=++this._fetchGen;Io(this.hass,e).then(e=>{t===this._fetchGen&&e!==this._registry&&(this._registry=e,this._registryError=null,this._config&&Ro.set(this._config.entry_id,Ko(e,this._config.entry_id)))}).catch(e=>{t===this._fetchGen&&(this._registryError=e?.message??"entity registry fetch failed")}).finally(()=>{t===this._fetchGen&&(this._fetchInFlight=!1)})}render(){if(!this._config||!this.hass)return q;if(null===this._registry)return H`<ha-card>
         <div class="empty">
           <p class="dim">
-            ${this._registryError?ot("tile.registry_failed",this.hass,{error:this._registryError}):ot("tile.loading",this.hass)}
+            ${this._registryError?it("tile.registry_failed",this.hass,{error:this._registryError}):it("tile.loading",this.hass)}
           </p>
         </div>
-      </ha-card>`;const e=this._discovered;if(!e)return W`<ha-card>
+      </ha-card>`;const e=this._discovered;if(!e)return H`<ha-card>
         <div class="empty">
           <p class="dim">
-            ${ot("tile.entry_not_found",this.hass,{entry:this._config.entry_id})}
+            ${it("tile.entry_not_found",this.hass,{entry:this._config.entry_id})}
           </p>
         </div>
-      </ha-card>`;if(e.is_group){const t=Mi(this._config.name,e);return W`
+      </ha-card>`;if(e.is_group){const t=Ii(this._config.name,e);return H`
         <ha-card>
           <acp-group-tile
             @pointerdown=${this._onPointerDown}
@@ -4936,7 +4953,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
           .showMemberBadges=${!1!==this._config.show_member_badges}
           @acp-dialog-close=${this._closeDialog}
         ></acp-group-dialog>
-      `}return W`
+      `}return H`
       <ha-card>${this._renderTile(e)}</ha-card>
       <acp-more-info-dialog
         .hass=${this.hass}
@@ -4958,43 +4975,43 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
         @acp-extend-confirm=${t=>this._onExtendConfirm(t,e)}
         @acp-extend-close=${()=>this._extendOpen=!1}
       ></acp-extend-override-dialog>
-    `}_extendPresets(e){const t=e.entities.position_forecast_sensor,o=t?this.hass.states[t]?.attributes:void 0;return function(e){const{events:t,nowMs:o,latitude:i,longitude:s,max:n=Bi}=e,r=t.filter(e=>{const t=Date.parse(e.t);return!Number.isNaN(t)&&t>o}).map(e=>({kind:e.kind,t:e.t,label:e.label}));if(r.length<2&&null!=i&&null!=s)for(const e of function(e,t,o){const i=[];for(let s=0;s<=1;s++){const n=new Date(o+24*s*60*60*1e3),r=Vo.getTimes(n,e,t);for(const[e,t]of[["sunrise",r.sunrise],["sunset",r.sunset]])t&&!Number.isNaN(t.getTime())&&(t.getTime()<=o||i.some(t=>t.kind===e)||i.push({kind:e,t:t.toISOString()}))}return i.sort((e,t)=>Date.parse(e.t)-Date.parse(t.t))}(i,s,o)){const t=r.some(t=>{return t.kind===e.kind&&(o=t.t,i=e.t,Math.floor(Date.parse(o)/6e4)===Math.floor(Date.parse(i)/6e4));var o,i});t||r.push({kind:e.kind,t:e.t,label:e.kind})}return r.sort((e,t)=>Date.parse(e.t)-Date.parse(t.t)).slice(0,n)}({events:o?.events??[],nowMs:Date.now(),latitude:this.hass.config?.latitude,longitude:this.hass.config?.longitude})}_manualEndMs(e){const t=e.entities.manual_override_end_sensor,o=t?this.hass.states[t]?.state:void 0;if(!o)return;const i=Date.parse(o);return Number.isNaN(i)?void 0:i}_onExtendConfirm(e,t){!function(e,t,o){const i={};if(o.endTime)i.end_time=o.endTime.toISOString();else{if(null==o.duration)return;i.duration={seconds:o.duration}}e.callService(Me,"engage_manual_override",i,{entity_id:t})}(this.hass,t.managed_covers,{endTime:new Date(e.detail.endMs)}),this._extendOpen=!1}_buildHandlerLabels(){const e={};for(const[t,o]of Object.entries(Pe))e[t]=ot(o,this.hass);return e}_renderTile(e){const t=this._config,o=Mi(t.name,e),i=this._resolvedCover(e),s=i?this.hass.states[i]:void 0,n=s?.attributes?.device_class,r=nt(s?.state),a=st(s?.state),l=this._currentPosition(e),c=a?null:this._liveCoverPosition(e,i),d=r?null:c??l,h=t.icon??(r?"mdi:help-rhombus-outline":ht({explicitIcon:s?.attributes?.icon,deviceClass:n,coverType:e.cover_type,position:d})),p=!1!==t.state_color?_t(s?.state):null,u=this._hasIconAction(),_=!1!==t.show_position,g=!1!==t.show_state,m=!1!==t.show_controls,v=!1!==t.show_badge,f=!1!==t.show_motion_icon?this._motionActiveState(e):null,b=ot("timeout_pending"===f?"tile.motion_pending":"tile.motion_detected",this.hass),y="one-line"!==t.layout,w=wt(e),x=w.find(e=>"position"!==e.id),$=xt(e),k=!1!==t.show_tilt&&!!x,A=!a&&x?this._liveAxis(i,x):null,S=!r&&x?this._axisTarget(e,x):null,C=w.find(e=>e.id===t.controls_axis)??xt(e),E=t.controls_cover&&(0===e.managed_covers.length||e.managed_covers.includes(t.controls_cover))?t.controls_cover:i,z=E?this.hass.states[E]:void 0,M=nt(z?.state),I=st(z?.state)||!C?null:"position"===C.id?Ht(this.hass,e,E):Ut(this.hass,C,E),T=null!==I&&I>=(C?.max??100),P=null!==I&&I<=(C?.min??0),O=this._winner(e),F=this._traceAttrs(e),B=this._manualEndIso(e),N=this._isFullyInert(t),D=bi(F),R=!0===t.show_decision_summary&&F?wi(F.trace??[],F,0,this._buildHandlerLabels(),ot("badge.safety",this.hass)):"",j=!!R&&y,K=this._switchOn(e,"integration_enabled_switch"),L=this._switchOn(e,"automatic_control_switch"),G=this._manualOverrideOn(e),H=function(e){const t=function(e){const t=Gi(e);return"motion"!==t?"auto"!==t?t:function(e,t){const o=Ki(e);for(const e of Ie){if("motion"===e)continue;if(!o.has(e))continue;const i=Re[e];if(void 0!==i){if("off"===i||"group"===i)return i;if(!1!==t?.[i])return i}}return null}(e.trace,e.badges)??"auto":!1===e.badges?.motion||e.showMotionIcon?!1===e.badges?.auto?null:"auto":t}(e);return!1===e.inTimeWindow&&!1!==e.badges?.off_schedule&&"off"!==t&&"manual"!==t&&"force"!==t?"off_schedule":t}({winner:O,integrationEnabled:K,manualActive:G,badges:t.badges,showMotionIcon:!1!==t.show_motion_icon,inTimeWindow:F?.in_time_window,trace:F?.trace}),U=Wi(F?.trace,O),q=null!==H&&Ri([H],t.badges,U).length>0,Y=v&&q&&!(!1===L&&!0===K),Q=function(e){if(!e.integrationEnabled)return!1;if(!e.automaticControl)return!1;if(e.manualActive)return!1;const t=yi(e.winner);return"force"!==t&&("custom_position"!==t||!e.bypassAutoControl&&!0!==e.safetyActive)}({winner:O,integrationEnabled:K,automaticControl:L,manualActive:G,bypassAutoControl:!0===F?.bypass_auto_control,safetyActive:D}),Z=y&&v&&!1!==t.badges?.auto&&Q,X=!(Z&&"auto"===H),J=this._transitState(e),ee=r?ot("tile.unavailable",this.hass):g?rt(this.hass,i,J??void 0):null,te=[ee,_&&null!==d?it(d):null,k&&!y&&null!==A?`⟂${it(A)}`:null].filter(e=>!!e),oe=!!ee,ie=function(e,t,o){if(!Array.isArray(e?.custom_position_slots))return null;const i=e.custom_position_slots.filter(e=>!0===e.min_mode&&!0===e.enabled&&null!==e.sensor&&null!==e.position&&"on"===t[e.sensor]?.state);if(0===i.length)return null;const s=i.reduce((e,t)=>(t.position??0)>(e.position??0)?t:e),n=s.position,r=s.priority??null;return{slot:s.slot,position:n,label:s.sensor_name??`#${s.slot}`,clamping:null!==o&&n>o,sensorOn:!0,priority:r,resistsManual:null!=r&&r>80}}(F,this.hass.states,l),se=yi(O),ne=v&&!!ie&&!("custom_position"===se&&!0===F?.custom_position_minimum_mode)&&K,re=G&&!!e.entities.reset_override_button,ae=G&&function(e){const t=e.services;return!!t?.[Me]?.engage_manual_override}(this.hass),le=te.length>0?W`<div class="position">${te.join(" · ")}</div>`:V,ce=ne?W`<span
+    `}_extendPresets(e){const t=e.entities.position_forecast_sensor,o=t?this.hass.states[t]?.attributes:void 0;return function(e){const{events:t,nowMs:o,latitude:i,longitude:s,max:n=Di}=e,r=t.filter(e=>{const t=Date.parse(e.t);return!Number.isNaN(t)&&t>o}).map(e=>({kind:e.kind,t:e.t,label:e.label}));if(r.length<2&&null!=i&&null!=s)for(const e of function(e,t,o){const i=[];for(let s=0;s<=1;s++){const n=new Date(o+24*s*60*60*1e3),r=Yo.getTimes(n,e,t);for(const[e,t]of[["sunrise",r.sunrise],["sunset",r.sunset]])t&&!Number.isNaN(t.getTime())&&(t.getTime()<=o||i.some(t=>t.kind===e)||i.push({kind:e,t:t.toISOString()}))}return i.sort((e,t)=>Date.parse(e.t)-Date.parse(t.t))}(i,s,o)){const t=r.some(t=>{return t.kind===e.kind&&(o=t.t,i=e.t,Math.floor(Date.parse(o)/6e4)===Math.floor(Date.parse(i)/6e4));var o,i});t||r.push({kind:e.kind,t:e.t,label:e.kind})}return r.sort((e,t)=>Date.parse(e.t)-Date.parse(t.t)).slice(0,n)}({events:o?.events??[],nowMs:Date.now(),latitude:this.hass.config?.latitude,longitude:this.hass.config?.longitude})}_manualEndMs(e){const t=e.entities.manual_override_end_sensor,o=t?this.hass.states[t]?.state:void 0;if(!o)return;const i=Date.parse(o);return Number.isNaN(i)?void 0:i}_onExtendConfirm(e,t){!function(e,t,o){const i={};if(o.endTime)i.end_time=o.endTime.toISOString();else{if(null==o.duration)return;i.duration={seconds:o.duration}}e.callService(Te,"engage_manual_override",i,{entity_id:t})}(this.hass,t.managed_covers,{endTime:new Date(e.detail.endMs)}),this._extendOpen=!1}_buildHandlerLabels(){const e={};for(const[t,o]of Object.entries(Oe))e[t]=it(o,this.hass);return e}_renderTile(e){const t=this._config,o=Ii(t.name,e),i=this._resolvedCover(e),s=i?this.hass.states[i]:void 0,n=s?.attributes?.device_class,r=rt(s?.state),a=nt(s?.state),l=this._currentPosition(e),c=a?null:this._liveCoverPosition(e,i),d=r?null:c??l,h=t.icon??(r?"mdi:help-rhombus-outline":pt({explicitIcon:s?.attributes?.icon,deviceClass:n,coverType:e.cover_type,position:d})),p=!1!==t.state_color?mt(s?.state):null,u=this._hasIconAction(),_=!1!==t.show_position,g=!1!==t.show_state,m=!1!==t.show_controls,v=!1!==t.show_badge,f=!1!==t.show_motion_icon?this._motionActiveState(e):null,b=it("timeout_pending"===f?"tile.motion_pending":"tile.motion_detected",this.hass),y="one-line"!==t.layout,w=$t(e),x=w.find(e=>"position"!==e.id),$=kt(e),k=!1!==t.show_tilt&&!!x,A=!a&&x?this._liveAxis(i,x):null,S=!r&&x?this._axisTarget(e,x):null,C=w.find(e=>e.id===t.controls_axis)??kt(e),E=t.controls_cover&&(0===e.managed_covers.length||e.managed_covers.includes(t.controls_cover))?t.controls_cover:i,z=E?this.hass.states[E]:void 0,M=rt(z?.state),T=nt(z?.state)||!C?null:"position"===C.id?Vt(this.hass,e,E):qt(this.hass,C,E),I=null!==T&&T>=(C?.max??100),P=null!==T&&T<=(C?.min??0),O=this._winner(e),B=this._traceAttrs(e),F=this._manualEndIso(e),N=this._isFullyInert(t),D=wi(B),R=!0===t.show_decision_summary&&B?$i(B.trace??[],B,0,this._buildHandlerLabels(),it("badge.safety",this.hass)):"",j=!!R&&y,K=this._switchOn(e,"integration_enabled_switch"),L=this._switchOn(e,"automatic_control_switch"),G=this._manualOverrideOn(e),W=function(e){const t=function(e){const t=Qi(e);return"motion"!==t?"auto"!==t?t:function(e,t){const o=qi(e);for(const e of Ie){if("motion"===e)continue;if(!o.has(e))continue;const i=je[e];if(void 0!==i){if("off"===i||"group"===i)return i;if(!1!==t?.[i])return i}}return null}(e.trace,e.badges)??"auto":!1===e.badges?.motion||e.showMotionIcon?!1===e.badges?.auto?null:"auto":t}(e);return!1===e.inTimeWindow&&!1!==e.badges?.off_schedule&&"off"!==t&&"manual"!==t&&"force"!==t?"off_schedule":t}({winner:O,integrationEnabled:K,manualActive:G,badges:t.badges,showMotionIcon:!1!==t.show_motion_icon,inTimeWindow:B?.in_time_window,trace:B?.trace}),U=Zi(B?.trace,O),V=null!==W&&Ui([W],t.badges,U).length>0,Y=v&&V&&!(!1===L&&!0===K),Q=function(e){if(!e.integrationEnabled)return!1;if(!e.automaticControl)return!1;if(e.manualActive)return!1;const t=xi(e.winner);return"force"!==t&&("custom_position"!==t||!e.bypassAutoControl&&!0!==e.safetyActive)}({winner:O,integrationEnabled:K,automaticControl:L,manualActive:G,bypassAutoControl:!0===B?.bypass_auto_control,safetyActive:D}),Z=y&&v&&!1!==t.badges?.auto&&Q,X=!(Z&&"auto"===W),J=this._transitState(e),ee=r?it("tile.unavailable",this.hass):g?at(this.hass,i,J??void 0):null,te=[ee,_&&null!==d?st(d):null,k&&!y&&null!==A?`⟂${st(A)}`:null].filter(e=>!!e),oe=!!ee,ie=function(e,t,o){if(!Array.isArray(e?.custom_position_slots))return null;const i=e.custom_position_slots.filter(e=>!0===e.min_mode&&!0===e.enabled&&null!==e.sensor&&null!==e.position&&"on"===t[e.sensor]?.state);if(0===i.length)return null;const s=i.reduce((e,t)=>(t.position??0)>(e.position??0)?t:e),n=s.position,r=s.priority??null;return{slot:s.slot,position:n,label:s.sensor_name??`#${s.slot}`,clamping:null!==o&&n>o,sensorOn:!0,priority:r,resistsManual:null!=r&&r>80}}(B,this.hass.states,l),se=xi(O),ne=v&&!!ie&&!("custom_position"===se&&!0===B?.custom_position_minimum_mode)&&K,re=G&&!!e.entities.reset_override_button,ae=G&&function(e){const t=e.services;return!!t?.[Te]?.engage_manual_override}(this.hass),le=te.length>0?H`<div class="position">${te.join(" · ")}</div>`:q,ce=ne?H`<span
           class=${`acp-floor-chip${ie.clamping?"":" is-armed"}${ie.resistsManual?" resists-manual":" is-bypassable"}`}
-          ${bo(ot("dialog.floor_tooltip",this.hass))}
-          >${ot("dialog.floor",this.hass)} ${it(ie.position)}</span
-        >`:V,de=Y?W`<acp-tile-badge
+          ${wo(it("dialog.floor_tooltip",this.hass))}
+          >${it("dialog.floor",this.hass)} ${st(ie.position)}</span
+        >`:q,de=Y?H`<acp-tile-badge
           .hass=${this.hass}
           .winner=${O}
-          .kindOverride=${H??void 0}
+          .kindOverride=${W??void 0}
           .integrationEnabled=${K}
-          .slotNumber=${F?.custom_position_active_slot}
-          .slotName=${F?.custom_position_active_slot_name}
-          .pct=${fi(F,l)??void 0}
-          .minimumMode=${F?.custom_position_minimum_mode}
+          .slotNumber=${B?.custom_position_active_slot}
+          .slotName=${B?.custom_position_active_slot_name}
+          .pct=${yi(B,l)??void 0}
+          .minimumMode=${B?.custom_position_minimum_mode}
           .safetyActive=${D}
-          .manualEndIso=${B}
+          .manualEndIso=${F}
           .manualActive=${G}
           .resumable=${re}
           .extendable=${ae}
           @acp-resume=${()=>this._resume(e)}
           @acp-extend=${()=>this._extendOpen=!0}
-        ></acp-tile-badge>`:V,he=Z?W`<acp-tile-badge
+        ></acp-tile-badge>`:q,he=Z?H`<acp-tile-badge
           .hass=${this.hass}
           .winner=${O}
           .kindOverride=${"auto"}
           .integrationEnabled=${K}
-        ></acp-tile-badge>`:V,pe=te.length>0?W`<div class="state">${te.join(" · ")}</div>`:V,ue=t.cover?[t.cover]:e.managed_covers.length>0?e.managed_covers:i?[i]:[],_e=t.covers?.length?e.managed_covers.length>0?t.covers.filter(t=>e.managed_covers.includes(t)):t.covers:[],ge=_e.length>0?_e:ue,me=Wt(this.hass,e),ve=t=>{if(t===i)return d;const o=this.hass.states[t];return nt(o?.state)?null:(st(o?.state)?null:Ht(this.hass,e,t))??me[t]??null},fe=function(e,t){const o=t.entities.position_verification_sensor;if(!o)return{};const i=e.states[o]?.attributes?.per_entity;if(!i||"object"!=typeof i)return{};const s=$t(t),n={};for(const[e,t]of Object.entries(i)){const o=t?.target;"number"==typeof o&&Number.isFinite(o)&&(n[e]=s?100-o:o)}return n}(this.hass,e),be=e=>e===i?l:fe[e]??null,ye=y&&!1!==t.show_position_bar&&ge.some(e=>null!==ve(e)),we=ye?1===ge.length?this._posBar(ge[0],ve(ge[0]),be(ge[0]),p,$):W`<div class="pos-stack">
-            ${ge.map(t=>{const o=ve(t),i=this._coverShortName(t,e);return W`<div class="pos-row">
+        ></acp-tile-badge>`:q,pe=te.length>0?H`<div class="state">${te.join(" · ")}</div>`:q,ue=t.cover?[t.cover]:e.managed_covers.length>0?e.managed_covers:i?[i]:[],_e=t.covers?.length?e.managed_covers.length>0?t.covers.filter(t=>e.managed_covers.includes(t)):t.covers:[],ge=_e.length>0?_e:ue,me=(()=>{const e=Wi(Li(this.hass,ge));return Gi(e)?e:null})(),ve=Ut(this.hass,e),fe=t=>{if(t===i)return d;const o=this.hass.states[t];return rt(o?.state)?null:(nt(o?.state)?null:Vt(this.hass,e,t))??ve[t]??null},be=function(e,t){const o=t.entities.position_verification_sensor;if(!o)return{};const i=e.states[o]?.attributes?.per_entity;if(!i||"object"!=typeof i)return{};const s=At(t),n={};for(const[e,t]of Object.entries(i)){const o=t?.target;"number"==typeof o&&Number.isFinite(o)&&(n[e]=s?100-o:o)}return n}(this.hass,e),ye=e=>e===i?l:be[e]??null,we=y&&!1!==t.show_position_bar&&ge.some(e=>null!==fe(e)),xe=we?1===ge.length?this._posBar(ge[0],fe(ge[0]),ye(ge[0]),$):H`<div class="pos-stack">
+            ${ge.map(t=>{const o=fe(t),i=this._coverShortName(t,e);return H`<div class="pos-row">
                 <ha-icon
                   class="pos-glyph"
                   icon=${this._railIcon(t,e,o)}
-                  ${bo(i)}
+                  ${wo(i)}
                 ></ha-icon>
-                ${this._posBar(t,o,be(t),p,$,i)}
+                ${this._posBar(t,o,ye(t),$,i)}
               </div>`})}
-          </div>`:V,xe=Y&&X,$e=y&&(Z||xe||ne),ke=$e?W`${he}${xe?de:V}${ce}`:V,Ae=y&&($e||ye);return W`
+          </div>`:q,$e=Y&&X,ke=y&&(Z||$e||ne),Ae=ke?H`${he}${$e?de:q}${ce}`:q,Se=y&&(ke||we);return H`
       <div
-        class=${`tile-body${y?" detailed":""}${oe?" has-state-label":""}${ne&&!y?" has-floor-chip":""}${k&&y?" has-tilt":""}${Ae?" has-chrome-row":""}${Ae&&!$e?" bar-only":""}${m?" has-controls":""}${r?" unavailable":""}`}
+        class=${`tile-body${y?" detailed":""}${oe?" has-state-label":""}${ne&&!y?" has-floor-chip":""}${k&&y?" has-tilt":""}${Se?" has-chrome-row":""}${Se&&!ke?" bar-only":""}${m?" has-controls":""}${r?" unavailable":""}`}
         role=${N?"group":"button"}
         tabindex=${N?-1:0}
         @pointerdown=${this._onPointerDown}
@@ -5005,10 +5022,10 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
       >
         <div
           class=${"cover-icon-wrap"+(u?" background":"")}
-          role=${u?"button":V}
-          tabindex=${u?0:V}
-          aria-label=${u?ot("tile.icon_action_label",this.hass):V}
-          style=${p?`--acp-tile-icon-color: ${p}`:V}
+          role=${u?"button":q}
+          tabindex=${u?0:q}
+          aria-label=${u?it("tile.icon_action_label",this.hass):q}
+          style=${p?`--acp-tile-icon-color: ${p}`:q}
           @click=${this._onIconClick}
           @keydown=${this._onIconKeydown}
         >
@@ -5017,21 +5034,26 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
             icon=${h}
             style=${p?`color: ${p}`:""}
           ></ha-icon>
-          ${f?W`<ha-icon
+          ${f?H`<ha-icon
                 class="motion-overlay ${f}"
                 icon="mdi:motion-sensor"
-                ${bo(b)}
-              ></ha-icon>`:V}
+                ${wo(b)}
+              ></ha-icon>`:q}
+          ${me?H`<ha-icon
+                class="battery-overlay"
+                icon=${Hi(me.level,me.charging)}
+                ${wo(null===me.level?it("tile.battery_unknown",this.hass):it("tile.battery_low",this.hass,{level:me.level}))}
+              ></ha-icon>`:q}
         </div>
         <div class="label">
           <div class="title">${o}</div>
-          ${y?pe:V}
-          ${R&&!y?W`<div class="summary">${R}</div>`:V}
-          ${j?W`<div class="summary" ${bo(R)}>${R}</div>`:V}
+          ${y?pe:q}
+          ${R&&!y?H`<div class="summary">${R}</div>`:q}
+          ${j?H`<div class="summary" ${wo(R)}>${R}</div>`:q}
         </div>
-        ${y?V:W`${le}${ce}`}
-        ${Ae?W`<div class="chrome-line">${ke}${we}</div>`:V}
-        ${k&&y?W`<div
+        ${y?q:H`${le}${ce}`}
+        ${Se?H`<div class="chrome-line">${Ae}${xe}</div>`:q}
+        ${k&&y?H`<div
               class="tilt-line"
               @click=${this._stop}
               @pointerdown=${this._stop}
@@ -5050,21 +5072,21 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
                 .disabled=${r}
                 @acp-tilt-set=${e=>x&&this._setAxis(i,x.id,e.detail)}
               ></acp-tilt-bar>
-            </div>`:V}
-        ${m?W`<div class="controls" @click=${this._stop} @pointerdown=${this._stop}>
+            </div>`:q}
+        ${m?H`<div class="controls" @click=${this._stop} @pointerdown=${this._stop}>
               <button
                 class="up"
                 type="button"
-                aria-label=${ot("tile.open",this.hass)}
-                ?disabled=${!E||M||T}
+                aria-label=${it("tile.open",this.hass)}
+                ?disabled=${!E||M||I}
                 @click=${()=>C&&this._setAxis(E,C.id,C.max)}
               >
-                <ha-icon icon=${pt(n)}></ha-icon>
+                <ha-icon icon=${ut(n)}></ha-icon>
               </button>
               <button
                 class="stop"
                 type="button"
-                aria-label=${ot("tile.stop",this.hass)}
+                aria-label=${it("tile.stop",this.hass)}
                 ?disabled=${!E||M}
                 @click=${()=>this._stopCover(E)}
               >
@@ -5073,42 +5095,45 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
               <button
                 class="down"
                 type="button"
-                aria-label=${ot("tile.close",this.hass)}
+                aria-label=${it("tile.close",this.hass)}
                 ?disabled=${!E||M||P}
                 @click=${()=>C&&this._setAxis(E,C.id,C.min)}
               >
-                <ha-icon icon=${ut(n)}></ha-icon>
+                <ha-icon icon=${_t(n)}></ha-icon>
               </button>
-            </div>`:V}
-        ${y?V:de}
+            </div>`:q}
+        ${y?q:de}
       </div>
-    `}_resolvedCover(e){return this._config?.cover?this._config.cover:e.managed_covers[0]}_currentPosition(e){return Lt(this.hass,e)}_transitState(e){const t=e.entities.target_position_sensor;if(!t)return null;const o=this._resolvedCover(e);if(!o)return null;const i=this.hass.states[t]?.attributes?.transit_states;return i?.[o]??null}_liveCoverPosition(e,t){return Ht(this.hass,e,t)}_winner(e){const t=e.entities.decision_trace_sensor;return t?this.hass.states[t]?.state??"default":"default"}_traceAttrs(e){const t=e.entities.decision_trace_sensor;if(t)return this.hass.states[t]?.attributes}_motionActiveState(e){const t=e.entities.motion_status_sensor;if(!t)return null;const o=this.hass.states[t]?.state;return"motion_detected"===o||"timeout_pending"===o?o:null}_manualOverrideOn(e){const t=e.entities.manual_override_binary;return!!t&&"on"===this.hass.states[t]?.state}_switchOn(e,t){const o=e.entities[t];return!o||"off"!==this.hass.states[o]?.state}_manualEndIso(e){if(!this._manualOverrideOn(e))return;const t=e.entities.manual_override_end_sensor;return t?this.hass.states[t]?.state:void 0}_setCoverPosition(e,t){e&&this._setAxis(e,"position",t)}_posBar(e,t,o,i,s,n){const r=this._posDrag?.id===e,a=r?this._posDrag.pct:t,l=null===a?0:gt(a,s),c=null===o?null:gt(o,s),d=null!==o?`${it(a)} · ${ot("dialog.target",this.hass)} ${it(o)}`:it(a);return W`<div
-      class="pos-slider${r?" dragging":""}"
+    `}_resolvedCover(e){return this._config?.cover?this._config.cover:e.managed_covers[0]}_currentPosition(e){return Wt(this.hass,e)}_transitState(e){const t=e.entities.target_position_sensor;if(!t)return null;const o=this._resolvedCover(e);if(!o)return null;const i=this.hass.states[t]?.attributes?.transit_states;return i?.[o]??null}_liveCoverPosition(e,t){return Vt(this.hass,e,t)}_winner(e){const t=e.entities.decision_trace_sensor;return t?this.hass.states[t]?.state??"default":"default"}_traceAttrs(e){const t=e.entities.decision_trace_sensor;if(t)return this.hass.states[t]?.attributes}_motionActiveState(e){const t=e.entities.motion_status_sensor;if(!t)return null;const o=this.hass.states[t]?.state;return"motion_detected"===o||"timeout_pending"===o?o:null}_manualOverrideOn(e){const t=e.entities.manual_override_binary;return!!t&&"on"===this.hass.states[t]?.state}_switchOn(e,t){const o=e.entities[t];return!o||"off"!==this.hass.states[o]?.state}_manualEndIso(e){if(!this._manualOverrideOn(e))return;const t=e.entities.manual_override_end_sensor;return t?this.hass.states[t]?.state:void 0}_setCoverPosition(e,t){e&&this._setAxis(e,"position",t)}_posBar(e,t,o,i,s){const n=this._posDrag?.id===e,r=n?this._posDrag.pct:t,a=null===r?0:vt(r,i),l=null===o?null:vt(o,i),c=null!==o?`${st(r)} · ${it("dialog.target",this.hass)} ${st(o)}`:st(r);return H`<div
+      class="pos-slider${n?" dragging":""}"
       role="slider"
       tabindex="0"
       aria-valuemin="0"
       aria-valuemax="100"
-      aria-valuenow=${l}
-      aria-valuetext=${ot("covers.position_open_value",this.hass,{pct:it(a)})}
-      aria-label=${n?`${n} · ${ot("covers.position_slider_label",this.hass)}`:ot("covers.position_slider_label",this.hass)}
-      @click=${t=>this._onPosClick(t,e,s)}
-      @pointerdown=${t=>this._onPosPointerDown(t,e,s)}
-      @pointermove=${t=>this._onPosPointerMove(t,e,s)}
+      aria-valuenow=${a}
+      aria-valuetext=${it("covers.position_open_value",this.hass,{pct:st(r)})}
+      aria-label=${s?`${s} · ${it("covers.position_slider_label",this.hass)}`:it("covers.position_slider_label",this.hass)}
+      @click=${t=>this._onPosClick(t,e,i)}
+      @pointerdown=${t=>this._onPosPointerDown(t,e,i)}
+      @pointermove=${t=>this._onPosPointerMove(t,e,i)}
       @pointerup=${this._onPosPointerEnd}
       @pointercancel=${this._onPosPointerEnd}
-      @keydown=${t=>this._onPosKeydown(t,e,l,s)}
+      @keydown=${t=>this._onPosKeydown(t,e,a,i)}
     >
-      <div class="pos-bar" ${bo(d)}>
-        <div
-          class="pos-fill"
-          style=${`width:${l}%${i?`;background:${i}`:""}`}
-        ></div>
-        ${null!==c?W`<div
+      <div class="pos-bar" ${wo(c)}>
+        <div class="pos-fill" style=${`width:${a}%`}></div>
+        ${null!==l?H`<div
               class="pos-marker"
-              style=${`left:clamp(1px, ${c}%, calc(100% - 1px))`}
-            ></div>`:V}
+              style=${`left:clamp(1px, ${l}%, calc(100% - 1px))`}
+            ></div>`:q}
       </div>
-    </div>`}_railIcon(e,t,o){const i=this.hass.states[e];return ht({explicitIcon:i?.attributes?.icon,deviceClass:i?.attributes?.device_class,coverType:t.cover_type,position:o})}_coverShortName(e,t){const o=this.hass.states[e]?.attributes?.friendly_name??e,i=t.entry_title;if(i&&o.toLowerCase().startsWith(i.toLowerCase())){const e=o.slice(i.length).replace(/^[\s\-–—:]+/,"");if(e)return e}return o}_posPctFromEvent(e,t){const o=t.getBoundingClientRect(),i=Math.round((e.clientX-o.left)/o.width*100);return Math.max(0,Math.min(100,i))}_onPosClick(e,t,o){e.stopPropagation(),this._setCoverPosition(t,gt(this._posPctFromEvent(e,e.currentTarget),o))}_onPosKeydown(e,t,o,i){let s;switch(e.key){case"ArrowRight":case"ArrowUp":s=o+1;break;case"ArrowLeft":case"ArrowDown":s=o-1;break;case"PageUp":s=o+10;break;case"PageDown":s=o-10;break;case"Home":s=0;break;case"End":s=100;break;default:return}e.preventDefault(),e.stopPropagation(),this._setCoverPosition(t,gt(Math.max(0,Math.min(100,s)),i))}_stopCover(e){e&&this.hass.callService(Me,"stop",{},{entity_id:e})}_setAxis(e,t,o){e&&Fi(this.hass,e,{[t]:o})}_axisTarget(e,t){const o=t.targetRole;if(!o)return null;const i=e.entities[o];if(!i)return null;const s=parseFloat(this.hass.states[i]?.state??"");return Number.isNaN(s)?null:s}_liveAxis(e,t){return Ut(this.hass,t,e)}_axisLabel(e){const t=He[e.id];return t?ot(t,this.hass):e.label}_resume(e){const t=e.entities.reset_override_button;t&&this.hass.callService("button","press",{entity_id:t})}_tapActionConfig(){const e=this._config?.tap_action;if("string"!=typeof e)return e}_isFullyInert(e){return!!(e=>!!e&&"none"===e.action)(this._tapActionConfig())&&!zi(e.hold_action)&&!zi(e.double_tap_action)}_fireAction(e){if(!this._config||!this.hass)return;const t=this._tapActionConfig();if("tap"===e&&void 0===t)return this._dialogOpen=!0,void this.dispatchEvent(new CustomEvent("acp-tile-tap",{bubbles:!0,composed:!0}));Ei(this,this.hass,{entity:this._actionEntity(),tap_action:t,hold_action:this._config.hold_action,double_tap_action:this._config.double_tap_action},e)}_hasIconAction(){return zi(this._config?.icon_tap_action)}_actionEntity(){const e=this._discovered;return e?.is_group?e.entities.group_cover??e.entities.group_position_sensor:this._resolvedCoverFromState()}_resolvedCoverFromState(){if(this._config?.cover)return this._config.cover;if(null===this._registry)return;const e=this._discovered??this._memo(this.hass,{type:this._config.type,entry_id:this._config.entry_id},this._registry);return e?.managed_covers[0]}_stop(e){e.stopPropagation()}};Pn.styles=r`
+      ${n?H`<div
+            class="pos-readout"
+            style=${`left:clamp(16px, ${a}%, calc(100% - 16px))`}
+          >
+            ${st(r)}
+          </div>`:q}
+    </div>`}_railIcon(e,t,o){const i=this.hass.states[e];return pt({explicitIcon:i?.attributes?.icon,deviceClass:i?.attributes?.device_class,coverType:t.cover_type,position:o})}_coverShortName(e,t){const o=this.hass.states[e]?.attributes?.friendly_name??e,i=t.entry_title;if(i&&o.toLowerCase().startsWith(i.toLowerCase())){const e=o.slice(i.length).replace(/^[\s\-–—:]+/,"");if(e)return e}return o}_posPctFromEvent(e,t){const o=t.getBoundingClientRect(),i=Math.round((e.clientX-o.left)/o.width*100);return Math.max(0,Math.min(100,i))}_onPosClick(e,t,o){e.stopPropagation(),this._setCoverPosition(t,vt(this._posPctFromEvent(e,e.currentTarget),o))}_onPosKeydown(e,t,o,i){let s;switch(e.key){case"ArrowRight":case"ArrowUp":s=o+1;break;case"ArrowLeft":case"ArrowDown":s=o-1;break;case"PageUp":s=o+10;break;case"PageDown":s=o-10;break;case"Home":s=0;break;case"End":s=100;break;default:return}e.preventDefault(),e.stopPropagation(),this._setCoverPosition(t,vt(Math.max(0,Math.min(100,s)),i))}_stopCover(e){e&&this.hass.callService(Te,"stop",{},{entity_id:e})}_setAxis(e,t,o){e&&Ni(this.hass,e,{[t]:o})}_axisTarget(e,t){const o=t.targetRole;if(!o)return null;const i=e.entities[o];if(!i)return null;const s=parseFloat(this.hass.states[i]?.state??"");return Number.isNaN(s)?null:s}_liveAxis(e,t){return qt(this.hass,t,e)}_axisLabel(e){const t=Ue[e.id];return t?it(t,this.hass):e.label}_resume(e){const t=e.entities.reset_override_button;t&&this.hass.callService("button","press",{entity_id:t})}_tapActionConfig(){const e=this._config?.tap_action;if("string"!=typeof e)return e}_isFullyInert(e){return!!(e=>!!e&&"none"===e.action)(this._tapActionConfig())&&!Ti(e.hold_action)&&!Ti(e.double_tap_action)}_fireAction(e){if(!this._config||!this.hass)return;const t=this._tapActionConfig();if("tap"===e&&void 0===t)return this._dialogOpen=!0,void this.dispatchEvent(new CustomEvent("acp-tile-tap",{bubbles:!0,composed:!0}));Mi(this,this.hass,{entity:this._actionEntity(),tap_action:t,hold_action:this._config.hold_action,double_tap_action:this._config.double_tap_action},e)}_hasIconAction(){return Ti(this._config?.icon_tap_action)}_actionEntity(){const e=this._discovered;return e?.is_group?e.entities.group_cover??e.entities.group_position_sensor:this._resolvedCoverFromState()}_resolvedCoverFromState(){if(this._config?.cover)return this._config.cover;if(null===this._registry)return;const e=this._discovered??this._memo(this.hass,{type:this._config.type,entry_id:this._config.entry_id},this._registry);return e?.managed_covers[0]}_stop(e){e.stopPropagation()}};jn.styles=a`
     :host {
       display: block;
       height: 100%;
@@ -5200,26 +5225,14 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
         'icon chrome chrome'
         'icon tilt   tilt';
     }
-    /* Bar-only (position bar, no badges): confine the bar to the label column so
-       the controls can span both rows, then center the name/state across the
-       full height with the bar hugging the bottom — so a bar-only tile centers
-       its label instead of pinning it to the top (issue #208). Scoped to
-       :not(.has-tilt): a tilt tile keeps its 3-row grid (label/chrome/tilt) and
-       must NOT span the label across the bar + tilt rows, which would overlap
-       them (the tilt grid wins on specificity, so the label span has to opt out
-       explicitly here). */
-    .tile-body.detailed.bar-only:not(.has-tilt) {
-      grid-template-areas:
-        'icon label  controls'
-        'icon chrome controls';
-    }
-    .tile-body.detailed.bar-only:not(.has-tilt) .label {
-      grid-row: 1 / -1;
-      align-self: center;
-    }
-    .tile-body.detailed.bar-only:not(.has-tilt) .chrome-line {
-      align-self: end;
-    }
+    /* Bar-only (position bar, no badges) gets NO grid special-case: it uses the
+       same .has-chrome-row grid as a badged tile, so the bar spans label+controls
+       at full tile width and the name/state sit in row 1. The old special-case
+       confined the bar to the label column and spanned .label across both rows to
+       keep it centered (issue #208) — but a centered label and a bottom-aligned
+       bar then shared one cell and overlapped (issue #260), and the confined bar
+       read as a different component from the badged tile's full-width one. A
+       bar-only tile is now a badged tile minus the badges. */
     /* Name over state, vertically centered against the icon (HA ha-tile-info).
        No gap: HA's .info stacks the two lines with no gap and lets the primary
        line-height (normal, 1.6) do the spacing. */
@@ -5265,6 +5278,15 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
       align-items: center;
       gap: 6px;
       min-width: 0;
+      /* Rail geometry, shared by the lone rail and the multi-cover stack so the
+         two stay the same length — see the .pos-stack note (issue #260). The
+         glyph lane is the per-rail glyph plus the .pos-row gap that separates it
+         from the rail. */
+      --acp-rail-basis: 170px;
+      --acp-rail-max: 55%;
+      --acp-rail-glyph-size: 15px;
+      --acp-rail-glyph-gap: 6px;
+      --acp-rail-glyph-lane: calc(var(--acp-rail-glyph-size) + var(--acp-rail-glyph-gap));
       /* Reserve the badge pill's height even when no badge is present, so a
          bar-only tile is the same height as one with badges — the position bar
          just centers in the reserved space (issue #208). Matches the tile-badge
@@ -5289,8 +5311,8 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
       margin-left: auto;
       align-self: center;
       position: relative;
-      flex: 0 1 170px;
-      max-width: 55%;
+      flex: 0 1 var(--acp-rail-basis);
+      max-width: var(--acp-rail-max);
       cursor: pointer;
       /* A touch-drag must move the fill, not scroll the dashboard. */
       touch-action: none;
@@ -5303,13 +5325,20 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
       inset: -8px 0;
     }
     /* Multi-cover entry: the rails stack in the slot the single rail occupies,
-       each labelled with its cover's short name. The stack owns the flex sizing
-       so each rail below it can size itself to the full stack width. */
+       each labelled with its cover's glyph. The stack owns the flex sizing so
+       each rail below it can size itself to the full stack width.
+
+       It is WIDER than a lone rail by exactly the glyph lane, so the glyphs hang
+       to the left of the rail track instead of shortening the rails. Both are
+       margin-left:auto, so the right edges meet and — the lane cancelling out on
+       the left — a stacked rail and a lone rail are the same length and start at
+       the same x (issue #260). Derive, never hardcode: the lane is the glyph's
+       own width plus the .pos-row gap. */
     .chrome-line .pos-stack {
       margin-left: auto;
       align-self: center;
-      flex: 0 1 170px;
-      max-width: 55%;
+      flex: 0 1 calc(var(--acp-rail-basis) + var(--acp-rail-glyph-lane));
+      max-width: calc(var(--acp-rail-max) + var(--acp-rail-glyph-lane));
       min-width: 0;
       display: flex;
       flex-direction: column;
@@ -5318,7 +5347,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
     .chrome-line .pos-stack .pos-row {
       display: flex;
       align-items: center;
-      gap: 6px;
+      gap: var(--acp-rail-glyph-gap);
       min-width: 0;
     }
     /* Per-rail glyph in place of a name: two rails of one shade have long,
@@ -5335,9 +5364,9 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
       justify-content: center;
       align-self: center;
       line-height: 0;
-      --mdc-icon-size: 15px;
-      width: 15px;
-      height: 15px;
+      --mdc-icon-size: var(--acp-rail-glyph-size);
+      width: var(--acp-rail-glyph-size);
+      height: var(--acp-rail-glyph-size);
       color: var(--secondary-text-color);
     }
     .chrome-line .pos-stack .pos-slider {
@@ -5360,6 +5389,26 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
     .chrome-line .pos-slider.dragging .pos-fill {
       transition: none;
     }
+    /* Live percentage while a drag is in flight. The hover tooltip carries the
+       same number, but a tooltip is mouse-only — on a phone, the finger setting
+       the position is also the thing covering the rail, so without this the user
+       is dragging blind. Sits in .pos-slider, NOT .pos-bar: the bar is
+       overflow:hidden to clip the fill, which would clip this too. Pointer-events
+       off so it never eats the drag it is reporting on. */
+    .chrome-line .pos-readout {
+      position: absolute;
+      bottom: calc(100% + 6px);
+      transform: translateX(-50%);
+      padding: 1px 5px;
+      border-radius: 4px;
+      background: var(--secondary-background-color, rgba(127, 127, 127, 0.9));
+      color: var(--primary-text-color);
+      font-size: var(--ha-font-size-s, 0.75rem);
+      line-height: var(--ha-line-height-condensed, 1.2);
+      white-space: nowrap;
+      pointer-events: none;
+      z-index: 2;
+    }
     .chrome-line .pos-bar {
       position: relative;
       width: 100%;
@@ -5371,7 +5420,13 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
     .chrome-line .pos-fill {
       position: absolute;
       inset: 0 auto 0 0;
-      background: var(--primary-color);
+      /* One constant color for every rail, never the cover's state color: a rail
+         that changed hue as it crossed open/closed read as a status light rather
+         than a measurement, and on a multi-rail tile the rails disagreed with
+         each other. The icon still carries state color (the state_color option),
+         which is where that signal belongs. Overridable per-theme via
+         --acp-pos-fill-color. */
+      background: var(--acp-pos-fill-color, ${r(gt)});
       opacity: 0.55;
       border-radius: 6px;
       transition: width 0.3s ease;
@@ -5508,6 +5563,20 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
       right: -6px;
       --mdc-icon-size: 12px;
       color: var(--warning-color, #f1c232);
+      background: var(--card-background-color, white);
+      border-radius: 50%;
+      padding: 1px;
+      line-height: 0;
+    }
+    /* Sibling of .motion-overlay, pinned to the opposite corner so a cover that
+       is both occupied and low on battery shows both without them colliding —
+       motion top-right, battery bottom-left. */
+    .battery-overlay {
+      position: absolute;
+      bottom: -4px;
+      left: -6px;
+      --mdc-icon-size: 12px;
+      color: var(--error-color, #db4437);
       background: var(--card-background-color, white);
       border-radius: 50%;
       padding: 1px;
@@ -5681,22 +5750,8 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
             'icon tilt'
             'controls controls';
         }
-        /* The wide bar-only grid is :not(.has-tilt) at (0,4,0), which out-weighs
-           the (0,3,0) has-chrome-row reflow above — so re-assert the reflowed
-           (controls on their own row) grid at matching specificity here, or a
-           bar-only tile would keep its inline layout on phones. */
-        .tile-body.detailed.bar-only:not(.has-tilt) {
-          grid-template-areas:
-            'icon label'
-            'icon chrome'
-            'controls controls';
-        }
-        /* Narrow reflow stacks the controls on their own row, so the bar-only
-           label span from the wide layout would overlap them — pin it back to
-           the name row. */
-        .tile-body.detailed.bar-only:not(.has-tilt) .label {
-          grid-row: 1 / 2;
-        }
+        /* No bar-only re-assertion needed: the wide layout no longer special-cases
+           bar-only, so the .has-chrome-row reflow above already applies (#260). */
         .tile-body.detailed .controls {
           margin-top: 4px;
           gap: 8px;
@@ -5739,20 +5794,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
           'tilt tilt'
           'controls controls';
       }
-      /* Re-assert the reflowed grid for bar-only (see the 480px block): the wide
-         bar-only rule out-specifies the has-chrome-row reflow, so without this a
-         bar-only tile in a narrow Sections column keeps its inline controls. */
-      .tile-body.detailed.bar-only:not(.has-tilt) {
-        grid-template-areas:
-          'icon label'
-          'icon chrome'
-          'controls controls';
-      }
-      /* Narrow reflow stacks the controls on their own row, so the bar-only
-         label span from the wide layout would overlap them — pin it back. */
-      .tile-body.detailed.bar-only:not(.has-tilt) .label {
-        grid-row: 1 / 2;
-      }
+      /* Same as the 480px block: no bar-only re-assertion needed (#260). */
       .tile-body.detailed .controls {
         margin-top: 4px;
         gap: 8px;
@@ -5772,35 +5814,35 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
       color: var(--secondary-text-color);
       margin: 0;
     }
-  `,e([_e({attribute:!1})],Pn.prototype,"hass",void 0),e([ge()],Pn.prototype,"_config",void 0),e([ge()],Pn.prototype,"_registry",void 0),e([ge()],Pn.prototype,"_registryError",void 0),e([ge()],Pn.prototype,"_dialogOpen",void 0),e([ge()],Pn.prototype,"_posDrag",void 0),e([ge()],Pn.prototype,"_extendOpen",void 0),Pn=e([he(xe)],Pn),window.customCards=window.customCards||[],window.customCards.some(e=>e.type===xe)||window.customCards.push({type:xe,name:"Adaptive Cover Pro — Tile",description:"Compact chip-style tile for one Adaptive Cover Pro instance: icon, name, position, ↑■↓, contextual badge.",preview:!0,documentationURL:"https://github.com/jrhubott/adaptive-cover-pro/wiki/Lovelace-Card",getEntitySuggestion:Oo(`custom:${xe}`,"entry_id")});let On=class extends ce{constructor(){super(...arguments),this.compact=!1}render(){if(!this.hass||!this.discovered)return V;const e=os(this.hass,this.discovered),t=Object.entries(e.memberPositions),o=!!e.target;return W`
+  `,e([ge({attribute:!1})],jn.prototype,"hass",void 0),e([me()],jn.prototype,"_config",void 0),e([me()],jn.prototype,"_registry",void 0),e([me()],jn.prototype,"_registryError",void 0),e([me()],jn.prototype,"_dialogOpen",void 0),e([me()],jn.prototype,"_posDrag",void 0),e([me()],jn.prototype,"_extendOpen",void 0),jn=e([pe($e)],jn),window.customCards=window.customCards||[],window.customCards.some(e=>e.type===$e)||window.customCards.push({type:$e,name:"Adaptive Cover Pro — Tile",description:"Compact chip-style tile for one Adaptive Cover Pro instance: icon, name, position, ↑■↓, contextual badge.",preview:!0,documentationURL:"https://github.com/jrhubott/adaptive-cover-pro/wiki/Lovelace-Card",getEntitySuggestion:Fo(`custom:${$e}`,"entry_id")});let Kn=class extends de{constructor(){super(...arguments),this.compact=!1}render(){if(!this.hass||!this.discovered)return q;const e=cs(this.hass,this.discovered),t=Object.entries(e.memberPositions),o=!!e.target;return H`
       <div class="group-view">
         <div class="summary">
-          <span class="agg-state">${ot(`group.state_${e.aggregate}`,this.hass)}</span>
-          <span class="agg-position">${it(e.position)}</span>
-          ${Ui(e.memberWinners).map(e=>W`<acp-tile-badge .hass=${this.hass} .winner=${e}></acp-tile-badge>`)}
+          <span class="agg-state">${it(`group.state_${e.aggregate}`,this.hass)}</span>
+          <span class="agg-position">${st(e.position)}</span>
+          ${Ji(e.memberWinners).map(e=>H`<acp-tile-badge .hass=${this.hass} .winner=${e}></acp-tile-badge>`)}
         </div>
 
         <acp-axis-bar
           layout="cover"
           .hass=${this.hass}
-          .label=${ot("group.position",this.hass)}
+          .label=${it("group.position",this.hass)}
           .hintKey=${"covers.click_to_set"}
           .targetHintKey=${"covers.target_tooltip"}
           .actual=${e.position}
-          .openBlocksSun=${xt(this.discovered).openBlocksSun}
+          .openBlocksSun=${kt(this.discovered).openBlocksSun}
           .compact=${this.compact}
           .disabled=${!o}
-          @acp-tilt-set=${t=>ns(this.hass,e,t.detail)}
+          @acp-tilt-set=${t=>ps(this.hass,e,t.detail)}
         ></acp-axis-bar>
-        ${e.tilt?W`<acp-axis-bar
+        ${e.tilt?H`<acp-axis-bar
               layout="cover"
               .hass=${this.hass}
-              .label=${ot("covers.tilt_title",this.hass)}
+              .label=${it("covers.tilt_title",this.hass)}
               .actual=${e.tilt.value}
               .openBlocksSun=${!1}
               .compact=${this.compact}
-              @acp-tilt-set=${t=>as(this.hass,e,t.detail)}
-            ></acp-axis-bar>`:V}
+              @acp-tilt-set=${t=>_s(this.hass,e,t.detail)}
+            ></acp-axis-bar>`:q}
 
         <div class="controls">
           <acp-cover-move-buttons
@@ -5820,21 +5862,21 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
         ></acp-group-controls-row>
 
         <div class="members">
-          <div class="members-head">${ot("group.members",this.hass)}</div>
-          ${0===t.length?W`<div class="member-placeholder">
-                ${ot("group.member_placeholder",this.hass)}
-              </div>`:us(t,([e])=>e,([t,o])=>W`<acp-group-member-row
+          <div class="members-head">${it("group.members",this.hass)}</div>
+          ${0===t.length?H`<div class="member-placeholder">
+                ${it("group.member_placeholder",this.hass)}
+              </div>`:ys(t,([e])=>e,([t,o])=>H`<acp-group-member-row
                     .hass=${this.hass}
                     .entityId=${t}
                     .position=${o}
                     .winner=${e.memberWinners?.[t]}
-                    .openBlocksSun=${xt(this.discovered).openBlocksSun}
+                    .openBlocksSun=${kt(this.discovered).openBlocksSun}
                     .acpManaged=${!!e.memberWinners&&t in e.memberWinners}
                     .compact=${this.compact}
                   ></acp-group-member-row>`)}
         </div>
       </div>
-    `}_move(e,t){"stop"===e.detail?rs(this.hass,this.discovered,t):ns(this.hass,t,"open"===e.detail?100:0)}};On.styles=r`
+    `}_move(e,t){"stop"===e.detail?us(this.hass,this.discovered,t):ps(this.hass,t,"open"===e.detail?100:0)}};Kn.styles=a`
     :host {
       display: block;
     }
@@ -5878,17 +5920,17 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
       text-align: center;
       padding: 12px;
     }
-  `,e([_e({attribute:!1})],On.prototype,"hass",void 0),e([_e({attribute:!1})],On.prototype,"discovered",void 0),e([_e({type:Boolean,reflect:!0})],On.prototype,"compact",void 0),On=e([he("acp-group-view")],On);const Fn=[{key:"sky",labelKey:"editor.main.section_sky_label",descKey:"editor.main.section_sky_desc"},{key:"elevation",labelKey:"editor.main.section_elevation_label",descKey:"editor.main.section_elevation_desc"},{key:"decision",labelKey:"editor.main.section_decision_label",descKey:"editor.main.section_decision_desc"},{key:"covers",labelKey:"editor.main.section_covers_label",descKey:"editor.main.section_covers_desc"},{key:"overrides",labelKey:"editor.main.section_overrides_label",descKey:"editor.main.section_overrides_desc"},{key:"climate",labelKey:"editor.main.section_climate_label",descKey:"editor.main.section_climate_desc"},{key:"solar",labelKey:"editor.main.section_solar_label",descKey:"editor.main.section_solar_desc",enabledByDefault:!1}],Bn=Fn.filter(e=>!1!==e.enabledByDefault).map(e=>e.key);let Nn=class extends ce{constructor(){super(...arguments),this._entries=null,this._entriesError=null,this._fetchInFlight=!1}setConfig(e){this._config=e}updated(e){e.has("hass")&&this.hass&&!this._entries&&!this._fetchInFlight&&(this._fetchInFlight=!0,Fo(this.hass).then(e=>{this._entries=e,this._entriesError=null,this._config?.entry_id||1!==e.length||this._emit({...this._config??{type:"",entry_id:""},entry_id:e[0].entry_id})}).catch(e=>{this._entriesError=e?.message??"failed to load config entries"}).finally(()=>{this._fetchInFlight=!1}))}get _currentSections(){return this._config?.show_sections??Bn}_emit(e){this._config=e,this.dispatchEvent(new CustomEvent("config-changed",{detail:{config:e},bubbles:!0,composed:!0}))}_onEntryChange(e){const t=e.target.value;this._emit({...this._config??{type:"",entry_id:""},entry_id:t})}_onSectionToggle(e,t){const o=new Set(this._currentSections);t?o.add(e):o.delete(e);const i=Fn.map(e=>e.key).filter(e=>o.has(e));this._emit({...this._config??{type:"",entry_id:""},show_sections:i})}_onCompactToggle(e){this._emit({...this._config??{type:"",entry_id:""},compact:e})}_onCompassStatsToggle(e){this._emit({...this._config??{type:"",entry_id:""},show_compass_stats:e})}_onCompassLegendToggle(e){this._emit({...this._config??{type:"",entry_id:""},show_compass_legend:e})}_onMoonToggle(e){this._emit({...this._config??{type:"",entry_id:""},show_moon:e})}_onHideInactiveToggle(e){this._emit({...this._config??{type:"",entry_id:""},hide_inactive_handlers:e})}_onStateColorToggle(e){this._emit({...this._config??{type:"",entry_id:""},state_color:e})}_onNorthOffsetChange(e){const t=parseFloat(e.target.value),o=Number.isFinite(t)?t:0;this._emit({...this._config??{type:"",entry_id:""},north_offset:o})}_onControlToggle(e,t){const o=this._config??{type:"",entry_id:""};this._emit({...o,controls:{...o.controls,[e]:t}})}_onCoverColorChange(e){const t=this._config??{type:"",entry_id:""};this._emit({...t,cover_colors:[e]})}_onCoverColorReset(){const e={...this._config??{type:"",entry_id:""}};delete e.cover_colors,this._emit(e)}render(){if(!this._config)return V;const e=new Set(this._currentSections);return W`
+  `,e([ge({attribute:!1})],Kn.prototype,"hass",void 0),e([ge({attribute:!1})],Kn.prototype,"discovered",void 0),e([ge({type:Boolean,reflect:!0})],Kn.prototype,"compact",void 0),Kn=e([pe("acp-group-view")],Kn);const Ln=[{key:"sky",labelKey:"editor.main.section_sky_label",descKey:"editor.main.section_sky_desc"},{key:"elevation",labelKey:"editor.main.section_elevation_label",descKey:"editor.main.section_elevation_desc"},{key:"decision",labelKey:"editor.main.section_decision_label",descKey:"editor.main.section_decision_desc"},{key:"covers",labelKey:"editor.main.section_covers_label",descKey:"editor.main.section_covers_desc"},{key:"overrides",labelKey:"editor.main.section_overrides_label",descKey:"editor.main.section_overrides_desc"},{key:"climate",labelKey:"editor.main.section_climate_label",descKey:"editor.main.section_climate_desc"},{key:"solar",labelKey:"editor.main.section_solar_label",descKey:"editor.main.section_solar_desc",enabledByDefault:!1}],Gn=Ln.filter(e=>!1!==e.enabledByDefault).map(e=>e.key);let Wn=class extends de{constructor(){super(...arguments),this._entries=null,this._entriesError=null,this._fetchInFlight=!1}setConfig(e){this._config=e}updated(e){e.has("hass")&&this.hass&&!this._entries&&!this._fetchInFlight&&(this._fetchInFlight=!0,No(this.hass).then(e=>{this._entries=e,this._entriesError=null,this._config?.entry_id||1!==e.length||this._emit({...this._config??{type:"",entry_id:""},entry_id:e[0].entry_id})}).catch(e=>{this._entriesError=e?.message??"failed to load config entries"}).finally(()=>{this._fetchInFlight=!1}))}get _currentSections(){return this._config?.show_sections??Gn}_emit(e){this._config=e,this.dispatchEvent(new CustomEvent("config-changed",{detail:{config:e},bubbles:!0,composed:!0}))}_onEntryChange(e){const t=e.target.value;this._emit({...this._config??{type:"",entry_id:""},entry_id:t})}_onSectionToggle(e,t){const o=new Set(this._currentSections);t?o.add(e):o.delete(e);const i=Ln.map(e=>e.key).filter(e=>o.has(e));this._emit({...this._config??{type:"",entry_id:""},show_sections:i})}_onCompactToggle(e){this._emit({...this._config??{type:"",entry_id:""},compact:e})}_onCompassStatsToggle(e){this._emit({...this._config??{type:"",entry_id:""},show_compass_stats:e})}_onCompassLegendToggle(e){this._emit({...this._config??{type:"",entry_id:""},show_compass_legend:e})}_onMoonToggle(e){this._emit({...this._config??{type:"",entry_id:""},show_moon:e})}_onHideInactiveToggle(e){this._emit({...this._config??{type:"",entry_id:""},hide_inactive_handlers:e})}_onStateColorToggle(e){this._emit({...this._config??{type:"",entry_id:""},state_color:e})}_onNorthOffsetChange(e){const t=parseFloat(e.target.value),o=Number.isFinite(t)?t:0;this._emit({...this._config??{type:"",entry_id:""},north_offset:o})}_onControlToggle(e,t){const o=this._config??{type:"",entry_id:""};this._emit({...o,controls:{...o.controls,[e]:t}})}_onCoverColorChange(e){const t=this._config??{type:"",entry_id:""};this._emit({...t,cover_colors:[e]})}_onCoverColorReset(){const e={...this._config??{type:"",entry_id:""}};delete e.cover_colors,this._emit(e)}render(){if(!this._config)return q;const e=new Set(this._currentSections);return H`
       <div class="form">
         <div class="section">
-          <label class="field-label">${ot("editor.common.entry_id",this.hass)}</label>
+          <label class="field-label">${it("editor.common.entry_id",this.hass)}</label>
           ${this._renderEntryPicker()}
         </div>
 
         <div class="section">
-          <label class="field-label">${ot("editor.main.sections",this.hass)}</label>
-          <div class="hint">${ot("editor.main.sections_hint",this.hass)}</div>
-          ${Fn.map(t=>W`
+          <label class="field-label">${it("editor.main.sections",this.hass)}</label>
+          <div class="hint">${it("editor.main.sections_hint",this.hass)}</div>
+          ${Ln.map(t=>H`
               <label class="toggle-row">
                 <input
                   type="checkbox"
@@ -5896,16 +5938,16 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
                   @change=${e=>this._onSectionToggle(t.key,e.target.checked)}
                 />
                 <span class="toggle-text">
-                  <span class="toggle-label">${ot(t.labelKey,this.hass)}</span>
-                  <span class="toggle-desc">${ot(t.descKey,this.hass)}</span>
+                  <span class="toggle-label">${it(t.labelKey,this.hass)}</span>
+                  <span class="toggle-desc">${it(t.descKey,this.hass)}</span>
                 </span>
               </label>
             `)}
         </div>
 
         <div class="section">
-          <label class="field-label">${ot("editor.main.controls",this.hass)}</label>
-          <div class="hint">${ot("editor.main.controls_hint",this.hass)}</div>
+          <label class="field-label">${it("editor.main.controls",this.hass)}</label>
+          <div class="hint">${it("editor.main.controls_hint",this.hass)}</div>
           <label class="toggle-row">
             <input
               type="checkbox"
@@ -5914,9 +5956,9 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
             />
             <span class="toggle-text">
               <span class="toggle-label"
-                >${ot("editor.main.integration_pill_label",this.hass)}</span
+                >${it("editor.main.integration_pill_label",this.hass)}</span
               >
-              <span class="toggle-desc">${ot("editor.main.integration_pill_desc",this.hass)}</span>
+              <span class="toggle-desc">${it("editor.main.integration_pill_desc",this.hass)}</span>
             </span>
           </label>
           <label class="toggle-row">
@@ -5926,8 +5968,8 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
               @change=${e=>this._onControlToggle("automatic_control",e.target.checked)}
             />
             <span class="toggle-text">
-              <span class="toggle-label">${ot("editor.main.automatic_pill_label",this.hass)}</span>
-              <span class="toggle-desc">${ot("editor.main.automatic_pill_desc",this.hass)}</span>
+              <span class="toggle-label">${it("editor.main.automatic_pill_label",this.hass)}</span>
+              <span class="toggle-desc">${it("editor.main.automatic_pill_desc",this.hass)}</span>
             </span>
           </label>
           <label class="toggle-row">
@@ -5937,17 +5979,17 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
               @change=${e=>this._onControlToggle("reset_manual_override",e.target.checked)}
             />
             <span class="toggle-text">
-              <span class="toggle-label">${ot("editor.main.reset_button_label",this.hass)}</span>
-              <span class="toggle-desc">${ot("editor.main.reset_button_desc",this.hass)}</span>
+              <span class="toggle-label">${it("editor.main.reset_button_label",this.hass)}</span>
+              <span class="toggle-desc">${it("editor.main.reset_button_desc",this.hass)}</span>
             </span>
           </label>
         </div>
 
-        ${this._config.entry_id?W`
+        ${this._config.entry_id?H`
               <div class="section">
-                <label class="field-label">${ot("editor.compass.cover_colors",this.hass)}</label>
-                <div class="hint">${ot("editor.compass.cover_colors_hint",this.hass)}</div>
-                ${(()=>{const e=this._config.cover_colors?.[0]??null,t=e??ai(0);return W`
+                <label class="field-label">${it("editor.compass.cover_colors",this.hass)}</label>
+                <div class="hint">${it("editor.compass.cover_colors_hint",this.hass)}</div>
+                ${(()=>{const e=this._config.cover_colors?.[0]??null,t=e??ci(0);return H`
                     <div class="color-row">
                       <input
                         type="color"
@@ -5956,7 +5998,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
                       />
                       <span class="toggle-text">
                         <span class="toggle-desc"
-                          >${e||ot("editor.compass.default_color",this.hass)}</span
+                          >${e||it("editor.compass.default_color",this.hass)}</span
                         >
                       </span>
                       <button
@@ -5965,15 +6007,15 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
                         ?disabled=${!e}
                         @click=${()=>this._onCoverColorReset()}
                       >
-                        ${ot("editor.common.reset",this.hass)}
+                        ${it("editor.common.reset",this.hass)}
                       </button>
                     </div>
                   `})()}
               </div>
-            `:V}
+            `:q}
 
         <div class="section">
-          <label class="field-label">${ot("editor.main.display",this.hass)}</label>
+          <label class="field-label">${it("editor.main.display",this.hass)}</label>
           <label class="toggle-row">
             <input
               type="checkbox"
@@ -5981,8 +6023,8 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
               @change=${e=>this._onCompactToggle(e.target.checked)}
             />
             <span class="toggle-text">
-              <span class="toggle-label">${ot("editor.main.compact_label",this.hass)}</span>
-              <span class="toggle-desc">${ot("editor.main.compact_desc",this.hass)}</span>
+              <span class="toggle-label">${it("editor.main.compact_label",this.hass)}</span>
+              <span class="toggle-desc">${it("editor.main.compact_desc",this.hass)}</span>
             </span>
           </label>
           <label class="toggle-row">
@@ -5993,10 +6035,10 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
             />
             <span class="toggle-text">
               <span class="toggle-label"
-                >${ot("editor.main.show_compass_stats_label",this.hass)}</span
+                >${it("editor.main.show_compass_stats_label",this.hass)}</span
               >
               <span class="toggle-desc"
-                >${ot("editor.main.show_compass_stats_desc",this.hass)}</span
+                >${it("editor.main.show_compass_stats_desc",this.hass)}</span
               >
             </span>
           </label>
@@ -6008,10 +6050,10 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
             />
             <span class="toggle-text">
               <span class="toggle-label"
-                >${ot("editor.main.show_compass_legend_label",this.hass)}</span
+                >${it("editor.main.show_compass_legend_label",this.hass)}</span
               >
               <span class="toggle-desc"
-                >${ot("editor.main.show_compass_legend_desc",this.hass)}</span
+                >${it("editor.main.show_compass_legend_desc",this.hass)}</span
               >
             </span>
           </label>
@@ -6022,8 +6064,8 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
               @change=${e=>this._onMoonToggle(e.target.checked)}
             />
             <span class="toggle-text">
-              <span class="toggle-label">${ot("editor.main.show_moon_label",this.hass)}</span>
-              <span class="toggle-desc">${ot("editor.main.show_moon_desc",this.hass)}</span>
+              <span class="toggle-label">${it("editor.main.show_moon_label",this.hass)}</span>
+              <span class="toggle-desc">${it("editor.main.show_moon_desc",this.hass)}</span>
             </span>
           </label>
           <label class="toggle-row">
@@ -6033,8 +6075,8 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
               @change=${e=>this._onHideInactiveToggle(e.target.checked)}
             />
             <span class="toggle-text">
-              <span class="toggle-label">${ot("editor.main.hide_inactive_label",this.hass)}</span>
-              <span class="toggle-desc">${ot("editor.main.hide_inactive_desc",this.hass)}</span>
+              <span class="toggle-label">${it("editor.main.hide_inactive_label",this.hass)}</span>
+              <span class="toggle-desc">${it("editor.main.hide_inactive_desc",this.hass)}</span>
             </span>
           </label>
           <label class="toggle-row">
@@ -6044,15 +6086,15 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
               @change=${e=>this._onStateColorToggle(e.target.checked)}
             />
             <span class="toggle-text">
-              <span class="toggle-label">${ot("editor.main.state_color_label",this.hass)}</span>
-              <span class="toggle-desc">${ot("editor.main.state_color_desc",this.hass)}</span>
+              <span class="toggle-label">${it("editor.main.state_color_label",this.hass)}</span>
+              <span class="toggle-desc">${it("editor.main.state_color_desc",this.hass)}</span>
             </span>
           </label>
         </div>
 
         <div class="section">
-          <label class="field-label">${ot("editor.common.north_offset",this.hass)}</label>
-          <div class="hint">${ot("editor.common.north_offset_hint",this.hass)}</div>
+          <label class="field-label">${it("editor.common.north_offset",this.hass)}</label>
+          <div class="hint">${it("editor.common.north_offset_hint",this.hass)}</div>
           <input
             type="number"
             class="text-input"
@@ -6062,36 +6104,36 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
             @change=${this._onNorthOffsetChange}
           />
         </div>
-        ${En(this.hass)}
+        ${Bn(this.hass)}
       </div>
-    `}_renderEntryPicker(){return this._entriesError?W`
+    `}_renderEntryPicker(){return this._entriesError?H`
         <div class="error">
-          ${ot("editor.common.load_failed",this.hass,{error:this._entriesError})}
+          ${it("editor.common.load_failed",this.hass,{error:this._entriesError})}
         </div>
         <input
           type="text"
           .value=${this._config?.entry_id??""}
-          placeholder=${ot("editor.common.entry_id_manual_placeholder",this.hass)}
+          placeholder=${it("editor.common.entry_id_manual_placeholder",this.hass)}
           @change=${this._onEntryChange}
           class="text-input"
         />
-      `:this._entries?0===this._entries.length?W`
+      `:this._entries?0===this._entries.length?H`
         <div class="error">
-          ${ot("editor.common.no_entries",this.hass)}
-          <code>${ot("editor.common.no_entries_path",this.hass)}</code>${ot("editor.common.no_entries_then",this.hass)}
+          ${it("editor.common.no_entries",this.hass)}
+          <code>${it("editor.common.no_entries_path",this.hass)}</code>${it("editor.common.no_entries_then",this.hass)}
         </div>
-      `:W`
+      `:H`
       <select class="select" .value=${this._config?.entry_id??""} @change=${this._onEntryChange}>
-        ${this._config?.entry_id&&!this._entries.some(e=>e.entry_id===this._config.entry_id)?W`<option value=${this._config.entry_id}>
-              ${ot("editor.common.unknown_entry",this.hass,{entry:this._config.entry_id})}
-            </option>`:V}
-        ${this._entries.map(e=>W`
+        ${this._config?.entry_id&&!this._entries.some(e=>e.entry_id===this._config.entry_id)?H`<option value=${this._config.entry_id}>
+              ${it("editor.common.unknown_entry",this.hass,{entry:this._config.entry_id})}
+            </option>`:q}
+        ${this._entries.map(e=>H`
             <option value=${e.entry_id} ?selected=${e.entry_id===this._config?.entry_id}>
               ${e.title}
             </option>
           `)}
       </select>
-    `:W`<div class="hint">${ot("editor.common.loading_entries",this.hass)}</div>`}};Nn.styles=r`
+    `:H`<div class="hint">${it("editor.common.loading_entries",this.hass)}</div>`}};Wn.styles=a`
     :host {
       display: block;
     }
@@ -6206,30 +6248,30 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
     .dim {
       color: var(--secondary-text-color);
     }
-  `,e([_e({attribute:!1})],Nn.prototype,"hass",void 0),e([ge()],Nn.prototype,"_config",void 0),e([ge()],Nn.prototype,"_entries",void 0),e([ge()],Nn.prototype,"_entriesError",void 0),Nn=e([he(be)],Nn);const Dn=[{key:"compact",labelKey:"editor.compass.toggle_compact_label",descKey:"editor.compass.toggle_compact_desc",defaultOn:!1},{key:"show_legend",labelKey:"editor.compass.toggle_legend_label",descKey:"editor.compass.toggle_legend_desc",defaultOn:!0},{key:"show_stats",labelKey:"editor.compass.toggle_stats_label",descKey:"editor.compass.toggle_stats_desc",defaultOn:!0},{key:"show_moon",labelKey:"editor.compass.toggle_moon_label",descKey:"editor.compass.toggle_moon_desc",defaultOn:!1},{key:"show_cardinals",labelKey:"editor.compass.toggle_cardinals_label",descKey:"editor.compass.toggle_cardinals_desc",defaultOn:!0},{key:"show_blind_spot",labelKey:"editor.compass.toggle_blind_spot_label",descKey:"editor.compass.toggle_blind_spot_desc",defaultOn:!0},{key:"show_sun_path",labelKey:"editor.compass.toggle_sun_path_label",descKey:"editor.compass.toggle_sun_path_desc",defaultOn:!0},{key:"show_sunrise_sunset",labelKey:"editor.compass.toggle_sunrise_sunset_label",descKey:"editor.compass.toggle_sunrise_sunset_desc",defaultOn:!0},{key:"show_cover_fill",labelKey:"editor.compass.toggle_cover_fill_label",descKey:"editor.compass.toggle_cover_fill_desc",defaultOn:!0},{key:"show_window_arrow",labelKey:"editor.compass.toggle_window_arrow_label",descKey:"editor.compass.toggle_window_arrow_desc",defaultOn:!0},{key:"show_elevation_chart",labelKey:"editor.compass.toggle_elevation_chart_label",descKey:"editor.compass.toggle_elevation_chart_desc",defaultOn:!0}];let Rn=class extends ce{constructor(){super(...arguments),this._entries=null,this._entriesError=null,this._fetchInFlight=!1}setConfig(e){this._config=e}updated(e){e.has("hass")&&this.hass&&!this._entries&&!this._fetchInFlight&&(this._fetchInFlight=!0,Fo(this.hass).then(e=>{this._entries=e,this._entriesError=null}).catch(e=>{this._entriesError=e?.message??"failed to load config entries"}).finally(()=>{this._fetchInFlight=!1}))}_emit(e){this._config=e,this.dispatchEvent(new CustomEvent("config-changed",{detail:{config:e},bubbles:!0,composed:!0}))}_baseConfig(){return this._config??{type:`custom:${ye}`,entry_ids:[]}}_trimColors(e){let t=-1;for(let o=0;o<e.length;o++)e[o]&&(t=o);if(!(t<0))return e.slice(0,t+1)}_emitWithColors(e,t,o){const i=this._trimColors(t),{cover_colors:s,...n}=e,r=i?{...n,...o,cover_colors:i}:{...n,...o};this._emit(r)}_onCoverColorChange(e,t){const o=this._baseConfig(),i=[...o.cover_colors??[]];for(;i.length<=e;)i.push(null);i[e]=t,this._emitWithColors(o,i)}_onCoverColorReset(e){const t=this._baseConfig(),o=[...t.cover_colors??[]];e<o.length&&(o[e]=null),this._emitWithColors(t,o)}_onEntryToggle(e,t){const o=this._baseConfig(),i=new Set(o.entry_ids);t?i.add(e):i.delete(e);const s=(this._entries??[]).map(e=>e.entry_id).filter(e=>i.has(e)),n=o.cover_colors??[],r=s.map(e=>{const t=o.entry_ids.indexOf(e);return t>=0?n[t]??null:null});this._emitWithColors(o,r,{entry_ids:s})}_onToggle(e,t){this._emit({...this._baseConfig(),[e]:t})}_onNorthOffsetChange(e){const t=parseFloat(e.target.value),o=Number.isFinite(t)?t:0;this._emit({...this._baseConfig(),north_offset:o})}_onTitleChange(e){const t=e.target.value,o=this._baseConfig();if(t)this._emit({...o,title:t});else{const{title:e,...t}=o;this._emit(t)}}render(){if(!this._config)return V;const e=new Set(this._config.entry_ids);return W`
+  `,e([ge({attribute:!1})],Wn.prototype,"hass",void 0),e([me()],Wn.prototype,"_config",void 0),e([me()],Wn.prototype,"_entries",void 0),e([me()],Wn.prototype,"_entriesError",void 0),Wn=e([pe(ye)],Wn);const Hn=[{key:"compact",labelKey:"editor.compass.toggle_compact_label",descKey:"editor.compass.toggle_compact_desc",defaultOn:!1},{key:"show_legend",labelKey:"editor.compass.toggle_legend_label",descKey:"editor.compass.toggle_legend_desc",defaultOn:!0},{key:"show_stats",labelKey:"editor.compass.toggle_stats_label",descKey:"editor.compass.toggle_stats_desc",defaultOn:!0},{key:"show_moon",labelKey:"editor.compass.toggle_moon_label",descKey:"editor.compass.toggle_moon_desc",defaultOn:!1},{key:"show_cardinals",labelKey:"editor.compass.toggle_cardinals_label",descKey:"editor.compass.toggle_cardinals_desc",defaultOn:!0},{key:"show_blind_spot",labelKey:"editor.compass.toggle_blind_spot_label",descKey:"editor.compass.toggle_blind_spot_desc",defaultOn:!0},{key:"show_sun_path",labelKey:"editor.compass.toggle_sun_path_label",descKey:"editor.compass.toggle_sun_path_desc",defaultOn:!0},{key:"show_sunrise_sunset",labelKey:"editor.compass.toggle_sunrise_sunset_label",descKey:"editor.compass.toggle_sunrise_sunset_desc",defaultOn:!0},{key:"show_cover_fill",labelKey:"editor.compass.toggle_cover_fill_label",descKey:"editor.compass.toggle_cover_fill_desc",defaultOn:!0},{key:"show_window_arrow",labelKey:"editor.compass.toggle_window_arrow_label",descKey:"editor.compass.toggle_window_arrow_desc",defaultOn:!0},{key:"show_elevation_chart",labelKey:"editor.compass.toggle_elevation_chart_label",descKey:"editor.compass.toggle_elevation_chart_desc",defaultOn:!0}];let Un=class extends de{constructor(){super(...arguments),this._entries=null,this._entriesError=null,this._fetchInFlight=!1}setConfig(e){this._config=e}updated(e){e.has("hass")&&this.hass&&!this._entries&&!this._fetchInFlight&&(this._fetchInFlight=!0,No(this.hass).then(e=>{this._entries=e,this._entriesError=null}).catch(e=>{this._entriesError=e?.message??"failed to load config entries"}).finally(()=>{this._fetchInFlight=!1}))}_emit(e){this._config=e,this.dispatchEvent(new CustomEvent("config-changed",{detail:{config:e},bubbles:!0,composed:!0}))}_baseConfig(){return this._config??{type:`custom:${we}`,entry_ids:[]}}_trimColors(e){let t=-1;for(let o=0;o<e.length;o++)e[o]&&(t=o);if(!(t<0))return e.slice(0,t+1)}_emitWithColors(e,t,o){const i=this._trimColors(t),{cover_colors:s,...n}=e,r=i?{...n,...o,cover_colors:i}:{...n,...o};this._emit(r)}_onCoverColorChange(e,t){const o=this._baseConfig(),i=[...o.cover_colors??[]];for(;i.length<=e;)i.push(null);i[e]=t,this._emitWithColors(o,i)}_onCoverColorReset(e){const t=this._baseConfig(),o=[...t.cover_colors??[]];e<o.length&&(o[e]=null),this._emitWithColors(t,o)}_onEntryToggle(e,t){const o=this._baseConfig(),i=new Set(o.entry_ids);t?i.add(e):i.delete(e);const s=(this._entries??[]).map(e=>e.entry_id).filter(e=>i.has(e)),n=o.cover_colors??[],r=s.map(e=>{const t=o.entry_ids.indexOf(e);return t>=0?n[t]??null:null});this._emitWithColors(o,r,{entry_ids:s})}_onToggle(e,t){this._emit({...this._baseConfig(),[e]:t})}_onNorthOffsetChange(e){const t=parseFloat(e.target.value),o=Number.isFinite(t)?t:0;this._emit({...this._baseConfig(),north_offset:o})}_onTitleChange(e){const t=e.target.value,o=this._baseConfig();if(t)this._emit({...o,title:t});else{const{title:e,...t}=o;this._emit(t)}}render(){if(!this._config)return q;const e=new Set(this._config.entry_ids);return H`
       <div class="form">
         <div class="section">
-          <label class="field-label">${ot("editor.compass.instances",this.hass)}</label>
-          <div class="hint">${ot("editor.compass.instances_hint",this.hass)}</div>
+          <label class="field-label">${it("editor.compass.instances",this.hass)}</label>
+          <div class="hint">${it("editor.compass.instances_hint",this.hass)}</div>
           ${this._renderEntryPicker(e)}
         </div>
 
         <div class="section">
-          <label class="field-label">${ot("editor.common.title_optional",this.hass)}</label>
+          <label class="field-label">${it("editor.common.title_optional",this.hass)}</label>
           <input
             type="text"
             class="text-input"
             .value=${this._config.title??""}
-            placeholder=${ot("editor.common.title_placeholder",this.hass)}
+            placeholder=${it("editor.common.title_placeholder",this.hass)}
             @change=${this._onTitleChange}
           />
         </div>
 
-        ${this._config.entry_ids.length>0?W`
+        ${this._config.entry_ids.length>0?H`
               <div class="section">
-                <label class="field-label">${ot("editor.compass.cover_colors",this.hass)}</label>
-                <div class="hint">${ot("editor.compass.cover_colors_hint",this.hass)}</div>
-                ${this._config.entry_ids.map((e,t)=>{const o=this._config.cover_colors?.[t]??null,i=o??ai(t),s=this._entries?.find(t=>t.entry_id===e);return W`
+                <label class="field-label">${it("editor.compass.cover_colors",this.hass)}</label>
+                <div class="hint">${it("editor.compass.cover_colors_hint",this.hass)}</div>
+                ${this._config.entry_ids.map((e,t)=>{const o=this._config.cover_colors?.[t]??null,i=o??ci(t),s=this._entries?.find(t=>t.entry_id===e);return H`
                     <div class="color-row">
                       <input
                         type="color"
@@ -6239,7 +6281,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
                       <span class="toggle-text">
                         <span class="toggle-label">${s?.title??e}</span>
                         <span class="toggle-desc"
-                          >${o||ot("editor.compass.default_color",this.hass)}</span
+                          >${o||it("editor.compass.default_color",this.hass)}</span
                         >
                       </span>
                       <button
@@ -6248,16 +6290,16 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
                         ?disabled=${!o}
                         @click=${()=>this._onCoverColorReset(t)}
                       >
-                        ${ot("editor.common.reset",this.hass)}
+                        ${it("editor.common.reset",this.hass)}
                       </button>
                     </div>
                   `})}
               </div>
-            `:V}
+            `:q}
 
         <div class="section">
-          <label class="field-label">${ot("editor.compass.display",this.hass)}</label>
-          ${Dn.map(e=>W`
+          <label class="field-label">${it("editor.compass.display",this.hass)}</label>
+          ${Hn.map(e=>H`
               <label class="toggle-row">
                 <input
                   type="checkbox"
@@ -6265,16 +6307,16 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
                   @change=${t=>this._onToggle(e.key,t.target.checked)}
                 />
                 <span class="toggle-text">
-                  <span class="toggle-label">${ot(e.labelKey,this.hass)}</span>
-                  <span class="toggle-desc">${ot(e.descKey,this.hass)}</span>
+                  <span class="toggle-label">${it(e.labelKey,this.hass)}</span>
+                  <span class="toggle-desc">${it(e.descKey,this.hass)}</span>
                 </span>
               </label>
             `)}
         </div>
 
         <div class="section">
-          <label class="field-label">${ot("editor.common.north_offset",this.hass)}</label>
-          <div class="hint">${ot("editor.common.north_offset_hint",this.hass)}</div>
+          <label class="field-label">${it("editor.common.north_offset",this.hass)}</label>
+          <div class="hint">${it("editor.common.north_offset_hint",this.hass)}</div>
           <input
             type="number"
             class="text-input"
@@ -6284,18 +6326,18 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
             @change=${this._onNorthOffsetChange}
           />
         </div>
-        ${En(this.hass)}
+        ${Bn(this.hass)}
       </div>
-    `}_renderEntryPicker(e){return this._entriesError?W`<div class="error">
-        ${ot("editor.common.load_failed",this.hass,{error:this._entriesError})}
-      </div>`:this._entries?0===this._entries.length?W`
+    `}_renderEntryPicker(e){return this._entriesError?H`<div class="error">
+        ${it("editor.common.load_failed",this.hass,{error:this._entriesError})}
+      </div>`:this._entries?0===this._entries.length?H`
         <div class="error">
-          ${ot("editor.common.no_entries",this.hass)}
-          <code>${ot("editor.common.no_entries_path",this.hass)}</code>${ot("editor.common.no_entries_then",this.hass)}
+          ${it("editor.common.no_entries",this.hass)}
+          <code>${it("editor.common.no_entries_path",this.hass)}</code>${it("editor.common.no_entries_then",this.hass)}
         </div>
-      `:W`
+      `:H`
       <div class="entry-list">
-        ${this._entries.map(t=>W`
+        ${this._entries.map(t=>H`
             <label class="toggle-row">
               <input
                 type="checkbox"
@@ -6309,7 +6351,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
             </label>
           `)}
       </div>
-    `:W`<div class="hint">${ot("editor.common.loading_entries",this.hass)}</div>`}};Rn.styles=r`
+    `:H`<div class="hint">${it("editor.common.loading_entries",this.hass)}</div>`}};Un.styles=a`
     :host {
       display: block;
     }
@@ -6426,22 +6468,22 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
     .dim {
       color: var(--secondary-text-color);
     }
-  `,e([_e({attribute:!1})],Rn.prototype,"hass",void 0),e([ge()],Rn.prototype,"_config",void 0),e([ge()],Rn.prototype,"_entries",void 0),e([ge()],Rn.prototype,"_entriesError",void 0),Rn=e([he(we)],Rn);let jn=class extends ce{constructor(){super(...arguments),this._registry=null,this._registryError=null,this._unsubRegistry=null,this._fetchInFlight=!1,this._listMemo=wo(),this._discoveredResult={list:[],missing:[]}}setConfig(e){if(!e||!Array.isArray(e.entry_ids)||0===e.entry_ids.length)throw new Error("adaptive-cover-pro-sky-compass-card: `entry_ids` must be a non-empty array");if(e.entry_ids.some(e=>"string"!=typeof e||0===e.length))throw new Error("adaptive-cover-pro-sky-compass-card: every `entry_ids` entry must be a non-empty string");if(this._config={...e,entry_ids:[...e.entry_ids]},e.tooltips&&mo(e.tooltips),null===this._registry){const e=this._config.entry_ids.map(e=>No.get(e)?.entries);e.every(e=>void 0!==e)&&(this._registry=e.flat())}}getCardSize(){return 4}getGridOptions(){return{columns:12,rows:"auto",min_columns:6,max_columns:12}}static async getConfigElement(){return document.createElement(we)}static async getStubConfig(e){let t=[];try{const o=await Fo(e);o[0]&&(t=[o[0].entry_id])}catch{}return{type:`custom:${ye}`,entry_ids:t}}connectedCallback(){if(super.connectedCallback(),null===this._registry){const e=zo();e&&(this._registry=e)}this.hass&&this._ensureRegistry()}disconnectedCallback(){super.disconnectedCallback(),this._unsubRegistry&&(this._unsubRegistry(),this._unsubRegistry=null)}updated(e){e.has("hass")&&this.hass&&this._ensureRegistry()}shouldUpdate(e){if(e.size>1||!e.has("hass"))return!0;const t=[];for(const e of this._discoveredResult.list)t.push(...Object.values(e.entities));return 0===t.length||me(e.get("hass"),this.hass,t)}willUpdate(e){this._config&&this.hass&&null!==this._registry&&(e.has("hass")||e.has("_registry")||e.has("_config"))&&(this._discoveredResult=this._listMemo(this.hass,this._config.entry_ids,this._registry,this._config.type))}_ensureRegistry(){this._fetchRegistry(),this._unsubRegistry||(this._unsubRegistry=So(this.hass,()=>{this._fetchRegistry(!0)}))}_fetchRegistry(e=!1){this._fetchInFlight||(this._fetchInFlight=!0,Mo(this.hass,e).then(e=>{if(e!==this._registry&&(this._registry=e,this._registryError=null,this._config))for(const t of this._config.entry_ids)No.set(t,Ro(e,t))}).catch(e=>{this._registryError=e?.message??"entity registry fetch failed"}).finally(()=>{this._fetchInFlight=!1}))}render(){if(!this._config||!this.hass)return V;if(null===this._registry)return W`<ha-card>
+  `,e([ge({attribute:!1})],Un.prototype,"hass",void 0),e([me()],Un.prototype,"_config",void 0),e([me()],Un.prototype,"_entries",void 0),e([me()],Un.prototype,"_entriesError",void 0),Un=e([pe(xe)],Un);let Vn=class extends de{constructor(){super(...arguments),this._registry=null,this._registryError=null,this._unsubRegistry=null,this._fetchInFlight=!1,this._listMemo=$o(),this._discoveredResult={list:[],missing:[]}}setConfig(e){if(!e||!Array.isArray(e.entry_ids)||0===e.entry_ids.length)throw new Error("adaptive-cover-pro-sky-compass-card: `entry_ids` must be a non-empty array");if(e.entry_ids.some(e=>"string"!=typeof e||0===e.length))throw new Error("adaptive-cover-pro-sky-compass-card: every `entry_ids` entry must be a non-empty string");if(this._config={...e,entry_ids:[...e.entry_ids]},e.tooltips&&fo(e.tooltips),null===this._registry){const e=this._config.entry_ids.map(e=>Ro.get(e)?.entries);e.every(e=>void 0!==e)&&(this._registry=e.flat())}}getCardSize(){return 4}getGridOptions(){return{columns:12,rows:"auto",min_columns:6,max_columns:12}}static async getConfigElement(){return document.createElement(xe)}static async getStubConfig(e){let t=[];try{const o=await No(e);o[0]&&(t=[o[0].entry_id])}catch{}return{type:`custom:${we}`,entry_ids:t}}connectedCallback(){if(super.connectedCallback(),null===this._registry){const e=To();e&&(this._registry=e)}this.hass&&this._ensureRegistry()}disconnectedCallback(){super.disconnectedCallback(),this._unsubRegistry&&(this._unsubRegistry(),this._unsubRegistry=null)}updated(e){e.has("hass")&&this.hass&&this._ensureRegistry()}shouldUpdate(e){if(e.size>1||!e.has("hass"))return!0;const t=[];for(const e of this._discoveredResult.list)t.push(...Object.values(e.entities));return 0===t.length||ve(e.get("hass"),this.hass,t)}willUpdate(e){this._config&&this.hass&&null!==this._registry&&(e.has("hass")||e.has("_registry")||e.has("_config"))&&(this._discoveredResult=this._listMemo(this.hass,this._config.entry_ids,this._registry,this._config.type))}_ensureRegistry(){this._fetchRegistry(),this._unsubRegistry||(this._unsubRegistry=Eo(this.hass,()=>{this._fetchRegistry(!0)}))}_fetchRegistry(e=!1){this._fetchInFlight||(this._fetchInFlight=!0,Io(this.hass,e).then(e=>{if(e!==this._registry&&(this._registry=e,this._registryError=null,this._config))for(const t of this._config.entry_ids)Ro.set(t,Ko(e,t))}).catch(e=>{this._registryError=e?.message??"entity registry fetch failed"}).finally(()=>{this._fetchInFlight=!1}))}render(){if(!this._config||!this.hass)return q;if(null===this._registry)return H`<ha-card>
         <div class="empty">
           <p class="dim">
-            ${this._registryError?ot("tile.registry_failed",this.hass,{error:this._registryError}):ot("root.loading_registry",this.hass)}
+            ${this._registryError?it("tile.registry_failed",this.hass,{error:this._registryError}):it("root.loading_registry",this.hass)}
           </p>
         </div>
-      </ha-card>`;const{list:e,missing:t}=this._discoveredResult;if(0===e.length)return W`<ha-card>
+      </ha-card>`;const{list:e,missing:t}=this._discoveredResult;if(0===e.length)return H`<ha-card>
         <div class="empty">
-          <p><strong>${ot("root.compass_no_match",this.hass)}</strong></p>
+          <p><strong>${it("root.compass_no_match",this.hass)}</strong></p>
           <p class="dim">
-            ${ot("root.compass_configured",this.hass,{entries:this._config.entry_ids.join(", ")})}
+            ${it("root.compass_configured",this.hass,{entries:this._config.entry_ids.join(", ")})}
           </p>
         </div>
-      </ha-card>`;const o=this._config;return W`
+      </ha-card>`;const o=this._config;return H`
       <ha-card>
-        ${o.title?W`<div class="card-header">${o.title}</div>`:V}
+        ${o.title?H`<div class="card-header">${o.title}</div>`:q}
         <acp-sky-compass
           .hass=${this.hass}
           .discovered_list=${e}
@@ -6456,19 +6498,19 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
           .showCoverFill=${o.show_cover_fill??!0}
           .showWindowArrow=${o.show_window_arrow??!0}
           .coverColors=${o.cover_colors??[]}
-          .northOffsetDeg=${zt(o.north_offset??0)}
+          .northOffsetDeg=${Tt(o.north_offset??0)}
         ></acp-sky-compass>
-        ${!1!==o.show_elevation_chart?W`<acp-elevation-chart
+        ${!1!==o.show_elevation_chart?H`<acp-elevation-chart
               .hass=${this.hass}
               .discoveredList=${e}
               .coverColors=${o.cover_colors??[]}
               ?compact=${!!o.compact}
-            ></acp-elevation-chart>`:V}
-        ${t.length>0?W`<div class="warn dim">
-              ${ot("root.compass_not_found",this.hass,{entries:t.join(", ")})}
-            </div>`:V}
+            ></acp-elevation-chart>`:q}
+        ${t.length>0?H`<div class="warn dim">
+              ${it("root.compass_not_found",this.hass,{entries:t.join(", ")})}
+            </div>`:q}
       </ha-card>
-    `}};jn.styles=r`
+    `}};Vn.styles=a`
     :host {
       display: block;
     }
@@ -6495,25 +6537,25 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
       font-size: 0.78rem;
       text-align: center;
     }
-  `,e([_e({attribute:!1})],jn.prototype,"hass",void 0),e([ge()],jn.prototype,"_config",void 0),e([ge()],jn.prototype,"_registry",void 0),e([ge()],jn.prototype,"_registryError",void 0),jn=e([he(ye)],jn),window.customCards=window.customCards||[],window.customCards.some(e=>e.type===ye)||window.customCards.push({type:ye,name:"Adaptive Cover Pro — Sky Compass",description:"Polar sun-vs-SAA plot; overlay one or more Adaptive Cover Pro entries on a single compass.",preview:!0,documentationURL:"https://github.com/jrhubott/adaptive-cover-pro/wiki/Lovelace-Card",getEntitySuggestion:Oo(`custom:${ye}`,"entry_ids")});const Kn={compact:!1,hide_inactive_handlers:!1,show_decision_summary:!0},Ln={entry_id:"editor.common.entry_id",title:"editor.decision.title",compact:"editor.decision.compact_label",hide_inactive_handlers:"editor.decision.hide_inactive_handlers_label",show_decision_summary:"editor.decision.show_decision_summary_label"},Gn={compact:"editor.decision.compact_desc",hide_inactive_handlers:"editor.decision.hide_inactive_handlers_desc",show_decision_summary:"editor.decision.show_decision_summary_desc"};let Wn=class extends ce{constructor(){super(...arguments),this._entries=null,this._entriesError=null,this._entriesFetchInFlight=!1,this._computeLabel=e=>{const t=Ln[e.name];return t?ot(t,this.hass):e.name},this._computeHelper=e=>{const t=Gn[e.name];return t?ot(t,this.hass):void 0},this._valueChanged=e=>{e.stopPropagation();const t={...e.detail.value};for(const[e,o]of Object.entries(Kn))this._config&&Object.prototype.hasOwnProperty.call(this._config,e)||t[e]!==o||delete t[e];const o={...this._config??{type:"",entry_id:""},...t};this._emit(o)}}setConfig(e){this._config={...e}}updated(e){e.has("hass")&&this.hass&&this._ensureEntries()}_ensureEntries(){this._entries||this._entriesFetchInFlight||(this._entriesFetchInFlight=!0,Fo(this.hass).then(e=>{this._entries=e,this._entriesError=null,this._config?.entry_id||1!==e.length||this._emit({...this._config??{type:"",entry_id:""},entry_id:e[0].entry_id})}).catch(e=>{this._entriesError=e?.message??"failed to load config entries"}).finally(()=>{this._entriesFetchInFlight=!1}))}_emit(e){this._config=e,this.dispatchEvent(new CustomEvent("config-changed",{detail:{config:e},bubbles:!0,composed:!0}))}render(){if(!this._config)return V;if(this._entriesError&&!this._entries)return W`
+  `,e([ge({attribute:!1})],Vn.prototype,"hass",void 0),e([me()],Vn.prototype,"_config",void 0),e([me()],Vn.prototype,"_registry",void 0),e([me()],Vn.prototype,"_registryError",void 0),Vn=e([pe(we)],Vn),window.customCards=window.customCards||[],window.customCards.some(e=>e.type===we)||window.customCards.push({type:we,name:"Adaptive Cover Pro — Sky Compass",description:"Polar sun-vs-SAA plot; overlay one or more Adaptive Cover Pro entries on a single compass.",preview:!0,documentationURL:"https://github.com/jrhubott/adaptive-cover-pro/wiki/Lovelace-Card",getEntitySuggestion:Fo(`custom:${we}`,"entry_ids")});const qn={compact:!1,hide_inactive_handlers:!1,show_decision_summary:!0},Yn={entry_id:"editor.common.entry_id",title:"editor.decision.title",compact:"editor.decision.compact_label",hide_inactive_handlers:"editor.decision.hide_inactive_handlers_label",show_decision_summary:"editor.decision.show_decision_summary_label"},Qn={compact:"editor.decision.compact_desc",hide_inactive_handlers:"editor.decision.hide_inactive_handlers_desc",show_decision_summary:"editor.decision.show_decision_summary_desc"};let Zn=class extends de{constructor(){super(...arguments),this._entries=null,this._entriesError=null,this._entriesFetchInFlight=!1,this._computeLabel=e=>{const t=Yn[e.name];return t?it(t,this.hass):e.name},this._computeHelper=e=>{const t=Qn[e.name];return t?it(t,this.hass):void 0},this._valueChanged=e=>{e.stopPropagation();const t={...e.detail.value};for(const[e,o]of Object.entries(qn))this._config&&Object.prototype.hasOwnProperty.call(this._config,e)||t[e]!==o||delete t[e];const o={...this._config??{type:"",entry_id:""},...t};this._emit(o)}}setConfig(e){this._config={...e}}updated(e){e.has("hass")&&this.hass&&this._ensureEntries()}_ensureEntries(){this._entries||this._entriesFetchInFlight||(this._entriesFetchInFlight=!0,No(this.hass).then(e=>{this._entries=e,this._entriesError=null,this._config?.entry_id||1!==e.length||this._emit({...this._config??{type:"",entry_id:""},entry_id:e[0].entry_id})}).catch(e=>{this._entriesError=e?.message??"failed to load config entries"}).finally(()=>{this._entriesFetchInFlight=!1}))}_emit(e){this._config=e,this.dispatchEvent(new CustomEvent("config-changed",{detail:{config:e},bubbles:!0,composed:!0}))}render(){if(!this._config)return q;if(this._entriesError&&!this._entries)return H`
         <div class="form">
           <div class="error">
-            ${ot("editor.common.load_failed",this.hass,{error:this._entriesError})}
+            ${it("editor.common.load_failed",this.hass,{error:this._entriesError})}
           </div>
           <label class="field-label" for="entry-id-fallback"
-            >${ot("editor.common.entry_id_fallback_label",this.hass)}</label
+            >${it("editor.common.entry_id_fallback_label",this.hass)}</label
           >
           <input
             id="entry-id-fallback"
             type="text"
             class="text-input"
             .value=${this._config.entry_id??""}
-            placeholder=${ot("editor.common.entry_id_manual_placeholder",this.hass)}
+            placeholder=${it("editor.common.entry_id_manual_placeholder",this.hass)}
             @change=${e=>this._emit({...this._config??{type:"",entry_id:""},entry_id:e.target.value})}
           />
-          ${En(this.hass)}
+          ${Bn(this.hass)}
         </div>
-      `;const e=this._schema(),t={...Kn,...this._config};return W`
+      `;const e=this._schema(),t={...qn,...this._config};return H`
       <div class="form">
         <ha-form
           .hass=${this.hass}
@@ -6523,9 +6565,9 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
           .computeHelper=${this._computeHelper}
           @value-changed=${this._valueChanged}
         ></ha-form>
-        ${En(this.hass)}
+        ${Bn(this.hass)}
       </div>
-    `}_schema(){const e=this._entries?.map(e=>({value:e.entry_id,label:e.title}))??[];return[{name:"entry_id",required:!0,selector:{select:{options:e,mode:"dropdown"}}},{name:"title",selector:{text:{}}},{name:"compact",selector:{boolean:{}}},{name:"hide_inactive_handlers",selector:{boolean:{}}},{name:"show_decision_summary",selector:{boolean:{}}}]}};Wn.styles=r`
+    `}_schema(){const e=this._entries?.map(e=>({value:e.entry_id,label:e.title}))??[];return[{name:"entry_id",required:!0,selector:{select:{options:e,mode:"dropdown"}}},{name:"title",selector:{text:{}}},{name:"compact",selector:{boolean:{}}},{name:"hide_inactive_handlers",selector:{boolean:{}}},{name:"show_decision_summary",selector:{boolean:{}}}]}};Zn.styles=a`
     :host {
       display: block;
     }
@@ -6561,22 +6603,22 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
     .dim {
       color: var(--secondary-text-color);
     }
-  `,e([_e({attribute:!1})],Wn.prototype,"hass",void 0),e([ge()],Wn.prototype,"_config",void 0),e([ge()],Wn.prototype,"_entries",void 0),e([ge()],Wn.prototype,"_entriesError",void 0),Wn=e([he(Ae)],Wn);let Hn=class extends ce{constructor(){super(...arguments),this._registry=null,this._registryError=null,this._historyOpen=!1,this._unsubRegistry=null,this._fetchInFlight=!1,this._fetchGen=0,this._memo=yo(),this._discovered=null}setConfig(e){if(!e||"string"!=typeof e.entry_id||0===e.entry_id.length)throw new Error(`${ke}: \`entry_id\` is required and must be a non-empty string`);if(this._config={...e},e.tooltips&&mo(e.tooltips),null===this._registry){const t=No.get(e.entry_id);t&&(this._registry=t.entries)}}getCardSize(){return 3}getGridOptions(){return{columns:12,rows:"auto",min_columns:4,max_columns:12}}static async getStubConfig(e){let t="";try{const o=await Fo(e);t=o[0]?.entry_id??""}catch{}return{type:`custom:${ke}`,entry_id:t}}static async getConfigElement(){return document.createElement(Ae)}connectedCallback(){if(super.connectedCallback(),null===this._registry){const e=zo();e&&(this._registry=e)}this.hass&&this._ensureRegistry()}disconnectedCallback(){super.disconnectedCallback(),this._unsubRegistry&&(this._unsubRegistry(),this._unsubRegistry=null)}updated(e){e.has("hass")&&this.hass&&this._ensureRegistry()}shouldUpdate(e){return e.size>1||!e.has("hass")||(!this._discovered||me(e.get("hass"),this.hass,Object.values(this._discovered.entities)))}willUpdate(e){this._config&&this.hass&&null!==this._registry&&(e.has("hass")||e.has("_registry")||e.has("_config"))&&(this._discovered=this._memo(this.hass,{type:this._config.type,entry_id:this._config.entry_id},this._registry))}_ensureRegistry(){this._fetchRegistry(),this._unsubRegistry||(this._unsubRegistry=So(this.hass,()=>{this._fetchRegistry(!0)}))}_fetchRegistry(e=!1){if(this._fetchInFlight)return;this._fetchInFlight=!0;const t=++this._fetchGen;Mo(this.hass,e).then(e=>{t===this._fetchGen&&e!==this._registry&&(this._registry=e,this._registryError=null,this._config&&No.set(this._config.entry_id,Ro(e,this._config.entry_id)))}).catch(e=>{t===this._fetchGen&&(this._registryError=e?.message??"entity registry fetch failed")}).finally(()=>{t===this._fetchGen&&(this._fetchInFlight=!1)})}render(){if(!this._config||!this.hass)return V;if(null===this._registry)return W`<ha-card>
+  `,e([ge({attribute:!1})],Zn.prototype,"hass",void 0),e([me()],Zn.prototype,"_config",void 0),e([me()],Zn.prototype,"_entries",void 0),e([me()],Zn.prototype,"_entriesError",void 0),Zn=e([pe(Se)],Zn);let Xn=class extends de{constructor(){super(...arguments),this._registry=null,this._registryError=null,this._historyOpen=!1,this._unsubRegistry=null,this._fetchInFlight=!1,this._fetchGen=0,this._memo=xo(),this._discovered=null}setConfig(e){if(!e||"string"!=typeof e.entry_id||0===e.entry_id.length)throw new Error(`${Ae}: \`entry_id\` is required and must be a non-empty string`);if(this._config={...e},e.tooltips&&fo(e.tooltips),null===this._registry){const t=Ro.get(e.entry_id);t&&(this._registry=t.entries)}}getCardSize(){return 3}getGridOptions(){return{columns:12,rows:"auto",min_columns:4,max_columns:12}}static async getStubConfig(e){let t="";try{const o=await No(e);t=o[0]?.entry_id??""}catch{}return{type:`custom:${Ae}`,entry_id:t}}static async getConfigElement(){return document.createElement(Se)}connectedCallback(){if(super.connectedCallback(),null===this._registry){const e=To();e&&(this._registry=e)}this.hass&&this._ensureRegistry()}disconnectedCallback(){super.disconnectedCallback(),this._unsubRegistry&&(this._unsubRegistry(),this._unsubRegistry=null)}updated(e){e.has("hass")&&this.hass&&this._ensureRegistry()}shouldUpdate(e){return e.size>1||!e.has("hass")||(!this._discovered||ve(e.get("hass"),this.hass,Object.values(this._discovered.entities)))}willUpdate(e){this._config&&this.hass&&null!==this._registry&&(e.has("hass")||e.has("_registry")||e.has("_config"))&&(this._discovered=this._memo(this.hass,{type:this._config.type,entry_id:this._config.entry_id},this._registry))}_ensureRegistry(){this._fetchRegistry(),this._unsubRegistry||(this._unsubRegistry=Eo(this.hass,()=>{this._fetchRegistry(!0)}))}_fetchRegistry(e=!1){if(this._fetchInFlight)return;this._fetchInFlight=!0;const t=++this._fetchGen;Io(this.hass,e).then(e=>{t===this._fetchGen&&e!==this._registry&&(this._registry=e,this._registryError=null,this._config&&Ro.set(this._config.entry_id,Ko(e,this._config.entry_id)))}).catch(e=>{t===this._fetchGen&&(this._registryError=e?.message??"entity registry fetch failed")}).finally(()=>{t===this._fetchGen&&(this._fetchInFlight=!1)})}render(){if(!this._config||!this.hass)return q;if(null===this._registry)return H`<ha-card>
         <div class="empty">
           <p class="dim">
-            ${this._registryError?ot("tile.registry_failed",this.hass,{error:this._registryError}):ot("tile.loading",this.hass)}
+            ${this._registryError?it("tile.registry_failed",this.hass,{error:this._registryError}):it("tile.loading",this.hass)}
           </p>
         </div>
-      </ha-card>`;const e=this._discovered;if(!e)return W`<ha-card>
+      </ha-card>`;const e=this._discovered;if(!e)return H`<ha-card>
         <div class="empty">
           <p class="dim">
-            ${ot("tile.entry_not_found",this.hass,{entry:this._config.entry_id})}
+            ${it("tile.entry_not_found",this.hass,{entry:this._config.entry_id})}
           </p>
         </div>
-      </ha-card>`;const t=this._config,o=ot("history.open",this.hass);return W`
+      </ha-card>`;const t=this._config,o=it("history.open",this.hass);return H`
       <ha-card>
         <div class="card-top">
-          ${t.title?W`<div class="card-header">${t.title}</div>`:V}
+          ${t.title?H`<div class="card-header">${t.title}</div>`:q}
           <button
             class="icon-btn"
             type="button"
@@ -6584,7 +6626,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
             title=${o}
             @click=${()=>{this._historyOpen=!0}}
           >
-            <ha-icon icon=${Ue}></ha-icon>
+            <ha-icon icon=${Ve}></ha-icon>
           </button>
         </div>
         <acp-decision-strip
@@ -6601,7 +6643,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
         .open=${this._historyOpen}
         @acp-history-closed=${()=>{this._historyOpen=!1}}
       ></acp-history-dialog>
-    `}};Hn.styles=r`
+    `}};Xn.styles=a`
     :host {
       display: block;
     }
@@ -6649,32 +6691,32 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
       color: var(--secondary-text-color);
       margin: 0;
     }
-  `,e([_e({attribute:!1})],Hn.prototype,"hass",void 0),e([ge()],Hn.prototype,"_config",void 0),e([ge()],Hn.prototype,"_registry",void 0),e([ge()],Hn.prototype,"_registryError",void 0),e([ge()],Hn.prototype,"_historyOpen",void 0),Hn=e([he(ke)],Hn),window.customCards=window.customCards||[],window.customCards.some(e=>e.type===ke)||window.customCards.push({type:ke,name:"Adaptive Cover Pro — Decision Strip",description:"Standalone decision strip: all pipeline handlers for one Adaptive Cover Pro instance with the winning row highlighted.",preview:!0,documentationURL:"https://github.com/jrhubott/adaptive-cover-pro/wiki/Lovelace-Card",getEntitySuggestion:Oo(`custom:${ke}`,"entry_id")});let Un=class extends ce{constructor(){super(...arguments),this._entries=null,this._entriesError=null,this._fetchInFlight=!1}setConfig(e){this._config=e}updated(e){e.has("hass")&&this.hass&&!this._entries&&!this._fetchInFlight&&(this._fetchInFlight=!0,Fo(this.hass).then(e=>{this._entries=e,this._entriesError=null}).catch(e=>{this._entriesError=e?.message??"failed to load config entries"}).finally(()=>{this._fetchInFlight=!1}))}_emit(e){this._config=e,this.dispatchEvent(new CustomEvent("config-changed",{detail:{config:e},bubbles:!0,composed:!0}))}_baseConfig(){return this._config??{type:`custom:${Se}`,entry_ids:[]}}_trimColors(e){let t=-1;for(let o=0;o<e.length;o++)e[o]&&(t=o);if(!(t<0))return e.slice(0,t+1)}_emitWithColors(e,t,o){const i=this._trimColors(t),{cover_colors:s,...n}=e,r=i?{...n,...o,cover_colors:i}:{...n,...o};this._emit(r)}_onCoverColorChange(e,t){const o=this._baseConfig(),i=[...o.cover_colors??[]];for(;i.length<=e;)i.push(null);i[e]=t,this._emitWithColors(o,i)}_onCoverColorReset(e){const t=this._baseConfig(),o=[...t.cover_colors??[]];e<o.length&&(o[e]=null),this._emitWithColors(t,o)}_onEntryToggle(e,t){const o=this._baseConfig(),i=new Set(o.entry_ids);t?i.add(e):i.delete(e);const s=(this._entries??[]).map(e=>e.entry_id).filter(e=>i.has(e)),n=o.cover_colors??[],r=s.map(e=>{const t=o.entry_ids.indexOf(e);return t>=0?n[t]??null:null});this._emitWithColors(o,r,{entry_ids:s})}_onToggle(e,t){this._emit({...this._baseConfig(),[e]:t})}_onTitleChange(e){const t=e.target.value,o=this._baseConfig();if(t)this._emit({...o,title:t});else{const{title:e,...t}=o;this._emit(t)}}render(){if(!this._config)return V;const e=new Set(this._config.entry_ids);return W`
+  `,e([ge({attribute:!1})],Xn.prototype,"hass",void 0),e([me()],Xn.prototype,"_config",void 0),e([me()],Xn.prototype,"_registry",void 0),e([me()],Xn.prototype,"_registryError",void 0),e([me()],Xn.prototype,"_historyOpen",void 0),Xn=e([pe(Ae)],Xn),window.customCards=window.customCards||[],window.customCards.some(e=>e.type===Ae)||window.customCards.push({type:Ae,name:"Adaptive Cover Pro — Decision Strip",description:"Standalone decision strip: all pipeline handlers for one Adaptive Cover Pro instance with the winning row highlighted.",preview:!0,documentationURL:"https://github.com/jrhubott/adaptive-cover-pro/wiki/Lovelace-Card",getEntitySuggestion:Fo(`custom:${Ae}`,"entry_id")});let Jn=class extends de{constructor(){super(...arguments),this._entries=null,this._entriesError=null,this._fetchInFlight=!1}setConfig(e){this._config=e}updated(e){e.has("hass")&&this.hass&&!this._entries&&!this._fetchInFlight&&(this._fetchInFlight=!0,No(this.hass).then(e=>{this._entries=e,this._entriesError=null}).catch(e=>{this._entriesError=e?.message??"failed to load config entries"}).finally(()=>{this._fetchInFlight=!1}))}_emit(e){this._config=e,this.dispatchEvent(new CustomEvent("config-changed",{detail:{config:e},bubbles:!0,composed:!0}))}_baseConfig(){return this._config??{type:`custom:${Ce}`,entry_ids:[]}}_trimColors(e){let t=-1;for(let o=0;o<e.length;o++)e[o]&&(t=o);if(!(t<0))return e.slice(0,t+1)}_emitWithColors(e,t,o){const i=this._trimColors(t),{cover_colors:s,...n}=e,r=i?{...n,...o,cover_colors:i}:{...n,...o};this._emit(r)}_onCoverColorChange(e,t){const o=this._baseConfig(),i=[...o.cover_colors??[]];for(;i.length<=e;)i.push(null);i[e]=t,this._emitWithColors(o,i)}_onCoverColorReset(e){const t=this._baseConfig(),o=[...t.cover_colors??[]];e<o.length&&(o[e]=null),this._emitWithColors(t,o)}_onEntryToggle(e,t){const o=this._baseConfig(),i=new Set(o.entry_ids);t?i.add(e):i.delete(e);const s=(this._entries??[]).map(e=>e.entry_id).filter(e=>i.has(e)),n=o.cover_colors??[],r=s.map(e=>{const t=o.entry_ids.indexOf(e);return t>=0?n[t]??null:null});this._emitWithColors(o,r,{entry_ids:s})}_onToggle(e,t){this._emit({...this._baseConfig(),[e]:t})}_onTitleChange(e){const t=e.target.value,o=this._baseConfig();if(t)this._emit({...o,title:t});else{const{title:e,...t}=o;this._emit(t)}}render(){if(!this._config)return q;const e=new Set(this._config.entry_ids);return H`
       <div class="form">
         <div class="section">
-          <label class="field-label">${ot("editor.solar_chart.instances",this.hass)}</label>
-          <div class="hint">${ot("editor.solar_chart.instances_hint",this.hass)}</div>
+          <label class="field-label">${it("editor.solar_chart.instances",this.hass)}</label>
+          <div class="hint">${it("editor.solar_chart.instances_hint",this.hass)}</div>
           ${this._renderEntryPicker(e)}
         </div>
 
         <div class="section">
-          <label class="field-label">${ot("editor.common.title_optional",this.hass)}</label>
+          <label class="field-label">${it("editor.common.title_optional",this.hass)}</label>
           <input
             type="text"
             class="text-input"
             .value=${this._config.title??""}
-            placeholder=${ot("editor.common.title_placeholder",this.hass)}
+            placeholder=${it("editor.common.title_placeholder",this.hass)}
             @change=${this._onTitleChange}
           />
         </div>
 
-        ${this._config.entry_ids.length>0?W`
+        ${this._config.entry_ids.length>0?H`
               <div class="section">
                 <label class="field-label"
-                  >${ot("editor.solar_chart.cover_colors",this.hass)}</label
+                  >${it("editor.solar_chart.cover_colors",this.hass)}</label
                 >
-                <div class="hint">${ot("editor.solar_chart.cover_colors_hint",this.hass)}</div>
-                ${this._config.entry_ids.map((e,t)=>{const o=this._config.cover_colors?.[t]??null,i=o??ai(t),s=this._entries?.find(t=>t.entry_id===e);return W`
+                <div class="hint">${it("editor.solar_chart.cover_colors_hint",this.hass)}</div>
+                ${this._config.entry_ids.map((e,t)=>{const o=this._config.cover_colors?.[t]??null,i=o??ci(t),s=this._entries?.find(t=>t.entry_id===e);return H`
                     <div class="color-row">
                       <input
                         type="color"
@@ -6684,7 +6726,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
                       <span class="toggle-text">
                         <span class="toggle-label">${s?.title??e}</span>
                         <span class="toggle-desc"
-                          >${o||ot("editor.solar_chart.default_color",this.hass)}</span
+                          >${o||it("editor.solar_chart.default_color",this.hass)}</span
                         >
                       </span>
                       <button
@@ -6693,15 +6735,15 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
                         ?disabled=${!o}
                         @click=${()=>this._onCoverColorReset(t)}
                       >
-                        ${ot("editor.common.reset",this.hass)}
+                        ${it("editor.common.reset",this.hass)}
                       </button>
                     </div>
                   `})}
               </div>
-            `:V}
+            `:q}
 
         <div class="section">
-          <label class="field-label">${ot("editor.solar_chart.display",this.hass)}</label>
+          <label class="field-label">${it("editor.solar_chart.display",this.hass)}</label>
           <label class="toggle-row">
             <input
               type="checkbox"
@@ -6710,26 +6752,26 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
             />
             <span class="toggle-text">
               <span class="toggle-label"
-                >${ot("editor.solar_chart.toggle_compact_label",this.hass)}</span
+                >${it("editor.solar_chart.toggle_compact_label",this.hass)}</span
               >
               <span class="toggle-desc"
-                >${ot("editor.solar_chart.toggle_compact_desc",this.hass)}</span
+                >${it("editor.solar_chart.toggle_compact_desc",this.hass)}</span
               >
             </span>
           </label>
         </div>
-        ${En(this.hass)}
+        ${Bn(this.hass)}
       </div>
-    `}_renderEntryPicker(e){return this._entriesError?W`<div class="error">
-        ${ot("editor.common.load_failed",this.hass,{error:this._entriesError})}
-      </div>`:this._entries?0===this._entries.length?W`
+    `}_renderEntryPicker(e){return this._entriesError?H`<div class="error">
+        ${it("editor.common.load_failed",this.hass,{error:this._entriesError})}
+      </div>`:this._entries?0===this._entries.length?H`
         <div class="error">
-          ${ot("editor.common.no_entries",this.hass)}
-          <code>${ot("editor.common.no_entries_path",this.hass)}</code>${ot("editor.common.no_entries_then",this.hass)}
+          ${it("editor.common.no_entries",this.hass)}
+          <code>${it("editor.common.no_entries_path",this.hass)}</code>${it("editor.common.no_entries_then",this.hass)}
         </div>
-      `:W`
+      `:H`
       <div class="entry-list">
-        ${this._entries.map(t=>W`
+        ${this._entries.map(t=>H`
             <label class="toggle-row">
               <input
                 type="checkbox"
@@ -6743,7 +6785,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
             </label>
           `)}
       </div>
-    `:W`<div class="hint">${ot("editor.common.loading_entries",this.hass)}</div>`}};Un.styles=r`
+    `:H`<div class="hint">${it("editor.common.loading_entries",this.hass)}</div>`}};Jn.styles=a`
     :host {
       display: block;
     }
@@ -6860,33 +6902,33 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
     .dim {
       color: var(--secondary-text-color);
     }
-  `,e([_e({attribute:!1})],Un.prototype,"hass",void 0),e([ge()],Un.prototype,"_config",void 0),e([ge()],Un.prototype,"_entries",void 0),e([ge()],Un.prototype,"_entriesError",void 0),Un=e([he(Ce)],Un);let Vn=class extends ce{constructor(){super(...arguments),this._registry=null,this._registryError=null,this._unsubRegistry=null,this._fetchInFlight=!1,this._listMemo=wo(),this._discoveredResult={list:[],missing:[]}}setConfig(e){if(!e||!Array.isArray(e.entry_ids)||0===e.entry_ids.length)throw new Error("adaptive-cover-pro-solar-chart-card: `entry_ids` must be a non-empty array");if(e.entry_ids.some(e=>"string"!=typeof e||0===e.length))throw new Error("adaptive-cover-pro-solar-chart-card: every `entry_ids` entry must be a non-empty string");if(this._config={...e,entry_ids:[...e.entry_ids]},e.tooltips&&mo(e.tooltips),null===this._registry){const e=this._config.entry_ids.map(e=>No.get(e)?.entries);e.every(e=>void 0!==e)&&(this._registry=e.flat())}}getCardSize(){return 2}getGridOptions(){return{columns:12,rows:"auto",min_columns:6,max_columns:12}}static async getConfigElement(){return document.createElement(Ce)}static async getStubConfig(e){let t=[];try{const o=await Fo(e);o[0]&&(t=[o[0].entry_id])}catch{}return{type:`custom:${Se}`,entry_ids:t}}connectedCallback(){if(super.connectedCallback(),null===this._registry){const e=zo();e&&(this._registry=e)}this.hass&&this._ensureRegistry()}disconnectedCallback(){super.disconnectedCallback(),this._unsubRegistry&&(this._unsubRegistry(),this._unsubRegistry=null)}updated(e){e.has("hass")&&this.hass&&this._ensureRegistry()}shouldUpdate(e){if(e.size>1||!e.has("hass"))return!0;const t=[];for(const e of this._discoveredResult.list)t.push(...Object.values(e.entities));return 0===t.length||me(e.get("hass"),this.hass,t)}willUpdate(e){this._config&&this.hass&&null!==this._registry&&(e.has("hass")||e.has("_registry")||e.has("_config"))&&(this._discoveredResult=this._listMemo(this.hass,this._config.entry_ids,this._registry,this._config.type))}_ensureRegistry(){this._fetchRegistry(),this._unsubRegistry||(this._unsubRegistry=So(this.hass,()=>{this._fetchRegistry(!0)}))}_fetchRegistry(e=!1){this._fetchInFlight||(this._fetchInFlight=!0,Mo(this.hass,e).then(e=>{if(e!==this._registry&&(this._registry=e,this._registryError=null,this._config))for(const t of this._config.entry_ids)No.set(t,Ro(e,t))}).catch(e=>{this._registryError=e?.message??"entity registry fetch failed"}).finally(()=>{this._fetchInFlight=!1}))}render(){if(!this._config||!this.hass)return V;if(null===this._registry)return W`<ha-card>
+  `,e([ge({attribute:!1})],Jn.prototype,"hass",void 0),e([me()],Jn.prototype,"_config",void 0),e([me()],Jn.prototype,"_entries",void 0),e([me()],Jn.prototype,"_entriesError",void 0),Jn=e([pe(Ee)],Jn);let er=class extends de{constructor(){super(...arguments),this._registry=null,this._registryError=null,this._unsubRegistry=null,this._fetchInFlight=!1,this._listMemo=$o(),this._discoveredResult={list:[],missing:[]}}setConfig(e){if(!e||!Array.isArray(e.entry_ids)||0===e.entry_ids.length)throw new Error("adaptive-cover-pro-solar-chart-card: `entry_ids` must be a non-empty array");if(e.entry_ids.some(e=>"string"!=typeof e||0===e.length))throw new Error("adaptive-cover-pro-solar-chart-card: every `entry_ids` entry must be a non-empty string");if(this._config={...e,entry_ids:[...e.entry_ids]},e.tooltips&&fo(e.tooltips),null===this._registry){const e=this._config.entry_ids.map(e=>Ro.get(e)?.entries);e.every(e=>void 0!==e)&&(this._registry=e.flat())}}getCardSize(){return 2}getGridOptions(){return{columns:12,rows:"auto",min_columns:6,max_columns:12}}static async getConfigElement(){return document.createElement(Ee)}static async getStubConfig(e){let t=[];try{const o=await No(e);o[0]&&(t=[o[0].entry_id])}catch{}return{type:`custom:${Ce}`,entry_ids:t}}connectedCallback(){if(super.connectedCallback(),null===this._registry){const e=To();e&&(this._registry=e)}this.hass&&this._ensureRegistry()}disconnectedCallback(){super.disconnectedCallback(),this._unsubRegistry&&(this._unsubRegistry(),this._unsubRegistry=null)}updated(e){e.has("hass")&&this.hass&&this._ensureRegistry()}shouldUpdate(e){if(e.size>1||!e.has("hass"))return!0;const t=[];for(const e of this._discoveredResult.list)t.push(...Object.values(e.entities));return 0===t.length||ve(e.get("hass"),this.hass,t)}willUpdate(e){this._config&&this.hass&&null!==this._registry&&(e.has("hass")||e.has("_registry")||e.has("_config"))&&(this._discoveredResult=this._listMemo(this.hass,this._config.entry_ids,this._registry,this._config.type))}_ensureRegistry(){this._fetchRegistry(),this._unsubRegistry||(this._unsubRegistry=Eo(this.hass,()=>{this._fetchRegistry(!0)}))}_fetchRegistry(e=!1){this._fetchInFlight||(this._fetchInFlight=!0,Io(this.hass,e).then(e=>{if(e!==this._registry&&(this._registry=e,this._registryError=null,this._config))for(const t of this._config.entry_ids)Ro.set(t,Ko(e,t))}).catch(e=>{this._registryError=e?.message??"entity registry fetch failed"}).finally(()=>{this._fetchInFlight=!1}))}render(){if(!this._config||!this.hass)return q;if(null===this._registry)return H`<ha-card>
         <div class="empty">
           <p class="dim">
-            ${this._registryError?ot("tile.registry_failed",this.hass,{error:this._registryError}):ot("root.loading_registry",this.hass)}
+            ${this._registryError?it("tile.registry_failed",this.hass,{error:this._registryError}):it("root.loading_registry",this.hass)}
           </p>
         </div>
-      </ha-card>`;const{list:e,missing:t}=this._discoveredResult;if(0===e.length)return W`<ha-card>
+      </ha-card>`;const{list:e,missing:t}=this._discoveredResult;if(0===e.length)return H`<ha-card>
         <div class="empty">
-          <p><strong>${ot("root.compass_no_match",this.hass)}</strong></p>
+          <p><strong>${it("root.compass_no_match",this.hass)}</strong></p>
           <p class="dim">
-            ${ot("root.compass_configured",this.hass,{entries:this._config.entry_ids.join(", ")})}
+            ${it("root.compass_configured",this.hass,{entries:this._config.entry_ids.join(", ")})}
           </p>
         </div>
-      </ha-card>`;const o=this._config;return W`
+      </ha-card>`;const o=this._config;return H`
       <ha-card>
-        ${o.title?W`<div class="card-header">${o.title}</div>`:V}
+        ${o.title?H`<div class="card-header">${o.title}</div>`:q}
         <acp-elevation-chart
           .hass=${this.hass}
           .discoveredList=${e}
           .coverColors=${o.cover_colors??[]}
           ?compact=${!!o.compact}
         ></acp-elevation-chart>
-        ${t.length>0?W`<div class="warn dim">
-              ${ot("root.compass_not_found",this.hass,{entries:t.join(", ")})}
-            </div>`:V}
+        ${t.length>0?H`<div class="warn dim">
+              ${it("root.compass_not_found",this.hass,{entries:t.join(", ")})}
+            </div>`:q}
       </ha-card>
-    `}};Vn.styles=r`
+    `}};er.styles=a`
     :host {
       display: block;
     }
@@ -6913,25 +6955,25 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
       font-size: 0.78rem;
       text-align: center;
     }
-  `,e([_e({attribute:!1})],Vn.prototype,"hass",void 0),e([ge()],Vn.prototype,"_config",void 0),e([ge()],Vn.prototype,"_registry",void 0),e([ge()],Vn.prototype,"_registryError",void 0),Vn=e([he(Se)],Vn),window.customCards=window.customCards||[],window.customCards.some(e=>e.type===Se)||window.customCards.push({type:Se,name:"Adaptive Cover Pro — Solar Chart",description:"Standalone solar elevation-vs-time chart; overlay one or more entries’ field-of-view windows.",preview:!0,documentationURL:"https://github.com/jrhubott/adaptive-cover-pro/wiki/Lovelace-Card",getEntitySuggestion:Oo(`custom:${Se}`,"entry_ids")});const qn={hours:24,advanced_open:!1,hide_advanced:!1,track_position:!0,track_who_won:!0,track_context:!0,track_actions:!0},Yn={track_position:"position",track_who_won:"who_won",track_context:"context",track_actions:"actions"},Qn={entry_id:"editor.common.entry_id",title:"editor.history.title",hours:"editor.history.hours_label",advanced_open:"editor.history.advanced_open_label",hide_advanced:"editor.history.hide_advanced_label",track_position:"editor.history.track_position_label",track_who_won:"editor.history.track_who_won_label",track_context:"editor.history.track_context_label",track_actions:"editor.history.track_actions_label"},Zn={hours:"editor.history.hours_desc",advanced_open:"editor.history.advanced_open_desc",hide_advanced:"editor.history.hide_advanced_desc",track_position:"editor.history.track_position_desc",track_who_won:"editor.history.track_who_won_desc",track_context:"editor.history.track_context_desc",track_actions:"editor.history.track_actions_desc"};let Xn=class extends ce{constructor(){super(...arguments),this._entries=null,this._entriesError=null,this._entriesFetchInFlight=!1,this._computeLabel=e=>{const t=Qn[e.name];return t?ot(t,this.hass):e.name},this._computeHelper=e=>{const t=Zn[e.name];return t?ot(t,this.hass):void 0},this._valueChanged=e=>{e.stopPropagation();const t={...e.detail.value},o={};for(const[e,i]of Object.entries(Yn))!1===t[e]&&(o[i]=!1),delete t[e];for(const[e,o]of Object.entries(qn))e in Yn||this._config&&Object.prototype.hasOwnProperty.call(this._config,e)||t[e]!==o||delete t[e];const i={...this._config??{type:"",entry_id:""},...t};Object.keys(o).length>0?i.tracks=o:delete i.tracks,this._emit(i)}}setConfig(e){this._config={...e}}updated(e){e.has("hass")&&this.hass&&this._ensureEntries()}_ensureEntries(){this._entries||this._entriesFetchInFlight||(this._entriesFetchInFlight=!0,Fo(this.hass).then(e=>{this._entries=e,this._entriesError=null,this._config?.entry_id||1!==e.length||this._emit({...this._config??{type:"",entry_id:""},entry_id:e[0].entry_id})}).catch(e=>{this._entriesError=e?.message??"failed to load config entries"}).finally(()=>{this._entriesFetchInFlight=!1}))}_emit(e){this._config=e,this.dispatchEvent(new CustomEvent("config-changed",{detail:{config:e},bubbles:!0,composed:!0}))}render(){if(!this._config)return V;if(this._entriesError&&!this._entries)return W`
+  `,e([ge({attribute:!1})],er.prototype,"hass",void 0),e([me()],er.prototype,"_config",void 0),e([me()],er.prototype,"_registry",void 0),e([me()],er.prototype,"_registryError",void 0),er=e([pe(Ce)],er),window.customCards=window.customCards||[],window.customCards.some(e=>e.type===Ce)||window.customCards.push({type:Ce,name:"Adaptive Cover Pro — Solar Chart",description:"Standalone solar elevation-vs-time chart; overlay one or more entries’ field-of-view windows.",preview:!0,documentationURL:"https://github.com/jrhubott/adaptive-cover-pro/wiki/Lovelace-Card",getEntitySuggestion:Fo(`custom:${Ce}`,"entry_ids")});const tr={hours:24,advanced_open:!1,hide_advanced:!1,track_position:!0,track_who_won:!0,track_context:!0,track_actions:!0},or={track_position:"position",track_who_won:"who_won",track_context:"context",track_actions:"actions"},ir={entry_id:"editor.common.entry_id",title:"editor.history.title",hours:"editor.history.hours_label",advanced_open:"editor.history.advanced_open_label",hide_advanced:"editor.history.hide_advanced_label",track_position:"editor.history.track_position_label",track_who_won:"editor.history.track_who_won_label",track_context:"editor.history.track_context_label",track_actions:"editor.history.track_actions_label"},sr={hours:"editor.history.hours_desc",advanced_open:"editor.history.advanced_open_desc",hide_advanced:"editor.history.hide_advanced_desc",track_position:"editor.history.track_position_desc",track_who_won:"editor.history.track_who_won_desc",track_context:"editor.history.track_context_desc",track_actions:"editor.history.track_actions_desc"};let nr=class extends de{constructor(){super(...arguments),this._entries=null,this._entriesError=null,this._entriesFetchInFlight=!1,this._computeLabel=e=>{const t=ir[e.name];return t?it(t,this.hass):e.name},this._computeHelper=e=>{const t=sr[e.name];return t?it(t,this.hass):void 0},this._valueChanged=e=>{e.stopPropagation();const t={...e.detail.value},o={};for(const[e,i]of Object.entries(or))!1===t[e]&&(o[i]=!1),delete t[e];for(const[e,o]of Object.entries(tr))e in or||this._config&&Object.prototype.hasOwnProperty.call(this._config,e)||t[e]!==o||delete t[e];const i={...this._config??{type:"",entry_id:""},...t};Object.keys(o).length>0?i.tracks=o:delete i.tracks,this._emit(i)}}setConfig(e){this._config={...e}}updated(e){e.has("hass")&&this.hass&&this._ensureEntries()}_ensureEntries(){this._entries||this._entriesFetchInFlight||(this._entriesFetchInFlight=!0,No(this.hass).then(e=>{this._entries=e,this._entriesError=null,this._config?.entry_id||1!==e.length||this._emit({...this._config??{type:"",entry_id:""},entry_id:e[0].entry_id})}).catch(e=>{this._entriesError=e?.message??"failed to load config entries"}).finally(()=>{this._entriesFetchInFlight=!1}))}_emit(e){this._config=e,this.dispatchEvent(new CustomEvent("config-changed",{detail:{config:e},bubbles:!0,composed:!0}))}render(){if(!this._config)return q;if(this._entriesError&&!this._entries)return H`
         <div class="form">
           <div class="error">
-            ${ot("editor.common.load_failed",this.hass,{error:this._entriesError})}
+            ${it("editor.common.load_failed",this.hass,{error:this._entriesError})}
           </div>
           <label class="field-label" for="entry-id-fallback"
-            >${ot("editor.common.entry_id_fallback_label",this.hass)}</label
+            >${it("editor.common.entry_id_fallback_label",this.hass)}</label
           >
           <input
             id="entry-id-fallback"
             type="text"
             class="text-input"
             .value=${this._config.entry_id??""}
-            placeholder=${ot("editor.common.entry_id_manual_placeholder",this.hass)}
+            placeholder=${it("editor.common.entry_id_manual_placeholder",this.hass)}
             @change=${e=>this._emit({...this._config??{type:"",entry_id:""},entry_id:e.target.value})}
           />
-          ${En(this.hass)}
+          ${Bn(this.hass)}
         </div>
-      `;const e=this._config,t={...qn,...e,track_position:!1!==e.tracks?.position,track_who_won:!1!==e.tracks?.who_won,track_context:!1!==e.tracks?.context,track_actions:!1!==e.tracks?.actions};return W`
+      `;const e=this._config,t={...tr,...e,track_position:!1!==e.tracks?.position,track_who_won:!1!==e.tracks?.who_won,track_context:!1!==e.tracks?.context,track_actions:!1!==e.tracks?.actions};return H`
       <div class="form">
         <ha-form
           .hass=${this.hass}
@@ -6941,9 +6983,9 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
           .computeHelper=${this._computeHelper}
           @value-changed=${this._valueChanged}
         ></ha-form>
-        ${En(this.hass)}
+        ${Bn(this.hass)}
       </div>
-    `}_schema(){const e=this._entries?.map(e=>({value:e.entry_id,label:e.title}))??[],t=Qe.map(e=>({value:e,label:ot("history.window_hours",this.hass,{hours:e})}));return[{name:"entry_id",required:!0,selector:{select:{options:e,mode:"dropdown"}}},{name:"title",selector:{text:{}}},{name:"hours",selector:{select:{options:t,mode:"dropdown"}}},{name:"track_position",selector:{boolean:{}}},{name:"track_who_won",selector:{boolean:{}}},{name:"track_context",selector:{boolean:{}}},{name:"track_actions",selector:{boolean:{}}},{name:"advanced_open",selector:{boolean:{}}},{name:"hide_advanced",selector:{boolean:{}}}]}};Xn.styles=r`
+    `}_schema(){const e=this._entries?.map(e=>({value:e.entry_id,label:e.title}))??[],t=Ze.map(e=>({value:e,label:it("history.window_hours",this.hass,{hours:e})}));return[{name:"entry_id",required:!0,selector:{select:{options:e,mode:"dropdown"}}},{name:"title",selector:{text:{}}},{name:"hours",selector:{select:{options:t,mode:"dropdown"}}},{name:"track_position",selector:{boolean:{}}},{name:"track_who_won",selector:{boolean:{}}},{name:"track_context",selector:{boolean:{}}},{name:"track_actions",selector:{boolean:{}}},{name:"advanced_open",selector:{boolean:{}}},{name:"hide_advanced",selector:{boolean:{}}}]}};nr.styles=a`
     :host {
       display: block;
     }
@@ -6979,21 +7021,21 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
     .dim {
       color: var(--secondary-text-color);
     }
-  `,e([_e({attribute:!1})],Xn.prototype,"hass",void 0),e([ge()],Xn.prototype,"_config",void 0),e([ge()],Xn.prototype,"_entries",void 0),e([ge()],Xn.prototype,"_entriesError",void 0),Xn=e([he(ze)],Xn);let Jn=class extends ce{constructor(){super(...arguments),this._registry=null,this._registryError=null,this._unsubRegistry=null,this._fetchInFlight=!1,this._fetchGen=0,this._memo=yo(),this._discovered=null}setConfig(e){if(!e||"string"!=typeof e.entry_id||0===e.entry_id.length)throw new Error(`${Ee}: \`entry_id\` is required and must be a non-empty string`);if(void 0!==e.hours&&("number"!=typeof e.hours||e.hours<=0))throw new Error(`${Ee}: \`hours\` must be a positive number`);if(this._config={...e},e.tooltips&&mo(e.tooltips),null===this._registry){const t=No.get(e.entry_id);t&&(this._registry=t.entries)}}getCardSize(){return 6}getGridOptions(){return{columns:12,rows:"auto",min_columns:6,max_columns:12}}static async getStubConfig(e){let t="";try{const o=await Fo(e);t=o[0]?.entry_id??""}catch{}return{type:`custom:${Ee}`,entry_id:t,hours:24}}static async getConfigElement(){return document.createElement(ze)}connectedCallback(){if(super.connectedCallback(),null===this._registry){const e=zo();e&&(this._registry=e)}this.hass&&this._ensureRegistry()}disconnectedCallback(){super.disconnectedCallback(),this._unsubRegistry&&(this._unsubRegistry(),this._unsubRegistry=null)}updated(e){e.has("hass")&&this.hass&&this._ensureRegistry()}willUpdate(e){this._config&&this.hass&&null!==this._registry&&(e.has("hass")||e.has("_registry")||e.has("_config"))&&(this._discovered=this._memo(this.hass,{type:this._config.type,entry_id:this._config.entry_id},this._registry))}_ensureRegistry(){this._fetchRegistry(),this._unsubRegistry||(this._unsubRegistry=So(this.hass,()=>{this._fetchRegistry(!0)}))}_fetchRegistry(e=!1){if(this._fetchInFlight)return;this._fetchInFlight=!0;const t=++this._fetchGen;Mo(this.hass,e).then(e=>{t===this._fetchGen&&e!==this._registry&&(this._registry=e,this._registryError=null,this._config&&No.set(this._config.entry_id,Ro(e,this._config.entry_id)))}).catch(e=>{t===this._fetchGen&&(this._registryError=e?.message??"entity registry fetch failed")}).finally(()=>{t===this._fetchGen&&(this._fetchInFlight=!1)})}render(){if(!this._config||!this.hass)return V;if(null===this._registry)return W`<ha-card>
+  `,e([ge({attribute:!1})],nr.prototype,"hass",void 0),e([me()],nr.prototype,"_config",void 0),e([me()],nr.prototype,"_entries",void 0),e([me()],nr.prototype,"_entriesError",void 0),nr=e([pe(Me)],nr);let rr=class extends de{constructor(){super(...arguments),this._registry=null,this._registryError=null,this._unsubRegistry=null,this._fetchInFlight=!1,this._fetchGen=0,this._memo=xo(),this._discovered=null}setConfig(e){if(!e||"string"!=typeof e.entry_id||0===e.entry_id.length)throw new Error(`${ze}: \`entry_id\` is required and must be a non-empty string`);if(void 0!==e.hours&&("number"!=typeof e.hours||e.hours<=0))throw new Error(`${ze}: \`hours\` must be a positive number`);if(this._config={...e},e.tooltips&&fo(e.tooltips),null===this._registry){const t=Ro.get(e.entry_id);t&&(this._registry=t.entries)}}getCardSize(){return 6}getGridOptions(){return{columns:12,rows:"auto",min_columns:6,max_columns:12}}static async getStubConfig(e){let t="";try{const o=await No(e);t=o[0]?.entry_id??""}catch{}return{type:`custom:${ze}`,entry_id:t,hours:24}}static async getConfigElement(){return document.createElement(Me)}connectedCallback(){if(super.connectedCallback(),null===this._registry){const e=To();e&&(this._registry=e)}this.hass&&this._ensureRegistry()}disconnectedCallback(){super.disconnectedCallback(),this._unsubRegistry&&(this._unsubRegistry(),this._unsubRegistry=null)}updated(e){e.has("hass")&&this.hass&&this._ensureRegistry()}willUpdate(e){this._config&&this.hass&&null!==this._registry&&(e.has("hass")||e.has("_registry")||e.has("_config"))&&(this._discovered=this._memo(this.hass,{type:this._config.type,entry_id:this._config.entry_id},this._registry))}_ensureRegistry(){this._fetchRegistry(),this._unsubRegistry||(this._unsubRegistry=Eo(this.hass,()=>{this._fetchRegistry(!0)}))}_fetchRegistry(e=!1){if(this._fetchInFlight)return;this._fetchInFlight=!0;const t=++this._fetchGen;Io(this.hass,e).then(e=>{t===this._fetchGen&&e!==this._registry&&(this._registry=e,this._registryError=null,this._config&&Ro.set(this._config.entry_id,Ko(e,this._config.entry_id)))}).catch(e=>{t===this._fetchGen&&(this._registryError=e?.message??"entity registry fetch failed")}).finally(()=>{t===this._fetchGen&&(this._fetchInFlight=!1)})}render(){if(!this._config||!this.hass)return q;if(null===this._registry)return H`<ha-card>
         <div class="empty">
           <p class="dim">
-            ${this._registryError?ot("tile.registry_failed",this.hass,{error:this._registryError}):ot("tile.loading",this.hass)}
+            ${this._registryError?it("tile.registry_failed",this.hass,{error:this._registryError}):it("tile.loading",this.hass)}
           </p>
         </div>
-      </ha-card>`;const e=this._discovered;if(!e)return W`<ha-card>
+      </ha-card>`;const e=this._discovered;if(!e)return H`<ha-card>
         <div class="empty">
           <p class="dim">
-            ${ot("tile.entry_not_found",this.hass,{entry:this._config.entry_id})}
+            ${it("tile.entry_not_found",this.hass,{entry:this._config.entry_id})}
           </p>
         </div>
-      </ha-card>`;const t=this._config;return W`
+      </ha-card>`;const t=this._config;return H`
       <ha-card>
-        <div class="card-header">${t.title??ot("history.title",this.hass)}</div>
+        <div class="card-header">${t.title??it("history.title",this.hass)}</div>
         <acp-history-view
           .hass=${this.hass}
           .discovered=${e}
@@ -7003,7 +7045,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
           .hideAdvanced=${!!t.hide_advanced}
         ></acp-history-view>
       </ha-card>
-    `}};Jn.styles=r`
+    `}};rr.styles=a`
     :host {
       display: block;
     }
@@ -7027,7 +7069,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
       color: var(--secondary-text-color);
       margin: 0;
     }
-  `,e([_e({attribute:!1})],Jn.prototype,"hass",void 0),e([ge()],Jn.prototype,"_config",void 0),e([ge()],Jn.prototype,"_registry",void 0),e([ge()],Jn.prototype,"_registryError",void 0),Jn=e([he(Ee)],Jn),window.customCards=window.customCards||[],window.customCards.some(e=>e.type===Ee)||window.customCards.push({type:Ee,name:"Adaptive Cover Pro — History",description:"Recorded position, winning handler, sun/glare/override context and cover actions for one Adaptive Cover Pro instance, plus the diagnostic event buffer.",preview:!0,documentationURL:"https://github.com/jrhubott/adaptive-cover-pro/wiki/Lovelace-Card",getEntitySuggestion:Oo(`custom:${Ee}`,"entry_id")});const er=["sky","elevation","decision","covers","overrides","climate"];let tr=class extends ce{constructor(){super(...arguments),this._registry=null,this._registryError=null,this._discovered=null,this._dialogOpen=!1,this._discoveredList=[],this._discoveredListSource=null,this._unsubRegistry=null,this._fetchInFlight=!1,this._memo=yo(),this._debounceTimer=null,this._debounceFirstAt=null,this._DEBOUNCE_DELAY=500,this._DEBOUNCE_MAX=2e3,this._openDialog=()=>{this._dialogOpen=!0},this._closeDialog=()=>{this._dialogOpen=!1},this._onHeaderInfoKeydown=e=>{"Enter"!==e.key&&" "!==e.key||(e.preventDefault(),this._openDialog())}}setConfig(e){if(!e?.entry_id)throw new Error("adaptive-cover-pro-card: `entry_id` is required");if(this._config={...e},e.tooltips&&mo(e.tooltips),null===this._registry){const t=No.get(e.entry_id);t&&(this._registry=t.entries)}}getCardSize(){return 6}getGridOptions(){return{columns:12,rows:"auto",min_columns:6,max_columns:12}}static async getConfigElement(){return document.createElement(be)}static async getStubConfig(e){let t="";try{const o=await Fo(e);t=o[0]?.entry_id??""}catch{}return{type:`custom:${fe}`,entry_id:t}}connectedCallback(){if(super.connectedCallback(),null===this._registry){const e=zo();e&&(this._registry=e)}this.hass&&this._ensureRegistry()}disconnectedCallback(){super.disconnectedCallback(),this._unsubRegistry&&(this._unsubRegistry(),this._unsubRegistry=null),null!==this._debounceTimer&&(clearTimeout(this._debounceTimer),this._debounceTimer=null,this._debounceFirstAt=null)}updated(e){e.has("hass")&&this.hass&&this._ensureRegistry()}shouldUpdate(e){return e.size>1||!e.has("hass")||(!this._discovered||(!!this._discovered.is_group||me(e.get("hass"),this.hass,Object.values(this._discovered.entities))))}willUpdate(e){null!==this._registry&&this._config&&this.hass&&(e.has("hass")||e.has("_registry")||e.has("_config"))&&(this._discovered=this._memo(this.hass,this._config,this._registry)),this._discovered!==this._discoveredListSource&&(this._discoveredListSource=this._discovered,this._discoveredList=this._discovered?[this._discovered]:[])}_ensureRegistry(){this._fetchRegistry(),this._unsubRegistry||(this._unsubRegistry=So(this.hass,e=>{const t=new Set(Ro(this._registry??[],this._config?.entry_id??"").map(e=>e.entity_id));(function(e,t){return"create"===e.action||t.has(e.entity_id)})(e,t)&&this._scheduleRefetch()}))}_fetchRegistry(e=!1){this._fetchInFlight||(this._fetchInFlight=!0,Mo(this.hass,e).then(e=>{if(e===this._registry)return;const t=this._config?.entry_id;if(t){const o=Ro(e,t);(null===this._registry||function(e,t){if(e.length!==t.length)return!0;const o=new Map(e.map(e=>[e.entity_id,Do(e)]));for(const e of t)if(o.get(e.entity_id)!==Do(e))return!0;return!1}(Ro(this._registry,t),o))&&(this._registry=e,o.length&&No.set(t,o))}else this._registry=e;this._registryError=null}).catch(e=>{this._registryError=e?.message??"entity registry fetch failed"}).finally(()=>{this._fetchInFlight=!1}))}_scheduleRefetch(){const e=Date.now();null===this._debounceFirstAt&&(this._debounceFirstAt=e);const t=e-this._debounceFirstAt,o=this._DEBOUNCE_MAX-t,i=Math.min(this._DEBOUNCE_DELAY,o);if(null!==this._debounceTimer&&clearTimeout(this._debounceTimer),i<=0)return this._debounceFirstAt=null,void this._fetchRegistry(!0);this._debounceTimer=setTimeout(()=>{this._debounceTimer=null,this._debounceFirstAt=null,this._fetchRegistry(!0)},i)}get _sections(){return this._config?.show_sections??er}_renderHeader(e,t){const o=e.managed_covers?.[0],i=o?this.hass.states[o]:void 0,s=ht({explicitIcon:i?.attributes?.icon,deviceClass:i?.attributes?.device_class,coverType:e.cover_type,position:Ht(this.hass,e,o)}),n=!1!==this._config.state_color?_t(i?.state):null,r=e.entities.integration_enabled_switch,a=e.entities.automatic_control_switch,l=!r||"on"===this.hass.states[r]?.state,c=!a||"on"===this.hass.states[a]?.state;return W`
+  `,e([ge({attribute:!1})],rr.prototype,"hass",void 0),e([me()],rr.prototype,"_config",void 0),e([me()],rr.prototype,"_registry",void 0),e([me()],rr.prototype,"_registryError",void 0),rr=e([pe(ze)],rr),window.customCards=window.customCards||[],window.customCards.some(e=>e.type===ze)||window.customCards.push({type:ze,name:"Adaptive Cover Pro — History",description:"Recorded position, winning handler, sun/glare/override context and cover actions for one Adaptive Cover Pro instance, plus the diagnostic event buffer.",preview:!0,documentationURL:"https://github.com/jrhubott/adaptive-cover-pro/wiki/Lovelace-Card",getEntitySuggestion:Fo(`custom:${ze}`,"entry_id")});const ar=["sky","elevation","decision","covers","overrides","climate"];let lr=class extends de{constructor(){super(...arguments),this._registry=null,this._registryError=null,this._discovered=null,this._dialogOpen=!1,this._discoveredList=[],this._discoveredListSource=null,this._unsubRegistry=null,this._fetchInFlight=!1,this._memo=xo(),this._debounceTimer=null,this._debounceFirstAt=null,this._DEBOUNCE_DELAY=500,this._DEBOUNCE_MAX=2e3,this._openDialog=()=>{this._dialogOpen=!0},this._closeDialog=()=>{this._dialogOpen=!1},this._onHeaderInfoKeydown=e=>{"Enter"!==e.key&&" "!==e.key||(e.preventDefault(),this._openDialog())}}setConfig(e){if(!e?.entry_id)throw new Error("adaptive-cover-pro-card: `entry_id` is required");if(this._config={...e},e.tooltips&&fo(e.tooltips),null===this._registry){const t=Ro.get(e.entry_id);t&&(this._registry=t.entries)}}getCardSize(){return 6}getGridOptions(){return{columns:12,rows:"auto",min_columns:6,max_columns:12}}static async getConfigElement(){return document.createElement(ye)}static async getStubConfig(e){let t="";try{const o=await No(e);t=o[0]?.entry_id??""}catch{}return{type:`custom:${be}`,entry_id:t}}connectedCallback(){if(super.connectedCallback(),null===this._registry){const e=To();e&&(this._registry=e)}this.hass&&this._ensureRegistry()}disconnectedCallback(){super.disconnectedCallback(),this._unsubRegistry&&(this._unsubRegistry(),this._unsubRegistry=null),null!==this._debounceTimer&&(clearTimeout(this._debounceTimer),this._debounceTimer=null,this._debounceFirstAt=null)}updated(e){e.has("hass")&&this.hass&&this._ensureRegistry()}shouldUpdate(e){return e.size>1||!e.has("hass")||(!this._discovered||(!!this._discovered.is_group||ve(e.get("hass"),this.hass,Object.values(this._discovered.entities))))}willUpdate(e){null!==this._registry&&this._config&&this.hass&&(e.has("hass")||e.has("_registry")||e.has("_config"))&&(this._discovered=this._memo(this.hass,this._config,this._registry)),this._discovered!==this._discoveredListSource&&(this._discoveredListSource=this._discovered,this._discoveredList=this._discovered?[this._discovered]:[])}_ensureRegistry(){this._fetchRegistry(),this._unsubRegistry||(this._unsubRegistry=Eo(this.hass,e=>{const t=new Set(Ko(this._registry??[],this._config?.entry_id??"").map(e=>e.entity_id));(function(e,t){return"create"===e.action||t.has(e.entity_id)})(e,t)&&this._scheduleRefetch()}))}_fetchRegistry(e=!1){this._fetchInFlight||(this._fetchInFlight=!0,Io(this.hass,e).then(e=>{if(e===this._registry)return;const t=this._config?.entry_id;if(t){const o=Ko(e,t);(null===this._registry||function(e,t){if(e.length!==t.length)return!0;const o=new Map(e.map(e=>[e.entity_id,jo(e)]));for(const e of t)if(o.get(e.entity_id)!==jo(e))return!0;return!1}(Ko(this._registry,t),o))&&(this._registry=e,o.length&&Ro.set(t,o))}else this._registry=e;this._registryError=null}).catch(e=>{this._registryError=e?.message??"entity registry fetch failed"}).finally(()=>{this._fetchInFlight=!1}))}_scheduleRefetch(){const e=Date.now();null===this._debounceFirstAt&&(this._debounceFirstAt=e);const t=e-this._debounceFirstAt,o=this._DEBOUNCE_MAX-t,i=Math.min(this._DEBOUNCE_DELAY,o);if(null!==this._debounceTimer&&clearTimeout(this._debounceTimer),i<=0)return this._debounceFirstAt=null,void this._fetchRegistry(!0);this._debounceTimer=setTimeout(()=>{this._debounceTimer=null,this._debounceFirstAt=null,this._fetchRegistry(!0)},i)}get _sections(){return this._config?.show_sections??ar}_renderHeader(e,t){const o=e.managed_covers?.[0],i=o?this.hass.states[o]:void 0,s=pt({explicitIcon:i?.attributes?.icon,deviceClass:i?.attributes?.device_class,coverType:e.cover_type,position:Vt(this.hass,e,o)}),n=!1!==this._config.state_color?mt(i?.state):null,r=e.entities.integration_enabled_switch,a=e.entities.automatic_control_switch,l=!r||"on"===this.hass.states[r]?.state,c=!a||"on"===this.hass.states[a]?.state;return H`
       <div class="header">
         <div
           class="header-info"
@@ -7040,37 +7082,37 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
           <span class="title">${e.entry_title}</span>
         </div>
         <span class="spacer"></span>
-        ${r?W`<acp-header-pill
+        ${r?H`<acp-header-pill
               .on=${l}
               .readonly=${!t.integration_enabled}
-              .label=${ot(l?"header.on":"header.off",this.hass)}
-              title=${ot("header.integration_enabled",this.hass)}
+              .label=${it(l?"header.on":"header.off",this.hass)}
+              title=${it("header.integration_enabled",this.hass)}
               @pill-click=${()=>this._toggle(r)}
-            ></acp-header-pill>`:V}
-        ${a?W`<acp-header-pill
+            ></acp-header-pill>`:q}
+        ${a?H`<acp-header-pill
               .on=${c}
               .readonly=${!t.automatic_control}
-              .label=${ot("header.auto",this.hass)}
-              title=${ot("header.automatic_control",this.hass)}
+              .label=${it("header.auto",this.hass)}
+              title=${it("header.automatic_control",this.hass)}
               @pill-click=${()=>this._toggle(a)}
-            ></acp-header-pill>`:V}
+            ></acp-header-pill>`:q}
       </div>
-    `}_toggle(e){const t=e.split(".")[0];this.hass.callService(t,"toggle",{entity_id:e})}_renderLoading(){return W`
+    `}_toggle(e){const t=e.split(".")[0];this.hass.callService(t,"toggle",{entity_id:e})}_renderLoading(){return H`
       <ha-card>
         <div class="empty">
-          <p class="dim">${ot("root.loading_registry",this.hass)}</p>
+          <p class="dim">${it("root.loading_registry",this.hass)}</p>
         </div>
       </ha-card>
-    `}_renderEmpty(e){const t=this._config.entry_id,o=this._registry?.length??0,i=this._registry?.filter(e=>e.config_entry_id===t&&"adaptive_cover_pro"===e.platform).length;return W`
+    `}_renderEmpty(e){const t=this._config.entry_id,o=this._registry?.length??0,i=this._registry?.filter(e=>e.config_entry_id===t&&"adaptive_cover_pro"===e.platform).length;return H`
       <ha-card>
         <div class="empty">
-          <p><strong>${ot("root.no_entities_title",this.hass)}</strong></p>
+          <p><strong>${it("root.no_entities_title",this.hass)}</strong></p>
           <p class="dim">Configured <code>entry_id</code>: <code>${t}</code></p>
           <ul class="diag">
             <li>Reason: <code>${e}</code></li>
             <li>Registry entries loaded: <code>${o}</code></li>
             <li>ACP entities matching entry_id: <code>${i??"—"}</code></li>
-            ${this._registryError?W`<li>Registry fetch error: <code>${this._registryError}</code></li>`:V}
+            ${this._registryError?H`<li>Registry fetch error: <code>${this._registryError}</code></li>`:q}
           </ul>
           <p class="dim">
             If the count is 0, the <code>entry_id</code> is wrong. Find it at
@@ -7079,7 +7121,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
           </p>
         </div>
       </ha-card>
-    `}render(){if(!this._config||!this.hass)return V;if(null===this._registry)return this._registryError?this._renderEmpty("registry fetch failed"):this._renderLoading();const e=this._discovered;if(!e)return this._renderEmpty("no matching entities after unique_id lookup");const t=(o=this._config,{...Ge,...o?.controls});var o;if(e.is_group)return W`
+    `}render(){if(!this._config||!this.hass)return q;if(null===this._registry)return this._registryError?this._renderEmpty("registry fetch failed"):this._renderLoading();const e=this._discovered;if(!e)return this._renderEmpty("no matching entities after unique_id lookup");const t=(o=this._config,{...We,...o?.controls});var o;if(e.is_group)return H`
         <ha-card>
           ${this._renderHeader(e,t)}
           <div class="body ${this._config.compact?"compact":""}">
@@ -7090,11 +7132,11 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
             ></acp-group-view>
           </div>
         </ha-card>
-      `;const i=this._sections;return W`
+      `;const i=this._sections;return H`
       <ha-card>
         ${this._renderHeader(e,t)}
         <div class="body ${this._config.compact?"compact":""}">
-          ${i.includes("sky")?W`<acp-sky-compass
+          ${i.includes("sky")?H`<acp-sky-compass
                 .hass=${this.hass}
                 .discovered_list=${this._discoveredList}
                 ?compact=${!!this._config.compact}
@@ -7102,44 +7144,44 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
                 .showLegend=${this._config.show_compass_legend??!0}
                 .showMoon=${this._config.show_moon??!1}
                 .coverColors=${this._config.cover_colors??[]}
-                .northOffsetDeg=${zt(this._config.north_offset??0)}
-              ></acp-sky-compass>`:V}
-          ${i.includes("elevation")?W`<acp-elevation-chart
+                .northOffsetDeg=${Tt(this._config.north_offset??0)}
+              ></acp-sky-compass>`:q}
+          ${i.includes("elevation")?H`<acp-elevation-chart
                 .hass=${this.hass}
                 .discoveredList=${this._discoveredList}
                 ?compact=${!!this._config.compact}
                 .coverColors=${this._config.cover_colors??[]}
-              ></acp-elevation-chart>`:V}
-          ${i.includes("decision")?W`<acp-decision-strip
+              ></acp-elevation-chart>`:q}
+          ${i.includes("decision")?H`<acp-decision-strip
                 .hass=${this.hass}
                 .discovered=${e}
                 ?compact=${!!this._config.compact}
                 ?hide-inactive=${!!this._config.hide_inactive_handlers||!!this._config.compact}
                 .showSummary=${!1!==this._config.show_decision_summary}
-              ></acp-decision-strip>`:V}
-          ${i.includes("covers")?W`<acp-cover-bar
+              ></acp-decision-strip>`:q}
+          ${i.includes("covers")?H`<acp-cover-bar
                 .hass=${this.hass}
                 .discovered=${e}
                 ?compact=${!!this._config.compact}
                 .coverColor=${this._config.cover_colors?.[0]??null}
                 @acp-open-more-info=${this._openDialog}
-              ></acp-cover-bar>`:V}
-          ${i.includes("overrides")?W`<acp-overrides-panel
+              ></acp-cover-bar>`:q}
+          ${i.includes("overrides")?H`<acp-overrides-panel
                 .hass=${this.hass}
                 .discovered=${e}
                 ?compact=${!!this._config.compact}
                 .resetEnabled=${t.reset_manual_override}
-              ></acp-overrides-panel>`:V}
-          ${i.includes("climate")?W`<acp-climate-panel
+              ></acp-overrides-panel>`:q}
+          ${i.includes("climate")?H`<acp-climate-panel
                 .hass=${this.hass}
                 .discovered=${e}
                 ?compact=${!!this._config.compact}
-              ></acp-climate-panel>`:V}
-          ${i.includes("solar")?W`<acp-solar-calc
+              ></acp-climate-panel>`:q}
+          ${i.includes("solar")?H`<acp-solar-calc
                 .hass=${this.hass}
                 .discovered=${e}
                 ?compact=${!!this._config.compact}
-              ></acp-solar-calc>`:V}
+              ></acp-solar-calc>`:q}
         </div>
       </ha-card>
       <acp-more-info-dialog
@@ -7149,7 +7191,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
         .stateColor=${!1!==this._config.state_color}
         @acp-dialog-close=${this._closeDialog}
       ></acp-more-info-dialog>
-    `}};tr.styles=r`
+    `}};lr.styles=a`
     :host {
       display: block;
     }
@@ -7214,4 +7256,4 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
     .dim {
       color: var(--secondary-text-color);
     }
-  `,e([_e({attribute:!1})],tr.prototype,"hass",void 0),e([ge()],tr.prototype,"_config",void 0),e([ge()],tr.prototype,"_registry",void 0),e([ge()],tr.prototype,"_registryError",void 0),e([ge()],tr.prototype,"_discovered",void 0),e([ge()],tr.prototype,"_dialogOpen",void 0),tr=e([he(fe)],tr),window.customCards=window.customCards||[],window.customCards.push({type:fe,name:"Adaptive Cover Pro",description:"Visualize sun/window geometry, the pipeline decision trace, and live cover positions with inline controls.",preview:!0,documentationURL:"https://github.com/jrhubott/adaptive-cover-pro/wiki/Lovelace-Card",getEntitySuggestion:Oo(`custom:${fe}`,"entry_id")}),console.info(`%c adaptive-cover-pro-card %c v${ve} `,"color: white; background: #3f51b5; font-weight: 700;","color: #3f51b5; background: white; font-weight: 700;");export{tr as AdaptiveCoverProCard};
+  `,e([ge({attribute:!1})],lr.prototype,"hass",void 0),e([me()],lr.prototype,"_config",void 0),e([me()],lr.prototype,"_registry",void 0),e([me()],lr.prototype,"_registryError",void 0),e([me()],lr.prototype,"_discovered",void 0),e([me()],lr.prototype,"_dialogOpen",void 0),lr=e([pe(be)],lr),window.customCards=window.customCards||[],window.customCards.push({type:be,name:"Adaptive Cover Pro",description:"Visualize sun/window geometry, the pipeline decision trace, and live cover positions with inline controls.",preview:!0,documentationURL:"https://github.com/jrhubott/adaptive-cover-pro/wiki/Lovelace-Card",getEntitySuggestion:Fo(`custom:${be}`,"entry_id")}),console.info(`%c adaptive-cover-pro-card %c v${fe} `,"color: white; background: #3f51b5; font-weight: 700;","color: #3f51b5; background: white; font-weight: 700;");export{lr as AdaptiveCoverProCard};

--- a/harness/src/control-panel.ts
+++ b/harness/src/control-panel.ts
@@ -724,6 +724,37 @@ export class AcpHarnessControlPanel extends LitElement {
                     html`<option value=${dc} ?selected=${c.device_class === dc}>${dc}</option>`,
                 )}
               </select>
+              <select
+                title="Battery — none emits no sensor at all; unknown emits it as 'unknown' (the card treats that as low)"
+                @change=${(ev: Event) => {
+                  const v = (ev.target as HTMLSelectElement).value;
+                  const battery = v === 'none' ? undefined : v === 'unknown' ? null : 50;
+                  const covers = e.covers.map((cc, i) => (i === ci ? { ...cc, battery } : cc));
+                  this._patchEntry(idx, { covers });
+                }}
+              >
+                <option value="none" ?selected=${c.battery === undefined}>batt: none</option>
+                <option value="level" ?selected=${typeof c.battery === 'number'}>
+                  batt: level
+                </option>
+                <option value="unknown" ?selected=${c.battery === null}>batt: unknown</option>
+              </select>
+              ${typeof c.battery === 'number'
+                ? html`<input
+                    type="number"
+                    min="0"
+                    max="100"
+                    title="Battery %"
+                    .value=${String(c.battery)}
+                    @change=${(ev: Event) => {
+                      const v = (ev.target as HTMLInputElement).value;
+                      const covers = e.covers.map((cc, i) =>
+                        i === ci ? { ...cc, battery: v === '' ? null : parseInt(v, 10) } : cc,
+                      );
+                      this._patchEntry(idx, { covers });
+                    }}
+                  />`
+                : ''}
               ${e.cover_type === 'cover_venetian'
                 ? html`<input
                     type="number"

--- a/harness/src/mock/hass.ts
+++ b/harness/src/mock/hass.ts
@@ -22,7 +22,7 @@ import {
   type CompressedSensorState,
   type LogbookRow,
 } from './events';
-import { buildStates, type GeneratedStates } from './state-gen';
+import { buildStates, batteryEntityId, coverDeviceId, type GeneratedStates } from './state-gen';
 
 export interface ServiceCallEvent {
   ts: number;
@@ -261,6 +261,27 @@ export function buildMockHass(
     if (areaId && e.area) areas[areaId] = { area_id: areaId, name: e.area };
   }
 
+  // `hass.entities` — the frontend's *display* entity registry. Distinct from the
+  // full websocket registry `buildRegistry` returns: it omits unique_id/platform
+  // but carries `device_id` for EVERY entity, which is the only way a card can
+  // get from a cover to a battery sensor sitting on the same physical device.
+  // Each managed cover is its own device (the motor), not part of ACP's device.
+  const entityRegistryDisplay: Record<string, { device_id?: string }> = {};
+  for (const e of cfg.entries) {
+    for (const c of e.covers) {
+      const deviceId = coverDeviceId(c.entity_id);
+      devices[deviceId] = {
+        id: deviceId,
+        name: c.friendly_name,
+        config_entries: [],
+      };
+      entityRegistryDisplay[c.entity_id] = { device_id: deviceId };
+      if (c.battery !== undefined) {
+        entityRegistryDisplay[batteryEntityId(c.entity_id)] = { device_id: deviceId };
+      }
+    }
+  }
+
   // Cover entity_id -> { entry, cover, index } for mocking recorder position
   // history. `index` lets the mock give each cover of a multi-cover entry its
   // own trajectory, so the History card's per-cover lines have something to
@@ -465,6 +486,7 @@ export function buildMockHass(
     } as unknown as HomeAssistant['user'],
     devices,
     areas,
+    entities: entityRegistryDisplay,
     callService: callService as unknown as HomeAssistant['callService'],
     callWS: callWS as unknown as HomeAssistant['callWS'],
     connection: {

--- a/harness/src/mock/state-gen.ts
+++ b/harness/src/mock/state-gen.ts
@@ -589,7 +589,33 @@ function addCoverStates(states: Record<string, HassState>, entry: HarnessEntry):
       ...(deviceClass !== undefined ? { device_class: deviceClass } : {}),
       ...(c.icon ? { icon: c.icon } : {}),
     });
+    // A battery-powered cover carries its charge on a SEPARATE sensor sitting on
+    // the cover's own device, the way a Zigbee shade motor does — not as an
+    // attribute of the cover. That separation is the whole reason the card has to
+    // walk `hass.entities` for a device_id, so mocking it any other way would
+    // exercise a path real installs never take. `null` emits `unknown`.
+    if (c.battery !== undefined) {
+      const batteryId = batteryEntityId(c.entity_id);
+      states[batteryId] = mkState(batteryId, c.battery === null ? 'unknown' : String(c.battery), {
+        friendly_name: `${c.friendly_name} battery`,
+        device_class: 'battery',
+        unit_of_measurement: '%',
+        state_class: 'measurement',
+      });
+    }
   }
+}
+
+/** The mock battery sensor paired with a cover — `cover.foo` → `sensor.foo_battery`. */
+export function batteryEntityId(coverEntityId: string): string {
+  return `sensor.${coverEntityId.split('.')[1]}_battery`;
+}
+
+/** The mock device a cover and its battery sensor both belong to. Distinct from
+ *  the ACP entry's own `device_<entry_id>`: in a real install the cover is its
+ *  own device (the motor), and the battery hangs off THAT, not off ACP. */
+export function coverDeviceId(coverEntityId: string): string {
+  return `device_${coverEntityId.replace('.', '_')}`;
 }
 
 /**

--- a/harness/src/scenarios.ts
+++ b/harness/src/scenarios.ts
@@ -410,7 +410,7 @@ export const SCENARIOS: Scenario[] = [
     id: 'day-night-dual-rail',
     label: 'Day/night shade — two rails (dual_entity)',
     description:
-      "A day/night shade in the integration's dual_entity control model: ONE config entry binding TWO cover.* rail entities (bottom rail carries the coverage, middle rail carries the sheer-vs-blackout fabric split). The blend is not a drivable tilt axis on either entity, so discovery reports position only — pre-fix the tile card rendered managed_covers[0] and nothing else, leaving the middle rail with no readout and no control anywhere on the tile. The tile must now show ONE POSITION RAIL PER MANAGED COVER, stacked in the slot the single bar used to occupy, each led by its own cover glyph rather than a name — resolved through the same chain as the tile icon (entity `icon` → `device_class` → `cover_type`), so the two rails here carry DIFFERENT glyphs only because the middle rail pins an explicit `icon`. Hover a glyph for that rail's name, and the slider's accessible name carries it too. Clear the middle rail's `icon` in this scenario and both rails collapse to the same shutter glyph — that is correct, and the reason the names moved to the tooltip instead of disappearing. BOTH rails carry an orange target tick, but from DIFFERENT sources, deliberately. The resolved cover (the bottom rail) keeps the entry-level pipeline target — the number this tile has always shown, and the one the dialog marker still shows. Every OTHER rail reads its own dispatched value from the position_verification sensor's per_entity map: the middle rail's is 30 against the entry target of 60, because its dispatched value is the fabric blend folded into an absolute position, so borrowing the entry target would put its tick on the wrong scale. Flip “Legacy integration” on to drop per_entity entirely — the bottom rail is unaffected and the middle rail goes tickless rather than showing a borrowed number. Rail ORDER follows the integration's own entity order (config_entry.options[entities]), which the card cannot influence — set “covers (rail order)” in the Tile card panel to Reversed and the two rails swap, or to “First rail only” to prove it doubles as a filter. The ORDER CARRIES INTO THE MORE-INFO DIALOG: open the tile and the dialog\'s stacked cover bars follow the same order and subset, so the two surfaces never disagree. Only an explicit covers list travels — a tile pinned with `cover` alone leaves the dialog showing every managed cover exactly as before. The rails draw COVERAGE, not openness: a full rail means the cover is blocking the most sun, the same polarity as the sky compass wedge — which now reads the same open_blocks_sun flag instead of testing for cover_awning, so an oscillating awning no longer draws an inverted wedge beside a correctly-filled rail. Polarity comes from the discovery axis flag open_blocks_sun, so it is per-axis and per-cover-type rather than hardcoded — compare against any AWNING scenario, where extending raises both the value and the coverage so its rail fills the other way. Drag, arrows and the target tick all follow the drawn direction; only the tooltip and the service call stay in the integration frame. Each rail is an independent slider: drag one and only that rail's fill follows (a single shared drag state used to paint both), release fires exactly one set_axes for THAT entity (watch the service log), and the gesture must not open the more-info dialog. Point “controls_cover” at the middle rail in the Tile card panel and the ↑■↓ buttons retarget to it — including their at-open/at-closed disabling, which now reads the retargeted entity rather than always the first cover.",
+      "A day/night shade in the integration's dual_entity control model: ONE config entry binding TWO cover.* rail entities (bottom rail carries the coverage, middle rail carries the sheer-vs-blackout fabric split). The blend is not a drivable tilt axis on either entity, so discovery reports position only — pre-fix the tile card rendered managed_covers[0] and nothing else, leaving the middle rail with no readout and no control anywhere on the tile. The tile must now show ONE POSITION RAIL PER MANAGED COVER, stacked in the slot the single bar used to occupy, each led by its own cover glyph rather than a name — resolved through the same chain as the tile icon (entity `icon` → `device_class` → `cover_type`), so the two rails here carry DIFFERENT glyphs only because the middle rail pins an explicit `icon`. Hover a glyph for that rail's name, and the slider's accessible name carries it too. Clear the middle rail's `icon` in this scenario and both rails collapse to the same shutter glyph — that is correct, and the reason the names moved to the tooltip instead of disappearing. BOTH rails carry an orange target tick, but from DIFFERENT sources, deliberately. The resolved cover (the bottom rail) keeps the entry-level pipeline target — the number this tile has always shown, and the one the dialog marker still shows. Every OTHER rail reads its own dispatched value from the position_verification sensor's per_entity map: the middle rail's is 30 against the entry target of 60, because its dispatched value is the fabric blend folded into an absolute position, so borrowing the entry target would put its tick on the wrong scale. Flip “Legacy integration” on to drop per_entity entirely — the bottom rail is unaffected and the middle rail goes tickless rather than showing a borrowed number. Rail ORDER follows the integration's own entity order (config_entry.options[entities]), which the card cannot influence — set “covers (rail order)” in the Tile card panel to Reversed and the two rails swap, or to “First rail only” to prove it doubles as a filter. The ORDER CARRIES INTO THE MORE-INFO DIALOG: open the tile and the dialog\'s stacked cover bars follow the same order and subset, so the two surfaces never disagree. Only an explicit covers list travels — a tile pinned with `cover` alone leaves the dialog showing every managed cover exactly as before. The rails draw COVERAGE, not openness: a full rail means the cover is blocking the most sun, the same polarity as the sky compass wedge — which now reads the same open_blocks_sun flag instead of testing for cover_awning, so an oscillating awning no longer draws an inverted wedge beside a correctly-filled rail. Polarity comes from the discovery axis flag open_blocks_sun, so it is per-axis and per-cover-type rather than hardcoded — compare against any AWNING scenario, where extending raises both the value and the coverage so its rail fills the other way. Drag, arrows and the target tick all follow the drawn direction; only the tooltip and the service call stay in the integration frame. Each rail is an independent slider: drag one and only that rail's fill follows (a single shared drag state used to paint both), release fires exactly one set_axes for THAT entity (watch the service log), and the gesture must not open the more-info dialog. Point “controls_cover” at the middle rail in the Tile card panel and the ↑■↓ buttons retarget to it — including their at-open/at-closed disabling, which now reads the retargeted entity rather than always the first cover. It retargets the BUTTONS ONLY, deliberately: the name/state line, position readout, icon, color and tap target all keep describing the resolved cover (the bottom rail), and the orange target ticks stay where they are. Making the display follow this option was tried and reverted — the tile's `cover` is simultaneously the displayed entity, the rail carrying the entry-level pipeline target, the tilt axis's read/write target and the anchor for the entry-scale position fallback, so moving it for display silently moved a service-call target too.",
     build: () => {
       const c = baseConfig('2026-06-21', 12 * 60);
       c.scenario = 'day-night-dual-rail';
@@ -2304,12 +2304,83 @@ export const SCENARIOS: Scenario[] = [
     },
   },
   {
+    id: 'cover-battery',
+    label: 'Cover battery — low overlay, dialog readout, unknown level (#260)',
+    added: '2026-07-31',
+    issue: 260,
+    description:
+      "Battery reporting across all three states the card distinguishes. A cover's battery is NOT an ACP entity — it is a separate `device_class: battery` sensor on the cover's OWN device — so the card resolves it by walking `hass.entities` for the cover's device_id and finding the battery sensor beside it. That is why this scenario gives each cover its own mock device. Three entries: 'Healthy' at 82% (no overlay — the tile icon must stay clean, and the dialog's battery button shows a full-ish glyph reading '82% battery'); 'Low' at 8% (the tile icon gains a RED battery overlay at its BOTTOM-LEFT, diagonally opposite the occupancy symbol's top-right so the two never collide, tooltip 'Low battery — 8%'); and 'Unknown' whose sensor reads `unknown` (treated as LOW deliberately — a battery that has stopped reporting is exactly what a warning is for — so it also overlays, with mdi:battery-alert-variant-outline). The threshold is LOW_BATTERY_PCT = 20 in src/lib/battery.ts, shared by the tile overlay and the dialog readout so they cannot drift. Check the multi-cover path too: 'Low' has two covers at 8% and 64%, so the icon must follow the WORST cell while the dialog tooltip names both ('Left: 8% · Right: 64%'). Set any of it live from Managed covers → the batt: select (none/level/unknown) in the control panel. A mains-powered cover (batt: none) emits no sensor at all and must render nothing anywhere.",
+    build: () => {
+      const c = baseConfig('2026-06-21', 12 * 60);
+      c.scenario = 'cover-battery';
+      c.tile.layout = 'detailed';
+      c.entries = [
+        makeEntry({
+          entry_id: 'healthy',
+          title: 'Healthy',
+          window_azimuth: 180,
+          color: '#43a047',
+          target_position: 70,
+          covers: [
+            {
+              entity_id: 'cover.healthy_shade',
+              friendly_name: 'Healthy shade',
+              position: 70,
+              device_class: 'shade',
+              battery: 82,
+            },
+          ],
+        }),
+        makeEntry({
+          entry_id: 'low',
+          title: 'Low',
+          window_azimuth: 180,
+          color: '#e53935',
+          target_position: 40,
+          covers: [
+            {
+              entity_id: 'cover.low_left',
+              friendly_name: 'Left',
+              position: 40,
+              device_class: 'shade',
+              battery: 8,
+            },
+            {
+              entity_id: 'cover.low_right',
+              friendly_name: 'Right',
+              position: 40,
+              device_class: 'shade',
+              battery: 64,
+            },
+          ],
+        }),
+        makeEntry({
+          entry_id: 'unknown_batt',
+          title: 'Unknown',
+          window_azimuth: 180,
+          color: '#8e24aa',
+          target_position: 55,
+          covers: [
+            {
+              entity_id: 'cover.unknown_shade',
+              friendly_name: 'Unknown shade',
+              position: 55,
+              device_class: 'shade',
+              battery: null,
+            },
+          ],
+        }),
+      ];
+      return c;
+    },
+  },
+  {
     id: 'bar-only-tile',
-    label: 'Bar-only tile — no badges, centered name/state (#208)',
+    label: 'Bar-only tile — no badges, same grid as a badged tile (#260)',
     added: '2026-07-13',
     issue: 208,
     description:
-      "The bar-only detailed tile (commit that centers name/state, #208): integration enabled but AUTOMATIC control OFF, no manual override and no floor slot, so NO chrome badges render — only the position bar. The name/state must sit VERTICALLY CENTERED across the tile height (not pinned to the top), with the bar hugging the bottom and reserving the badge-height so this tile is the same height as a badged one. Two entries: one at ~65% open, one fully open. Note the rail draws COVERAGE, so 65% open is a 35%-filled rail and the fully-open one is empty. Verify the responsive fix: drag the tile-width control DOWN below ~340px — the ↑■↓ controls must drop to their own full-width row (they previously stayed inline for bar-only tiles because the wide grid out-specified the reflow). Toggle 'show_position_bar' off in Per-card config to confirm the chrome row collapses entirely (single-row tile) and that no slider remains. The bar is also the tile's position slider: press and drag it and the fill plus the tooltip readout follow live with no service call until release, then exactly one set_axes fires (watch the service log) — dragging RIGHT closes the cover, because the rail draws coverage and the write is the un-mirrored logical value. The gesture must NOT open the more-info dialog, though a tap anywhere else on the tile still must. Its grab area extends about 8px above and below the 6px rail without changing the tile's height, and Tab reaches it for arrow (±1), Page Up/Down (±10) and Home/End control.",
+      "The bar-only detailed tile: integration enabled but AUTOMATIC control OFF, no manual override and no floor slot, so NO chrome badges render — only the position bar. Since #260 a bar-only tile has NO grid special-case at all — it uses the same two-row grid as a badged tile, so the name/state sit in row 1 and the bar spans label+controls beneath them. It must look exactly like a badged tile with the badge pills removed: same name/state position, same full-width bar, same tile height (the chrome row still reserves the 22px badge height). The old layout centered the name/state across the full tile height and confined the bar to the label column; that centering is what produced #260's overlap — a centered label spanning both rows sat on top of the bottom-aligned bar — so it is deliberately gone, and the tile must NOT look vertically centered any more. Two entries: one at ~65% open, one fully open. Note the rail draws COVERAGE, so 65% open is a 35%-filled rail and the fully-open one is empty. Verify the responsive reflow: drag the tile-width control DOWN below ~340px — the ↑■↓ controls must drop to their own full-width row, now inherited from the plain has-chrome-row reflow rather than a bar-only re-assertion. Toggle 'show_position_bar' off in Per-card config to confirm the chrome row collapses entirely (single-row tile) and that no slider remains. The bar is also the tile's position slider: press and drag it and the fill plus the tooltip readout follow live with no service call until release, then exactly one set_axes fires (watch the service log) — dragging RIGHT closes the cover, because the rail draws coverage and the write is the un-mirrored logical value. The gesture must NOT open the more-info dialog, though a tap anywhere else on the tile still must. Its grab area extends about 8px above and below the 6px rail without changing the tile's height, and Tab reaches it for arrow (±1), Page Up/Down (±10) and Home/End control.",
     build: () => {
       const c = baseConfig('2026-06-21', 12 * 60);
       c.scenario = 'bar-only-tile';

--- a/harness/src/types.ts
+++ b/harness/src/types.ts
@@ -117,6 +117,12 @@ export interface ManagedCoverCfg {
    *  shade's middle rail carries the fabric blend folded into an absolute
    *  position. */
   command_target?: number;
+  /** Battery charge for this cover, 0..100. Emits a `device_class: battery`
+   *  sensor on the cover's own device — the same shape a Zigbee shade motor
+   *  produces, and the only thing `resolveCoverBatteries` looks for. Omit for a
+   *  mains-powered cover (no battery entity at all, nothing renders); `null`
+   *  emits the sensor as `unknown`, which the card treats as low. */
+  battery?: number | null;
 }
 
 export interface HarnessEntry {

--- a/src/adaptive-cover-pro-tile-card.ts
+++ b/src/adaptive-cover-pro-tile-card.ts
@@ -1,4 +1,12 @@
-import { LitElement, html, css, nothing, type TemplateResult, type PropertyValues } from 'lit';
+import {
+  LitElement,
+  html,
+  css,
+  nothing,
+  unsafeCSS,
+  type TemplateResult,
+  type PropertyValues,
+} from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import {
   handleAction,
@@ -23,8 +31,15 @@ import { buildOverridePresets } from './lib/override-presets';
 import './components/extend-override-dialog';
 import { AXIS_LABEL_I18N_KEYS } from './const';
 import { entityStateChanged } from './lib/hass-change';
+import { resolveCoverBatteries, lowestBattery, batteryIcon, isLowBattery } from './lib/battery';
 import { fetchAcpConfigEntries } from './lib/config-entries';
-import { coverStateIcon, coverStateColor, coverOpenIcon, coverCloseIcon } from './lib/icons';
+import {
+  coverStateIcon,
+  coverStateColor,
+  coverOpenIcon,
+  coverCloseIcon,
+  COVER_ACTIVE_COLOR,
+} from './lib/icons';
 import { subscribeEntityRegistry, type EntityRegistryEntry } from './lib/entity-registry';
 import { loadEntityRegistry, getCachedRegistry } from './lib/registry-store';
 import { registryCache } from './lib/registry-cache';
@@ -712,6 +727,14 @@ export class AdaptiveCoverProTileCard extends LitElement {
         : cfg.covers
       : [];
     const barCovers = listed.length > 0 ? listed : defaultCovers;
+    // Low-battery overlay on the tile icon, sibling to the motion overlay. Keyed
+    // off the tile's OWN cover list, not the entry's: a tile narrowed to one rail
+    // of a dual-rail shade must not warn about the battery of a cover it doesn't
+    // show. Renders only when low, so a healthy or mains-powered cover is silent.
+    const lowBattery = (() => {
+      const worst = lowestBattery(resolveCoverBatteries(this.hass, barCovers));
+      return isLowBattery(worst) ? worst : null;
+    })();
     // Live value for any rail. The resolved cover keeps the value the rest of
     // the tile (icon, readout, controls) already agrees on; every other rail
     // reproduces the same resolution for ITSELF rather than reading a raw
@@ -742,18 +765,16 @@ export class AdaptiveCoverProTileCard extends LitElement {
       id === cover ? calculatedPosition : (commandTargets[id] ?? null);
     const showPositionBar =
       detailed && cfg.show_position_bar !== false && barCovers.some((id) => railLive(id) !== null);
+    // A single cover shows a bare rail — no glyph, there is nothing to tell apart.
+    // The stack reserves a glyph lane to its LEFT rather than taking it out of the
+    // rails, so a stacked rail and a lone rail are the same length and line up on
+    // both edges (issue #260).
     const posBarTpl = showPositionBar
       ? barCovers.length === 1
         ? // Same per-rail resolution as the stack below. Reading `livePosition`
           // here painted the RESOLVED cover's value onto whatever cover
           // `covers[0]` names, while clicks/drags wrote to `covers[0]`.
-          this._posBar(
-            barCovers[0],
-            railLive(barCovers[0]),
-            railTarget(barCovers[0]),
-            iconColor,
-            positionAxis,
-          )
+          this._posBar(barCovers[0], railLive(barCovers[0]), railTarget(barCovers[0]), positionAxis)
         : html`<div class="pos-stack">
             ${barCovers.map((id) => {
               const live = railLive(id);
@@ -764,7 +785,7 @@ export class AdaptiveCoverProTileCard extends LitElement {
                   icon=${this._railIcon(id, discovered, live)}
                   ${tooltip(railName)}
                 ></ha-icon>
-                ${this._posBar(id, live, railTarget(id), iconColor, positionAxis, railName)}
+                ${this._posBar(id, live, railTarget(id), positionAxis, railName)}
               </div>`;
             })}
           </div>`
@@ -779,9 +800,9 @@ export class AdaptiveCoverProTileCard extends LitElement {
       ? html`${autoBadgeTpl}${showWinnerBadge ? badgeTpl : nothing}${floorChipTpl}`
       : nothing;
     const hasChromeRow = detailed && (hasDetailBadges || showPositionBar);
-    // Bar-only: the chrome row carries just the position bar (no badges). Center
-    // the name/state across the reserved row height and let the bar hug the
-    // bottom, instead of pinning the label to the top (issue #208).
+    // Bar-only: the chrome row carries just the position bar (no badges). Kept
+    // as a class for tests and styling hooks, but the layout is identical to a
+    // badged tile's — see the .bar-only note in the stylesheet (issue #260).
     const barOnly = hasChromeRow && !hasDetailBadges;
 
     return html`
@@ -814,6 +835,17 @@ export class AdaptiveCoverProTileCard extends LitElement {
                 class="motion-overlay ${motionState}"
                 icon="mdi:motion-sensor"
                 ${tooltip(motionTitle)}
+              ></ha-icon>`
+            : nothing}
+          ${lowBattery
+            ? html`<ha-icon
+                class="battery-overlay"
+                icon=${batteryIcon(lowBattery.level, lowBattery.charging)}
+                ${tooltip(
+                  lowBattery.level === null
+                    ? t('tile.battery_unknown', this.hass)
+                    : t('tile.battery_low', this.hass, { level: lowBattery.level }),
+                )}
               ></ha-icon>`
             : nothing}
         </div>
@@ -984,7 +1016,6 @@ export class AdaptiveCoverProTileCard extends LitElement {
     id: string,
     live: number | null,
     target: number | null,
-    iconColor: string | null,
     axis: ResolvedAxis,
     /** Rail name, folded into the slider's accessible name on a multi-rail tile
      *  where "Position" alone doesn't say which cover is being driven. */
@@ -1028,10 +1059,7 @@ export class AdaptiveCoverProTileCard extends LitElement {
       @keydown=${(e: KeyboardEvent) => this._onPosKeydown(e, id, shownFill, axis)}
     >
       <div class="pos-bar" ${tooltip(tip)}>
-        <div
-          class="pos-fill"
-          style=${`width:${shownFill}%${iconColor ? `;background:${iconColor}` : ''}`}
-        ></div>
+        <div class="pos-fill" style=${`width:${shownFill}%`}></div>
         ${targetFill !== null
           ? html`<div
               class="pos-marker"
@@ -1039,6 +1067,14 @@ export class AdaptiveCoverProTileCard extends LitElement {
             ></div>`
           : nothing}
       </div>
+      ${dragging
+        ? html`<div
+            class="pos-readout"
+            style=${`left:clamp(16px, ${shownFill}%, calc(100% - 16px))`}
+          >
+            ${formatPercent(shown)}
+          </div>`
+        : nothing}
     </div>`;
   }
 
@@ -1439,26 +1475,14 @@ export class AdaptiveCoverProTileCard extends LitElement {
         'icon chrome chrome'
         'icon tilt   tilt';
     }
-    /* Bar-only (position bar, no badges): confine the bar to the label column so
-       the controls can span both rows, then center the name/state across the
-       full height with the bar hugging the bottom — so a bar-only tile centers
-       its label instead of pinning it to the top (issue #208). Scoped to
-       :not(.has-tilt): a tilt tile keeps its 3-row grid (label/chrome/tilt) and
-       must NOT span the label across the bar + tilt rows, which would overlap
-       them (the tilt grid wins on specificity, so the label span has to opt out
-       explicitly here). */
-    .tile-body.detailed.bar-only:not(.has-tilt) {
-      grid-template-areas:
-        'icon label  controls'
-        'icon chrome controls';
-    }
-    .tile-body.detailed.bar-only:not(.has-tilt) .label {
-      grid-row: 1 / -1;
-      align-self: center;
-    }
-    .tile-body.detailed.bar-only:not(.has-tilt) .chrome-line {
-      align-self: end;
-    }
+    /* Bar-only (position bar, no badges) gets NO grid special-case: it uses the
+       same .has-chrome-row grid as a badged tile, so the bar spans label+controls
+       at full tile width and the name/state sit in row 1. The old special-case
+       confined the bar to the label column and spanned .label across both rows to
+       keep it centered (issue #208) — but a centered label and a bottom-aligned
+       bar then shared one cell and overlapped (issue #260), and the confined bar
+       read as a different component from the badged tile's full-width one. A
+       bar-only tile is now a badged tile minus the badges. */
     /* Name over state, vertically centered against the icon (HA ha-tile-info).
        No gap: HA's .info stacks the two lines with no gap and lets the primary
        line-height (normal, 1.6) do the spacing. */
@@ -1504,6 +1528,15 @@ export class AdaptiveCoverProTileCard extends LitElement {
       align-items: center;
       gap: 6px;
       min-width: 0;
+      /* Rail geometry, shared by the lone rail and the multi-cover stack so the
+         two stay the same length — see the .pos-stack note (issue #260). The
+         glyph lane is the per-rail glyph plus the .pos-row gap that separates it
+         from the rail. */
+      --acp-rail-basis: 170px;
+      --acp-rail-max: 55%;
+      --acp-rail-glyph-size: 15px;
+      --acp-rail-glyph-gap: 6px;
+      --acp-rail-glyph-lane: calc(var(--acp-rail-glyph-size) + var(--acp-rail-glyph-gap));
       /* Reserve the badge pill's height even when no badge is present, so a
          bar-only tile is the same height as one with badges — the position bar
          just centers in the reserved space (issue #208). Matches the tile-badge
@@ -1528,8 +1561,8 @@ export class AdaptiveCoverProTileCard extends LitElement {
       margin-left: auto;
       align-self: center;
       position: relative;
-      flex: 0 1 170px;
-      max-width: 55%;
+      flex: 0 1 var(--acp-rail-basis);
+      max-width: var(--acp-rail-max);
       cursor: pointer;
       /* A touch-drag must move the fill, not scroll the dashboard. */
       touch-action: none;
@@ -1542,13 +1575,20 @@ export class AdaptiveCoverProTileCard extends LitElement {
       inset: -8px 0;
     }
     /* Multi-cover entry: the rails stack in the slot the single rail occupies,
-       each labelled with its cover's short name. The stack owns the flex sizing
-       so each rail below it can size itself to the full stack width. */
+       each labelled with its cover's glyph. The stack owns the flex sizing so
+       each rail below it can size itself to the full stack width.
+
+       It is WIDER than a lone rail by exactly the glyph lane, so the glyphs hang
+       to the left of the rail track instead of shortening the rails. Both are
+       margin-left:auto, so the right edges meet and — the lane cancelling out on
+       the left — a stacked rail and a lone rail are the same length and start at
+       the same x (issue #260). Derive, never hardcode: the lane is the glyph's
+       own width plus the .pos-row gap. */
     .chrome-line .pos-stack {
       margin-left: auto;
       align-self: center;
-      flex: 0 1 170px;
-      max-width: 55%;
+      flex: 0 1 calc(var(--acp-rail-basis) + var(--acp-rail-glyph-lane));
+      max-width: calc(var(--acp-rail-max) + var(--acp-rail-glyph-lane));
       min-width: 0;
       display: flex;
       flex-direction: column;
@@ -1557,7 +1597,7 @@ export class AdaptiveCoverProTileCard extends LitElement {
     .chrome-line .pos-stack .pos-row {
       display: flex;
       align-items: center;
-      gap: 6px;
+      gap: var(--acp-rail-glyph-gap);
       min-width: 0;
     }
     /* Per-rail glyph in place of a name: two rails of one shade have long,
@@ -1574,9 +1614,9 @@ export class AdaptiveCoverProTileCard extends LitElement {
       justify-content: center;
       align-self: center;
       line-height: 0;
-      --mdc-icon-size: 15px;
-      width: 15px;
-      height: 15px;
+      --mdc-icon-size: var(--acp-rail-glyph-size);
+      width: var(--acp-rail-glyph-size);
+      height: var(--acp-rail-glyph-size);
       color: var(--secondary-text-color);
     }
     .chrome-line .pos-stack .pos-slider {
@@ -1599,6 +1639,26 @@ export class AdaptiveCoverProTileCard extends LitElement {
     .chrome-line .pos-slider.dragging .pos-fill {
       transition: none;
     }
+    /* Live percentage while a drag is in flight. The hover tooltip carries the
+       same number, but a tooltip is mouse-only — on a phone, the finger setting
+       the position is also the thing covering the rail, so without this the user
+       is dragging blind. Sits in .pos-slider, NOT .pos-bar: the bar is
+       overflow:hidden to clip the fill, which would clip this too. Pointer-events
+       off so it never eats the drag it is reporting on. */
+    .chrome-line .pos-readout {
+      position: absolute;
+      bottom: calc(100% + 6px);
+      transform: translateX(-50%);
+      padding: 1px 5px;
+      border-radius: 4px;
+      background: var(--secondary-background-color, rgba(127, 127, 127, 0.9));
+      color: var(--primary-text-color);
+      font-size: var(--ha-font-size-s, 0.75rem);
+      line-height: var(--ha-line-height-condensed, 1.2);
+      white-space: nowrap;
+      pointer-events: none;
+      z-index: 2;
+    }
     .chrome-line .pos-bar {
       position: relative;
       width: 100%;
@@ -1610,7 +1670,13 @@ export class AdaptiveCoverProTileCard extends LitElement {
     .chrome-line .pos-fill {
       position: absolute;
       inset: 0 auto 0 0;
-      background: var(--primary-color);
+      /* One constant color for every rail, never the cover's state color: a rail
+         that changed hue as it crossed open/closed read as a status light rather
+         than a measurement, and on a multi-rail tile the rails disagreed with
+         each other. The icon still carries state color (the state_color option),
+         which is where that signal belongs. Overridable per-theme via
+         --acp-pos-fill-color. */
+      background: var(--acp-pos-fill-color, ${unsafeCSS(COVER_ACTIVE_COLOR)});
       opacity: 0.55;
       border-radius: 6px;
       transition: width 0.3s ease;
@@ -1747,6 +1813,20 @@ export class AdaptiveCoverProTileCard extends LitElement {
       right: -6px;
       --mdc-icon-size: 12px;
       color: var(--warning-color, #f1c232);
+      background: var(--card-background-color, white);
+      border-radius: 50%;
+      padding: 1px;
+      line-height: 0;
+    }
+    /* Sibling of .motion-overlay, pinned to the opposite corner so a cover that
+       is both occupied and low on battery shows both without them colliding —
+       motion top-right, battery bottom-left. */
+    .battery-overlay {
+      position: absolute;
+      bottom: -4px;
+      left: -6px;
+      --mdc-icon-size: 12px;
+      color: var(--error-color, #db4437);
       background: var(--card-background-color, white);
       border-radius: 50%;
       padding: 1px;
@@ -1920,22 +2000,8 @@ export class AdaptiveCoverProTileCard extends LitElement {
             'icon tilt'
             'controls controls';
         }
-        /* The wide bar-only grid is :not(.has-tilt) at (0,4,0), which out-weighs
-           the (0,3,0) has-chrome-row reflow above — so re-assert the reflowed
-           (controls on their own row) grid at matching specificity here, or a
-           bar-only tile would keep its inline layout on phones. */
-        .tile-body.detailed.bar-only:not(.has-tilt) {
-          grid-template-areas:
-            'icon label'
-            'icon chrome'
-            'controls controls';
-        }
-        /* Narrow reflow stacks the controls on their own row, so the bar-only
-           label span from the wide layout would overlap them — pin it back to
-           the name row. */
-        .tile-body.detailed.bar-only:not(.has-tilt) .label {
-          grid-row: 1 / 2;
-        }
+        /* No bar-only re-assertion needed: the wide layout no longer special-cases
+           bar-only, so the .has-chrome-row reflow above already applies (#260). */
         .tile-body.detailed .controls {
           margin-top: 4px;
           gap: 8px;
@@ -1978,20 +2044,7 @@ export class AdaptiveCoverProTileCard extends LitElement {
           'tilt tilt'
           'controls controls';
       }
-      /* Re-assert the reflowed grid for bar-only (see the 480px block): the wide
-         bar-only rule out-specifies the has-chrome-row reflow, so without this a
-         bar-only tile in a narrow Sections column keeps its inline controls. */
-      .tile-body.detailed.bar-only:not(.has-tilt) {
-        grid-template-areas:
-          'icon label'
-          'icon chrome'
-          'controls controls';
-      }
-      /* Narrow reflow stacks the controls on their own row, so the bar-only
-         label span from the wide layout would overlap them — pin it back. */
-      .tile-body.detailed.bar-only:not(.has-tilt) .label {
-        grid-row: 1 / 2;
-      }
+      /* Same as the 480px block: no bar-only re-assertion needed (#260). */
       .tile-body.detailed .controls {
         margin-top: 4px;
         gap: 8px;

--- a/src/components/group-tile.ts
+++ b/src/components/group-tile.ts
@@ -1,4 +1,4 @@
-import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
+import { LitElement, html, css, nothing, unsafeCSS, type TemplateResult } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import type { HomeAssistant } from 'custom-card-helpers';
 
@@ -6,7 +6,7 @@ import type { DiscoveredEntities } from '../types';
 import { memberBadgeWinners } from '../lib/badge-visibility';
 import { axisDisplayValue, positionAxisFor } from '../lib/axes';
 import { formatPercent } from '../lib/formatters';
-import { coverStateColor } from '../lib/icons';
+import { coverStateColor, COVER_ACTIVE_COLOR } from '../lib/icons';
 import {
   groupIcon,
   readGroup,
@@ -169,10 +169,7 @@ export class GroupTile extends LitElement {
                 @keydown=${(e: KeyboardEvent) => this._onPosKeydown(e, s)}
               >
                 <div class="pos-bar">
-                  <div
-                    class="pos-fill"
-                    style=${`width:${shownFill}%;background:${iconColor || 'var(--primary-color)'}`}
-                  ></div>
+                  <div class="pos-fill" style=${`width:${shownFill}%`}></div>
                 </div>
               </div>`
             : nothing}
@@ -521,6 +518,10 @@ export class GroupTile extends LitElement {
     .pos-fill {
       position: absolute;
       inset: 0 auto 0 0;
+      /* One constant color for every rail, never the cover's state color: a rail
+         that changed hue as it crossed open/closed read as a status light rather
+         than a measurement. Overridable per-theme via --acp-pos-fill-color. */
+      background: var(--acp-pos-fill-color, ${unsafeCSS(COVER_ACTIVE_COLOR)});
       opacity: 0.55;
       border-radius: 6px;
       transition: width 0.3s ease;

--- a/src/components/more-info-dialog.ts
+++ b/src/components/more-info-dialog.ts
@@ -36,6 +36,7 @@ import type {
   PositionHistorySample,
 } from '../types';
 import { formatPercent } from '../lib/formatters';
+import { resolveCoverBatteries, lowestBattery, batteryIcon, isLowBattery } from '../lib/battery';
 import { fetchPositionHistory } from '../lib/position-history';
 import { startOfDay } from '../lib/sun-model';
 import { t } from '../lib/i18n';
@@ -194,6 +195,46 @@ export class MoreInfoDialog extends LitElement {
     return coverStateColor(stateObj?.state);
   }
 
+  /**
+   * Battery indicator beside the History button, rendered only when at least one
+   * managed cover reports a battery. The icon tracks the WORST cell in the entry
+   * — a two-motor shade with one flat battery has to read as flat — while the
+   * tooltip names every cover so which one is low stays recoverable.
+   */
+  private _batteryTpl(): TemplateResult | typeof nothing {
+    const covers = this.coverOrder ?? this.discovered?.managed_covers ?? [];
+    const batteries = resolveCoverBatteries(this.hass, covers);
+    const worst = lowestBattery(batteries);
+    if (!worst) return nothing;
+
+    const title =
+      batteries.length === 1
+        ? worst.level === null
+          ? t('dialog.battery_unknown', this.hass)
+          : t('dialog.battery', this.hass, { level: worst.level })
+        : batteries
+            .map((b) =>
+              t('dialog.battery_named', this.hass, {
+                name: this._coverName(b.cover_id),
+                level: b.level === null ? '—' : b.level,
+              }),
+            )
+            .join(' · ');
+
+    return html`<div
+      class="icon-btn battery${isLowBattery(worst) ? ' low' : ''}"
+      role="img"
+      aria-label=${title}
+      ${tooltip(title)}
+    >
+      <ha-icon icon=${batteryIcon(worst.level, worst.charging)}></ha-icon>
+    </div>`;
+  }
+
+  private _coverName(coverId: string): string {
+    return (this.hass?.states[coverId]?.attributes?.friendly_name as string | undefined) ?? coverId;
+  }
+
   protected render(): TemplateResult | typeof nothing {
     if (!this.open || !this.hass || !this.discovered) return nothing;
     const winner = this._winner();
@@ -258,6 +299,7 @@ export class MoreInfoDialog extends LitElement {
                         ></acp-tile-badge>`,
                     )}
             </div>
+            ${this._batteryTpl()}
             <button
               class="icon-btn history-link"
               type="button"
@@ -686,6 +728,14 @@ export class MoreInfoDialog extends LitElement {
       display: inline-flex;
       align-items: center;
       --mdc-icon-size: 18px;
+    }
+    /* The battery shares .icon-btn's metrics so it lines up with the buttons
+       beside it, but it is a readout, not a control — no pointer affordance. */
+    .icon-btn.battery {
+      cursor: default;
+    }
+    .icon-btn.battery.low {
+      color: var(--error-color, #db4437);
     }
     .icon-btn:hover {
       color: var(--primary-text-color);

--- a/src/lib/battery.ts
+++ b/src/lib/battery.ts
@@ -1,0 +1,173 @@
+import type { HomeAssistant } from 'custom-card-helpers';
+
+/**
+ * Battery level for a managed cover.
+ *
+ * A cover's battery is never an ACP entity — it belongs to the cover's own
+ * device (a Zigbee shade motor, say), so it can't come from `discoverEntities`.
+ * We reach it through the *display* entity registry (`hass.entities`), which
+ * carries `device_id` for every entity: resolve the cover's device, then find a
+ * `device_class: battery` sensor sitting on that same device.
+ *
+ * Some integrations skip the separate sensor and put `battery_level` straight on
+ * the cover's own attributes; that path is checked first since it needs no
+ * registry walk at all.
+ */
+export interface CoverBattery {
+  /** The cover this level belongs to. */
+  cover_id: string;
+  /** The entity the level was read from — the battery sensor, or the cover
+   *  itself when it exposes `battery_level` directly. */
+  source_id: string;
+  /** 0–100, or null when the source is unavailable/non-numeric. */
+  level: number | null;
+  charging: boolean;
+}
+
+interface EntityDisplayEntry {
+  device_id?: string | null;
+}
+
+/** `hass.entities` is the synchronous display registry — a subset of the full
+ *  websocket registry that omits `unique_id`/`config_entry_id` but does carry
+ *  `device_id`, which is all this lookup needs. Undeclared on
+ *  `custom-card-helpers`' `HomeAssistant`, so declare it the same way
+ *  `entity-discovery.ts` declares `hass.devices` / `hass.areas`. */
+type HassWithEntities = HomeAssistant & {
+  entities?: Record<string, EntityDisplayEntry>;
+};
+
+function numericLevel(raw: unknown): number | null {
+  // Reject the empty-ish values BEFORE coercing: `Number(null)`, `Number('')`
+  // and `Number([])` are all 0, so a cover reporting `battery_level: None` would
+  // otherwise read as a flat 0% battery and paint a red low-battery warning
+  // instead of the unknown-level icon.
+  if (raw === null || raw === undefined || raw === '') return null;
+  if (typeof raw !== 'number' && typeof raw !== 'string') return null;
+  const n = typeof raw === 'number' ? raw : Number(raw);
+  if (!Number.isFinite(n)) return null;
+  return Math.max(0, Math.min(100, n));
+}
+
+/**
+ * Resolve a battery level per cover, in the order given. Covers with no battery
+ * are simply absent from the result — the caller renders nothing for them.
+ *
+ * Walks `hass.entities` once and indexes by device, so N covers cost one pass
+ * rather than N.
+ */
+export function resolveCoverBatteries(hass: HomeAssistant, coverIds: string[]): CoverBattery[] {
+  if (!hass || coverIds.length === 0) return [];
+  const registry = (hass as HassWithEntities).entities;
+
+  // device_id → the battery sensor found on it.
+  let batteryByDevice: Map<string, string> | null = null;
+  const indexBatteries = (): Map<string, string> => {
+    const index = new Map<string, string>();
+    if (!registry) return index;
+    for (const [entityId, entry] of Object.entries(registry)) {
+      const deviceId = entry?.device_id;
+      if (!deviceId) continue;
+      // `sensor.` only. Z-Wave JS, ZHA and deCONZ all ship a
+      // `binary_sensor.*_battery` (HA's BinarySensorDeviceClass.BATTERY is also
+      // the string "battery") ALONGSIDE the percentage sensor, and it reports
+      // on/off — "low battery yes/no", not a level. Accepting it meant
+      // Number('off') → NaN → level null → treated as low, so a fully-charged
+      // cover showed a permanent red warning depending purely on which of the
+      // two enumerated first.
+      if (!entityId.startsWith('sensor.')) continue;
+      const state = hass.states[entityId];
+      if (state?.attributes?.device_class !== 'battery') continue;
+
+      const existing = index.get(deviceId);
+      if (existing === undefined) {
+        index.set(deviceId, entityId);
+        continue;
+      }
+      // A device with several battery sensors: prefer one that is actually
+      // reporting a number. Never SKIP a non-numeric one outright — a battery
+      // sensor gone `unavailable` is exactly what the warning exists for, and
+      // dropping it would silently hide a dead cell instead of flagging it.
+      if (
+        numericLevel(hass.states[existing]?.state) === null &&
+        numericLevel(state.state) !== null
+      ) {
+        index.set(deviceId, entityId);
+      }
+    }
+    return index;
+  };
+
+  const out: CoverBattery[] = [];
+  for (const coverId of coverIds) {
+    const coverState = hass.states[coverId];
+    if (!coverState) continue;
+
+    // 1. The cover carries the level itself.
+    const inline = numericLevel(coverState.attributes?.battery_level);
+    if (inline !== null) {
+      out.push({
+        cover_id: coverId,
+        source_id: coverId,
+        level: inline,
+        charging: coverState.attributes?.battery_charging === true,
+      });
+      continue;
+    }
+
+    // 2. A battery sensor on the cover's device.
+    const deviceId = registry?.[coverId]?.device_id;
+    if (!deviceId) continue;
+    batteryByDevice ??= indexBatteries();
+    const sourceId = batteryByDevice.get(deviceId);
+    if (!sourceId) continue;
+
+    const source = hass.states[sourceId];
+    out.push({
+      cover_id: coverId,
+      source_id: sourceId,
+      level: numericLevel(source?.state),
+      charging: source?.attributes?.battery_charging === true,
+    });
+  }
+  return out;
+}
+
+/** At or below this percentage a battery is "low": the tile paints a warning
+ *  overlay on its icon and the dialog's readout turns red. One constant so the
+ *  two surfaces can never disagree about what low means. */
+export const LOW_BATTERY_PCT = 20;
+
+/** An unknown level counts as low — a battery sensor that has stopped reporting
+ *  is exactly the case a warning exists for. */
+export function isLowBattery(battery: CoverBattery | null): boolean {
+  if (!battery) return false;
+  return battery.level === null || battery.level <= LOW_BATTERY_PCT;
+}
+
+/** The lowest-charged battery in a set — what a single indicator should show.
+ *  An unknown level (null) sorts worst, so a dead sensor is never hidden behind
+ *  a healthy sibling. */
+export function lowestBattery(batteries: CoverBattery[]): CoverBattery | null {
+  let worst: CoverBattery | null = null;
+  for (const b of batteries) {
+    if (!worst) worst = b;
+    else if (b.level === null) worst = worst.level === null ? worst : b;
+    else if (worst.level !== null && b.level < worst.level) worst = b;
+  }
+  return worst;
+}
+
+/**
+ * MDI icon for a level, matching HA's own battery iconography: `mdi:battery` at
+ * full, `mdi:battery-alert-variant-outline` when the level is unknown, and
+ * `mdi:battery-N0` / `mdi:battery-charging-N0` in between (N rounded down to the
+ * nearest 10, since a 9% battery should not read as `battery-10`).
+ */
+export function batteryIcon(level: number | null, charging = false): string {
+  if (level === null) return 'mdi:battery-alert-variant-outline';
+  const step = Math.max(0, Math.min(10, Math.floor(level / 10)));
+  if (step === 10) return charging ? 'mdi:battery-charging-100' : 'mdi:battery';
+  if (step === 0) return charging ? 'mdi:battery-charging-10' : 'mdi:battery-outline';
+  return charging ? `mdi:battery-charging-${step * 10}` : `mdi:battery-${step * 10}`;
+}

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -81,6 +81,9 @@ export const de: EnDict = {
     legend_actual: 'Ist',
   },
   dialog: {
+    battery: 'Batterie {level}%',
+    battery_named: '{name}: {level}%',
+    battery_unknown: 'Batteriestand unbekannt',
     extend: {
       title: 'Manuelle Übersteuerung verlängern',
       presets_label: 'Bis',
@@ -259,6 +262,8 @@ export const de: EnDict = {
   tile: {
     motion_pending: 'Anwesenheits-Timeout läuft',
     motion_detected: 'Anwesenheit erkannt',
+    battery_low: 'Batterie schwach — {level}%',
+    battery_unknown: 'Batteriestand unbekannt',
     icon_action_label: 'Aktion des Beschattungssymbols',
     open: 'Öffnen',
     stop: 'Stopp',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -77,6 +77,9 @@ export const en = {
     legend_actual: 'Actual',
   },
   dialog: {
+    battery: '{level}% battery',
+    battery_named: '{name}: {level}%',
+    battery_unknown: 'Battery level unknown',
     extend: {
       title: 'Extend manual override',
       presets_label: 'Until',
@@ -254,6 +257,8 @@ export const en = {
   tile: {
     motion_pending: 'Occupancy timeout pending',
     motion_detected: 'Occupancy detected',
+    battery_low: 'Low battery — {level}%',
+    battery_unknown: 'Battery level unknown',
     icon_action_label: 'Cover icon action',
     open: 'Open',
     stop: 'Stop',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -83,6 +83,9 @@ export const fr: EnDict = {
     legend_actual: 'Réel',
   },
   dialog: {
+    battery: 'Batterie {level}%',
+    battery_named: '{name} : {level}%',
+    battery_unknown: 'Niveau de batterie inconnu',
     extend: {
       title: 'Prolonger la dérogation manuelle',
       presets_label: "Jusqu'à",
@@ -263,6 +266,8 @@ export const fr: EnDict = {
   tile: {
     motion_pending: "Délai d'occupation en cours",
     motion_detected: 'Occupation détectée',
+    battery_low: 'Batterie faible — {level}%',
+    battery_unknown: 'Niveau de batterie inconnu',
     icon_action_label: "Action de l'icône du store",
     open: 'Ouvrir',
     stop: 'Arrêter',

--- a/src/lib/icons.ts
+++ b/src/lib/icons.ts
@@ -122,6 +122,22 @@ export function coverCloseIcon(deviceClass?: string): string {
  * home-assistant-frontend's `stateActive()` (`UNAVAILABLE`/`UNKNOWN` both
  * return `false`) — an unknown cover reads as grey/off, not amber/on.
  */
+/**
+ * The cover's ACTIVE state color, with the per-state layer deliberately dropped.
+ *
+ * {@link coverStateColor} resolves `--state-cover-<state>-color` first, so its
+ * result changes as the cover crosses open/closed. This is the same chain minus
+ * that layer: one constant color that still tracks the user's theme and still
+ * reads as "this is a cover", which is what the position rails want — a rail is
+ * a measurement, not a status light. Ends at `--primary-color` for themes that
+ * define none of the HA state tokens.
+ */
+export const COVER_ACTIVE_COLOR =
+  'var(--state-cover-active-color, ' +
+  'var(--state-cover-color, ' +
+  'var(--state-active-color, ' +
+  'var(--primary-color))))';
+
 export function coverStateColor(state: string | null | undefined): string {
   // The `|| !state` is redundant with `isOffline` at runtime (it already
   // treats a missing state as offline) but narrows `state` to `string` for

--- a/src/types.ts
+++ b/src/types.ts
@@ -102,7 +102,14 @@ export interface AdaptiveCoverProTileCardConfig extends LovelaceCardConfig {
    *  cover (`cover`, else the first key of `actual_positions`). Only meaningful
    *  when the entry manages more than one cover — a day/night shade in the
    *  integration's `dual_entity` model binds two rail entities, and the buttons
-   *  can be pointed at either rail. */
+   *  can be pointed at either rail.
+   *
+   *  Buttons ONLY. The tile's state line, position readout, icon, color and tap
+   *  target continue to describe the resolved cover. Making the display follow
+   *  this option was tried and reverted: `cover` simultaneously means the
+   *  displayed entity, the rail whose tick carries the entry-level pipeline
+   *  target, the tilt axis's read/write target, and the anchor for the
+   *  entry-scale position fallback — moving one moved all four. */
   controls_cover?: string;
   /** Which discovered axis the ↑■▼ buttons drive, by axis id (`position`,
    *  `tilt`, …). Defaults to `position`. Open drives the axis maximum, close

--- a/tests/battery.test.ts
+++ b/tests/battery.test.ts
@@ -1,0 +1,297 @@
+import { describe, it, expect } from 'vitest';
+import {
+  resolveCoverBatteries,
+  lowestBattery,
+  batteryIcon,
+  isLowBattery,
+  LOW_BATTERY_PCT,
+  type CoverBattery,
+} from '../src/lib/battery';
+import type { HomeAssistant } from 'custom-card-helpers';
+
+/** Minimal `hass` carrying only what `resolveCoverBatteries` reads: the states
+ *  map and the display entity registry (`hass.entities`, which is where
+ *  `device_id` lives — the full websocket registry is never consulted). */
+function makeHass(opts: {
+  states?: Record<string, { state: string; attributes?: Record<string, unknown> }>;
+  entities?: Record<string, { device_id?: string | null }>;
+}): HomeAssistant {
+  return {
+    states: opts.states ?? {},
+    ...(opts.entities !== undefined ? { entities: opts.entities } : {}),
+  } as unknown as HomeAssistant;
+}
+
+function batterySensor(state: string, extra: Record<string, unknown> = {}) {
+  return { state, attributes: { device_class: 'battery', ...extra } };
+}
+
+describe('resolveCoverBatteries', () => {
+  it('resolves a battery sensor sitting on the cover’s own device', () => {
+    const hass = makeHass({
+      states: {
+        'cover.shade': { state: 'open', attributes: {} },
+        'sensor.shade_battery': batterySensor('72'),
+      },
+      entities: {
+        'cover.shade': { device_id: 'dev_1' },
+        'sensor.shade_battery': { device_id: 'dev_1' },
+      },
+    });
+    expect(resolveCoverBatteries(hass, ['cover.shade'])).toEqual([
+      { cover_id: 'cover.shade', source_id: 'sensor.shade_battery', level: 72, charging: false },
+    ]);
+  });
+
+  it('omits a cover whose device carries no battery sensor', () => {
+    const hass = makeHass({
+      states: { 'cover.mains': { state: 'open', attributes: {} } },
+      entities: { 'cover.mains': { device_id: 'dev_1' } },
+    });
+    expect(resolveCoverBatteries(hass, ['cover.mains'])).toEqual([]);
+  });
+
+  it('omits a cover that has no device at all', () => {
+    const hass = makeHass({
+      states: { 'cover.orphan': { state: 'open', attributes: {} } },
+      entities: { 'cover.orphan': { device_id: null } },
+    });
+    expect(resolveCoverBatteries(hass, ['cover.orphan'])).toEqual([]);
+  });
+
+  it('does not reach across devices for a battery', () => {
+    const hass = makeHass({
+      states: {
+        'cover.shade': { state: 'open', attributes: {} },
+        'sensor.other_battery': batterySensor('5'),
+      },
+      entities: {
+        'cover.shade': { device_id: 'dev_1' },
+        'sensor.other_battery': { device_id: 'dev_2' },
+      },
+    });
+    expect(resolveCoverBatteries(hass, ['cover.shade'])).toEqual([]);
+  });
+
+  it('prefers a battery_level attribute on the cover itself, without touching the registry', () => {
+    const hass = makeHass({
+      states: {
+        'cover.inline': { state: 'open', attributes: { battery_level: 41 } },
+      },
+    });
+    expect(resolveCoverBatteries(hass, ['cover.inline'])).toEqual([
+      { cover_id: 'cover.inline', source_id: 'cover.inline', level: 41, charging: false },
+    ]);
+  });
+
+  it('reports charging from either source', () => {
+    const hass = makeHass({
+      states: {
+        'cover.inline': {
+          state: 'open',
+          attributes: { battery_level: 41, battery_charging: true },
+        },
+        'cover.sensored': { state: 'open', attributes: {} },
+        'sensor.sensored_battery': batterySensor('60', { battery_charging: true }),
+      },
+      entities: {
+        'cover.sensored': { device_id: 'dev_2' },
+        'sensor.sensored_battery': { device_id: 'dev_2' },
+      },
+    });
+    const out = resolveCoverBatteries(hass, ['cover.inline', 'cover.sensored']);
+    expect(out.map((b) => b.charging)).toEqual([true, true]);
+  });
+
+  // The bug this guard exists for: Z-Wave JS / ZHA / deCONZ ship a
+  // `binary_sensor.*_battery` (device_class "battery", state on/off) ALONGSIDE
+  // the percentage sensor. Accepting it made `Number('off')` → NaN → level null
+  // → "low", so a healthy cover showed a permanent red warning.
+  it('ignores a binary_sensor battery even when it enumerates first', () => {
+    const hass = makeHass({
+      states: {
+        'cover.shade': { state: 'open', attributes: {} },
+        'binary_sensor.shade_battery': batterySensor('off'),
+        'sensor.shade_battery': batterySensor('95'),
+      },
+      entities: {
+        'binary_sensor.shade_battery': { device_id: 'dev_1' },
+        'cover.shade': { device_id: 'dev_1' },
+        'sensor.shade_battery': { device_id: 'dev_1' },
+      },
+    });
+    expect(resolveCoverBatteries(hass, ['cover.shade'])).toEqual([
+      { cover_id: 'cover.shade', source_id: 'sensor.shade_battery', level: 95, charging: false },
+    ]);
+  });
+
+  it('surfaces an unavailable battery sensor as an unknown level rather than hiding it', () => {
+    const hass = makeHass({
+      states: {
+        'cover.shade': { state: 'open', attributes: {} },
+        'sensor.shade_battery': batterySensor('unavailable'),
+      },
+      entities: {
+        'cover.shade': { device_id: 'dev_1' },
+        'sensor.shade_battery': { device_id: 'dev_1' },
+      },
+    });
+    expect(resolveCoverBatteries(hass, ['cover.shade'])[0].level).toBeNull();
+  });
+
+  it('prefers a reporting sensor when a device carries two, regardless of order', () => {
+    const entities = {
+      'cover.shade': { device_id: 'dev_1' },
+      'sensor.a_battery': { device_id: 'dev_1' },
+      'sensor.b_battery': { device_id: 'dev_1' },
+    };
+    const dead = batterySensor('unknown');
+    const live = batterySensor('33');
+    // Dead one enumerates first…
+    expect(
+      resolveCoverBatteries(
+        makeHass({
+          states: {
+            'cover.shade': { state: 'open' },
+            'sensor.a_battery': dead,
+            'sensor.b_battery': live,
+          },
+          entities,
+        }),
+        ['cover.shade'],
+      )[0],
+    ).toMatchObject({ source_id: 'sensor.b_battery', level: 33 });
+    // …and when it enumerates second, the reporting one is still kept.
+    expect(
+      resolveCoverBatteries(
+        makeHass({
+          states: {
+            'cover.shade': { state: 'open' },
+            'sensor.a_battery': live,
+            'sensor.b_battery': dead,
+          },
+          entities,
+        }),
+        ['cover.shade'],
+      )[0],
+    ).toMatchObject({ source_id: 'sensor.a_battery', level: 33 });
+  });
+
+  // `Number(null)` and `Number('')` are both 0, so a cover reporting a null
+  // battery_level would read as a flat 0% and paint a red low-battery warning.
+  it('treats a null/empty battery_level as absent, not as 0%', () => {
+    for (const battery_level of [null, '', undefined]) {
+      const hass = makeHass({
+        states: { 'cover.x': { state: 'open', attributes: { battery_level } } },
+      });
+      expect(resolveCoverBatteries(hass, ['cover.x'])).toEqual([]);
+    }
+  });
+
+  it('clamps out-of-range levels into 0..100', () => {
+    const hass = makeHass({
+      states: {
+        'cover.hi': { state: 'open', attributes: { battery_level: 140 } },
+        'cover.lo': { state: 'open', attributes: { battery_level: -20 } },
+      },
+    });
+    expect(resolveCoverBatteries(hass, ['cover.hi', 'cover.lo']).map((b) => b.level)).toEqual([
+      100, 0,
+    ]);
+  });
+
+  it('preserves the caller’s cover order and skips unknown covers', () => {
+    const hass = makeHass({
+      states: {
+        'cover.a': { state: 'open', attributes: { battery_level: 10 } },
+        'cover.b': { state: 'open', attributes: { battery_level: 20 } },
+      },
+    });
+    expect(
+      resolveCoverBatteries(hass, ['cover.b', 'cover.ghost', 'cover.a']).map((b) => b.cover_id),
+    ).toEqual(['cover.b', 'cover.a']);
+  });
+
+  it('is safe with no registry, no covers, or no hass', () => {
+    expect(resolveCoverBatteries(makeHass({}), [])).toEqual([]);
+    expect(
+      resolveCoverBatteries(makeHass({ states: { 'cover.a': { state: 'open' } } }), ['cover.a']),
+    ).toEqual([]);
+    expect(resolveCoverBatteries(undefined as unknown as HomeAssistant, ['cover.a'])).toEqual([]);
+  });
+});
+
+describe('lowestBattery', () => {
+  const b = (level: number | null): CoverBattery => ({
+    cover_id: `cover.${level}`,
+    source_id: 's',
+    level,
+    charging: false,
+  });
+
+  it('returns null for an empty set', () => {
+    expect(lowestBattery([])).toBeNull();
+  });
+
+  it('picks the lowest level', () => {
+    expect(lowestBattery([b(80), b(12), b(45)])?.level).toBe(12);
+  });
+
+  // An unknown level sorts WORST so a dead sensor is never hidden behind a
+  // healthy sibling on a multi-cover tile.
+  it('sorts an unknown level as worse than any number, in either order', () => {
+    expect(lowestBattery([b(80), b(null)])?.level).toBeNull();
+    expect(lowestBattery([b(null), b(3)])?.level).toBeNull();
+  });
+
+  it('keeps the first of equal levels', () => {
+    const first = b(50);
+    expect(lowestBattery([first, { ...b(50), cover_id: 'cover.other' }])).toBe(first);
+  });
+});
+
+describe('isLowBattery', () => {
+  it('is false for no battery', () => {
+    expect(isLowBattery(null)).toBe(false);
+  });
+
+  it('is true at and below the threshold, false above', () => {
+    const at = { cover_id: 'c', source_id: 's', level: LOW_BATTERY_PCT, charging: false };
+    expect(isLowBattery(at)).toBe(true);
+    expect(isLowBattery({ ...at, level: LOW_BATTERY_PCT - 1 })).toBe(true);
+    expect(isLowBattery({ ...at, level: LOW_BATTERY_PCT + 1 })).toBe(false);
+  });
+
+  it('treats an unknown level as low — a battery that stopped reporting is the warning case', () => {
+    expect(isLowBattery({ cover_id: 'c', source_id: 's', level: null, charging: false })).toBe(
+      true,
+    );
+  });
+});
+
+describe('batteryIcon', () => {
+  it('uses the alert glyph for an unknown level', () => {
+    expect(batteryIcon(null)).toBe('mdi:battery-alert-variant-outline');
+    expect(batteryIcon(null, true)).toBe('mdi:battery-alert-variant-outline');
+  });
+
+  it('uses the bare full glyph at 100', () => {
+    expect(batteryIcon(100)).toBe('mdi:battery');
+    expect(batteryIcon(100, true)).toBe('mdi:battery-charging-100');
+  });
+
+  it('uses the outline glyph below 10', () => {
+    expect(batteryIcon(0)).toBe('mdi:battery-outline');
+    expect(batteryIcon(9)).toBe('mdi:battery-outline');
+    expect(batteryIcon(0, true)).toBe('mdi:battery-charging-10');
+  });
+
+  // Rounded DOWN, deliberately: a 19% battery must not read as `battery-20`.
+  it('rounds down to the nearest ten in between', () => {
+    expect(batteryIcon(10)).toBe('mdi:battery-10');
+    expect(batteryIcon(19)).toBe('mdi:battery-10');
+    expect(batteryIcon(20)).toBe('mdi:battery-20');
+    expect(batteryIcon(99)).toBe('mdi:battery-90');
+    expect(batteryIcon(55, true)).toBe('mdi:battery-charging-50');
+  });
+});

--- a/tests/group-tile.test.ts
+++ b/tests/group-tile.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import '../src/components/group-tile';
+import { GroupTile } from '../src/components/group-tile';
 import type { HomeAssistant } from 'custom-card-helpers';
 import type { DiscoveredEntities } from '../src/types';
 import { loadEntityRegistry } from '../src/lib/registry-store';
@@ -483,5 +483,25 @@ describe('acp-group-tile — icon interactivity', () => {
     await el.updateComplete;
     expect(iconAction).not.toHaveBeenCalled();
     expect(moreInfo).toHaveBeenCalled();
+  });
+});
+
+describe('group tile — rail color is constant (#260)', () => {
+  // The inline `background:${iconColor || 'var(--primary-color)'}` was removed
+  // so the rail no longer changes hue with the aggregate state. This element's
+  // `.pos-fill` had NO background in CSS at all before that — it relied entirely
+  // on the inline style — so the CSS default is load-bearing, not cosmetic.
+  it('declares a background on .pos-fill in CSS', () => {
+    const css = GroupTile.styles.toString();
+    expect(css).toMatch(/\.pos-fill\s*\{[^}]*background:/);
+    expect(css).toContain('--acp-pos-fill-color');
+    expect(css).toContain('var(--state-cover-active-color');
+  });
+
+  it('never writes an inline background onto the fill', async () => {
+    const el = await mount(makeHass(), makeDiscovered());
+    const fill = el.shadowRoot!.querySelector('.pos-fill');
+    expect(fill).toBeTruthy();
+    expect(fill!.getAttribute('style') ?? '').not.toContain('background');
   });
 });

--- a/tests/harness-config.test.ts
+++ b/tests/harness-config.test.ts
@@ -14,6 +14,8 @@ import { applyService } from '../harness/src/mock/services';
 import { zonedNowMs, zoneForLongitude, hourInZone } from '../harness/src/zone';
 import { INTEGRATION_DOMAIN } from '../src/const';
 import { buildRegistry } from '../harness/src/mock/registry';
+import { buildMockHass } from '../harness/src/mock/hass';
+import { resolveCoverBatteries, lowestBattery } from '../src/lib/battery';
 import { discoverEntities } from '../src/lib/entity-discovery';
 import { positionAxisInverted, resolveAxes } from '../src/lib/axes';
 import {
@@ -700,5 +702,59 @@ describe('harness inverse_tilt scenario (#236)', () => {
     const { hass, discovered } = discoverFor('inverse-tilt-venetian');
     const tilt = resolveAxes(discovered).find((a) => a.id === 'tilt')!;
     expect(logicalAxisValue(hass, tilt, VENETIAN)).toBe(35);
+  });
+});
+
+// ── Harness battery mirroring (#260) ────────────────────────────────────────
+
+describe('harness — cover battery mock', () => {
+  const scenario = () => {
+    const s = findScenario('cover-battery');
+    expect(s).toBeTruthy();
+    return normalizeConfig(s!.build());
+  };
+
+  it('ships a cover-battery scenario covering healthy, low and unknown', () => {
+    const levels = scenario().entries.flatMap((e) => e.covers.map((c) => c.battery));
+    expect(levels).toContain(82);
+    expect(levels).toContain(8);
+    expect(levels).toContain(null);
+  });
+
+  it('emits a device_class:battery SENSOR per battery-backed cover, and none otherwise', () => {
+    const cfg = scenario();
+    cfg.entries[0].covers[0].battery = undefined;
+    const { states } = buildStates(cfg);
+
+    expect(states['sensor.healthy_shade_battery']).toBeUndefined();
+    const low = states['sensor.low_left_battery'];
+    expect(low).toBeTruthy();
+    expect(low.attributes.device_class).toBe('battery');
+    expect(low.state).toBe('8');
+    // A null level models a sensor that has stopped reporting.
+    expect(states['sensor.unknown_shade_battery'].state).toBe('unknown');
+  });
+
+  // The gap that made this invisible in the harness while working on real HA:
+  // `device_id` lives ONLY on the display registry, which the mock never built.
+  it('exposes hass.entities with each cover and its battery on the cover’s own device', () => {
+    const cfg = scenario();
+    const { hass } = buildMockHass(cfg, () => {});
+    const entities = (hass as unknown as { entities: Record<string, { device_id?: string }> })
+      .entities;
+
+    expect(entities['cover.low_left'].device_id).toBe(
+      entities['sensor.low_left_battery'].device_id,
+    );
+    // …and NOT the ACP entry's device: a real battery hangs off the motor.
+    expect(entities['cover.low_left'].device_id).not.toBe('device_low');
+  });
+
+  it('resolves through the card’s own lookup end to end', () => {
+    const cfg = scenario();
+    const { hass } = buildMockHass(cfg, () => {});
+    const out = resolveCoverBatteries(hass, ['cover.low_left', 'cover.low_right']);
+    expect(out.map((b) => b.level)).toEqual([8, 64]);
+    expect(lowestBattery(out)!.cover_id).toBe('cover.low_left');
   });
 });

--- a/tests/icons.test.ts
+++ b/tests/icons.test.ts
@@ -5,6 +5,7 @@ import {
   coverOpenIcon,
   coverCloseIcon,
   coverStateColor,
+  COVER_ACTIVE_COLOR,
 } from '../src/lib/icons';
 
 describe('pickCoverIcon', () => {
@@ -216,5 +217,34 @@ describe('coverStateColor', () => {
   });
   it('empty string resolves to the unavailable var', () => {
     expect(coverStateColor('')).toBe('var(--state-unavailable-color)');
+  });
+});
+
+describe('COVER_ACTIVE_COLOR', () => {
+  it('drops only the per-state layer from coverStateColor’s cascade', () => {
+    // Same theme cascade, minus `--state-cover-<state>-color` — so a position
+    // rail still tracks the theme and still reads as "cover", but stays one
+    // constant color instead of changing hue as the cover crosses open/closed.
+    expect(COVER_ACTIVE_COLOR).toBe(
+      'var(--state-cover-active-color, var(--state-cover-color, var(--state-active-color, var(--primary-color))))',
+    );
+    expect(COVER_ACTIVE_COLOR).not.toContain('-open-');
+    expect(COVER_ACTIVE_COLOR).not.toContain('-closed-');
+  });
+
+  it('shares its inner tiers with the active branch of coverStateColor', () => {
+    const active = coverStateColor('open');
+    for (const tier of [
+      '--state-cover-active-color',
+      '--state-cover-color',
+      '--state-active-color',
+    ]) {
+      expect(active).toContain(tier);
+      expect(COVER_ACTIVE_COLOR).toContain(tier);
+    }
+  });
+
+  it('ends at --primary-color so a theme defining no state tokens still paints', () => {
+    expect(COVER_ACTIVE_COLOR.endsWith('var(--primary-color))))')).toBe(true);
   });
 });

--- a/tests/more-info-dialog.test.ts
+++ b/tests/more-info-dialog.test.ts
@@ -957,3 +957,112 @@ describe('acp-more-info-dialog: position-history fetch cache (#234)', () => {
     expect(callWS).toHaveBeenCalledTimes(1);
   });
 });
+
+// ── Battery indicator in the header (#260) ──────────────────────────────────
+
+describe('more-info dialog — battery indicator', () => {
+  /** Attach a battery sensor to a cover's device via `hass.entities`, the
+   *  display registry the lookup walks. */
+  function withBatteries(
+    h: HomeAssistant,
+    covers: Array<{ cover: string; sensor: string; device: string; state: string; name?: string }>,
+  ): HomeAssistant {
+    const raw = h as unknown as {
+      states: Record<string, unknown>;
+      entities?: Record<string, { device_id?: string | null }>;
+    };
+    raw.entities = {};
+    for (const c of covers) {
+      raw.states[c.cover] = { state: 'open', attributes: { friendly_name: c.name ?? c.cover } };
+      raw.states[c.sensor] = { state: c.state, attributes: { device_class: 'battery' } };
+      raw.entities[c.cover] = { device_id: c.device };
+      raw.entities[c.sensor] = { device_id: c.device };
+    }
+    return h;
+  }
+
+  const battery = (el: DialogLike): Element | null =>
+    el.shadowRoot!.querySelector('.icon-btn.battery');
+
+  it('renders nothing when no managed cover reports a battery', async () => {
+    const el = await mount({ hass: hass(), discovered: discovered(), open: true });
+    expect(battery(el)).toBeFalsy();
+  });
+
+  it('renders the level for a single battery-backed cover', async () => {
+    const el = await mount({
+      hass: withBatteries(hass(), [
+        { cover: 'cover.left', sensor: 'sensor.left_batt', device: 'dev_l', state: '82' },
+      ]),
+      discovered: discovered(),
+      open: true,
+    });
+    const btn = battery(el)!;
+    expect(btn).toBeTruthy();
+    expect(btn.getAttribute('aria-label')).toContain('82');
+    expect(btn.classList.contains('low')).toBe(false);
+    expect(btn.querySelector('ha-icon')!.getAttribute('icon')).toBe('mdi:battery-80');
+  });
+
+  it('marks a low battery and uses the matching glyph', async () => {
+    const el = await mount({
+      hass: withBatteries(hass(), [
+        { cover: 'cover.left', sensor: 'sensor.left_batt', device: 'dev_l', state: '11' },
+      ]),
+      discovered: discovered(),
+      open: true,
+    });
+    const btn = battery(el)!;
+    expect(btn.classList.contains('low')).toBe(true);
+    expect(btn.querySelector('ha-icon')!.getAttribute('icon')).toBe('mdi:battery-10');
+  });
+
+  // The icon follows the WORST cell so a flat battery can't hide behind a
+  // healthy sibling, while the tooltip names every cover so which one is low
+  // stays recoverable.
+  it('follows the worst cell and names every cover on a multi-cover entry', async () => {
+    const d = discovered();
+    d.managed_covers = ['cover.left', 'cover.right'];
+    const el = await mount({
+      hass: withBatteries(hass(), [
+        {
+          cover: 'cover.left',
+          sensor: 'sensor.l_batt',
+          device: 'dev_l',
+          state: '64',
+          name: 'Left',
+        },
+        {
+          cover: 'cover.right',
+          sensor: 'sensor.r_batt',
+          device: 'dev_r',
+          state: '8',
+          name: 'Right',
+        },
+      ]),
+      discovered: d,
+      open: true,
+    });
+    const btn = battery(el)!;
+    expect(btn.classList.contains('low')).toBe(true);
+    expect(btn.querySelector('ha-icon')!.getAttribute('icon')).toBe('mdi:battery-outline');
+    const label = btn.getAttribute('aria-label')!;
+    expect(label).toContain('Left');
+    expect(label).toContain('64');
+    expect(label).toContain('Right');
+    expect(label).toContain('8');
+  });
+
+  it('is a readout, not a control — no button element, no pointer affordance', async () => {
+    const el = await mount({
+      hass: withBatteries(hass(), [
+        { cover: 'cover.left', sensor: 'sensor.left_batt', device: 'dev_l', state: '50' },
+      ]),
+      discovered: discovered(),
+      open: true,
+    });
+    const btn = battery(el)!;
+    expect(btn.tagName).not.toBe('BUTTON');
+    expect(btn.getAttribute('role')).toBe('img');
+  });
+});

--- a/tests/tile-card.test.ts
+++ b/tests/tile-card.test.ts
@@ -3672,3 +3672,254 @@ describe('adaptive-cover-pro-tile-card — controls_cover / controls_axis', () =
     );
   });
 });
+
+// ── Bar-only layout, rail geometry, battery + rail chrome (#260) ─────────────
+
+describe('tile card — bar-only layout (#260)', () => {
+  // The overlap fix: the bar-only grid special-case was deleted outright, so a
+  // bar-only tile uses the same `.has-chrome-row` grid as a badged one. The old
+  // rule spanned `.label` across both rows in the same column as `.chrome-line`,
+  // and `.tile-body`'s `align-items: center` then centered the label on top of
+  // the bottom-aligned bar. happy-dom does no layout, so the stylesheet text is
+  // the only assertable trace of the mechanism being gone.
+  const css = (): string => AdaptiveCoverProTileCard.styles.toString();
+
+  it('no longer spans the bar-only label across both grid rows', () => {
+    expect(css()).not.toContain('grid-row: 1 / -1');
+  });
+
+  it('has no bar-only grid override left at any breakpoint', () => {
+    expect(css()).not.toContain('.tile-body.detailed.bar-only');
+  });
+
+  it('still emits the bar-only class as a styling/test hook', async () => {
+    const el = await mount(
+      { type: TYPE, entry_id: ENTRY, show_badge: false },
+      makeHass({ coverLeftCurrentPosition: 60 }),
+    );
+    const body = el.shadowRoot!.querySelector('.tile-body.detailed')!;
+    expect(body.classList.contains('bar-only')).toBe(true);
+  });
+
+  // The regression guard flagged during investigation: ~15 rules are scoped
+  // `.chrome-line .pos-*`, so the bar markup must stay under `.chrome-line`.
+  it('keeps .chrome-line as the bar’s wrapper, as a sibling of .label', async () => {
+    for (const showBadge of [true, false]) {
+      const el = await mount(
+        { type: TYPE, entry_id: ENTRY, show_badge: showBadge },
+        makeHass({ coverLeftCurrentPosition: 60 }),
+      );
+      const body = el.shadowRoot!.querySelector('.tile-body.detailed')!;
+      expect(body.querySelector('.chrome-line .pos-bar')).toBeTruthy();
+      expect(body.querySelector('.label .chrome-line')).toBeFalsy();
+    }
+  });
+});
+
+describe('tile card — rail geometry (#260)', () => {
+  const css = (): string => AdaptiveCoverProTileCard.styles.toString();
+
+  // A lone rail and a stacked rail must be the same length. The stack is wider
+  // than a lone rail by exactly the glyph lane, so the glyphs hang to its LEFT
+  // instead of eating into the rails.
+  it('derives the glyph lane from the glyph size and row gap rather than hardcoding it', () => {
+    const text = css();
+    expect(text).toContain(
+      '--acp-rail-glyph-lane: calc(var(--acp-rail-glyph-size) + var(--acp-rail-glyph-gap))',
+    );
+    expect(text).toContain('calc(var(--acp-rail-basis) + var(--acp-rail-glyph-lane))');
+  });
+
+  it('sizes the glyph and the row gap from those same tokens, so the lane cannot drift', () => {
+    const text = css();
+    expect(text).toContain('width: var(--acp-rail-glyph-size)');
+    expect(text).toContain('gap: var(--acp-rail-glyph-gap)');
+  });
+
+  it('renders a bare rail with no glyph for a single cover', async () => {
+    const el = await mount(
+      { type: TYPE, entry_id: ENTRY, covers: ['cover.left'] },
+      makeHass({ coverLeftCurrentPosition: 60 }),
+    );
+    const body = el.shadowRoot!.querySelector('.tile-body.detailed')!;
+    expect(body.querySelector('.pos-bar')).toBeTruthy();
+    expect(body.querySelector('.pos-stack')).toBeFalsy();
+    expect(body.querySelector('.pos-glyph')).toBeFalsy();
+  });
+
+  it('renders one glyph-led row per cover for a multi-cover entry', async () => {
+    const el = await mount(
+      { type: TYPE, entry_id: ENTRY },
+      makeHass({ coverLeftCurrentPosition: 60 }),
+    );
+    const body = el.shadowRoot!.querySelector('.tile-body.detailed')!;
+    expect(body.querySelectorAll('.pos-stack .pos-row').length).toBe(2);
+    expect(body.querySelectorAll('.pos-stack .pos-row .pos-glyph').length).toBe(2);
+  });
+});
+
+describe('tile card — rail color is constant (#260)', () => {
+  const css = (): string => AdaptiveCoverProTileCard.styles.toString();
+
+  // A rail is a measurement, not a status light: it must not change hue as the
+  // cover crosses open/closed, and on a multi-rail tile the rails must agree.
+  it('paints the fill from the cover-active token, not the per-state one', () => {
+    const text = css();
+    expect(text).toContain('--acp-pos-fill-color');
+    expect(text).toContain('var(--state-cover-active-color');
+    expect(text).not.toContain('--state-cover-open-color');
+  });
+
+  it('never writes an inline background onto the fill', async () => {
+    for (const coverLeftState of ['open', 'closed']) {
+      const el = await mount(
+        { type: TYPE, entry_id: ENTRY },
+        makeHass({ coverLeftCurrentPosition: 60, coverLeftState }),
+      );
+      const fills = el.shadowRoot!.querySelectorAll('.pos-fill');
+      expect(fills.length).toBeGreaterThan(0);
+      for (const fill of fills) {
+        expect(fill.getAttribute('style') ?? '').not.toContain('background');
+      }
+    }
+  });
+});
+
+describe('tile card — low-battery overlay (#260)', () => {
+  /** `hass.entities` is the display registry the battery lookup walks; the
+   *  tile-card fixture has no reason to carry it otherwise. */
+  function withBattery(
+    hass: HomeAssistant,
+    level: string | null,
+    opts: { deviceClass?: string; entityId?: string } = {},
+  ): HomeAssistant {
+    const id = opts.entityId ?? 'sensor.left_battery';
+    const h = hass as unknown as {
+      states: Record<string, unknown>;
+      entities?: Record<string, { device_id?: string | null }>;
+    };
+    if (level !== null) {
+      h.states[id] = { state: level, attributes: { device_class: opts.deviceClass ?? 'battery' } };
+    }
+    h.entities = {
+      'cover.left': { device_id: 'dev_left' },
+      ...(level !== null ? { [id]: { device_id: 'dev_left' } } : {}),
+    };
+    return hass;
+  }
+
+  it('renders no overlay for a healthy battery', async () => {
+    const el = await mount(
+      { type: TYPE, entry_id: ENTRY, covers: ['cover.left'] },
+      withBattery(makeHass({ coverLeftCurrentPosition: 60 }), '82'),
+    );
+    expect(el.shadowRoot!.querySelector('.battery-overlay')).toBeFalsy();
+  });
+
+  it('renders no overlay for a mains-powered cover with no battery entity', async () => {
+    const el = await mount(
+      { type: TYPE, entry_id: ENTRY, covers: ['cover.left'] },
+      withBattery(makeHass({ coverLeftCurrentPosition: 60 }), null),
+    );
+    expect(el.shadowRoot!.querySelector('.battery-overlay')).toBeFalsy();
+  });
+
+  it('renders a level-appropriate overlay below the threshold', async () => {
+    const el = await mount(
+      { type: TYPE, entry_id: ENTRY, covers: ['cover.left'] },
+      withBattery(makeHass({ coverLeftCurrentPosition: 60 }), '8'),
+    );
+    const overlay = el.shadowRoot!.querySelector('.battery-overlay')!;
+    expect(overlay).toBeTruthy();
+    expect(overlay.getAttribute('icon')).toBe('mdi:battery-outline');
+  });
+
+  // A battery sensor that has stopped reporting is exactly the warning case.
+  it('renders the alert overlay for an unknown level', async () => {
+    const el = await mount(
+      { type: TYPE, entry_id: ENTRY, covers: ['cover.left'] },
+      withBattery(makeHass({ coverLeftCurrentPosition: 60 }), 'unavailable'),
+    );
+    expect(el.shadowRoot!.querySelector('.battery-overlay')!.getAttribute('icon')).toBe(
+      'mdi:battery-alert-variant-outline',
+    );
+  });
+
+  // Z-Wave/ZHA ship a binary_sensor battery alongside the percentage sensor.
+  it('ignores a binary_sensor battery instead of warning on its on/off state', async () => {
+    const el = await mount(
+      { type: TYPE, entry_id: ENTRY, covers: ['cover.left'] },
+      withBattery(makeHass({ coverLeftCurrentPosition: 60 }), 'off', {
+        entityId: 'binary_sensor.left_battery',
+      }),
+    );
+    expect(el.shadowRoot!.querySelector('.battery-overlay')).toBeFalsy();
+  });
+
+  // Motion sits top-right, battery bottom-left, so both can show at once.
+  it('pins the two icon overlays to opposite corners', () => {
+    const text = AdaptiveCoverProTileCard.styles.toString();
+    expect(text).toMatch(/\.motion-overlay\s*\{[^}]*top:\s*-4px;[^}]*right:\s*-6px/);
+    expect(text).toMatch(/\.battery-overlay\s*\{[^}]*bottom:\s*-4px;[^}]*left:\s*-6px/);
+  });
+});
+
+describe('tile card — drag position readout (#260)', () => {
+  interface Draggable extends CardLike {
+    _posDrag: { id: string; pct: number } | null;
+  }
+
+  it('shows no readout when idle', async () => {
+    const el = await mount(
+      { type: TYPE, entry_id: ENTRY, covers: ['cover.left'] },
+      makeHass({ coverLeftCurrentPosition: 60 }),
+    );
+    expect(el.shadowRoot!.querySelector('.pos-readout')).toBeFalsy();
+  });
+
+  // The hover tooltip carries the same number, but a tooltip is mouse-only —
+  // on a phone the finger setting the position also covers the rail.
+  it('shows the live logical percentage on the dragged rail only', async () => {
+    const el = (await mount(
+      { type: TYPE, entry_id: ENTRY },
+      makeHass({ coverLeftCurrentPosition: 60 }),
+    )) as Draggable;
+    el._posDrag = { id: 'cover.left', pct: 37 };
+    await el.updateComplete;
+
+    const readouts = el.shadowRoot!.querySelectorAll('.pos-readout');
+    expect(readouts.length).toBe(1);
+    expect(readouts[0].textContent!.trim()).toContain('37');
+  });
+
+  it('clears the readout when the drag ends', async () => {
+    const el = (await mount(
+      { type: TYPE, entry_id: ENTRY, covers: ['cover.left'] },
+      makeHass({ coverLeftCurrentPosition: 60 }),
+    )) as Draggable;
+    el._posDrag = { id: 'cover.left', pct: 37 };
+    await el.updateComplete;
+    expect(el.shadowRoot!.querySelector('.pos-readout')).toBeTruthy();
+
+    el._posDrag = null;
+    await el.updateComplete;
+    expect(el.shadowRoot!.querySelector('.pos-readout')).toBeFalsy();
+  });
+
+  // .pos-bar is overflow:hidden to clip the fill, so the readout must not live
+  // inside it, and it must never swallow the drag it reports on.
+  it('sits outside the clipped bar and is pointer-transparent', async () => {
+    const el = (await mount(
+      { type: TYPE, entry_id: ENTRY, covers: ['cover.left'] },
+      makeHass({ coverLeftCurrentPosition: 60 }),
+    )) as Draggable;
+    el._posDrag = { id: 'cover.left', pct: 37 };
+    await el.updateComplete;
+
+    expect(el.shadowRoot!.querySelector('.pos-slider > .pos-readout')).toBeTruthy();
+    expect(el.shadowRoot!.querySelector('.pos-bar .pos-readout')).toBeFalsy();
+    expect(AdaptiveCoverProTileCard.styles.toString()).toMatch(
+      /\.pos-readout\s*\{[^}]*pointer-events:\s*none/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

**The fix for #260.** A detailed tile showing a position bar and **no chrome badges** overlapped its own name/state. `.tile-body.detailed.bar-only:not(.has-tilt)` spanned `.label` across `grid-row: 1 / -1` in the same column as `.chrome-line` (`grid-area: chrome`, row 2), and `.tile-body`'s `align-items: center` centered the label over the full two-row height, on top of the bottom-aligned bar. With badges present the 22px badge pill held them apart, which is why it only showed on a bar-only tile.

The whole bar-only grid special-case is **deleted** — the wide rule and both narrow-reflow re-assertions — so a bar-only tile now uses the same `.has-chrome-row` grid as a badged one. This deliberately drops the #208 intent that such a tile *centers* its name/state: that centering was the mechanism of the overlap.

This PR carries four further changes from the same prototype session. They are not #260, and are listed here because they ship together:

- **Rails line up between tile types.** A single-cover entry renders a bare rail, a multi-cover entry a glyph-led stack. Both used identical flex sizing, so the glyph lane was taken out of the stacked rails and the two never aligned. The stack is now wider by a derived `--acp-rail-glyph-lane` and the glyphs hang to the left of a shared rail track.
- **Cover battery (new feature).** `src/lib/battery.ts` resolves a cover's battery via `hass.entities` — the frontend *display* registry, the only place `device_id` lives — to a `device_class: battery` **sensor** on the cover's own device, or a `battery_level` attribute on the cover. It surfaces as a readout in the more-info dialog header and a low-battery overlay on the tile icon (bottom-left, diagonally opposite the occupancy symbol). `binary_sensor` batteries are ignored: Z-Wave JS / ZHA / deCONZ ship an on/off one beside the percentage sensor, and `Number('off')` → NaN would have read as a permanent low-battery warning.
- **Rails no longer take the cover's state color.** A rail is a measurement, not a status light, and on a multi-rail tile the rails disagreed with each other. `COVER_ACTIVE_COLOR` is `coverStateColor`'s theme cascade minus the per-state layer, overridable via `--acp-pos-fill-color`. `state_color` continues to govern the icon.
- **A live `%` bubble while dragging a rail.** The hover tooltip already carried the number but is mouse-only — on a phone the finger setting the position is also what covers the rail.

### Reverted before merge

Making `controls_cover` drive the tile's *display* was prototyped and **backed out**. `cover` simultaneously means the displayed entity, the rail carrying the entry-level pipeline target, the tilt axis's read/write target and the anchor for the entry-scale position fallback — moving it for display silently retargeted a `set_axes` call. Two review rounds produced nine defects from that one change. `controls_cover` still means the buttons, and `src/types.ts` now records why.

## Testing

- ✅ 1971 tests passing (58 new)
- ✅ `tsc --noEmit`, `./scripts/lint` and `npm run build` clean; `dist/` rebuilt and committed
- Two independent opus design-review passes; all MUST-FIX findings fixed or reverted
- Verified live against a real HA instance across 11 deploy rounds

⚠️ happy-dom does no CSS layout, so no test can observe the overlap itself. The new tests assert what *is* structurally observable: the absence of the `grid-row: 1 / -1` mechanism, DOM shape, class lists, and the derived-token relationships.

## Related Issues

Refs #260