### PR TITLE
feat: battery history link, blind-spot slots, roster order, move indicator (#272)

### DIFF
--- a/dist/adaptive-cover-pro-card.js
+++ b/dist/adaptive-cover-pro-card.js
@@ -1,7 +1,7 @@
 /*! adaptive-cover-pro-card v2.17.0 | MIT License | https://github.com/jrhubott/adaptive-cover-pro-card */
-function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPropertyDescriptor(t,o):i;if("object"==typeof Reflect&&"function"==typeof Reflect.decorate)r=Reflect.decorate(e,t,o,i);else for(var a=e.length-1;a>=0;a--)(s=e[a])&&(r=(n<3?s(r):n>3?s(t,o,r):s(t,o))||r);return n>3&&r&&Object.defineProperty(t,o,r),r}"function"==typeof SuppressedError&&SuppressedError;const t=globalThis,o=t.ShadowRoot&&(void 0===t.ShadyCSS||t.ShadyCSS.nativeShadow)&&"adoptedStyleSheets"in Document.prototype&&"replace"in CSSStyleSheet.prototype,i=Symbol(),s=new WeakMap;let n=class{constructor(e,t,o){if(this._$cssResult$=!0,o!==i)throw Error("CSSResult is not constructable. Use `unsafeCSS` or `css` instead.");this.cssText=e,this.t=t}get styleSheet(){let e=this.o;const t=this.t;if(o&&void 0===e){const o=void 0!==t&&1===t.length;o&&(e=s.get(t)),void 0===e&&((this.o=e=new CSSStyleSheet).replaceSync(this.cssText),o&&s.set(t,e))}return e}toString(){return this.cssText}};const r=e=>new n("string"==typeof e?e:e+"",void 0,i),a=(e,...t)=>{const o=1===e.length?e[0]:t.reduce((t,o,i)=>t+(e=>{if(!0===e._$cssResult$)return e.cssText;if("number"==typeof e)return e;throw Error("Value passed to 'css' function must be a 'css' function result: "+e+". Use 'unsafeCSS' to pass non-literal values, but take care to ensure page security.")})(o)+e[i+1],e[0]);return new n(o,e,i)},l=o?e=>e:e=>e instanceof CSSStyleSheet?(e=>{let t="";for(const o of e.cssRules)t+=o.cssText;return r(t)})(e):e,{is:c,defineProperty:d,getOwnPropertyDescriptor:h,getOwnPropertyNames:p,getOwnPropertySymbols:u,getPrototypeOf:_}=Object,g=globalThis,m=g.trustedTypes,v=m?m.emptyScript:"",f=g.reactiveElementPolyfillSupport,b=(e,t)=>e,y={toAttribute(e,t){switch(t){case Boolean:e=e?v:null;break;case Object:case Array:e=null==e?e:JSON.stringify(e)}return e},fromAttribute(e,t){let o=e;switch(t){case Boolean:o=null!==e;break;case Number:o=null===e?null:Number(e);break;case Object:case Array:try{o=JSON.parse(e)}catch(e){o=null}}return o}},w=(e,t)=>!c(e,t),x={attribute:!0,type:String,converter:y,reflect:!1,useDefault:!1,hasChanged:w};Symbol.metadata??=Symbol("metadata"),g.litPropertyMetadata??=new WeakMap;let $=class extends HTMLElement{static addInitializer(e){this._$Ei(),(this.l??=[]).push(e)}static get observedAttributes(){return this.finalize(),this._$Eh&&[...this._$Eh.keys()]}static createProperty(e,t=x){if(t.state&&(t.attribute=!1),this._$Ei(),this.prototype.hasOwnProperty(e)&&((t=Object.create(t)).wrapped=!0),this.elementProperties.set(e,t),!t.noAccessor){const o=Symbol(),i=this.getPropertyDescriptor(e,o,t);void 0!==i&&d(this.prototype,e,i)}}static getPropertyDescriptor(e,t,o){const{get:i,set:s}=h(this.prototype,e)??{get(){return this[t]},set(e){this[t]=e}};return{get:i,set(t){const n=i?.call(this);s?.call(this,t),this.requestUpdate(e,n,o)},configurable:!0,enumerable:!0}}static getPropertyOptions(e){return this.elementProperties.get(e)??x}static _$Ei(){if(this.hasOwnProperty(b("elementProperties")))return;const e=_(this);e.finalize(),void 0!==e.l&&(this.l=[...e.l]),this.elementProperties=new Map(e.elementProperties)}static finalize(){if(this.hasOwnProperty(b("finalized")))return;if(this.finalized=!0,this._$Ei(),this.hasOwnProperty(b("properties"))){const e=this.properties,t=[...p(e),...u(e)];for(const o of t)this.createProperty(o,e[o])}const e=this[Symbol.metadata];if(null!==e){const t=litPropertyMetadata.get(e);if(void 0!==t)for(const[e,o]of t)this.elementProperties.set(e,o)}this._$Eh=new Map;for(const[e,t]of this.elementProperties){const o=this._$Eu(e,t);void 0!==o&&this._$Eh.set(o,e)}this.elementStyles=this.finalizeStyles(this.styles)}static finalizeStyles(e){const t=[];if(Array.isArray(e)){const o=new Set(e.flat(1/0).reverse());for(const e of o)t.unshift(l(e))}else void 0!==e&&t.push(l(e));return t}static _$Eu(e,t){const o=t.attribute;return!1===o?void 0:"string"==typeof o?o:"string"==typeof e?e.toLowerCase():void 0}constructor(){super(),this._$Ep=void 0,this.isUpdatePending=!1,this.hasUpdated=!1,this._$Em=null,this._$Ev()}_$Ev(){this._$ES=new Promise(e=>this.enableUpdating=e),this._$AL=new Map,this._$E_(),this.requestUpdate(),this.constructor.l?.forEach(e=>e(this))}addController(e){(this._$EO??=new Set).add(e),void 0!==this.renderRoot&&this.isConnected&&e.hostConnected?.()}removeController(e){this._$EO?.delete(e)}_$E_(){const e=new Map,t=this.constructor.elementProperties;for(const o of t.keys())this.hasOwnProperty(o)&&(e.set(o,this[o]),delete this[o]);e.size>0&&(this._$Ep=e)}createRenderRoot(){const e=this.shadowRoot??this.attachShadow(this.constructor.shadowRootOptions);return((e,i)=>{if(o)e.adoptedStyleSheets=i.map(e=>e instanceof CSSStyleSheet?e:e.styleSheet);else for(const o of i){const i=document.createElement("style"),s=t.litNonce;void 0!==s&&i.setAttribute("nonce",s),i.textContent=o.cssText,e.appendChild(i)}})(e,this.constructor.elementStyles),e}connectedCallback(){this.renderRoot??=this.createRenderRoot(),this.enableUpdating(!0),this._$EO?.forEach(e=>e.hostConnected?.())}enableUpdating(e){}disconnectedCallback(){this._$EO?.forEach(e=>e.hostDisconnected?.())}attributeChangedCallback(e,t,o){this._$AK(e,o)}_$ET(e,t){const o=this.constructor.elementProperties.get(e),i=this.constructor._$Eu(e,o);if(void 0!==i&&!0===o.reflect){const s=(void 0!==o.converter?.toAttribute?o.converter:y).toAttribute(t,o.type);this._$Em=e,null==s?this.removeAttribute(i):this.setAttribute(i,s),this._$Em=null}}_$AK(e,t){const o=this.constructor,i=o._$Eh.get(e);if(void 0!==i&&this._$Em!==i){const e=o.getPropertyOptions(i),s="function"==typeof e.converter?{fromAttribute:e.converter}:void 0!==e.converter?.fromAttribute?e.converter:y;this._$Em=i;const n=s.fromAttribute(t,e.type);this[i]=n??this._$Ej?.get(i)??n,this._$Em=null}}requestUpdate(e,t,o,i=!1,s){if(void 0!==e){const n=this.constructor;if(!1===i&&(s=this[e]),o??=n.getPropertyOptions(e),!((o.hasChanged??w)(s,t)||o.useDefault&&o.reflect&&s===this._$Ej?.get(e)&&!this.hasAttribute(n._$Eu(e,o))))return;this.C(e,t,o)}!1===this.isUpdatePending&&(this._$ES=this._$EP())}C(e,t,{useDefault:o,reflect:i,wrapped:s},n){o&&!(this._$Ej??=new Map).has(e)&&(this._$Ej.set(e,n??t??this[e]),!0!==s||void 0!==n)||(this._$AL.has(e)||(this.hasUpdated||o||(t=void 0),this._$AL.set(e,t)),!0===i&&this._$Em!==e&&(this._$Eq??=new Set).add(e))}async _$EP(){this.isUpdatePending=!0;try{await this._$ES}catch(e){Promise.reject(e)}const e=this.scheduleUpdate();return null!=e&&await e,!this.isUpdatePending}scheduleUpdate(){return this.performUpdate()}performUpdate(){if(!this.isUpdatePending)return;if(!this.hasUpdated){if(this.renderRoot??=this.createRenderRoot(),this._$Ep){for(const[e,t]of this._$Ep)this[e]=t;this._$Ep=void 0}const e=this.constructor.elementProperties;if(e.size>0)for(const[t,o]of e){const{wrapped:e}=o,i=this[t];!0!==e||this._$AL.has(t)||void 0===i||this.C(t,void 0,o,i)}}let e=!1;const t=this._$AL;try{e=this.shouldUpdate(t),e?(this.willUpdate(t),this._$EO?.forEach(e=>e.hostUpdate?.()),this.update(t)):this._$EM()}catch(t){throw e=!1,this._$EM(),t}e&&this._$AE(t)}willUpdate(e){}_$AE(e){this._$EO?.forEach(e=>e.hostUpdated?.()),this.hasUpdated||(this.hasUpdated=!0,this.firstUpdated(e)),this.updated(e)}_$EM(){this._$AL=new Map,this.isUpdatePending=!1}get updateComplete(){return this.getUpdateComplete()}getUpdateComplete(){return this._$ES}shouldUpdate(e){return!0}update(e){this._$Eq&&=this._$Eq.forEach(e=>this._$ET(e,this[e])),this._$EM()}updated(e){}firstUpdated(e){}};$.elementStyles=[],$.shadowRootOptions={mode:"open"},$[b("elementProperties")]=new Map,$[b("finalized")]=new Map,f?.({ReactiveElement:$}),(g.reactiveElementVersions??=[]).push("2.1.2");const k=globalThis,A=e=>e,S=k.trustedTypes,C=S?S.createPolicy("lit-html",{createHTML:e=>e}):void 0,E="$lit$",z=`lit$${Math.random().toFixed(9).slice(2)}$`,M="?"+z,T=`<${M}>`,I=document,P=()=>I.createComment(""),O=e=>null===e||"object"!=typeof e&&"function"!=typeof e,N=Array.isArray,D="[ \t\n\f\r]",B=/<(?:(!--|\/[^a-zA-Z])|(\/?[a-zA-Z][^>\s]*)|(\/?$))/g,F=/-->/g,R=/>/g,j=RegExp(`>|${D}(?:([^\\s"'>=/]+)(${D}*=${D}*(?:[^ \t\n\f\r"'\`<>=]|("|')|))|$)`,"g"),L=/'/g,K=/"/g,G=/^(?:script|style|textarea|title)$/i,W=e=>(t,...o)=>({_$litType$:e,strings:t,values:o}),H=W(1),U=W(2),q=Symbol.for("lit-noChange"),V=Symbol.for("lit-nothing"),Y=new WeakMap,Z=I.createTreeWalker(I,129);function Q(e,t){if(!N(e)||!e.hasOwnProperty("raw"))throw Error("invalid template strings array");return void 0!==C?C.createHTML(t):t}class X{constructor({strings:e,_$litType$:t},o){let i;this.parts=[];let s=0,n=0;const r=e.length-1,a=this.parts,[l,c]=((e,t)=>{const o=e.length-1,i=[];let s,n=2===t?"<svg>":3===t?"<math>":"",r=B;for(let t=0;t<o;t++){const o=e[t];let a,l,c=-1,d=0;for(;d<o.length&&(r.lastIndex=d,l=r.exec(o),null!==l);)d=r.lastIndex,r===B?"!--"===l[1]?r=F:void 0!==l[1]?r=R:void 0!==l[2]?(G.test(l[2])&&(s=RegExp("</"+l[2],"g")),r=j):void 0!==l[3]&&(r=j):r===j?">"===l[0]?(r=s??B,c=-1):void 0===l[1]?c=-2:(c=r.lastIndex-l[2].length,a=l[1],r=void 0===l[3]?j:'"'===l[3]?K:L):r===K||r===L?r=j:r===F||r===R?r=B:(r=j,s=void 0);const h=r===j&&e[t+1].startsWith("/>")?" ":"";n+=r===B?o+T:c>=0?(i.push(a),o.slice(0,c)+E+o.slice(c)+z+h):o+z+(-2===c?t:h)}return[Q(e,n+(e[o]||"<?>")+(2===t?"</svg>":3===t?"</math>":"")),i]})(e,t);if(this.el=X.createElement(l,o),Z.currentNode=this.el.content,2===t||3===t){const e=this.el.content.firstChild;e.replaceWith(...e.childNodes)}for(;null!==(i=Z.nextNode())&&a.length<r;){if(1===i.nodeType){if(i.hasAttributes())for(const e of i.getAttributeNames())if(e.endsWith(E)){const t=c[n++],o=i.getAttribute(e).split(z),r=/([.?@])?(.*)/.exec(t);a.push({type:1,index:s,name:r[2],strings:o,ctor:"."===r[1]?ie:"?"===r[1]?se:"@"===r[1]?ne:oe}),i.removeAttribute(e)}else e.startsWith(z)&&(a.push({type:6,index:s}),i.removeAttribute(e));if(G.test(i.tagName)){const e=i.textContent.split(z),t=e.length-1;if(t>0){i.textContent=S?S.emptyScript:"";for(let o=0;o<t;o++)i.append(e[o],P()),Z.nextNode(),a.push({type:2,index:++s});i.append(e[t],P())}}}else if(8===i.nodeType)if(i.data===M)a.push({type:2,index:s});else{let e=-1;for(;-1!==(e=i.data.indexOf(z,e+1));)a.push({type:7,index:s}),e+=z.length-1}s++}}static createElement(e,t){const o=I.createElement("template");return o.innerHTML=e,o}}function J(e,t,o=e,i){if(t===q)return t;let s=void 0!==i?o._$Co?.[i]:o._$Cl;const n=O(t)?void 0:t._$litDirective$;return s?.constructor!==n&&(s?._$AO?.(!1),void 0===n?s=void 0:(s=new n(e),s._$AT(e,o,i)),void 0!==i?(o._$Co??=[])[i]=s:o._$Cl=s),void 0!==s&&(t=J(e,s._$AS(e,t.values),s,i)),t}class ee{constructor(e,t){this._$AV=[],this._$AN=void 0,this._$AD=e,this._$AM=t}get parentNode(){return this._$AM.parentNode}get _$AU(){return this._$AM._$AU}u(e){const{el:{content:t},parts:o}=this._$AD,i=(e?.creationScope??I).importNode(t,!0);Z.currentNode=i;let s=Z.nextNode(),n=0,r=0,a=o[0];for(;void 0!==a;){if(n===a.index){let t;2===a.type?t=new te(s,s.nextSibling,this,e):1===a.type?t=new a.ctor(s,a.name,a.strings,this,e):6===a.type&&(t=new re(s,this,e)),this._$AV.push(t),a=o[++r]}n!==a?.index&&(s=Z.nextNode(),n++)}return Z.currentNode=I,i}p(e){let t=0;for(const o of this._$AV)void 0!==o&&(void 0!==o.strings?(o._$AI(e,o,t),t+=o.strings.length-2):o._$AI(e[t])),t++}}class te{get _$AU(){return this._$AM?._$AU??this._$Cv}constructor(e,t,o,i){this.type=2,this._$AH=V,this._$AN=void 0,this._$AA=e,this._$AB=t,this._$AM=o,this.options=i,this._$Cv=i?.isConnected??!0}get parentNode(){let e=this._$AA.parentNode;const t=this._$AM;return void 0!==t&&11===e?.nodeType&&(e=t.parentNode),e}get startNode(){return this._$AA}get endNode(){return this._$AB}_$AI(e,t=this){e=J(this,e,t),O(e)?e===V||null==e||""===e?(this._$AH!==V&&this._$AR(),this._$AH=V):e!==this._$AH&&e!==q&&this._(e):void 0!==e._$litType$?this.$(e):void 0!==e.nodeType?this.T(e):(e=>N(e)||"function"==typeof e?.[Symbol.iterator])(e)?this.k(e):this._(e)}O(e){return this._$AA.parentNode.insertBefore(e,this._$AB)}T(e){this._$AH!==e&&(this._$AR(),this._$AH=this.O(e))}_(e){this._$AH!==V&&O(this._$AH)?this._$AA.nextSibling.data=e:this.T(I.createTextNode(e)),this._$AH=e}$(e){const{values:t,_$litType$:o}=e,i="number"==typeof o?this._$AC(e):(void 0===o.el&&(o.el=X.createElement(Q(o.h,o.h[0]),this.options)),o);if(this._$AH?._$AD===i)this._$AH.p(t);else{const e=new ee(i,this),o=e.u(this.options);e.p(t),this.T(o),this._$AH=e}}_$AC(e){let t=Y.get(e.strings);return void 0===t&&Y.set(e.strings,t=new X(e)),t}k(e){N(this._$AH)||(this._$AH=[],this._$AR());const t=this._$AH;let o,i=0;for(const s of e)i===t.length?t.push(o=new te(this.O(P()),this.O(P()),this,this.options)):o=t[i],o._$AI(s),i++;i<t.length&&(this._$AR(o&&o._$AB.nextSibling,i),t.length=i)}_$AR(e=this._$AA.nextSibling,t){for(this._$AP?.(!1,!0,t);e!==this._$AB;){const t=A(e).nextSibling;A(e).remove(),e=t}}setConnected(e){void 0===this._$AM&&(this._$Cv=e,this._$AP?.(e))}}class oe{get tagName(){return this.element.tagName}get _$AU(){return this._$AM._$AU}constructor(e,t,o,i,s){this.type=1,this._$AH=V,this._$AN=void 0,this.element=e,this.name=t,this._$AM=i,this.options=s,o.length>2||""!==o[0]||""!==o[1]?(this._$AH=Array(o.length-1).fill(new String),this.strings=o):this._$AH=V}_$AI(e,t=this,o,i){const s=this.strings;let n=!1;if(void 0===s)e=J(this,e,t,0),n=!O(e)||e!==this._$AH&&e!==q,n&&(this._$AH=e);else{const i=e;let r,a;for(e=s[0],r=0;r<s.length-1;r++)a=J(this,i[o+r],t,r),a===q&&(a=this._$AH[r]),n||=!O(a)||a!==this._$AH[r],a===V?e=V:e!==V&&(e+=(a??"")+s[r+1]),this._$AH[r]=a}n&&!i&&this.j(e)}j(e){e===V?this.element.removeAttribute(this.name):this.element.setAttribute(this.name,e??"")}}class ie extends oe{constructor(){super(...arguments),this.type=3}j(e){this.element[this.name]=e===V?void 0:e}}class se extends oe{constructor(){super(...arguments),this.type=4}j(e){this.element.toggleAttribute(this.name,!!e&&e!==V)}}class ne extends oe{constructor(e,t,o,i,s){super(e,t,o,i,s),this.type=5}_$AI(e,t=this){if((e=J(this,e,t,0)??V)===q)return;const o=this._$AH,i=e===V&&o!==V||e.capture!==o.capture||e.once!==o.once||e.passive!==o.passive,s=e!==V&&(o===V||i);i&&this.element.removeEventListener(this.name,this,o),s&&this.element.addEventListener(this.name,this,e),this._$AH=e}handleEvent(e){"function"==typeof this._$AH?this._$AH.call(this.options?.host??this.element,e):this._$AH.handleEvent(e)}}class re{constructor(e,t,o){this.element=e,this.type=6,this._$AN=void 0,this._$AM=t,this.options=o}get _$AU(){return this._$AM._$AU}_$AI(e){J(this,e)}}const ae={I:te},le=k.litHtmlPolyfillSupport;le?.(X,te),(k.litHtmlVersions??=[]).push("3.3.2");const ce=globalThis;let de=class extends ${constructor(){super(...arguments),this.renderOptions={host:this},this._$Do=void 0}createRenderRoot(){const e=super.createRenderRoot();return this.renderOptions.renderBefore??=e.firstChild,e}update(e){const t=this.render();this.hasUpdated||(this.renderOptions.isConnected=this.isConnected),super.update(e),this._$Do=((e,t,o)=>{const i=o?.renderBefore??t;let s=i._$litPart$;if(void 0===s){const e=o?.renderBefore??null;i._$litPart$=s=new te(t.insertBefore(P(),e),e,void 0,o??{})}return s._$AI(e),s})(t,this.renderRoot,this.renderOptions)}connectedCallback(){super.connectedCallback(),this._$Do?.setConnected(!0)}disconnectedCallback(){super.disconnectedCallback(),this._$Do?.setConnected(!1)}render(){return q}};de._$litElement$=!0,de.finalized=!0,ce.litElementHydrateSupport?.({LitElement:de});const he=ce.litElementPolyfillSupport;he?.({LitElement:de}),(ce.litElementVersions??=[]).push("4.2.2");const pe=e=>(t,o)=>{void 0!==o?o.addInitializer(()=>{customElements.define(e,t)}):customElements.define(e,t)},ue={attribute:!0,type:String,converter:y,reflect:!1,hasChanged:w},_e=(e=ue,t,o)=>{const{kind:i,metadata:s}=o;let n=globalThis.litPropertyMetadata.get(s);if(void 0===n&&globalThis.litPropertyMetadata.set(s,n=new Map),"setter"===i&&((e=Object.create(e)).wrapped=!0),n.set(o.name,e),"accessor"===i){const{name:i}=o;return{set(o){const s=t.get.call(this);t.set.call(this,o),this.requestUpdate(i,s,e,!0,o)},init(t){return void 0!==t&&this.C(i,void 0,e,t),t}}}if("setter"===i){const{name:i}=o;return function(o){const s=this[i];t.call(this,o),this.requestUpdate(i,s,e,!0,o)}}throw Error("Unsupported decorator location: "+i)};function ge(e){return(t,o)=>"object"==typeof o?_e(e,t,o):((e,t,o)=>{const i=t.hasOwnProperty(o);return t.constructor.createProperty(o,e),i?Object.getOwnPropertyDescriptor(t,o):void 0})(e,t,o)}function me(e){return ge({...e,state:!0,attribute:!1})}function ve(e,t,o){if(!e)return!0;for(const i of o)if(i&&e.states[i]!==t.states[i])return!0;return!1}const fe="2.17.0",be="adaptive-cover-pro-card",ye="adaptive-cover-pro-card-editor",we="adaptive-cover-pro-sky-compass-card",xe="adaptive-cover-pro-sky-compass-card-editor",$e="adaptive-cover-pro-tile-card",ke="adaptive-cover-pro-tile-card-editor",Ae="adaptive-cover-pro-decision-card",Se="adaptive-cover-pro-decision-card-editor",Ce="adaptive-cover-pro-solar-chart-card",Ee="adaptive-cover-pro-solar-chart-card-editor",ze="adaptive-cover-pro-history-card",Me="adaptive-cover-pro-history-card-editor",Te="adaptive_cover_pro",Ie=["force","weather","group_scene","manual","group_lock","custom_position","motion","cloud","climate","glare_zone","solar","default","floor_clamp"],Pe={force:"Force Override",weather:"Weather Safety",group_scene:"Group Scene",manual:"Manual Override",group_lock:"Group Lock",custom_position:"Custom Position",motion:"Occupancy Timeout",cloud:"Cloud Suppression",climate:"Climate",glare_zone:"Glare Zone",solar:"Solar Tracking",default:"Default",floor_clamp:"Min Floor"},Oe={force:"handler.force",weather:"handler.weather",group_scene:"handler.group_scene",manual:"handler.manual",group_lock:"handler.group_lock",custom_position:"handler.custom_position",motion:"handler.motion",cloud:"handler.cloud",climate:"handler.climate",glare_zone:"handler.glare_zone",solar:"handler.solar",default:"handler.default",floor_clamp:"handler.floor_clamp"},Ne={cover_blind:"mdi:blinds-horizontal",cover_awning:"mdi:awning-outline",cover_tilt:"mdi:blinds",cover_venetian:"mdi:blinds"},De={cover_blind:"mdi:blinds-open",cover_awning:"mdi:awning-outline",cover_tilt:"mdi:blinds-open",cover_venetian:"mdi:blinds-open"},Be={cover_blind:"mdi:blinds-horizontal-closed",cover_awning:"mdi:window-closed-variant",cover_tilt:"mdi:blinds",cover_venetian:"mdi:blinds"},Fe={awning:{open:"mdi:awning-outline",partial:"mdi:awning-outline",closed:"mdi:awning-outline"},blind:{open:"mdi:blinds-open",partial:"mdi:blinds-horizontal",closed:"mdi:blinds-horizontal-closed"},curtain:{open:"mdi:curtains",partial:"mdi:curtains",closed:"mdi:curtains-closed"},damper:{open:"mdi:circle",partial:"mdi:circle-slice-8",closed:"mdi:circle-slice-8"},door:{open:"mdi:door-open",partial:"mdi:door-open",closed:"mdi:door-closed"},garage:{open:"mdi:garage-open",partial:"mdi:garage-open",closed:"mdi:garage"},gate:{open:"mdi:gate-open",partial:"mdi:gate-open",closed:"mdi:gate"},shade:{open:"mdi:roller-shade",partial:"mdi:roller-shade",closed:"mdi:roller-shade-closed"},shutter:{open:"mdi:window-shutter-open",partial:"mdi:window-shutter",closed:"mdi:window-shutter"},window:{open:"mdi:window-open",partial:"mdi:window-open",closed:"mdi:window-closed"}},Re=new Set(["awning","curtain","door","gate"]),je={manual:"manual",force:"force",weather:"weather",glare_zone:"glare_zone",climate:"climate",cloud:"cloud",custom_position:"custom_position",solar:"solar",motion:"motion",group_scene:"group",group_lock:"group"};function Le(e,t,o=22){return{label:e,accent:t,bg:`color-mix(in srgb, ${t} ${o}%, transparent)`,fg:`color-mix(in srgb, ${t} 40%, var(--primary-text-color, #212121))`}}const Ke={auto:Le("Auto","#4caf50",18),manual:Le("Manual","#ff9800"),force:Le("Force","#f44336"),weather:Le("Sun protection","#f44336"),glare_zone:Le("Glare","#f44336"),climate:Le("Climate","#009688"),cloud:Le("Cloudy","#2196f3"),custom_position:Le("Custom","#9c27b0"),solar:Le("Solar tracking","#4caf50"),motion:Le("Occupancy","#ffeb3b"),off:Le("Off","#616161",28),off_schedule:Le("Off-schedule","#607d8b"),group:Le("Group","#4caf50",18)},Ge={auto:"badge.auto",manual:"badge.manual",force:"badge.force",weather:"badge.weather",glare_zone:"badge.glare_zone",climate:"badge.climate",cloud:"badge.cloud",custom_position:"badge.custom_position",solar:"badge.solar",motion:"badge.motion",off:"badge.off",off_schedule:"badge.off_schedule",group:"badge.group"},We={auto:"mdi:autorenew",manual:"mdi:hand-back-right",force:"mdi:flash",weather:"mdi:shield-sun",glare_zone:"mdi:weather-sunny-alert",climate:"mdi:thermostat",cloud:"mdi:weather-cloudy",custom_position:"mdi:bookmark",solar:"mdi:white-balance-sunny",motion:"mdi:motion-sensor",off:"mdi:power",off_schedule:"mdi:clock-alert-outline",group:"mdi:window-shutter-cog"},He={integration_enabled:!0,automatic_control:!0,reset_manual_override:!0},Ue={position:"target_position_sensor",tilt:"target_tilt_sensor"},qe={position:"covers.position_title",tilt:"covers.tilt_title"},Ve="mdi:chart-box",Ye={active:"control_status.active",outside_time_window:"control_status.outside_time_window",position_delta_too_small:"control_status.position_delta_too_small",time_delta_too_small:"control_status.time_delta_too_small",manual_override:"control_status.manual_override",automatic_control_off:"control_status.automatic_control_off",sun_not_visible:"control_status.sun_not_visible",force_override_active:"control_status.force_override_active",weather_override_active:"control_status.weather_override_active",motion_timeout:"control_status.motion_timeout"},Ze=new Set(["active"]),Qe=[{role:"integration_enabled_switch",key:"history.track_enabled",cls:"ctx-enabled"},{role:"automatic_control_switch",key:"history.track_auto",cls:"ctx-auto"},{role:"sun_infront_binary",key:"history.track_sun",cls:"ctx-sun"},{role:"glare_active_binary",key:"history.track_glare",cls:"ctx-glare"},{role:"manual_override_binary",key:"history.track_manual",cls:"ctx-manual"},{role:"position_mismatch_binary",key:"history.track_mismatch",cls:"ctx-mismatch"}],Xe=[6,12,24,48,72],Je={pipeline_evaluated:"info",cover_command_sent:"action",cover_command_skipped:"warn",end_time_default_sent:"action",manual_override_gate_closed:"warn",sun_entered_fov:"info",sun_left_fov:"info",sunset_window_opened:"info",transit_cleared:"info",transit_optimistic_target_replay:"info",transit_progress_forward:"info",transit_startup_delay:"warn",transit_timeout_cleared:"warn",reconcile_gave_up:"warn",reconcile_skipped_in_transit:"warn"},et={"sensor:Cover_Position":"target_position_sensor","sensor:Cover_Tilt":"target_tilt_sensor","sensor:sun_position":"sun_sensor","sensor:Start Sun":"start_sensor","sensor:End Sun":"end_sensor","sensor:control_status":"control_status_sensor","sensor:decision_trace":"decision_trace_sensor","sensor:last_cover_action":"last_action_sensor","sensor:last_skipped_action":"last_skipped_sensor","sensor:manual_override_end_time":"manual_override_end_sensor","sensor:position_verification":"position_verification_sensor","sensor:motion_status":"motion_status_sensor","sensor:climate_status":"climate_status_sensor","sensor:position_forecast":"position_forecast_sensor","sensor:solar_calculation":"solar_calculation_sensor","binary_sensor:sun_motion":"sun_infront_binary","binary_sensor:manual_override":"manual_override_binary","binary_sensor:position_mismatch":"position_mismatch_binary","binary_sensor:glare_active":"glare_active_binary","switch:Integration Enabled":"integration_enabled_switch","switch:Automatic Control":"automatic_control_switch","switch:Manual Override":"manual_toggle_switch","switch:Climate Mode":"climate_mode_switch","switch:Motion Control":"motion_control_switch","button:Reset Manual Override":"reset_override_button","sensor:group_position":"group_position_sensor","sensor:group_state":"group_state_sensor","sensor:group_active_scene":"group_active_scene_sensor","sensor:group_climate_mode":"group_climate_mode_sensor","sensor:group_who_won":"group_who_won_sensor","select:group_scene_select":"group_scene_select","switch:group_automation":"group_automation_switch","switch:group_lock":"group_lock_switch","button:group_scene_all_open":"group_scene_all_open_button","button:group_scene_all_closed":"group_scene_all_closed_button","button:group_scene_privacy":"group_scene_privacy_button","button:group_clear_overrides":"group_clear_overrides_button","cover:group_cover":"group_cover"},tt={en:{handler:{force:"Force Override",weather:"Weather Safety",group_scene:"Group Scene",manual:"Manual Override",group_lock:"Group Lock",custom_position:"Custom Position",motion:"Occupancy Timeout",cloud:"Cloud Suppression",climate:"Climate",glare_zone:"Glare Zone",solar:"Solar Tracking",default:"Default",floor_clamp:"Min Floor"},badge:{auto:"Auto",manual:"Manual",force:"Force",weather:"Weather safety",glare_zone:"Glare",climate:"Climate",cloud:"Cloudy",custom_position:"Custom",solar:"Solar tracking",motion:"Occupancy idle",off:"Off",off_schedule:"Off-schedule",floor_suffix:" ↥",safety:"Safety",group:"Group",tip:{auto:"Automatic control is on and no handler is overriding — the cover follows the pipeline result.",manual:"Manual override is active — the cover is held where you put it and automatic control is paused.",manual_until:"Manual override is active until {time} — the cover is held where you put it until then.",force:"A forced position is overriding every other handler.",weather:"Weather safety is driving the position.",glare_zone:"The sun is in a configured glare zone, and the glare handler is driving the position.",climate:"Climate control is driving the position.",cloud:"Cloud cover is suppressing solar tracking.",custom_position:"A custom position slot is driving this cover.",custom_position_slot:"Slot: {name}.",custom_position_value:"Its position is {pct}%.",custom_position_floor:"It is applied as a floor: it raises the position above the raw calculation rather than replacing it.",solar:"Solar tracking — the position follows the sun across the window.",motion:"The room reads as unoccupied, so the occupancy handler is holding position.",off:"The integration is disabled for this cover — nothing is being driven.",off_schedule:"Outside the configured schedule window, so automatic control is paused.",group:"The Cover Group is currently deciding this position.",safety:"A safety position is overriding every other handler."}},group:{title:"Cover Group",scene:"Scene",scene_auto:"Auto",scene_all_open:"All open",scene_all_closed:"All closed",scene_privacy:"Privacy",state_open:"Open",state_closed:"Closed",state_mixed:"Mixed",state_unknown:"Unknown",lock:"Lock group",unlock:"Unlock group",automation:"Automation",automation_count:"{count} of {total} members automating",clear_overrides:"Clear overrides",clear_overrides_none:"No member overrides to clear",who_won:"{count} of {total} members are group-driven — a group scene or the group lock is currently deciding their position",members:"Members",member_placeholder:"No members reported by the integration.",position:"Position",open:"Open group",close:"Close group",stop:"Stop group",position_slider_label:"Group position",range:"{min}–{max}%",exception_held:"{count} held",exception_unavailable:"{count} unavailable",drag_to_set_all:"Drag to set all {count} covers",spread_value:"{min}% to {max}% across {count} covers"},forecast:{event:{sunrise:"Sunrise",sunset:"Sunset",fov_enter:"Sun enters window sun acceptance angle",fov_exit:"Sun leaves window sun acceptance angle"},hover_hint:"Hover the curve for time + forecast position; hover a colored line for the event it marks.",solar_only_note:"Solar geometry only — does not reflect manual overrides, custom positions, cloud suppression, or weather.",legend_forecast:"Forecast",legend_actual:"Actual"},dialog:{battery:"{level}% battery",battery_named:"{name}: {level}%",battery_unknown:"Battery level unknown",extend:{title:"Extend manual override",presets_label:"Until",relative_label:"Add time",absolute_label:"End at",preview:"Override until {time}",confirm:"Extend",cancel:"Cancel",tomorrow_suffix:" (tomorrow)"},configure_integration:"Configure integration",open_device_page:"Open device page",close:"Close",target:"Target",resume_auto:"Resume Auto",hide_advanced:"▼ Hide advanced",show_advanced:"▶ Advanced",custom_positions:"Custom positions",floor_tooltip:"Floor — slot raises position above raw calc",floor:"↥",disable_slot:"Disable slot {slot}",enable_slot:"Enable slot {slot}",on:"On",off:"Off",controls:"Controls",automatic:"Automatic",climate:"Climate",motion:"Occupancy",toggle_hint:"{label} {state} — tap to toggle",state_on:"on",state_off:"off",todays_forecast:"Today's forecast"},overrides:{title:"Overrides",manual:"Manual",force:"Force",motion:"Occupancy",active:"Active",off:"Off",ends_in:"ends in {time}",active_count:"{count} active",timeout:"expires in {time}",reset_manual:"Reset Manual"},climate:{title:"Climate",active:"Active: {strategy}",indoor:"Indoor",outdoor:"Outdoor",presence:"Presence",sunny:"Sunny",lux:"Lux",irradiance:"Irradiance",mode_off:"Climate mode off",standby:"Standby",threshold_low:"low",threshold_high:"high",threshold_summer_outside:"summer",reason:{outside_time_window:"Outside the operating time window",thresholds_not_met:"Temperatures within the comfort band — no action needed",other_mode_active:"Another control mode is currently active",readings_unavailable:"Temperature readings unavailable",mode_off:"Climate mode is turned off"}},compass:{placeholder_no_entries:"No Adaptive Cover Pro entries selected.",placeholder_no_sun:"Sun sensor not yet populated.",sun_tooltip:"Sun: {az} az / {el} el",sunrise_tooltip:"Sunrise: {time}",sunset_tooltip:"Sunset: {time}",moon_tooltip:"Moon: {phase} ({pct}%)",sun_path_tooltip:"Sun path (today)",in_fov_check:"✓ in SAA",in_fov:"in SAA",in_fov_tooltip:"Sun is currently within this window’s sun acceptance angle",none:"—",sun:"Sun",moon:"Moon",sun_up_not_hitting:"Sun (up, not hitting)",sun_below_horizon:"Sun (below horizon)",window_fov:"Window SAA",sun_path:"Sun path",sunrise:"Sunrise",sunset:"Sunset",cover_target:"Cover target",cover_held:"Cover position (held)",window_normal:"Window azimuth",stat_sun:"Sun: ",stat_azi:"Azi: ",stat_elev:"Elev: ",stat_window:"Window: ",active_sun_arc:"Active sun arc {from} – {to}{elev}",fov_arc:"SAA {left} left / {right} right{elev}",window_normal_tooltip:"Window azimuth: {bearing}",cover_position_target:"Target: {pct}%",cover_position_target_awning:"Target (extended): {pct}%",cover_position_actual:"Actual: {pct}%",blind_spot:"Blind spot: {from} – {to}",elev_suffix:" · elev {min}–{max}"},covers:{placeholder:"No covers reported by the integration.",title:"Covers",target:"Target: {pct}",target_solar:"Solar target: {pct}",click_to_set:"Click to set position",position_slider_label:"Cover position slider",position_open_value:"{pct} open",opening:"Opening…",closing:"Closing…",target_tooltip:"Target {pct}%",target_tooltip_override:"Would-be solar target {pct}% — cover is held by manual override",target_tooltip_motor:"Motor: {pct}% (before calibration)",position_title:"Position",tilt_title:"Tilt",tilt_target:"Tilt: {pct}",tilt_click_to_set:"Click to set tilt",tilt_target_tooltip:"Tilt target {pct}%",goto_target:"Move to target ({pct}%) — keeps automatic control"},decision:{placeholder:"Decision trace not yet populated.",pipeline:"Pipeline",winner:"Winner: {name}",summary_tooltip:"Why this position?",not_evaluated:"not evaluated",floor_suffix:" floor",outside_schedule:"Outside schedule — automatic control paused",outside_schedule_tooltip:"The configured schedule window is not active, so automatic positioning is paused.",solar_would_be:"solar {pct}",next_change_in:"Next adjustment allowed in {time}"},solar:{title:"Solar Calculation",axis_position:"Position axis",axis_tilt:"Tilt axis",group_inputs:"Inputs",group_intermediates:"Intermediates",group_output:"Output",show_all:"Show all {count} values",show_less:"Show less",no_target:"No solar target — {status}",status:{direct_sun:"Direct sun",fov_exit:"Default · SAA exit",elevation_limit:"Default · elevation limit",sunset_offset:"Default · sunset offset",blind_spot:"Default · blind spot",default:"Default"},field:{sol_elev_deg:"Sun elevation",gamma_deg:"Relative azimuth (γ)",position_pct:"Position",effective_distance_m:"Effective distance",adjusted_height_m:"Adjusted height",safety_margin:"Safety margin",awn_angle_deg:"Awning angle",vertical_position_m:"Vertical position",length_m:"Extension length",slat_angle_raw_deg:"Slat angle",tilt_mode:"Tilt mode",max_degrees:"Max angle"}},header:{on:"ON",off:"OFF",integration_enabled:"Integration Enabled",auto:"Auto",automatic_control:"Automatic Control"},tile:{motion_pending:"Occupancy timeout pending",motion_detected:"Occupancy detected",battery_low:"Low battery — {level}%",battery_unknown:"Battery level unknown",icon_action_label:"Cover icon action",open:"Open",stop:"Stop",close:"Close",resume_aria:"Resume automatic control",extend_aria:"Extend manual override",registry_failed:"Registry fetch failed: {error}",loading:"Loading…",entry_not_found:"Adaptive Cover Pro entry {entry} not found.",unavailable:"Unavailable",rails_layered:"{count} rails of one cover",rails_separate:"{count} covers",rails_layered_hint:"Rails of one cover"},formatters:{expired:"expired"},elevation:{title:"Sun today",fov_window:"SAA: {from} → {to}",fov_windows:"SAA: {windows}",fov_window_named:"{name}: {windows}",no_fov_today:"Sun does not enter SAA today",placeholder:"Sun elevation chart unavailable.",schedule:"Schedule {from} – {to}",schedule_from:"Schedule from {from}",schedule_until:"Schedule until {to}",schedule_start_tooltip:"Schedule start",schedule_end_tooltip:"Schedule end"},control_status:{active:"Active",outside_time_window:"Outside time window",position_delta_too_small:"Position change too small",time_delta_too_small:"Too soon since last move",manual_override:"Manual override",automatic_control_off:"Automatic control off",sun_not_visible:"Sun not visible",force_override_active:"Force override",weather_override_active:"Weather safety",motion_timeout:"Occupancy timeout"},history:{title:"History",open:"History",close:"Close",refresh:"Refresh",loading:"Loading history…",no_data:"No recorded data",window_label:"History window",window_hours:"{hours}h",show_more:"Show more",expand:"Expand to full view",collapse:"Back to history",today:"Today",yesterday:"Yesterday",section_tracks:"Timeline",track_position:"Position",track_who_won:"Who won",track_control_status:"Control status",track_enabled:"Integration",track_auto:"Automatic control",track_sun:"Sun in SAA",track_glare:"Glare",track_manual:"Manual override",track_mismatch:"Position mismatch",legend_target:"Target",legend_actual:"Actual",legend_per_cover:"Per cover",legend_saa:"Sun in SAA",legend_night:"Night",stat_moves:"moves",stat_travel:"pts travelled",stat_override:"in manual override",copy_diagnostics:"Copy diagnostics",copied:"Copied",no_recorder_data:"Not recorded — check your recorder settings",activity_title:"Activity",activity_empty:"No recorded activity in this window.",advanced:"Advanced — event buffer",events_search:"Filter events…",events_count:"{shown} of {total} events",events_empty:"No events match the filter.",events_unavailable:"Event buffer unavailable — the integration did not return diagnostics.",buffer_size:"Buffer size: {size}",data_window:"Buffer window: {from} → {to}"},root:{loading_registry:"Loading Adaptive Cover Pro registry…",no_entities_title:"No Adaptive Cover Pro entities found",footer_version:"adaptive-cover-pro-card v{version}",compass_no_match:"No matching Adaptive Cover Pro entities",compass_configured:"Configured entries: {entries}",compass_not_found:"Entries not found: {entries}"},editor:{common:{entry_id:"Adaptive Cover Pro instance",support_alt:"Buy me a coffee",title_optional:"Title (optional)",title_placeholder:"e.g. West-facing windows",north_offset:"Compass north offset (°)",north_offset_hint:'Rotate the compass clockwise so "up" matches your map. Default: 0.',loading_entries:"Loading Adaptive Cover Pro config entries…",load_failed:"Failed to load config entries: {error}",no_entries:"No Adaptive Cover Pro config entries found. Add an instance under",no_entries_path:"Settings → Devices & Services",no_entries_then:", then come back.",entry_id_manual_placeholder:"Enter config entry ID manually",entry_id_fallback_label:"Entry ID",unknown_entry:"(unknown: {entry})",reset:"Reset"},main:{sections:"Sections",sections_hint:"Toggle which parts of the card are shown.",section_sky_label:"Sky compass",section_sky_desc:"Sun vs. window SAA, polar plot",section_elevation_label:"Sun today",section_elevation_desc:"Elevation-vs-time chart with SAA band and current-time cursor",section_decision_label:"Decision strip",section_decision_desc:"All 10 pipeline handlers with the winning row highlighted",section_covers_label:"Cover positions",section_covers_desc:"Per-cover live vs. target bars; click to set position",section_overrides_label:"Overrides panel",section_overrides_desc:"Manual, force, occupancy tiles + reset button",section_climate_label:"Climate panel",section_climate_desc:"Summer/winter/intermediate strategy; shows standby when climate mode is off or inactive",section_solar_label:"Solar calculation",section_solar_desc:"Raw solar geometry breakdown (inputs → intermediates → output); requires the integration’s solar_calculation sensor",controls:"Controls",controls_hint:"Render as read-only (visible but not clickable).",integration_pill_label:"Integration ON/OFF pill",integration_pill_desc:"Allow toggling the integration from the card header.",automatic_pill_label:"Automatic Control pill",automatic_pill_desc:"Allow toggling automatic control from the card header.",reset_button_label:"Reset Manual Override button",reset_button_desc:"Allow pressing the reset tile in the overrides panel.",display:"Display",compact_label:"Compact mode",compact_desc:"Tighter spacing between sections.",show_compass_stats_label:"Show compass stats",show_compass_stats_desc:"Azi, Elev, ∠, and Window angle below the sky compass.",show_compass_legend_label:"Show compass legend",show_compass_legend_desc:"Color key below the sky compass.",show_moon_label:"Show moon on compass",show_moon_desc:"Moon position and phase overlay on the sky compass.",hide_inactive_label:"Hide inactive handlers",hide_inactive_desc:"Show only the winner and actively matched pipeline handlers.",state_color_label:"Color icon by state",state_color_desc:"Header cover icon takes on the theme’s open/closed/active color."},tile:{name:"Title override",icon:"Icon override",cover:"Cover entity",layout:"Layout",show_position:"Show position %",show_state:"Show state (Open/Closed)",show_decision_summary:"Show decision summary",show_controls:"Show ↑ ■ ↓ controls",covers:"Position bars (order)",covers_hint:"Drag a row, or use the arrows, to set the order the position bars appear in. The eye hides a bar without unbinding the cover.",member_names:"Member names",member_names_hint:"Rename a group member as it appears on this card. Leave blank to use the entry’s own name.",covers_move_up:"Move up",covers_move_down:"Move down",covers_hide:"Hide this bar",covers_show:"Show this bar",controls_cover:"Cover driven by ↑ ■ ↓",controls_axis:"Axis driven by ↑ ■ ↓",show_badge:"Show contextual badge",show_position_bar:"Show position bar",show_tilt:"Show tilt bar",content_section:"Content",controls_section:"Controls",dialog_section:"Dialog sections",group_row_section:"Group controls",show_scene_select:"Show scene selector",show_lock:"Show group lock",show_automation:"Show member automation toggle",show_clear_overrides:"Show clear-overrides button",show_member_badges:"Show member override badges",badge_section:"Badges",badge_auto:"Auto",badge_solar:"Solar tracking",badge_force:"Force override",badge_weather:"Weather safety",badge_manual:"Manual override",badge_custom_position:"Custom position",badge_motion:"Occupancy",badge_climate:"Climate",badge_glare_zone:"Glare zone",badge_cloud:"Cloud suppression",show_compass:"Show sun compass in dialog",show_elevation_chart:"Show sun-today chart in dialog",show_solar_calc:"Show solar calculation in dialog",show_motion_icon:"Show occupancy indicator",state_color:"Color icon by state",interactions_section:"Interactions",tap_action:"Tap action",icon_tap_action:"Icon tap behavior",hold_action:"Hold action",double_tap_action:"Double-tap action",cover_blank_hint:"Leave blank to use the first managed cover automatically.",name_composed_hint:"A composed name is set in YAML. Type a new title here to replace it with plain text.",layout_option_one_line:"One line (compact)",layout_option_detailed:"Detailed (title, state, indicators)"},compass:{instances:"Adaptive Cover Pro instances",instances_hint:"Pick one or more. Each selected entry adds an overlay to the compass.",cover_colors:"Cover colors",cover_colors_hint:"Override the default palette color for each overlay.",default_color:"default",display:"Display",toggle_compact_label:"Compact mode",toggle_compact_desc:"Smaller SVG, legend hidden.",toggle_legend_label:"Legend",toggle_legend_desc:"Color swatches + entry labels below compass.",toggle_stats_label:"Stats",toggle_stats_desc:"Sun + per-window numeric rows.",toggle_moon_label:"Moon",toggle_moon_desc:"Render moon position and phase.",toggle_cardinals_label:"Cardinal labels",toggle_cardinals_desc:"N/E/S/W letters around the compass.",toggle_blind_spot_label:"Blind spots",toggle_blind_spot_desc:"Hatched wedges for each window’s blind range.",toggle_sun_path_label:"Sun path",toggle_sun_path_desc:"Today’s sun arc across the sky.",toggle_sunrise_sunset_label:"Sunrise / sunset markers",toggle_sunrise_sunset_desc:"Small dots at rise and set azimuths.",toggle_cover_fill_label:"Cover closure fill",toggle_cover_fill_desc:"Inner wedge showing how closed each cover is.",toggle_window_arrow_label:"Window-normal arrow",toggle_window_arrow_desc:"Line from center toward each window’s azimuth.",toggle_elevation_chart_label:"Sun-today chart",toggle_elevation_chart_desc:"Elevation-vs-time chart below the compass, with SAA band and elevation limits."},decision:{title:"Title (optional)",compact_label:"Compact mode",compact_desc:"Tighter rows; also hides inactive handlers.",hide_inactive_handlers_label:"Hide inactive handlers",hide_inactive_handlers_desc:"Show only the winner and actively matched pipeline handlers.",show_decision_summary_label:"Show decision summary",show_decision_summary_desc:'Render a plain-English "Why this position?" sentence above the strip.'},solar_chart:{instances:"Adaptive Cover Pro instances",instances_hint:"Pick one or more. Each selected entry adds a SAA overlay to the chart.",cover_colors:"Cover colors",cover_colors_hint:"Override the default palette color for each overlay.",default_color:"default",display:"Display",toggle_compact_label:"Compact mode",toggle_compact_desc:"Smaller chart, tighter spacing."},history:{title:"Title (optional)",hours_label:"History window",hours_desc:"How far back the tracks reach, counting from now.",track_position_label:"Position track",track_position_desc:"Recorded cover position over the window.",track_who_won_label:"Who-won track",track_who_won_desc:"Banded strip of the winning pipeline handler over time.",track_context_label:"Context tracks",track_context_desc:"Sun-in-SAA, glare and manual-override spans.",track_actions_label:"Cover actions list",track_actions_desc:"Recorded cover actions and skipped actions, newest first.",advanced_open_label:"Start with Advanced open",advanced_open_desc:"Expand the event-buffer section on load.",hide_advanced_label:"Hide Advanced section",hide_advanced_desc:"Never show the diagnostic event buffer on this card."}}},fr:{handler:{force:"Dérogation forcée",weather:"Sécurité météo",group_scene:"Scène de groupe",manual:"Dérogation manuelle",group_lock:"Verrouillage de groupe",custom_position:"Position personnalisée",motion:"Délai d'occupation",cloud:"Désactivation par temps nuageux",climate:"Climatique",glare_zone:"Zone d'éblouissement",solar:"Suivi solaire",default:"Par défaut",floor_clamp:"Plancher"},badge:{auto:"Auto",manual:"Manuel",force:"Forcé",weather:"Sécurité météo",glare_zone:"Éblouissement",climate:"Climatique",cloud:"Nuageux",custom_position:"Personnalisé",solar:"Suivi solaire",motion:"Occupation inactive",off:"Off",off_schedule:"Hors planning",floor_suffix:" ↥",safety:"Sécurité",group:"Groupe",tip:{auto:"Le contrôle automatique est actif et aucun gestionnaire ne le remplace — le volet suit le résultat du pipeline.",manual:"Une dérogation manuelle est active — le volet reste où vous l'avez placé et le contrôle automatique est en pause.",manual_until:"Une dérogation manuelle est active jusqu'à {time} — le volet reste où vous l'avez placé jusque-là.",force:"Une position forcée remplace tous les autres gestionnaires.",weather:"La sécurité météo pilote la position.",glare_zone:"Le soleil se trouve dans une zone d'éblouissement configurée, et le gestionnaire d'éblouissement pilote la position.",climate:"Le contrôle climatique pilote la position.",cloud:"La couverture nuageuse désactive le suivi solaire.",custom_position:"Un emplacement de position personnalisée pilote ce volet.",custom_position_slot:"Emplacement : {name}.",custom_position_value:"Sa position est de {pct} %.",custom_position_floor:"Il agit comme un plancher : il relève la position au-dessus du calcul brut au lieu de le remplacer.",solar:"Suivi solaire — la position suit la course du soleil devant la fenêtre.",motion:"La pièce est considérée comme inoccupée, le gestionnaire d'occupation maintient donc la position.",off:"L'intégration est désactivée pour ce volet — rien n'est piloté.",off_schedule:"En dehors de la plage horaire configurée, le contrôle automatique est donc en pause.",group:"Le groupe de volets décide actuellement de cette position.",safety:"Une position de sécurité remplace tous les autres gestionnaires."}},group:{title:"Groupe de couvertures",scene:"Scène",scene_auto:"Auto",scene_all_open:"Tout ouvrir",scene_all_closed:"Tout fermer",scene_privacy:"Intimité",state_open:"Ouvert",state_closed:"Fermé",state_mixed:"Mixte",state_unknown:"Inconnu",lock:"Verrouiller le groupe",unlock:"Déverrouiller le groupe",automation:"Automatisation",automation_count:"{count} membre(s) sur {total} automatisé(s)",clear_overrides:"Effacer les dérogations",clear_overrides_none:"Aucune dérogation de membre à effacer",who_won:"{count} membre(s) sur {total} sont pilotés par le groupe — une scène de groupe ou le verrouillage du groupe détermine actuellement leur position",members:"Membres",member_placeholder:"Aucun membre signalé par l'intégration.",position:"Position",open:"Ouvrir le groupe",close:"Fermer le groupe",stop:"Arrêter le groupe",position_slider_label:"Position du groupe",range:"{min}–{max} %",exception_held:"{count} maintenu(s)",exception_unavailable:"{count} indisponible(s)",drag_to_set_all:"Glisser pour régler les {count} stores",spread_value:"de {min} % à {max} % sur {count} stores"},forecast:{event:{sunrise:"Lever du soleil",sunset:"Coucher du soleil",fov_enter:"Le soleil entre dans l'angle d'acceptation solaire de la fenêtre",fov_exit:"Le soleil quitte l'angle d'acceptation solaire de la fenêtre"},hover_hint:"Survolez la courbe pour voir l'heure et la position prévue ; survolez une ligne colorée pour voir l'événement qu'elle indique.",solar_only_note:"Géométrie solaire uniquement — ne tient pas compte des dérogations manuelles, des positions personnalisées, de la désactivation par temps nuageux ni des conditions météo.",legend_forecast:"Prévision",legend_actual:"Réel"},dialog:{battery:"Batterie {level}%",battery_named:"{name} : {level}%",battery_unknown:"Niveau de batterie inconnu",extend:{title:"Prolonger la dérogation manuelle",presets_label:"Jusqu'à",relative_label:"Ajouter du temps",absolute_label:"Fin à",preview:"Dérogation jusqu'à {time}",confirm:"Prolonger",cancel:"Annuler",tomorrow_suffix:" (demain)"},configure_integration:"Configurer l'intégration",open_device_page:"Ouvrir la page de l'appareil",close:"Fermer",target:"Cible",resume_auto:"Reprendre l'automatique",hide_advanced:"▼ Masquer les options avancées",show_advanced:"▶ Afficher les options avancées",custom_positions:"Positions personnalisées",floor_tooltip:"Plancher — cette valeur force une position minimale au-dessus du calcul automatique",floor:"↥",disable_slot:"Désactiver le créneau {slot}",enable_slot:"Activer le créneau {slot}",on:"Activé",off:"Désactivé",controls:"Commandes",automatic:"Automatique",climate:"Climatique",motion:"Occupation",toggle_hint:"{label} {state} — appuyez pour basculer",state_on:"activé",state_off:"désactivé",todays_forecast:"Prévisions du jour"},overrides:{title:"Dérogations",manual:"Manuel",force:"Forcé",motion:"Occupation",active:"Actif",off:"Désactivé",ends_in:"se termine dans {time}",active_count:"{count} dérogation(s) active(s)",timeout:"expire dans {time}",reset_manual:"Réinitialiser le mode manuel"},climate:{title:"Climatique",active:"Actif : {strategy}",indoor:"Intérieur",outdoor:"Extérieur",presence:"Présence",sunny:"Ensoleillé",lux:"Lux",irradiance:"Irradiance",mode_off:"Mode climatique désactivé",standby:"En veille",threshold_low:"bas",threshold_high:"haut",threshold_summer_outside:"été",reason:{outside_time_window:"En dehors de la plage horaire de fonctionnement",thresholds_not_met:"Températures dans la plage de confort — aucune action requise",other_mode_active:"Un autre mode de contrôle est actuellement actif",readings_unavailable:"Relevés de température indisponibles",mode_off:"Le mode climatique est désactivé"}},compass:{placeholder_no_entries:"Aucune instance Adaptive Cover Pro sélectionnée.",placeholder_no_sun:"Le capteur solaire n'est pas encore renseigné.",sun_tooltip:"Soleil : {az} az / {el} él",sunrise_tooltip:"Lever du soleil : {time}",sunset_tooltip:"Coucher du soleil : {time}",moon_tooltip:"Lune : {phase} ({pct}%)",sun_path_tooltip:"Trajectoire solaire (aujourd'hui)",in_fov_check:"✓ dans le SAA",in_fov:"dans le SAA",in_fov_tooltip:"Le soleil est actuellement dans l'angle d'acceptation solaire de cette fenêtre",none:"—",sun:"Soleil",moon:"Lune",sun_up_not_hitting:"Soleil (levé, ne frappe pas)",sun_below_horizon:"Soleil (sous l’horizon)",window_fov:"SAA de la fenêtre",sun_path:"Trajectoire solaire",sunrise:"Lever du soleil",sunset:"Coucher du soleil",cover_target:"Cible du store",cover_held:"Position du store (maintenue)",window_normal:"Azimut de la fenêtre",stat_sun:"Soleil : ",stat_azi:"Azi : ",stat_elev:"Élév : ",stat_window:"Fenêtre : ",active_sun_arc:"Arc solaire actif {from} – {to}{elev}",fov_arc:"SAA {left} gauche / {right} droite{elev}",window_normal_tooltip:"Azimut de la fenêtre : {bearing}",cover_position_target:"Cible : {pct}%",cover_position_target_awning:"Cible (déployé) : {pct}%",cover_position_actual:"Réel : {pct}%",blind_spot:"Soleil masqué : {from} - {to}",elev_suffix:" · élév {min}–{max}"},covers:{placeholder:"Aucun store signalé par l'intégration.",title:"Stores",target:"Cible : {pct}",target_solar:"Cible solaire : {pct}",click_to_set:"Cliquer pour définir la position",position_slider_label:"Curseur de position du store",position_open_value:"{pct} ouvert",opening:"Ouverture…",closing:"Fermeture…",target_tooltip:"Cible {pct}%",target_tooltip_override:"Cible solaire théorique {pct}% — le store est maintenu par la commande manuelle",target_tooltip_motor:"Moteur : {pct}% (avant étalonnage)",position_title:"Position",tilt_title:"Inclinaison",tilt_target:"Inclinaison : {pct}",tilt_click_to_set:"Cliquer pour définir l'inclinaison",tilt_target_tooltip:"Cible inclinaison {pct}%",goto_target:"Aller à la cible ({pct}%) — le contrôle automatique est conservé"},decision:{placeholder:"La trace de décision n'est pas encore renseignée.",pipeline:"Pipeline",winner:"Actif : {name}",summary_tooltip:"Pourquoi cette position ?",not_evaluated:"non évalué",floor_suffix:" plancher",outside_schedule:"Hors planning — contrôle automatique en pause",outside_schedule_tooltip:"La fenêtre de planning configurée n'est pas active, le positionnement automatique est donc en pause.",solar_would_be:"solaire {pct}",next_change_in:"Prochain ajustement autorisé dans {time}"},solar:{title:"Calcul solaire",axis_position:"Axe de position",axis_tilt:"Axe d'inclinaison",group_inputs:"Entrées",group_intermediates:"Intermédiaires",group_output:"Sortie",show_all:"Afficher les {count} valeurs",show_less:"Afficher moins",no_target:"Pas de cible solaire — {status}",status:{direct_sun:"Soleil direct",fov_exit:"Par défaut · sortie du SAA",elevation_limit:"Par défaut · limite d'élévation",sunset_offset:"Par défaut · décalage coucher du soleil",blind_spot:"Par défaut · angle mort",default:"Par défaut"},field:{sol_elev_deg:"Élévation du soleil",gamma_deg:"Azimut relatif (γ)",position_pct:"Position",effective_distance_m:"Distance effective",adjusted_height_m:"Hauteur ajustée",safety_margin:"Marge de sécurité",awn_angle_deg:"Angle du store",vertical_position_m:"Position verticale",length_m:"Longueur d'extension",slat_angle_raw_deg:"Angle des lamelles",tilt_mode:"Mode d'inclinaison",max_degrees:"Angle maximal"}},header:{on:"ON",off:"OFF",integration_enabled:"Intégration activée",auto:"Auto",automatic_control:"Contrôle automatique"},tile:{motion_pending:"Délai d'occupation en cours",motion_detected:"Occupation détectée",battery_low:"Batterie faible — {level}%",battery_unknown:"Niveau de batterie inconnu",icon_action_label:"Action de l'icône du store",open:"Ouvrir",stop:"Arrêter",close:"Fermer",resume_aria:"Reprendre le contrôle automatique",extend_aria:"Prolonger la dérogation manuelle",registry_failed:"Échec de la récupération du registre : {error}",loading:"Chargement…",entry_not_found:"Instance Adaptive Cover Pro {entry} introuvable.",unavailable:"Indisponible",rails_layered:"{count} toiles d’un même store",rails_separate:"{count} stores",rails_layered_hint:"Toiles d’un même store"},formatters:{expired:"expiré"},elevation:{title:"Soleil aujourd'hui",fov_window:"SAA : {from} → {to}",fov_windows:"SAA : {windows}",fov_window_named:"{name} : {windows}",no_fov_today:"Le soleil n'entre pas dans le SAA aujourd'hui",placeholder:"Graphique d'élévation solaire indisponible.",schedule:"Programmation {from} – {to}",schedule_from:"Programmation à partir de {from}",schedule_until:"Programmation jusqu'à {to}",schedule_start_tooltip:"Début de programmation",schedule_end_tooltip:"Fin de programmation"},control_status:{active:"Actif",outside_time_window:"Hors plage horaire",position_delta_too_small:"Changement de position trop faible",time_delta_too_small:"Trop tôt depuis le dernier mouvement",manual_override:"Dérogation manuelle",automatic_control_off:"Contrôle automatique désactivé",sun_not_visible:"Soleil non visible",force_override_active:"Dérogation forcée",weather_override_active:"Sécurité météo",motion_timeout:"Délai d'occupation"},history:{title:"Historique",open:"Historique",close:"Fermer",refresh:"Actualiser",loading:"Chargement de l'historique…",no_data:"Aucune donnée enregistrée",window_label:"Fenêtre d'historique",window_hours:"{hours} h",show_more:"Afficher plus",expand:"Afficher en plein écran",collapse:"Retour à l'historique",today:"Aujourd'hui",yesterday:"Hier",section_tracks:"Chronologie",track_position:"Position",track_who_won:"Gagnant",track_control_status:"État du contrôle",track_enabled:"Intégration",track_auto:"Contrôle automatique",track_sun:"Soleil dans SAA",track_glare:"Éblouissement",track_manual:"Dérogation manuelle",track_mismatch:"Écart de position",legend_target:"Cible",legend_actual:"Réel",legend_per_cover:"Par store",legend_saa:"Soleil dans SAA",legend_night:"Nuit",stat_moves:"mouvements",stat_travel:"pts parcourus",stat_override:"en dérogation manuelle",copy_diagnostics:"Copier les diagnostics",copied:"Copié",no_recorder_data:"Non enregistré — vérifiez la configuration du recorder",activity_title:"Activité",activity_empty:"Aucune activité enregistrée sur cette période.",advanced:"Avancé — tampon d'événements",events_search:"Filtrer les événements…",events_count:"{shown} événements sur {total}",events_empty:"Aucun événement ne correspond au filtre.",events_unavailable:"Tampon d'événements indisponible — l'intégration n'a pas renvoyé de diagnostics.",buffer_size:"Taille du tampon : {size}",data_window:"Fenêtre du tampon : {from} → {to}"},root:{loading_registry:"Chargement du registre Adaptive Cover Pro…",no_entities_title:"Aucune entité Adaptive Cover Pro trouvée",footer_version:"adaptive-cover-pro-card v{version}",compass_no_match:"Aucune entité Adaptive Cover Pro correspondante",compass_configured:"Instances configurées : {entries}",compass_not_found:"Instances introuvables : {entries}"},editor:{common:{entry_id:"Instance Adaptive Cover Pro",support_alt:"Offrez-moi un café",title_optional:"Titre (facultatif)",title_placeholder:"ex. Fenêtres côté ouest",north_offset:"Décalage nord de la boussole (°)",north_offset_hint:"Faites pivoter la boussole dans le sens horaire pour que « haut » corresponde à votre carte. Par défaut : 0.",loading_entries:"Chargement des entrées de configuration Adaptive Cover Pro…",load_failed:"Échec du chargement des entrées de configuration : {error}",no_entries:"Aucune entrée de configuration Adaptive Cover Pro trouvée. Ajoutez une instance sous",no_entries_path:"Paramètres → Appareils et services",no_entries_then:", puis revenez ici.",entry_id_manual_placeholder:"Saisir manuellement l'ID d'entrée de configuration",entry_id_fallback_label:"ID d'entrée",unknown_entry:"(inconnu : {entry})",reset:"Réinitialiser"},main:{sections:"Sections",sections_hint:"Activer ou désactiver les parties de la carte affichées.",section_sky_label:"Boussole céleste",section_sky_desc:"Soleil par rapport au SAA de la fenêtre, tracé polaire",section_elevation_label:"Soleil aujourd'hui",section_elevation_desc:"Graphique élévation/temps avec bande SAA et curseur temps réel",section_decision_label:"Bande de décision",section_decision_desc:"Les 10 gestionnaires du pipeline avec la ligne gagnante mise en évidence",section_covers_label:"Positions des stores",section_covers_desc:"Barres position réelle/cible par store ; cliquer pour définir la position",section_overrides_label:"Panneau des dérogations",section_overrides_desc:"Tuiles Manuel, Forcé, Occupation + bouton de réinitialisation",section_climate_label:"Panneau climatique",section_climate_desc:"Stratégie été/hiver/intermédiaire ; affiche le mode veille si le mode climatique est désactivé ou inactif",section_solar_label:"Calcul solaire",section_solar_desc:"Décomposition de la géométrie solaire brute (entrées → intermédiaires → sortie) ; nécessite le capteur solar_calculation de l’intégration",controls:"Commandes",controls_hint:"Afficher en lecture seule (visible mais non cliquable).",integration_pill_label:"Bouton ON/OFF de l'intégration",integration_pill_desc:"Permettre de basculer l'intégration depuis l'en-tête de la carte.",automatic_pill_label:"Bouton contrôle automatique",automatic_pill_desc:"Permettre de basculer le contrôle automatique depuis l'en-tête de la carte.",reset_button_label:"Bouton de réinitialisation de la dérogation manuelle",reset_button_desc:"Permettre d'appuyer sur la tuile de réinitialisation dans le panneau des dérogations.",display:"Affichage",compact_label:"Mode compact",compact_desc:"Espacement réduit entre les sections.",show_compass_stats_label:"Afficher les statistiques de la boussole",show_compass_stats_desc:"Azi, Élév, ∠ et angle de fenêtre sous la boussole céleste.",show_compass_legend_label:"Afficher la légende de la boussole",show_compass_legend_desc:"Clé de couleur sous la boussole céleste.",show_moon_label:"Afficher la lune sur la boussole",show_moon_desc:"Position et phase de la lune en superposition sur la boussole céleste.",hide_inactive_label:"Masquer les gestionnaires inactifs",hide_inactive_desc:"Afficher uniquement le gestionnaire sélectionné et les gestionnaires du pipeline actifs.",state_color_label:"Colorer l'icône selon l'état",state_color_desc:"L'icône d'en-tête prend la couleur ouvert/fermé/actif du thème."},tile:{name:"Titre personnalisé",icon:"Icône personnalisée",cover:"Entité de store",layout:"Disposition",show_position:"Afficher la position %",show_state:"Afficher l'état (Ouvert/Fermé)",show_decision_summary:"Afficher le résumé de décision",show_controls:"Afficher les commandes ↑ ■ ↓",covers:"Barres de position (ordre)",covers_hint:"Faites glisser une ligne, ou utilisez les flèches, pour définir l'ordre des barres de position. L'œil masque une barre sans dissocier le volet.",member_names:"Noms des membres",member_names_hint:"Renommer un membre du groupe tel qu'il apparaît sur cette carte. Laisser vide pour utiliser le nom de l'instance.",covers_move_up:"Monter",covers_move_down:"Descendre",covers_hide:"Masquer cette barre",covers_show:"Afficher cette barre",controls_cover:"Volet piloté par ↑ ■ ↓",controls_axis:"Axe piloté par ↑ ■ ↓",show_badge:"Afficher le badge contextuel",show_position_bar:"Afficher la barre de position",show_tilt:"Afficher la barre d'inclinaison",content_section:"Contenu",controls_section:"Commandes",dialog_section:"Sections de la boîte de dialogue",group_row_section:"Commandes de groupe",show_scene_select:"Afficher le sélecteur de scène",show_lock:"Afficher le verrouillage du groupe",show_automation:"Afficher l'interrupteur d'automatisation des membres",show_clear_overrides:"Afficher le bouton d’effacement des dérogations",show_member_badges:"Afficher les badges de dérogation des membres",badge_section:"Badges",badge_auto:"Auto",badge_solar:"Suivi solaire",badge_force:"Dérogation forcée",badge_weather:"Sécurité météo",badge_manual:"Dérogation manuelle",badge_custom_position:"Position personnalisée",badge_motion:"Occupation",badge_climate:"Climatique",badge_glare_zone:"Zone d'éblouissement",badge_cloud:"Suppression nuageuse",show_compass:"Afficher la boussole solaire dans le dialogue",show_elevation_chart:"Afficher le graphique du soleil dans le dialogue",show_solar_calc:"Afficher le calcul solaire dans le dialogue",show_motion_icon:"Afficher l'indicateur d'occupation",state_color:"Colorer l'icône selon l'état",interactions_section:"Interactions",tap_action:"Action au toucher",icon_tap_action:"Action au toucher de l'icône",hold_action:"Action au maintien",double_tap_action:"Action au double toucher",cover_blank_hint:"Laisser vide pour utiliser automatiquement le premier store géré.",name_composed_hint:"Un titre composé est défini en YAML. Saisissez un nouveau titre ici pour le remplacer par du texte simple.",layout_option_one_line:"Une ligne (compact)",layout_option_detailed:"Détaillé (titre, état, indicateurs)"},compass:{instances:"Instances Adaptive Cover Pro",instances_hint:"Sélectionnez une ou plusieurs instances. Chaque instance sélectionnée ajoute une superposition à la boussole.",cover_colors:"Couleurs des stores",cover_colors_hint:"Remplacer la couleur de palette par défaut pour chaque superposition.",default_color:"par défaut",display:"Affichage",toggle_compact_label:"Mode compact",toggle_compact_desc:"SVG plus petit, légende masquée.",toggle_legend_label:"Légende",toggle_legend_desc:"Échantillons de couleur et étiquettes d'instance sous la boussole.",toggle_stats_label:"Statistiques",toggle_stats_desc:"Soleil + lignes numériques par fenêtre.",toggle_moon_label:"Lune",toggle_moon_desc:"Afficher la position et la phase de la lune.",toggle_cardinals_label:"Points cardinaux",toggle_cardinals_desc:"Lettres N/E/S/O autour de la boussole.",toggle_blind_spot_label:"Zones de soleil masqué",toggle_blind_spot_desc:"Secteurs hachurés pour la plage où le soleil est masqué de chaque fenêtre.",toggle_sun_path_label:"Trajectoire solaire",toggle_sun_path_desc:"Arc solaire du jour dans le ciel.",toggle_sunrise_sunset_label:"Repères lever / coucher du soleil",toggle_sunrise_sunset_desc:"Petits points aux azimuts de lever et coucher du soleil.",toggle_cover_fill_label:"Remplissage de fermeture du store",toggle_cover_fill_desc:"Secteur intérieur indiquant le taux de fermeture de chaque store.",toggle_window_arrow_label:"Flèche de normale de fenêtre",toggle_window_arrow_desc:"Ligne du centre vers l'azimut de chaque fenêtre.",toggle_elevation_chart_label:"Graphique du soleil",toggle_elevation_chart_desc:"Graphique élévation/temps sous la boussole, avec bande SAA et limites d'élévation."},decision:{title:"Titre (facultatif)",compact_label:"Mode compact",compact_desc:"Lignes plus serrées ; masque aussi les gestionnaires inactifs.",hide_inactive_handlers_label:"Masquer les gestionnaires inactifs",hide_inactive_handlers_desc:"Afficher uniquement le gestionnaire sélectionné et les gestionnaires du pipeline actifs.",show_decision_summary_label:"Afficher le résumé de décision",show_decision_summary_desc:"Afficher une phrase explicite « Pourquoi cette position ? » au-dessus de la bande."},solar_chart:{instances:"Instances Adaptive Cover Pro",instances_hint:"Sélectionnez une ou plusieurs instances. Chaque instance sélectionnée ajoute une superposition SAA au graphique.",cover_colors:"Couleurs des stores",cover_colors_hint:"Remplacer la couleur de palette par défaut pour chaque superposition.",default_color:"par défaut",display:"Affichage",toggle_compact_label:"Mode compact",toggle_compact_desc:"Graphique plus petit, espacement plus serré."},history:{title:"Titre (facultatif)",hours_label:"Fenêtre d'historique",hours_desc:"Profondeur de l'historique affiché, à partir de maintenant.",track_position_label:"Piste Position",track_position_desc:"Position enregistrée du store sur la période.",track_who_won_label:"Piste Gagnant",track_who_won_desc:"Bandes du gestionnaire de pipeline gagnant au fil du temps.",track_context_label:"Pistes de contexte",track_context_desc:"Périodes soleil-dans-SAA, éblouissement et dérogation manuelle.",track_actions_label:"Liste des actions",track_actions_desc:"Actions de store enregistrées et ignorées, les plus récentes en premier.",advanced_open_label:"Ouvrir Avancé au démarrage",advanced_open_desc:"Déplier la section du tampon d'événements au chargement.",hide_advanced_label:"Masquer la section Avancé",hide_advanced_desc:"Ne jamais afficher le tampon d'événements de diagnostic sur cette carte."}}},de:{handler:{force:"Zwangsübersteuerung",weather:"Wettersicherheit",group_scene:"Gruppenszene",manual:"Manuelle Übersteuerung",group_lock:"Gruppensperre",custom_position:"Benutzerdefinierte Position",motion:"Anwesenheits-Timeout",cloud:"Wolkenunterdrückung",climate:"Klima",glare_zone:"Blendungszone",solar:"Sonnenverfolgung",default:"Standard",floor_clamp:"Mindestposition"},badge:{auto:"Auto",manual:"Manuell",force:"Zwang",weather:"Wettersicherheit",glare_zone:"Blendung",climate:"Klima",cloud:"Bewölkt",custom_position:"Benutzerdefiniert",solar:"Sonnenverfolgung",motion:"Anwesenheit inaktiv",off:"Aus",off_schedule:"Außerhalb des Zeitplans",floor_suffix:" ↥",safety:"Sicherheit",group:"Gruppe",tip:{auto:"Die Automatiksteuerung ist aktiv und kein Handler übersteuert — die Abdeckung folgt dem Ergebnis der Pipeline.",manual:"Eine manuelle Übersteuerung ist aktiv — die Abdeckung bleibt dort, wo Sie sie eingestellt haben, und die Automatik pausiert.",manual_until:"Eine manuelle Übersteuerung ist bis {time} aktiv — bis dahin bleibt die Abdeckung dort, wo Sie sie eingestellt haben.",force:"Eine erzwungene Position übersteuert alle anderen Handler.",weather:"Die Wettersicherheit steuert die Position.",glare_zone:"Die Sonne steht in einer konfigurierten Blendungszone, und der Blendungs-Handler steuert die Position.",climate:"Die Klimasteuerung steuert die Position.",cloud:"Bewölkung unterdrückt die Sonnenverfolgung.",custom_position:"Ein benutzerdefinierter Positions-Slot steuert diese Abdeckung.",custom_position_slot:"Slot: {name}.",custom_position_value:"Seine Position beträgt {pct} %.",custom_position_floor:"Er wirkt als Mindestposition: Er hebt die Position über den Rohwert der Berechnung an, statt ihn zu ersetzen.",solar:"Sonnenverfolgung — die Position folgt der Sonne über das Fenster.",motion:"Der Raum gilt als nicht belegt, daher hält der Anwesenheits-Handler die Position.",off:"Die Integration ist für diese Abdeckung deaktiviert — es wird nichts gesteuert.",off_schedule:"Außerhalb des konfigurierten Zeitfensters, daher pausiert die Automatiksteuerung.",group:"Die Abdeckungsgruppe bestimmt derzeit diese Position.",safety:"Eine Sicherheitsposition übersteuert alle anderen Handler."}},group:{title:"Abdeckungsgruppe",scene:"Szene",scene_auto:"Auto",scene_all_open:"Alle öffnen",scene_all_closed:"Alle schließen",scene_privacy:"Sichtschutz",state_open:"Offen",state_closed:"Geschlossen",state_mixed:"Gemischt",state_unknown:"Unbekannt",lock:"Gruppe sperren",unlock:"Gruppe entsperren",automation:"Automatisierung",automation_count:"{count} von {total} Mitgliedern automatisiert",clear_overrides:"Übersteuerungen löschen",clear_overrides_none:"Keine Mitglieder-Übersteuerungen zum Löschen",who_won:"{count} von {total} Mitgliedern sind gruppengesteuert — eine Gruppenszene oder die Gruppensperre bestimmt derzeit ihre Position",members:"Mitglieder",member_placeholder:"Keine Mitglieder von der Integration gemeldet.",position:"Position",open:"Gruppe öffnen",close:"Gruppe schließen",stop:"Gruppe stoppen",position_slider_label:"Gruppenposition",range:"{min}–{max} %",exception_held:"{count} gehalten",exception_unavailable:"{count} nicht verfügbar",drag_to_set_all:"Ziehen, um alle {count} Behänge zu setzen",spread_value:"{min} % bis {max} % über {count} Behänge"},forecast:{event:{sunrise:"Sonnenaufgang",sunset:"Sonnenuntergang",fov_enter:"Sonne tritt in den Sonnenakzeptanzwinkel des Fensters ein",fov_exit:"Sonne verlässt den Sonnenakzeptanzwinkel des Fensters"},hover_hint:"Kurve überfahren für Uhrzeit und prognostizierte Position; farbige Linie überfahren für das markierte Ereignis.",solar_only_note:"Nur Sonnengeometrie — berücksichtigt keine manuellen Übersteuerungen, benutzerdefinierten Positionen, Wolkenunterdrückung oder Wetter.",legend_forecast:"Prognose",legend_actual:"Ist"},dialog:{battery:"Batterie {level}%",battery_named:"{name}: {level}%",battery_unknown:"Batteriestand unbekannt",extend:{title:"Manuelle Übersteuerung verlängern",presets_label:"Bis",relative_label:"Zeit hinzufügen",absolute_label:"Ende um",preview:"Übersteuerung bis {time}",confirm:"Verlängern",cancel:"Abbrechen",tomorrow_suffix:" (morgen)"},configure_integration:"Integration konfigurieren",open_device_page:"Geräteseite öffnen",close:"Schließen",target:"Ziel",resume_auto:"Automatik fortsetzen",hide_advanced:"▼ Erweitert ausblenden",show_advanced:"▶ Erweitert",custom_positions:"Benutzerdefinierte Positionen",floor_tooltip:"Mindestposition — hebt die Position über den berechneten Wert",floor:"↥",disable_slot:"Slot {slot} deaktivieren",enable_slot:"Slot {slot} aktivieren",on:"An",off:"Aus",controls:"Steuerung",automatic:"Automatisch",climate:"Klima",motion:"Anwesenheit",toggle_hint:"{label} {state} — tippen zum Umschalten",state_on:"an",state_off:"aus",todays_forecast:"Heutige Prognose"},overrides:{title:"Übersteuerungen",manual:"Manuell",force:"Zwang",motion:"Anwesenheit",active:"Aktiv",off:"Aus",ends_in:"endet in {time}",active_count:"{count} aktiv",timeout:"läuft in {time} ab",reset_manual:"Manuell zurücksetzen"},climate:{title:"Klima",active:"Aktiv: {strategy}",indoor:"Innen",outdoor:"Außen",presence:"Anwesenheit",sunny:"Sonnig",lux:"Lux",irradiance:"Einstrahlung",mode_off:"Klimamodus deaktiviert",standby:"Bereitschaft",threshold_low:"niedrig",threshold_high:"hoch",threshold_summer_outside:"Sommer",reason:{outside_time_window:"Außerhalb des Betriebszeitfensters",thresholds_not_met:"Temperaturen im Komfortbereich — keine Maßnahme erforderlich",other_mode_active:"Ein anderer Steuermodus ist derzeit aktiv",readings_unavailable:"Temperaturwerte nicht verfügbar",mode_off:"Klimamodus ist deaktiviert"}},compass:{placeholder_no_entries:"Kein Adaptive Cover Pro-Eintrag ausgewählt.",placeholder_no_sun:"Sonnensensor noch nicht befüllt.",sun_tooltip:"Sonne: {az} az / {el} el",sunrise_tooltip:"Sonnenaufgang: {time}",sunset_tooltip:"Sonnenuntergang: {time}",moon_tooltip:"Mond: {phase} ({pct}%)",sun_path_tooltip:"Sonnenbahn (heute)",in_fov_check:"✓ im SAA",in_fov:"im SAA",in_fov_tooltip:"Sonne befindet sich derzeit im Sonnenakzeptanzwinkel dieses Fensters",none:"—",sun:"Sonne",moon:"Mond",sun_up_not_hitting:"Sonne (aufgegangen, trifft nicht)",sun_below_horizon:"Sonne (unter dem Horizont)",window_fov:"Fenster-SAA",sun_path:"Sonnenbahn",sunrise:"Sonnenaufgang",sunset:"Sonnenuntergang",cover_target:"Beschattungsziel",cover_held:"Beschattungsposition (gehalten)",window_normal:"Fensterazimut",stat_sun:"Sonne: ",stat_azi:"Azi: ",stat_elev:"Elev: ",stat_window:"Fenster: ",active_sun_arc:"Aktiver Sonnenbogen {from} – {to}{elev}",fov_arc:"SAA {left} links / {right} rechts{elev}",window_normal_tooltip:"Fensterazimut: {bearing}",cover_position_target:"Ziel: {pct}%",cover_position_target_awning:"Ziel (ausgefahren): {pct}%",cover_position_actual:"Aktuell: {pct}%",blind_spot:"Blindfleck: {from} – {to}",elev_suffix:" · Elev {min}–{max}"},covers:{placeholder:"Keine Beschattungen von der Integration gemeldet.",title:"Beschattungen",target:"Ziel: {pct}",target_solar:"Sonnenziel: {pct}",click_to_set:"Klicken zum Festlegen der Position",position_slider_label:"Positionsschieberegler",position_open_value:"{pct} offen",opening:"Öffnet…",closing:"Schließt…",target_tooltip:"Ziel {pct}%",target_tooltip_override:"Theoretisches Sonnenziel {pct}% — Beschattung wird durch manuelle Übersteuerung gehalten",target_tooltip_motor:"Motor: {pct}% (vor Kalibrierung)",position_title:"Position",tilt_title:"Neigung",tilt_target:"Neigung: {pct}",tilt_click_to_set:"Klicken zum Festlegen der Neigung",tilt_target_tooltip:"Neigungsziel {pct}%",goto_target:"Auf Ziel fahren ({pct}%) — automatische Steuerung bleibt aktiv"},decision:{placeholder:"Entscheidungsprotokoll noch nicht befüllt.",pipeline:"Pipeline",winner:"Gewinner: {name}",summary_tooltip:"Warum diese Position?",not_evaluated:"nicht ausgewertet",floor_suffix:" Mindestposition",outside_schedule:"Außerhalb des Zeitplans — automatische Steuerung pausiert",outside_schedule_tooltip:"Das konfigurierte Zeitplanfenster ist nicht aktiv, daher ist die automatische Positionierung pausiert.",solar_would_be:"solar {pct}",next_change_in:"Nächste Anpassung erlaubt in {time}"},solar:{title:"Sonnenberechnung",axis_position:"Positionsachse",axis_tilt:"Neigungsachse",group_inputs:"Eingaben",group_intermediates:"Zwischenwerte",group_output:"Ausgabe",show_all:"Alle {count} Werte anzeigen",show_less:"Weniger anzeigen",no_target:"Kein Sonnenziel — {status}",status:{direct_sun:"Direkte Sonne",fov_exit:"Standard · SAA-Austritt",elevation_limit:"Standard · Höhengrenze",sunset_offset:"Standard · Sonnenuntergangs-Versatz",blind_spot:"Standard · Blindfleck",default:"Standard"},field:{sol_elev_deg:"Sonnenhöhe",gamma_deg:"Relativer Azimut (γ)",position_pct:"Position",effective_distance_m:"Effektive Distanz",adjusted_height_m:"Angepasste Höhe",safety_margin:"Sicherheitsabstand",awn_angle_deg:"Markisenwinkel",vertical_position_m:"Vertikale Position",length_m:"Ausfahrlänge",slat_angle_raw_deg:"Lamellenwinkel",tilt_mode:"Neigungsmodus",max_degrees:"Maximaler Winkel"}},header:{on:"ON",off:"OFF",integration_enabled:"Integration aktiviert",auto:"Auto",automatic_control:"Automatische Steuerung"},tile:{motion_pending:"Anwesenheits-Timeout läuft",motion_detected:"Anwesenheit erkannt",battery_low:"Batterie schwach — {level}%",battery_unknown:"Batteriestand unbekannt",icon_action_label:"Aktion des Beschattungssymbols",open:"Öffnen",stop:"Stopp",close:"Schließen",resume_aria:"Automatische Steuerung fortsetzen",extend_aria:"Manuelle Übersteuerung verlängern",registry_failed:"Registry-Abruf fehlgeschlagen: {error}",loading:"Wird geladen…",entry_not_found:"Adaptive Cover Pro-Eintrag {entry} nicht gefunden.",unavailable:"Nicht verfügbar",rails_layered:"{count} Behänge einer Beschattung",rails_separate:"{count} Beschattungen",rails_layered_hint:"Behänge einer Beschattung"},formatters:{expired:"abgelaufen"},elevation:{title:"Sonne heute",fov_window:"SAA: {from} → {to}",fov_windows:"SAA: {windows}",fov_window_named:"{name}: {windows}",no_fov_today:"Sonne tritt heute nicht in den SAA ein",placeholder:"Sonnenhöhen-Diagramm nicht verfügbar.",schedule:"Zeitplan {from} – {to}",schedule_from:"Zeitplan ab {from}",schedule_until:"Zeitplan bis {to}",schedule_start_tooltip:"Zeitplanstart",schedule_end_tooltip:"Zeitplanende"},control_status:{active:"Aktiv",outside_time_window:"Außerhalb des Zeitfensters",position_delta_too_small:"Positionsänderung zu gering",time_delta_too_small:"Zu kurz seit der letzten Bewegung",manual_override:"Manuelle Übersteuerung",automatic_control_off:"Automatische Steuerung aus",sun_not_visible:"Sonne nicht sichtbar",force_override_active:"Zwangsübersteuerung",weather_override_active:"Wettersicherheit",motion_timeout:"Anwesenheits-Timeout"},history:{title:"Verlauf",open:"Verlauf",close:"Schließen",refresh:"Aktualisieren",loading:"Verlauf wird geladen…",no_data:"Keine aufgezeichneten Daten",window_label:"Verlaufszeitraum",window_hours:"{hours} Std.",show_more:"Mehr anzeigen",expand:"Vollansicht öffnen",collapse:"Zurück zum Verlauf",today:"Heute",yesterday:"Gestern",section_tracks:"Zeitverlauf",track_position:"Position",track_who_won:"Gewinner",track_control_status:"Steuerungsstatus",track_enabled:"Integration",track_auto:"Automatische Steuerung",track_sun:"Sonne im SAA",track_glare:"Blendung",track_manual:"Manuelle Übersteuerung",track_mismatch:"Positionsabweichung",legend_target:"Ziel",legend_actual:"Ist",legend_per_cover:"Pro Beschattung",legend_saa:"Sonne im SAA",legend_night:"Nacht",stat_moves:"Bewegungen",stat_travel:"Pkt. zurückgelegt",stat_override:"in manueller Übersteuerung",copy_diagnostics:"Diagnose kopieren",copied:"Kopiert",no_recorder_data:"Nicht aufgezeichnet — Recorder-Einstellungen prüfen",activity_title:"Aktivität",activity_empty:"Keine aufgezeichnete Aktivität in diesem Zeitraum.",advanced:"Erweitert — Ereignispuffer",events_search:"Ereignisse filtern…",events_count:"{shown} von {total} Ereignissen",events_empty:"Keine Ereignisse entsprechen dem Filter.",events_unavailable:"Ereignispuffer nicht verfügbar — die Integration hat keine Diagnose zurückgegeben.",buffer_size:"Puffergröße: {size}",data_window:"Pufferzeitraum: {from} → {to}"},root:{loading_registry:"Adaptive Cover Pro-Registry wird geladen…",no_entities_title:"Keine Adaptive Cover Pro-Entitäten gefunden",footer_version:"adaptive-cover-pro-card v{version}",compass_no_match:"Keine passenden Adaptive Cover Pro-Entitäten",compass_configured:"Konfigurierte Einträge: {entries}",compass_not_found:"Einträge nicht gefunden: {entries}"},editor:{common:{entry_id:"Adaptive Cover Pro-Instanz",support_alt:"Kauf mir einen Kaffee",title_optional:"Titel (optional)",title_placeholder:"z. B. Fenster Westseite",north_offset:"Kompass-Nordversatz (°)",north_offset_hint:'Kompass im Uhrzeigersinn drehen, sodass „oben" Ihrer Karte entspricht. Standard: 0.',loading_entries:"Adaptive Cover Pro-Konfigurationseinträge werden geladen…",load_failed:"Konfigurationseinträge konnten nicht geladen werden: {error}",no_entries:"Keine Adaptive Cover Pro-Konfigurationseinträge gefunden. Fügen Sie eine Instanz unter",no_entries_path:"Einstellungen → Geräte & Dienste",no_entries_then:" hinzu und kehren Sie dann zurück.",entry_id_manual_placeholder:"Konfigurations-Eintrags-ID manuell eingeben",entry_id_fallback_label:"Eintrags-ID",unknown_entry:"(unbekannt: {entry})",reset:"Zurücksetzen"},main:{sections:"Abschnitte",sections_hint:"Sichtbare Bereiche der Karte ein- oder ausblenden.",section_sky_label:"Himmelskompass",section_sky_desc:"Sonne vs. Fenster-SAA, Polardiagramm",section_elevation_label:"Sonne heute",section_elevation_desc:"Höhen-Zeit-Diagramm mit SAA-Bereich und aktuellem Zeitcursor",section_decision_label:"Entscheidungsleiste",section_decision_desc:"Alle 10 Pipeline-Handler mit hervorgehobener Gewinnerzeile",section_covers_label:"Beschattungspositionen",section_covers_desc:"Aktuelle und Zielposition je Beschattung; klicken zum Festlegen der Position",section_overrides_label:"Übersteuerungsbereich",section_overrides_desc:"Kacheln für Manuell, Zwang, Anwesenheit + Zurücksetzen-Schaltfläche",section_climate_label:"Klimabereich",section_climate_desc:"Sommer-/Winter-/Übergangsstrategie; zeigt Bereitschaft, wenn Klimamodus deaktiviert oder inaktiv ist",section_solar_label:"Sonnenberechnung",section_solar_desc:"Aufschlüsselung der Sonnengeometrie (Eingaben → Zwischenwerte → Ausgabe); erfordert den solar_calculation-Sensor der Integration",controls:"Steuerung",controls_hint:"Als schreibgeschützt anzeigen (sichtbar, aber nicht klickbar).",integration_pill_label:"Integration EIN/AUS-Schalter",integration_pill_desc:"Integration über den Karten-Header umschalten.",automatic_pill_label:"Automatische Steuerung-Schalter",automatic_pill_desc:"Automatische Steuerung über den Karten-Header umschalten.",reset_button_label:'Schaltfläche „Manuelle Übersteuerung zurücksetzen"',reset_button_desc:"Zurücksetzen-Kachel im Übersteuerungsbereich betätigen lassen.",display:"Anzeige",compact_label:"Kompaktmodus",compact_desc:"Engerer Abstand zwischen Abschnitten.",show_compass_stats_label:"Kompassstatistiken anzeigen",show_compass_stats_desc:"Azi, Elev, ∠ und Fensterwinkel unterhalb des Himmelskompasses.",show_compass_legend_label:"Kompasslegende anzeigen",show_compass_legend_desc:"Farbschlüssel unterhalb des Himmelskompasses.",show_moon_label:"Mond auf Kompass anzeigen",show_moon_desc:"Mondposition und Mondphase als Überlagerung auf dem Himmelskompass.",hide_inactive_label:"Inaktive Handler ausblenden",hide_inactive_desc:"Nur den Gewinner und aktiv übereinstimmende Pipeline-Handler anzeigen.",state_color_label:"Symbol nach Status einfärben",state_color_desc:"Kopfzeilen-Symbol nimmt die Offen/Geschlossen/Aktiv-Farbe des Themes an."},tile:{name:"Titel überschreiben",icon:"Symbol überschreiben",cover:"Beschattungsentität",layout:"Layout",show_position:"Position % anzeigen",show_state:"Status anzeigen (Offen/Geschlossen)",show_decision_summary:"Entscheidungszusammenfassung anzeigen",show_controls:"Steuerung ↑ ■ ↓ anzeigen",covers:"Positionsleisten (Reihenfolge)",covers_hint:"Ziehen Sie eine Zeile oder verwenden Sie die Pfeile, um die Reihenfolge der Positionsleisten festzulegen. Das Auge blendet eine Leiste aus, ohne den Behang zu entfernen.",member_names:"Mitgliedsnamen",member_names_hint:"Benennen Sie ein Gruppenmitglied nur für diese Karte um. Leer lassen, um den Namen des Eintrags zu verwenden.",covers_move_up:"Nach oben",covers_move_down:"Nach unten",covers_hide:"Diese Leiste ausblenden",covers_show:"Diese Leiste anzeigen",controls_cover:"Von ↑ ■ ↓ gesteuerter Behang",controls_axis:"Von ↑ ■ ↓ gesteuerte Achse",show_badge:"Kontextbadge anzeigen",show_position_bar:"Positionsleiste anzeigen",show_tilt:"Neigungsleiste anzeigen",content_section:"Inhalt",controls_section:"Bedienelemente",dialog_section:"Dialogbereiche",group_row_section:"Gruppensteuerung",show_scene_select:"Szenenauswahl anzeigen",show_lock:"Gruppensperre anzeigen",show_automation:"Umschalter für Mitglieder-Automatisierung anzeigen",show_clear_overrides:"Schaltfläche „Übersteuerungen löschen“ anzeigen",show_member_badges:"Mitglieder-Übersteuerungs-Badges anzeigen",badge_section:"Badges",badge_auto:"Auto",badge_solar:"Sonnenverfolgung",badge_force:"Zwangsübersteuerung",badge_weather:"Wettersicherheit",badge_manual:"Manuelle Übersteuerung",badge_custom_position:"Benutzerdefinierte Position",badge_motion:"Anwesenheit",badge_climate:"Klima",badge_glare_zone:"Blendungszone",badge_cloud:"Wolkenunterdrückung",show_compass:"Sonnenkompass im Dialog anzeigen",show_elevation_chart:"Sonne-heute-Diagramm im Dialog anzeigen",show_solar_calc:"Sonnenberechnung im Dialog anzeigen",show_motion_icon:"Anwesenheitsanzeige einblenden",state_color:"Symbol nach Status einfärben",interactions_section:"Interaktionen",tap_action:"Tipp-Aktion",icon_tap_action:"Tipp-Aktion für Symbol",hold_action:"Gedrückthalten-Aktion",double_tap_action:"Doppeltippen-Aktion",cover_blank_hint:"Leer lassen, um automatisch die erste verwaltete Beschattung zu verwenden.",name_composed_hint:"In YAML ist ein zusammengesetzter Titel festgelegt. Hier einen neuen Titel eingeben, um ihn durch einfachen Text zu ersetzen.",layout_option_one_line:"Eine Zeile (kompakt)",layout_option_detailed:"Detailliert (Titel, Status, Indikatoren)"},compass:{instances:"Adaptive Cover Pro-Instanzen",instances_hint:"Eine oder mehrere auswählen. Jeder gewählte Eintrag fügt dem Kompass eine Überlagerung hinzu.",cover_colors:"Beschattungsfarben",cover_colors_hint:"Standardpalettenfarbe für jede Überlagerung überschreiben.",default_color:"Standard",display:"Anzeige",toggle_compact_label:"Kompaktmodus",toggle_compact_desc:"Kleineres SVG, Legende ausgeblendet.",toggle_legend_label:"Legende",toggle_legend_desc:"Farbmuster und Eintragsbezeichnungen unterhalb des Kompasses.",toggle_stats_label:"Statistiken",toggle_stats_desc:"Sonne + numerische Zeilen je Fenster.",toggle_moon_label:"Mond",toggle_moon_desc:"Mondposition und Mondphase anzeigen.",toggle_cardinals_label:"Himmelsrichtungen",toggle_cardinals_desc:"N/O/S/W-Buchstaben rund um den Kompass.",toggle_blind_spot_label:"Blindflecke",toggle_blind_spot_desc:"Schraffierte Sektoren für den Blindfleckbereich jedes Fensters.",toggle_sun_path_label:"Sonnenbahn",toggle_sun_path_desc:"Heutiger Sonnenbogen am Himmel.",toggle_sunrise_sunset_label:"Sonnenaufgangs-/Untergangsmarkierungen",toggle_sunrise_sunset_desc:"Kleine Punkte bei Aufgangs- und Untergangsazimut.",toggle_cover_fill_label:"Schlussfüllbereich der Beschattung",toggle_cover_fill_desc:"Innerer Sektor, der zeigt, wie weit jede Beschattung geschlossen ist.",toggle_window_arrow_label:"Fenster-Normalenpfeil",toggle_window_arrow_desc:"Linie vom Mittelpunkt zum Azimut jedes Fensters.",toggle_elevation_chart_label:"Sonne-heute-Diagramm",toggle_elevation_chart_desc:"Höhen-Zeit-Diagramm unterhalb des Kompasses, mit SAA-Bereich und Höhengrenzen."},decision:{title:"Titel (optional)",compact_label:"Kompaktmodus",compact_desc:"Engere Zeilen; blendet inaktive Handler ebenfalls aus.",hide_inactive_handlers_label:"Inaktive Handler ausblenden",hide_inactive_handlers_desc:"Nur den Gewinner und aktiv übereinstimmende Pipeline-Handler anzeigen.",show_decision_summary_label:"Entscheidungszusammenfassung anzeigen",show_decision_summary_desc:'Einen verständlichen Satz „Warum diese Position?" oberhalb der Leiste anzeigen.'},solar_chart:{instances:"Adaptive Cover Pro-Instanzen",instances_hint:"Eine oder mehrere auswählen. Jeder gewählte Eintrag fügt dem Diagramm eine SAA-Überlagerung hinzu.",cover_colors:"Beschattungsfarben",cover_colors_hint:"Standardpalettenfarbe für jede Überlagerung überschreiben.",default_color:"Standard",display:"Anzeige",toggle_compact_label:"Kompaktmodus",toggle_compact_desc:"Kleineres Diagramm, engerer Abstand."},history:{title:"Titel (optional)",hours_label:"Verlaufszeitraum",hours_desc:"Wie weit die Spuren zurückreichen, gerechnet ab jetzt.",track_position_label:"Positionsspur",track_position_desc:"Aufgezeichnete Beschattungsposition im Zeitraum.",track_who_won_label:"Gewinner-Spur",track_who_won_desc:"Bänder des jeweils gewinnenden Pipeline-Handlers im Zeitverlauf.",track_context_label:"Kontextspuren",track_context_desc:"Zeiträume für Sonne-im-SAA, Blendung und manuelle Übersteuerung.",track_actions_label:"Aktionsliste",track_actions_desc:"Aufgezeichnete und übersprungene Beschattungsaktionen, neueste zuerst.",advanced_open_label:"Erweitert beim Start öffnen",advanced_open_desc:"Den Ereignispuffer-Abschnitt beim Laden ausklappen.",hide_advanced_label:"Erweitert-Abschnitt ausblenden",hide_advanced_desc:"Den Diagnose-Ereignispuffer auf dieser Karte nie anzeigen."}}}};function ot(e,t){const o=t.split(".");let i=e;for(const e of o){if("object"!=typeof i||null===i)return;i=i[e]}return"string"==typeof i?i:void 0}function it(e,t){return t?e.replace(/\{(\w+)\}/g,(e,o)=>Object.prototype.hasOwnProperty.call(t,o)?String(t[o]):e):e}function st(e,t,o){const i=function(e){const t=(e?.locale?.language??e?.language??"en").toLowerCase().split("-")[0];return t in tt?t:"en"}(t),s=ot(tt[i],e);if(void 0!==s)return it(s,o);if("en"!==i){const t=ot(tt.en,e);if(void 0!==t)return it(t,o)}return e}function nt(e){return null==e||Number.isNaN(e)?"—":`${Math.round(e)}%`}function rt(e){return!e||"unavailable"===e||"unknown"===e}function at(e){return!e||"unavailable"===e}function lt(e,t,o){if(!e||!t)return null;const i=e.states[t];if(!i||at(i.state))return null;const s=o?{...i,state:o}:i;if("function"==typeof e.formatEntityState){const t=e.formatEntityState(s);if(t)return t}if("function"==typeof e.localize){const t=e.localize(`component.cover.entity_component._.state.${s.state}`);if(t)return t}return s.state.charAt(0).toUpperCase()+s.state.slice(1)}function ct(e){return null==e||Number.isNaN(e)?"—":`${e.toFixed(1)}°`}function dt(e,t){if(!e)return"—";const o=new Date(e);return Number.isNaN(o.getTime())?"—":o.toLocaleTimeString([],{hour:"2-digit",minute:"2-digit",timeZone:t})}function ht(e,t){if(!e)return"—";const o=new Date(e).getTime();if(Number.isNaN(o))return"—";const i=Math.round((o-Date.now())/1e3);return i<=0?t?st("formatters.expired",t):"expired":function(e){if(null==e||Number.isNaN(e))return"—";const t=Math.max(0,Math.round(e));if(t<60)return`${t}s`;const o=Math.floor(t/60);return o<60?`${o}m ${t%60}s`:`${Math.floor(o/60)}h ${o%60}m`}(i)}function pt(e,t){if(null!==t&&!Number.isNaN(t)){if(t>=95)return e.open;if(t<=5)return e.closed}return e.partial}function ut(e){const{explicitIcon:t,deviceClass:o,coverType:i,position:s}=e;if("string"==typeof t&&t.length>0)return t;if(o){const e=Fe[o];if(e)return pt(e,s)}return function(e,t){return pt({open:De[e]??"mdi:window-shutter-open",partial:Ne[e]??"mdi:window-shutter",closed:Be[e]??"mdi:window-shutter"},t)}(i,s)}function _t(e){return e&&Re.has(e)?"mdi:arrow-expand-horizontal":"mdi:arrow-up"}function gt(e){return e&&Re.has(e)?"mdi:arrow-collapse-horizontal":"mdi:arrow-down"}const mt="var(--state-cover-active-color, var(--state-cover-color, var(--state-active-color, var(--primary-color))))";function vt(e){if(at(e)||!e)return"var(--state-unavailable-color)";const t=e.toLowerCase(),o="closed"!==t&&"unknown"!==t?"active":"inactive";return`var(--state-cover-${t}-color, var(--state-cover-${o}-color, var(--state-cover-color, var(--state-${o}-color))))`}function ft(e,t){return t.openBlocksSun?e:t.min+t.max-e}const bt=100,yt="%",wt=new Set(["cover_awning","cover_oscillating_awning"]);function xt(e,t){return"position"===t&&wt.has(e.cover_type)}function $t(e){return e.charAt(0).toUpperCase()+e.slice(1)}function kt(e){const t=e.discovery?.axes;if(Array.isArray(t))return t.filter(e=>!!e&&"string"==typeof e.id&&!1!==e.supported).map(t=>({id:t.id,label:t.label??$t(t.id),min:"number"==typeof t.min?t.min:0,max:"number"==typeof t.max?t.max:bt,unit:"string"==typeof t.unit?t.unit:yt,stateAttr:"string"==typeof t.state_attr?t.state_attr:void 0,targetRole:Ue[t.id],inverted:!0===t.inverted,openBlocksSun:"boolean"==typeof t.open_blocks_sun?t.open_blocks_sun:xt(e,t.id)}));const o=[{id:"position",label:$t("position"),min:0,max:bt,unit:yt,stateAttr:"current_position",targetRole:"target_position_sensor",inverted:!1,openBlocksSun:xt(e,"position")}];return e.entities.target_tilt_sensor&&o.push({id:"tilt",label:$t("tilt"),min:0,max:bt,unit:yt,stateAttr:"current_tilt_position",targetRole:"target_tilt_sensor",inverted:!1,openBlocksSun:!1}),o}function At(e){return kt(e).find(e=>"position"===e.id)??{id:"position",label:"Position",min:0,max:bt,unit:yt,stateAttr:"current_position",targetRole:"target_position_sensor",inverted:!1,openBlocksSun:xt(e,"position")}}function St(e){return kt(e).find(e=>"position"===e.id)?.inverted??!1}const Ct=[12,16];function Et(e,t,o=0){const i=(e-90+o)*Math.PI/180;return{x:t*Math.cos(i),y:t*Math.sin(i)}}function zt(e){return 1-Math.max(0,Math.min(90,e))/90}function Mt(e,t,o,i=0,s=0){const n=e=>(e%360+360)%360,r=n(e),a=n(t);let l=a-r;l<0&&(l+=360);const c=l>180?1:0,d=Et(r,o,s),h=Et(a,o,s);if(i<=0)return`M 0 0 L ${d.x} ${d.y} A ${o} ${o} 0 ${c} 1 ${h.x} ${h.y} Z`;const p=Et(a,i,s),u=Et(r,i,s);return[`M ${d.x} ${d.y}`,`A ${o} ${o} 0 ${c} 1 ${h.x} ${h.y}`,`L ${p.x} ${p.y}`,`A ${i} ${i} 0 ${c} 0 ${u.x} ${u.y}`,"Z"].join(" ")}function Tt(e,t,o=0){return Et(e,zt(t),o)}function It(e){return(e%360+360)%360}function Pt(e,t,o,i){const s=i??0;let n=-1,r=-1;for(let i=t;i<=o&&i<e.length;i++)e[i].elevation>s&&(-1===n&&(n=i),r=i);return-1===n?null:{wedgeStart:e[n].azimuth,wedgeEnd:e[r].azimuth}}function Ot(e,t,o){const i=(e-t)/864e5;return Math.max(0,Math.min(o,i*o))}function Nt(e,t,o){return t+(1-(Number.isNaN(e)?0:Math.max(0,Math.min(100,e)))/100)*o}function Dt(e,t,o){return((e-t)%360+360)%360<=((o-t)%360+360)%360}function Bt(e,t,o,i){return Dt(o,e,t)||Dt(i,e,t)||Dt(e,o,i)||Dt(t,o,i)}function Ft(e){const t=Object.values(e).filter(e=>"number"==typeof e);return 0===t.length?null:t.reduce((e,t)=>e+t,0)/t.length}function Rt(e,t,o,i){const s=t?e/100:1-e/100;return Math.min(o*s,i)}function jt(e,t,o){return e&&null!=t&&Number.isFinite(t)?t===o?null:t:null}function Lt(e,t){return e<.5?-4*t*e:4*t*(1-e)}function Kt(e,t,o,i,s){const n=Et(o,1),r=-n.y,a=n.x,l=e-n.x*i,c=t-n.y*i;return`M ${e} ${t} L ${l+r*s} ${c+a*s} L ${l-r*s} ${c-a*s} Z`}function Gt(e,t){const o=t.entities.target_position_sensor;if(!o)return null;const i=parseFloat(e.states[o]?.state??"");return Number.isNaN(i)?null:i}function Wt(e,t){const o=t.entities.target_position_sensor;if(!o)return null;const i=e.states[o]?.attributes,s=i?.linear_position;return"number"==typeof s&&Number.isFinite(s)?s:null}function Ht(e,t){return Wt(e,t)??Gt(e,t)}function Ut(e,t){const o=t.entities.target_position_sensor;if(!o)return null;const i=e.states[o]?.attributes,s=i?.raw_calculated_position;return"number"==typeof s&&Number.isFinite(s)?s:null}function qt(e,t){const o=t.entities.target_position_sensor;if(!o)return{};const i=e.states[o]?.attributes,s=i?.linear_actual_positions;if(s&&"object"==typeof s)return s;const n=i?.actual_positions;return n?St(t)?Object.fromEntries(Object.entries(n).map(([e,t])=>[e,"number"==typeof t?100-t:null])):n:{}}function Vt(e,t,o){if(!o)return null;const i=e.states[o]?.attributes?.current_position;return"number"!=typeof i||Number.isNaN(i)?null:St(t)?100-i:i}function Yt(e,t,o){if(!o||!t.stateAttr)return null;const i=e.states[o]?.attributes?.[t.stateAttr];return"number"!=typeof i||Number.isNaN(i)?null:t.inverted?100-i:i}function Zt(e,t){return Ft(qt(e,t))}function Qt(e,t){const o=t.entities.manual_override_binary;return!!o&&"on"===e.states[o]?.state}function Xt(e,t){const o=Ht(e,t);return jt(Qt(e,t),Ut(e,t),o)??o}const{I:Jt}=ae,eo=e=>e,to=()=>document.createComment(""),oo=(e,t,o)=>{const i=e._$AA.parentNode,s=void 0===t?e._$AB:t._$AA;if(void 0===o){const t=i.insertBefore(to(),s),n=i.insertBefore(to(),s);o=new Jt(t,n,e,e.options)}else{const t=o._$AB.nextSibling,n=o._$AM,r=n!==e;if(r){let t;o._$AQ?.(e),o._$AM=e,void 0!==o._$AP&&(t=e._$AU)!==n._$AU&&o._$AP(t)}if(t!==s||r){let e=o._$AA;for(;e!==t;){const t=eo(e).nextSibling;eo(i).insertBefore(e,s),e=t}}}return o},io=(e,t,o=e)=>(e._$AI(t,o),e),so={},no=(e,t=so)=>e._$AH=t,ro=e=>{e._$AR(),e._$AA.remove()},ao=e=>(...t)=>({_$litDirective$:e,values:t});class lo{constructor(e){}get _$AU(){return this._$AM._$AU}_$AT(e,t,o){this._$Ct=e,this._$AM=t,this._$Ci=o}_$AS(e,t){return this.update(e,t)}update(e,t){return this.render(...t)}}const co=(e,t)=>{const o=e._$AN;if(void 0===o)return!1;for(const e of o)e._$AO?.(t,!1),co(e,t);return!0},ho=e=>{let t,o;do{if(void 0===(t=e._$AM))break;o=t._$AN,o.delete(e),e=t}while(0===o?.size)},po=e=>{for(let t;t=e._$AM;e=t){let o=t._$AN;if(void 0===o)t._$AN=o=new Set;else if(o.has(e))break;o.add(e),go(t)}};function uo(e){void 0!==this._$AN?(ho(this),this._$AM=e,po(this)):this._$AM=e}function _o(e,t=!1,o=0){const i=this._$AH,s=this._$AN;if(void 0!==s&&0!==s.size)if(t)if(Array.isArray(i))for(let e=o;e<i.length;e++)co(i[e],!1),ho(i[e]);else null!=i&&(co(i,!1),ho(i));else co(this,e)}const go=e=>{2==e.type&&(e._$AP??=_o,e._$AQ??=uo)};class mo extends lo{constructor(){super(...arguments),this._$AN=void 0}_$AT(e,t,o){super._$AT(e,t,o),po(this),this.isConnected=e._$AU}_$AO(e,t=!0){e!==this.isConnected&&(this.isConnected=e,e?this.reconnected?.():this.disconnected?.()),t&&(co(this,e),ho(this))}setValue(e){if((()=>void 0===this._$Ct.strings)())this._$Ct._$AI(e,this);else{const t=[...this._$Ct._$AH];t[this._$Ci]=e,this._$Ct._$AI(t,this,0)}}disconnected(){}reconnected(){}}let vo=class extends de{constructor(){super(...arguments),this.text="",this.cursorX=0,this.cursorY=0,this.offset=Ct,this.visible=!1,this._x=0,this._y=0}connectedCallback(){super.connectedCallback(),this.hasAttribute("role")||this.setAttribute("role","tooltip")}updated(){if(!this.visible)return;this.setAttribute("aria-hidden","false");const e=this.shadowRoot?.querySelector(".bubble"),t=e?.offsetWidth??0,o=e?.offsetHeight??0,i="undefined"!=typeof window?window.innerWidth:0,s="undefined"!=typeof window?window.innerHeight:0,{x:n,y:r}=function(e){const{cursorX:t,cursorY:o,ttW:i,ttH:s,vpW:n,vpH:r}=e,[a,l]=e.offset??Ct;let c=t+a,d=!1;c+i>n&&(c=t-a-i,d=!0),c<0&&(c=0);let h=o+l;return h+s>r&&(h=o-l-s),h<0&&(h=0),{x:c,y:h,flipped:d}}({cursorX:this.cursorX,cursorY:this.cursorY,ttW:t,ttH:o,vpW:i,vpH:s,offset:this.offset});n!==this._x&&(this._x=n),r!==this._y&&(this._y=r)}render(){return this.visible?H`<div class="bubble" style="transform: translate3d(${this._x}px, ${this._y}px, 0)">
+function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPropertyDescriptor(t,o):i;if("object"==typeof Reflect&&"function"==typeof Reflect.decorate)r=Reflect.decorate(e,t,o,i);else for(var a=e.length-1;a>=0;a--)(s=e[a])&&(r=(n<3?s(r):n>3?s(t,o,r):s(t,o))||r);return n>3&&r&&Object.defineProperty(t,o,r),r}"function"==typeof SuppressedError&&SuppressedError;const t=globalThis,o=t.ShadowRoot&&(void 0===t.ShadyCSS||t.ShadyCSS.nativeShadow)&&"adoptedStyleSheets"in Document.prototype&&"replace"in CSSStyleSheet.prototype,i=Symbol(),s=new WeakMap;let n=class{constructor(e,t,o){if(this._$cssResult$=!0,o!==i)throw Error("CSSResult is not constructable. Use `unsafeCSS` or `css` instead.");this.cssText=e,this.t=t}get styleSheet(){let e=this.o;const t=this.t;if(o&&void 0===e){const o=void 0!==t&&1===t.length;o&&(e=s.get(t)),void 0===e&&((this.o=e=new CSSStyleSheet).replaceSync(this.cssText),o&&s.set(t,e))}return e}toString(){return this.cssText}};const r=e=>new n("string"==typeof e?e:e+"",void 0,i),a=(e,...t)=>{const o=1===e.length?e[0]:t.reduce((t,o,i)=>t+(e=>{if(!0===e._$cssResult$)return e.cssText;if("number"==typeof e)return e;throw Error("Value passed to 'css' function must be a 'css' function result: "+e+". Use 'unsafeCSS' to pass non-literal values, but take care to ensure page security.")})(o)+e[i+1],e[0]);return new n(o,e,i)},l=o?e=>e:e=>e instanceof CSSStyleSheet?(e=>{let t="";for(const o of e.cssRules)t+=o.cssText;return r(t)})(e):e,{is:c,defineProperty:d,getOwnPropertyDescriptor:h,getOwnPropertyNames:p,getOwnPropertySymbols:u,getPrototypeOf:_}=Object,g=globalThis,m=g.trustedTypes,v=m?m.emptyScript:"",f=g.reactiveElementPolyfillSupport,b=(e,t)=>e,y={toAttribute(e,t){switch(t){case Boolean:e=e?v:null;break;case Object:case Array:e=null==e?e:JSON.stringify(e)}return e},fromAttribute(e,t){let o=e;switch(t){case Boolean:o=null!==e;break;case Number:o=null===e?null:Number(e);break;case Object:case Array:try{o=JSON.parse(e)}catch(e){o=null}}return o}},w=(e,t)=>!c(e,t),x={attribute:!0,type:String,converter:y,reflect:!1,useDefault:!1,hasChanged:w};Symbol.metadata??=Symbol("metadata"),g.litPropertyMetadata??=new WeakMap;let $=class extends HTMLElement{static addInitializer(e){this._$Ei(),(this.l??=[]).push(e)}static get observedAttributes(){return this.finalize(),this._$Eh&&[...this._$Eh.keys()]}static createProperty(e,t=x){if(t.state&&(t.attribute=!1),this._$Ei(),this.prototype.hasOwnProperty(e)&&((t=Object.create(t)).wrapped=!0),this.elementProperties.set(e,t),!t.noAccessor){const o=Symbol(),i=this.getPropertyDescriptor(e,o,t);void 0!==i&&d(this.prototype,e,i)}}static getPropertyDescriptor(e,t,o){const{get:i,set:s}=h(this.prototype,e)??{get(){return this[t]},set(e){this[t]=e}};return{get:i,set(t){const n=i?.call(this);s?.call(this,t),this.requestUpdate(e,n,o)},configurable:!0,enumerable:!0}}static getPropertyOptions(e){return this.elementProperties.get(e)??x}static _$Ei(){if(this.hasOwnProperty(b("elementProperties")))return;const e=_(this);e.finalize(),void 0!==e.l&&(this.l=[...e.l]),this.elementProperties=new Map(e.elementProperties)}static finalize(){if(this.hasOwnProperty(b("finalized")))return;if(this.finalized=!0,this._$Ei(),this.hasOwnProperty(b("properties"))){const e=this.properties,t=[...p(e),...u(e)];for(const o of t)this.createProperty(o,e[o])}const e=this[Symbol.metadata];if(null!==e){const t=litPropertyMetadata.get(e);if(void 0!==t)for(const[e,o]of t)this.elementProperties.set(e,o)}this._$Eh=new Map;for(const[e,t]of this.elementProperties){const o=this._$Eu(e,t);void 0!==o&&this._$Eh.set(o,e)}this.elementStyles=this.finalizeStyles(this.styles)}static finalizeStyles(e){const t=[];if(Array.isArray(e)){const o=new Set(e.flat(1/0).reverse());for(const e of o)t.unshift(l(e))}else void 0!==e&&t.push(l(e));return t}static _$Eu(e,t){const o=t.attribute;return!1===o?void 0:"string"==typeof o?o:"string"==typeof e?e.toLowerCase():void 0}constructor(){super(),this._$Ep=void 0,this.isUpdatePending=!1,this.hasUpdated=!1,this._$Em=null,this._$Ev()}_$Ev(){this._$ES=new Promise(e=>this.enableUpdating=e),this._$AL=new Map,this._$E_(),this.requestUpdate(),this.constructor.l?.forEach(e=>e(this))}addController(e){(this._$EO??=new Set).add(e),void 0!==this.renderRoot&&this.isConnected&&e.hostConnected?.()}removeController(e){this._$EO?.delete(e)}_$E_(){const e=new Map,t=this.constructor.elementProperties;for(const o of t.keys())this.hasOwnProperty(o)&&(e.set(o,this[o]),delete this[o]);e.size>0&&(this._$Ep=e)}createRenderRoot(){const e=this.shadowRoot??this.attachShadow(this.constructor.shadowRootOptions);return((e,i)=>{if(o)e.adoptedStyleSheets=i.map(e=>e instanceof CSSStyleSheet?e:e.styleSheet);else for(const o of i){const i=document.createElement("style"),s=t.litNonce;void 0!==s&&i.setAttribute("nonce",s),i.textContent=o.cssText,e.appendChild(i)}})(e,this.constructor.elementStyles),e}connectedCallback(){this.renderRoot??=this.createRenderRoot(),this.enableUpdating(!0),this._$EO?.forEach(e=>e.hostConnected?.())}enableUpdating(e){}disconnectedCallback(){this._$EO?.forEach(e=>e.hostDisconnected?.())}attributeChangedCallback(e,t,o){this._$AK(e,o)}_$ET(e,t){const o=this.constructor.elementProperties.get(e),i=this.constructor._$Eu(e,o);if(void 0!==i&&!0===o.reflect){const s=(void 0!==o.converter?.toAttribute?o.converter:y).toAttribute(t,o.type);this._$Em=e,null==s?this.removeAttribute(i):this.setAttribute(i,s),this._$Em=null}}_$AK(e,t){const o=this.constructor,i=o._$Eh.get(e);if(void 0!==i&&this._$Em!==i){const e=o.getPropertyOptions(i),s="function"==typeof e.converter?{fromAttribute:e.converter}:void 0!==e.converter?.fromAttribute?e.converter:y;this._$Em=i;const n=s.fromAttribute(t,e.type);this[i]=n??this._$Ej?.get(i)??n,this._$Em=null}}requestUpdate(e,t,o,i=!1,s){if(void 0!==e){const n=this.constructor;if(!1===i&&(s=this[e]),o??=n.getPropertyOptions(e),!((o.hasChanged??w)(s,t)||o.useDefault&&o.reflect&&s===this._$Ej?.get(e)&&!this.hasAttribute(n._$Eu(e,o))))return;this.C(e,t,o)}!1===this.isUpdatePending&&(this._$ES=this._$EP())}C(e,t,{useDefault:o,reflect:i,wrapped:s},n){o&&!(this._$Ej??=new Map).has(e)&&(this._$Ej.set(e,n??t??this[e]),!0!==s||void 0!==n)||(this._$AL.has(e)||(this.hasUpdated||o||(t=void 0),this._$AL.set(e,t)),!0===i&&this._$Em!==e&&(this._$Eq??=new Set).add(e))}async _$EP(){this.isUpdatePending=!0;try{await this._$ES}catch(e){Promise.reject(e)}const e=this.scheduleUpdate();return null!=e&&await e,!this.isUpdatePending}scheduleUpdate(){return this.performUpdate()}performUpdate(){if(!this.isUpdatePending)return;if(!this.hasUpdated){if(this.renderRoot??=this.createRenderRoot(),this._$Ep){for(const[e,t]of this._$Ep)this[e]=t;this._$Ep=void 0}const e=this.constructor.elementProperties;if(e.size>0)for(const[t,o]of e){const{wrapped:e}=o,i=this[t];!0!==e||this._$AL.has(t)||void 0===i||this.C(t,void 0,o,i)}}let e=!1;const t=this._$AL;try{e=this.shouldUpdate(t),e?(this.willUpdate(t),this._$EO?.forEach(e=>e.hostUpdate?.()),this.update(t)):this._$EM()}catch(t){throw e=!1,this._$EM(),t}e&&this._$AE(t)}willUpdate(e){}_$AE(e){this._$EO?.forEach(e=>e.hostUpdated?.()),this.hasUpdated||(this.hasUpdated=!0,this.firstUpdated(e)),this.updated(e)}_$EM(){this._$AL=new Map,this.isUpdatePending=!1}get updateComplete(){return this.getUpdateComplete()}getUpdateComplete(){return this._$ES}shouldUpdate(e){return!0}update(e){this._$Eq&&=this._$Eq.forEach(e=>this._$ET(e,this[e])),this._$EM()}updated(e){}firstUpdated(e){}};$.elementStyles=[],$.shadowRootOptions={mode:"open"},$[b("elementProperties")]=new Map,$[b("finalized")]=new Map,f?.({ReactiveElement:$}),(g.reactiveElementVersions??=[]).push("2.1.2");const k=globalThis,A=e=>e,S=k.trustedTypes,C=S?S.createPolicy("lit-html",{createHTML:e=>e}):void 0,E="$lit$",z=`lit$${Math.random().toFixed(9).slice(2)}$`,M="?"+z,T=`<${M}>`,I=document,P=()=>I.createComment(""),O=e=>null===e||"object"!=typeof e&&"function"!=typeof e,N=Array.isArray,D="[ \t\n\f\r]",F=/<(?:(!--|\/[^a-zA-Z])|(\/?[a-zA-Z][^>\s]*)|(\/?$))/g,B=/-->/g,R=/>/g,j=RegExp(`>|${D}(?:([^\\s"'>=/]+)(${D}*=${D}*(?:[^ \t\n\f\r"'\`<>=]|("|')|))|$)`,"g"),K=/'/g,L=/"/g,G=/^(?:script|style|textarea|title)$/i,W=e=>(t,...o)=>({_$litType$:e,strings:t,values:o}),H=W(1),U=W(2),q=Symbol.for("lit-noChange"),V=Symbol.for("lit-nothing"),Y=new WeakMap,Z=I.createTreeWalker(I,129);function Q(e,t){if(!N(e)||!e.hasOwnProperty("raw"))throw Error("invalid template strings array");return void 0!==C?C.createHTML(t):t}class X{constructor({strings:e,_$litType$:t},o){let i;this.parts=[];let s=0,n=0;const r=e.length-1,a=this.parts,[l,c]=((e,t)=>{const o=e.length-1,i=[];let s,n=2===t?"<svg>":3===t?"<math>":"",r=F;for(let t=0;t<o;t++){const o=e[t];let a,l,c=-1,d=0;for(;d<o.length&&(r.lastIndex=d,l=r.exec(o),null!==l);)d=r.lastIndex,r===F?"!--"===l[1]?r=B:void 0!==l[1]?r=R:void 0!==l[2]?(G.test(l[2])&&(s=RegExp("</"+l[2],"g")),r=j):void 0!==l[3]&&(r=j):r===j?">"===l[0]?(r=s??F,c=-1):void 0===l[1]?c=-2:(c=r.lastIndex-l[2].length,a=l[1],r=void 0===l[3]?j:'"'===l[3]?L:K):r===L||r===K?r=j:r===B||r===R?r=F:(r=j,s=void 0);const h=r===j&&e[t+1].startsWith("/>")?" ":"";n+=r===F?o+T:c>=0?(i.push(a),o.slice(0,c)+E+o.slice(c)+z+h):o+z+(-2===c?t:h)}return[Q(e,n+(e[o]||"<?>")+(2===t?"</svg>":3===t?"</math>":"")),i]})(e,t);if(this.el=X.createElement(l,o),Z.currentNode=this.el.content,2===t||3===t){const e=this.el.content.firstChild;e.replaceWith(...e.childNodes)}for(;null!==(i=Z.nextNode())&&a.length<r;){if(1===i.nodeType){if(i.hasAttributes())for(const e of i.getAttributeNames())if(e.endsWith(E)){const t=c[n++],o=i.getAttribute(e).split(z),r=/([.?@])?(.*)/.exec(t);a.push({type:1,index:s,name:r[2],strings:o,ctor:"."===r[1]?ie:"?"===r[1]?se:"@"===r[1]?ne:oe}),i.removeAttribute(e)}else e.startsWith(z)&&(a.push({type:6,index:s}),i.removeAttribute(e));if(G.test(i.tagName)){const e=i.textContent.split(z),t=e.length-1;if(t>0){i.textContent=S?S.emptyScript:"";for(let o=0;o<t;o++)i.append(e[o],P()),Z.nextNode(),a.push({type:2,index:++s});i.append(e[t],P())}}}else if(8===i.nodeType)if(i.data===M)a.push({type:2,index:s});else{let e=-1;for(;-1!==(e=i.data.indexOf(z,e+1));)a.push({type:7,index:s}),e+=z.length-1}s++}}static createElement(e,t){const o=I.createElement("template");return o.innerHTML=e,o}}function J(e,t,o=e,i){if(t===q)return t;let s=void 0!==i?o._$Co?.[i]:o._$Cl;const n=O(t)?void 0:t._$litDirective$;return s?.constructor!==n&&(s?._$AO?.(!1),void 0===n?s=void 0:(s=new n(e),s._$AT(e,o,i)),void 0!==i?(o._$Co??=[])[i]=s:o._$Cl=s),void 0!==s&&(t=J(e,s._$AS(e,t.values),s,i)),t}class ee{constructor(e,t){this._$AV=[],this._$AN=void 0,this._$AD=e,this._$AM=t}get parentNode(){return this._$AM.parentNode}get _$AU(){return this._$AM._$AU}u(e){const{el:{content:t},parts:o}=this._$AD,i=(e?.creationScope??I).importNode(t,!0);Z.currentNode=i;let s=Z.nextNode(),n=0,r=0,a=o[0];for(;void 0!==a;){if(n===a.index){let t;2===a.type?t=new te(s,s.nextSibling,this,e):1===a.type?t=new a.ctor(s,a.name,a.strings,this,e):6===a.type&&(t=new re(s,this,e)),this._$AV.push(t),a=o[++r]}n!==a?.index&&(s=Z.nextNode(),n++)}return Z.currentNode=I,i}p(e){let t=0;for(const o of this._$AV)void 0!==o&&(void 0!==o.strings?(o._$AI(e,o,t),t+=o.strings.length-2):o._$AI(e[t])),t++}}class te{get _$AU(){return this._$AM?._$AU??this._$Cv}constructor(e,t,o,i){this.type=2,this._$AH=V,this._$AN=void 0,this._$AA=e,this._$AB=t,this._$AM=o,this.options=i,this._$Cv=i?.isConnected??!0}get parentNode(){let e=this._$AA.parentNode;const t=this._$AM;return void 0!==t&&11===e?.nodeType&&(e=t.parentNode),e}get startNode(){return this._$AA}get endNode(){return this._$AB}_$AI(e,t=this){e=J(this,e,t),O(e)?e===V||null==e||""===e?(this._$AH!==V&&this._$AR(),this._$AH=V):e!==this._$AH&&e!==q&&this._(e):void 0!==e._$litType$?this.$(e):void 0!==e.nodeType?this.T(e):(e=>N(e)||"function"==typeof e?.[Symbol.iterator])(e)?this.k(e):this._(e)}O(e){return this._$AA.parentNode.insertBefore(e,this._$AB)}T(e){this._$AH!==e&&(this._$AR(),this._$AH=this.O(e))}_(e){this._$AH!==V&&O(this._$AH)?this._$AA.nextSibling.data=e:this.T(I.createTextNode(e)),this._$AH=e}$(e){const{values:t,_$litType$:o}=e,i="number"==typeof o?this._$AC(e):(void 0===o.el&&(o.el=X.createElement(Q(o.h,o.h[0]),this.options)),o);if(this._$AH?._$AD===i)this._$AH.p(t);else{const e=new ee(i,this),o=e.u(this.options);e.p(t),this.T(o),this._$AH=e}}_$AC(e){let t=Y.get(e.strings);return void 0===t&&Y.set(e.strings,t=new X(e)),t}k(e){N(this._$AH)||(this._$AH=[],this._$AR());const t=this._$AH;let o,i=0;for(const s of e)i===t.length?t.push(o=new te(this.O(P()),this.O(P()),this,this.options)):o=t[i],o._$AI(s),i++;i<t.length&&(this._$AR(o&&o._$AB.nextSibling,i),t.length=i)}_$AR(e=this._$AA.nextSibling,t){for(this._$AP?.(!1,!0,t);e!==this._$AB;){const t=A(e).nextSibling;A(e).remove(),e=t}}setConnected(e){void 0===this._$AM&&(this._$Cv=e,this._$AP?.(e))}}class oe{get tagName(){return this.element.tagName}get _$AU(){return this._$AM._$AU}constructor(e,t,o,i,s){this.type=1,this._$AH=V,this._$AN=void 0,this.element=e,this.name=t,this._$AM=i,this.options=s,o.length>2||""!==o[0]||""!==o[1]?(this._$AH=Array(o.length-1).fill(new String),this.strings=o):this._$AH=V}_$AI(e,t=this,o,i){const s=this.strings;let n=!1;if(void 0===s)e=J(this,e,t,0),n=!O(e)||e!==this._$AH&&e!==q,n&&(this._$AH=e);else{const i=e;let r,a;for(e=s[0],r=0;r<s.length-1;r++)a=J(this,i[o+r],t,r),a===q&&(a=this._$AH[r]),n||=!O(a)||a!==this._$AH[r],a===V?e=V:e!==V&&(e+=(a??"")+s[r+1]),this._$AH[r]=a}n&&!i&&this.j(e)}j(e){e===V?this.element.removeAttribute(this.name):this.element.setAttribute(this.name,e??"")}}class ie extends oe{constructor(){super(...arguments),this.type=3}j(e){this.element[this.name]=e===V?void 0:e}}class se extends oe{constructor(){super(...arguments),this.type=4}j(e){this.element.toggleAttribute(this.name,!!e&&e!==V)}}class ne extends oe{constructor(e,t,o,i,s){super(e,t,o,i,s),this.type=5}_$AI(e,t=this){if((e=J(this,e,t,0)??V)===q)return;const o=this._$AH,i=e===V&&o!==V||e.capture!==o.capture||e.once!==o.once||e.passive!==o.passive,s=e!==V&&(o===V||i);i&&this.element.removeEventListener(this.name,this,o),s&&this.element.addEventListener(this.name,this,e),this._$AH=e}handleEvent(e){"function"==typeof this._$AH?this._$AH.call(this.options?.host??this.element,e):this._$AH.handleEvent(e)}}class re{constructor(e,t,o){this.element=e,this.type=6,this._$AN=void 0,this._$AM=t,this.options=o}get _$AU(){return this._$AM._$AU}_$AI(e){J(this,e)}}const ae={I:te},le=k.litHtmlPolyfillSupport;le?.(X,te),(k.litHtmlVersions??=[]).push("3.3.2");const ce=globalThis;let de=class extends ${constructor(){super(...arguments),this.renderOptions={host:this},this._$Do=void 0}createRenderRoot(){const e=super.createRenderRoot();return this.renderOptions.renderBefore??=e.firstChild,e}update(e){const t=this.render();this.hasUpdated||(this.renderOptions.isConnected=this.isConnected),super.update(e),this._$Do=((e,t,o)=>{const i=o?.renderBefore??t;let s=i._$litPart$;if(void 0===s){const e=o?.renderBefore??null;i._$litPart$=s=new te(t.insertBefore(P(),e),e,void 0,o??{})}return s._$AI(e),s})(t,this.renderRoot,this.renderOptions)}connectedCallback(){super.connectedCallback(),this._$Do?.setConnected(!0)}disconnectedCallback(){super.disconnectedCallback(),this._$Do?.setConnected(!1)}render(){return q}};de._$litElement$=!0,de.finalized=!0,ce.litElementHydrateSupport?.({LitElement:de});const he=ce.litElementPolyfillSupport;he?.({LitElement:de}),(ce.litElementVersions??=[]).push("4.2.2");const pe=e=>(t,o)=>{void 0!==o?o.addInitializer(()=>{customElements.define(e,t)}):customElements.define(e,t)},ue={attribute:!0,type:String,converter:y,reflect:!1,hasChanged:w},_e=(e=ue,t,o)=>{const{kind:i,metadata:s}=o;let n=globalThis.litPropertyMetadata.get(s);if(void 0===n&&globalThis.litPropertyMetadata.set(s,n=new Map),"setter"===i&&((e=Object.create(e)).wrapped=!0),n.set(o.name,e),"accessor"===i){const{name:i}=o;return{set(o){const s=t.get.call(this);t.set.call(this,o),this.requestUpdate(i,s,e,!0,o)},init(t){return void 0!==t&&this.C(i,void 0,e,t),t}}}if("setter"===i){const{name:i}=o;return function(o){const s=this[i];t.call(this,o),this.requestUpdate(i,s,e,!0,o)}}throw Error("Unsupported decorator location: "+i)};function ge(e){return(t,o)=>"object"==typeof o?_e(e,t,o):((e,t,o)=>{const i=t.hasOwnProperty(o);return t.constructor.createProperty(o,e),i?Object.getOwnPropertyDescriptor(t,o):void 0})(e,t,o)}function me(e){return ge({...e,state:!0,attribute:!1})}function ve(e,t,o){if(!e)return!0;for(const i of o)if(i&&e.states[i]!==t.states[i])return!0;return!1}const fe="2.17.0",be="adaptive-cover-pro-card",ye="adaptive-cover-pro-card-editor",we="adaptive-cover-pro-sky-compass-card",xe="adaptive-cover-pro-sky-compass-card-editor",$e="adaptive-cover-pro-tile-card",ke="adaptive-cover-pro-tile-card-editor",Ae="adaptive-cover-pro-decision-card",Se="adaptive-cover-pro-decision-card-editor",Ce="adaptive-cover-pro-solar-chart-card",Ee="adaptive-cover-pro-solar-chart-card-editor",ze="adaptive-cover-pro-history-card",Me="adaptive-cover-pro-history-card-editor",Te="adaptive_cover_pro",Ie=["force","weather","group_scene","manual","group_lock","custom_position","motion","cloud","climate","glare_zone","solar","default","floor_clamp"],Pe={force:"Force Override",weather:"Weather Safety",group_scene:"Group Scene",manual:"Manual Override",group_lock:"Group Lock",custom_position:"Custom Position",motion:"Occupancy Timeout",cloud:"Cloud Suppression",climate:"Climate",glare_zone:"Glare Zone",solar:"Solar Tracking",default:"Default",floor_clamp:"Min Floor"},Oe={force:"handler.force",weather:"handler.weather",group_scene:"handler.group_scene",manual:"handler.manual",group_lock:"handler.group_lock",custom_position:"handler.custom_position",motion:"handler.motion",cloud:"handler.cloud",climate:"handler.climate",glare_zone:"handler.glare_zone",solar:"handler.solar",default:"handler.default",floor_clamp:"handler.floor_clamp"},Ne={cover_blind:"mdi:blinds-horizontal",cover_awning:"mdi:awning-outline",cover_tilt:"mdi:blinds",cover_venetian:"mdi:blinds"},De={cover_blind:"mdi:blinds-open",cover_awning:"mdi:awning-outline",cover_tilt:"mdi:blinds-open",cover_venetian:"mdi:blinds-open"},Fe={cover_blind:"mdi:blinds-horizontal-closed",cover_awning:"mdi:window-closed-variant",cover_tilt:"mdi:blinds",cover_venetian:"mdi:blinds"},Be={awning:{open:"mdi:awning-outline",partial:"mdi:awning-outline",closed:"mdi:awning-outline"},blind:{open:"mdi:blinds-open",partial:"mdi:blinds-horizontal",closed:"mdi:blinds-horizontal-closed"},curtain:{open:"mdi:curtains",partial:"mdi:curtains",closed:"mdi:curtains-closed"},damper:{open:"mdi:circle",partial:"mdi:circle-slice-8",closed:"mdi:circle-slice-8"},door:{open:"mdi:door-open",partial:"mdi:door-open",closed:"mdi:door-closed"},garage:{open:"mdi:garage-open",partial:"mdi:garage-open",closed:"mdi:garage"},gate:{open:"mdi:gate-open",partial:"mdi:gate-open",closed:"mdi:gate"},shade:{open:"mdi:roller-shade",partial:"mdi:roller-shade",closed:"mdi:roller-shade-closed"},shutter:{open:"mdi:window-shutter-open",partial:"mdi:window-shutter",closed:"mdi:window-shutter"},window:{open:"mdi:window-open",partial:"mdi:window-open",closed:"mdi:window-closed"}},Re=new Set(["awning","curtain","door","gate"]),je={manual:"manual",force:"force",weather:"weather",glare_zone:"glare_zone",climate:"climate",cloud:"cloud",custom_position:"custom_position",solar:"solar",motion:"motion",group_scene:"group",group_lock:"group"};function Ke(e,t,o=22){return{label:e,accent:t,bg:`color-mix(in srgb, ${t} ${o}%, transparent)`,fg:`color-mix(in srgb, ${t} 40%, var(--primary-text-color, #212121))`}}const Le={auto:Ke("Auto","#4caf50",18),manual:Ke("Manual","#ff9800"),force:Ke("Force","#f44336"),weather:Ke("Sun protection","#f44336"),glare_zone:Ke("Glare","#f44336"),climate:Ke("Climate","#009688"),cloud:Ke("Cloudy","#2196f3"),custom_position:Ke("Custom","#9c27b0"),solar:Ke("Solar tracking","#4caf50"),motion:Ke("Occupancy","#ffeb3b"),off:Ke("Off","#616161",28),off_schedule:Ke("Off-schedule","#607d8b"),group:Ke("Group","#4caf50",18)},Ge={auto:"badge.auto",manual:"badge.manual",force:"badge.force",weather:"badge.weather",glare_zone:"badge.glare_zone",climate:"badge.climate",cloud:"badge.cloud",custom_position:"badge.custom_position",solar:"badge.solar",motion:"badge.motion",off:"badge.off",off_schedule:"badge.off_schedule",group:"badge.group"},We={auto:"mdi:autorenew",manual:"mdi:hand-back-right",force:"mdi:flash",weather:"mdi:shield-sun",glare_zone:"mdi:weather-sunny-alert",climate:"mdi:thermostat",cloud:"mdi:weather-cloudy",custom_position:"mdi:bookmark",solar:"mdi:white-balance-sunny",motion:"mdi:motion-sensor",off:"mdi:power",off_schedule:"mdi:clock-alert-outline",group:"mdi:window-shutter-cog"},He={integration_enabled:!0,automatic_control:!0,reset_manual_override:!0},Ue={position:"target_position_sensor",tilt:"target_tilt_sensor"},qe={position:"covers.position_title",tilt:"covers.tilt_title"},Ve="mdi:chart-box",Ye={active:"control_status.active",outside_time_window:"control_status.outside_time_window",position_delta_too_small:"control_status.position_delta_too_small",time_delta_too_small:"control_status.time_delta_too_small",manual_override:"control_status.manual_override",automatic_control_off:"control_status.automatic_control_off",sun_not_visible:"control_status.sun_not_visible",force_override_active:"control_status.force_override_active",weather_override_active:"control_status.weather_override_active",motion_timeout:"control_status.motion_timeout"},Ze=new Set(["active"]),Qe=[{role:"integration_enabled_switch",key:"history.track_enabled",cls:"ctx-enabled"},{role:"automatic_control_switch",key:"history.track_auto",cls:"ctx-auto"},{role:"sun_infront_binary",key:"history.track_sun",cls:"ctx-sun"},{role:"glare_active_binary",key:"history.track_glare",cls:"ctx-glare"},{role:"manual_override_binary",key:"history.track_manual",cls:"ctx-manual"},{role:"position_mismatch_binary",key:"history.track_mismatch",cls:"ctx-mismatch"}],Xe=[6,12,24,48,72],Je={pipeline_evaluated:"info",cover_command_sent:"action",cover_command_skipped:"warn",end_time_default_sent:"action",manual_override_gate_closed:"warn",sun_entered_fov:"info",sun_left_fov:"info",sunset_window_opened:"info",transit_cleared:"info",transit_optimistic_target_replay:"info",transit_progress_forward:"info",transit_startup_delay:"warn",transit_timeout_cleared:"warn",reconcile_gave_up:"warn",reconcile_skipped_in_transit:"warn"},et={"sensor:Cover_Position":"target_position_sensor","sensor:Cover_Tilt":"target_tilt_sensor","sensor:sun_position":"sun_sensor","sensor:Start Sun":"start_sensor","sensor:End Sun":"end_sensor","sensor:control_status":"control_status_sensor","sensor:decision_trace":"decision_trace_sensor","sensor:last_cover_action":"last_action_sensor","sensor:last_skipped_action":"last_skipped_sensor","sensor:manual_override_end_time":"manual_override_end_sensor","sensor:position_verification":"position_verification_sensor","sensor:motion_status":"motion_status_sensor","sensor:climate_status":"climate_status_sensor","sensor:position_forecast":"position_forecast_sensor","sensor:solar_calculation":"solar_calculation_sensor","binary_sensor:sun_motion":"sun_infront_binary","binary_sensor:manual_override":"manual_override_binary","binary_sensor:position_mismatch":"position_mismatch_binary","binary_sensor:glare_active":"glare_active_binary","switch:Integration Enabled":"integration_enabled_switch","switch:Automatic Control":"automatic_control_switch","switch:Manual Override":"manual_toggle_switch","switch:Climate Mode":"climate_mode_switch","switch:Motion Control":"motion_control_switch","button:Reset Manual Override":"reset_override_button","sensor:group_position":"group_position_sensor","sensor:group_state":"group_state_sensor","sensor:group_active_scene":"group_active_scene_sensor","sensor:group_climate_mode":"group_climate_mode_sensor","sensor:group_who_won":"group_who_won_sensor","select:group_scene_select":"group_scene_select","switch:group_automation":"group_automation_switch","switch:group_lock":"group_lock_switch","button:group_scene_all_open":"group_scene_all_open_button","button:group_scene_all_closed":"group_scene_all_closed_button","button:group_scene_privacy":"group_scene_privacy_button","button:group_clear_overrides":"group_clear_overrides_button","cover:group_cover":"group_cover"},tt={en:{handler:{force:"Force Override",weather:"Weather Safety",group_scene:"Group Scene",manual:"Manual Override",group_lock:"Group Lock",custom_position:"Custom Position",motion:"Occupancy Timeout",cloud:"Cloud Suppression",climate:"Climate",glare_zone:"Glare Zone",solar:"Solar Tracking",default:"Default",floor_clamp:"Min Floor"},badge:{auto:"Auto",manual:"Manual",force:"Force",weather:"Weather safety",glare_zone:"Glare",climate:"Climate",cloud:"Cloudy",custom_position:"Custom",solar:"Solar tracking",motion:"Occupancy idle",off:"Off",off_schedule:"Off-schedule",floor_suffix:" ↥",safety:"Safety",group:"Group",tip:{auto:"Automatic control is on and no handler is overriding — the cover follows the pipeline result.",manual:"Manual override is active — the cover is held where you put it and automatic control is paused.",manual_until:"Manual override is active until {time} — the cover is held where you put it until then.",force:"A forced position is overriding every other handler.",weather:"Weather safety is driving the position.",glare_zone:"The sun is in a configured glare zone, and the glare handler is driving the position.",climate:"Climate control is driving the position.",cloud:"Cloud cover is suppressing solar tracking.",custom_position:"A custom position slot is driving this cover.",custom_position_slot:"Slot: {name}.",custom_position_value:"Its position is {pct}%.",custom_position_floor:"It is applied as a floor: it raises the position above the raw calculation rather than replacing it.",solar:"Solar tracking — the position follows the sun across the window.",motion:"The room reads as unoccupied, so the occupancy handler is holding position.",off:"The integration is disabled for this cover — nothing is being driven.",off_schedule:"Outside the configured schedule window, so automatic control is paused.",group:"The Cover Group is currently deciding this position.",safety:"A safety position is overriding every other handler."}},group:{title:"Cover Group",scene:"Scene",scene_auto:"Auto",scene_all_open:"All open",scene_all_closed:"All closed",scene_privacy:"Privacy",state_open:"Open",state_closed:"Closed",state_mixed:"Mixed",state_unknown:"Unknown",lock:"Lock group",unlock:"Unlock group",automation:"Automation",automation_count:"{count} of {total} members automating",clear_overrides:"Clear overrides",clear_overrides_none:"No member overrides to clear",who_won:"{count} of {total} members are group-driven — a group scene or the group lock is currently deciding their position",members:"Members",member_placeholder:"No members reported by the integration.",position:"Position",open:"Open group",close:"Close group",stop:"Stop group",position_slider_label:"Group position",range:"{min}–{max}%",exception_held:"{count} held",exception_unavailable:"{count} unavailable",drag_to_set_all:"Drag to set all {count} covers",spread_value:"{min}% to {max}% across {count} covers"},forecast:{event:{sunrise:"Sunrise",sunset:"Sunset",fov_enter:"Sun enters window sun acceptance angle",fov_exit:"Sun leaves window sun acceptance angle"},hover_hint:"Hover the curve for time + forecast position; hover a colored line for the event it marks.",solar_only_note:"Solar geometry only — does not reflect manual overrides, custom positions, cloud suppression, or weather.",legend_forecast:"Forecast",legend_actual:"Actual"},dialog:{battery:"{level}% battery",battery_named:"{name}: {level}%",battery_unknown:"Battery level unknown",battery_history:"Open battery history",extend:{title:"Extend manual override",presets_label:"Until",relative_label:"Add time",absolute_label:"End at",preview:"Override until {time}",confirm:"Extend",cancel:"Cancel",tomorrow_suffix:" (tomorrow)"},configure_integration:"Configure integration",open_device_page:"Open device page",close:"Close",target:"Target",resume_auto:"Resume Auto",hide_advanced:"▼ Hide advanced",show_advanced:"▶ Advanced",custom_positions:"Custom positions",floor_tooltip:"Floor — slot raises position above raw calc",floor:"↥",disable_slot:"Disable slot {slot}",enable_slot:"Enable slot {slot}",on:"On",off:"Off",controls:"Controls",automatic:"Automatic",climate:"Climate",motion:"Occupancy",toggle_hint:"{label} {state} — tap to toggle",state_on:"on",state_off:"off",todays_forecast:"Today's forecast"},overrides:{title:"Overrides",manual:"Manual",force:"Force",motion:"Occupancy",active:"Active",off:"Off",ends_in:"ends in {time}",active_count:"{count} active",timeout:"expires in {time}",reset_manual:"Reset Manual"},climate:{title:"Climate",active:"Active: {strategy}",indoor:"Indoor",outdoor:"Outdoor",presence:"Presence",sunny:"Sunny",lux:"Lux",irradiance:"Irradiance",mode_off:"Climate mode off",standby:"Standby",threshold_low:"low",threshold_high:"high",threshold_summer_outside:"summer",reason:{outside_time_window:"Outside the operating time window",thresholds_not_met:"Temperatures within the comfort band — no action needed",other_mode_active:"Another control mode is currently active",readings_unavailable:"Temperature readings unavailable",mode_off:"Climate mode is turned off"}},compass:{placeholder_no_entries:"No Adaptive Cover Pro entries selected.",placeholder_no_sun:"Sun sensor not yet populated.",sun_tooltip:"Sun: {az} az / {el} el",sunrise_tooltip:"Sunrise: {time}",sunset_tooltip:"Sunset: {time}",moon_tooltip:"Moon: {phase} ({pct}%)",sun_path_tooltip:"Sun path (today)",in_fov_check:"✓ in SAA",in_fov:"in SAA",in_fov_tooltip:"Sun is currently within this window’s sun acceptance angle",none:"—",sun:"Sun",moon:"Moon",sun_up_not_hitting:"Sun (up, not hitting)",sun_below_horizon:"Sun (below horizon)",window_fov:"Window SAA",sun_path:"Sun path",sunrise:"Sunrise",sunset:"Sunset",cover_target:"Cover target",cover_held:"Cover position (held)",window_normal:"Window azimuth",stat_sun:"Sun: ",stat_azi:"Azi: ",stat_elev:"Elev: ",stat_window:"Window: ",active_sun_arc:"Active sun arc {from} – {to}{elev}",fov_arc:"SAA {left} left / {right} right{elev}",window_normal_tooltip:"Window azimuth: {bearing}",cover_position_target:"Target: {pct}%",cover_position_target_awning:"Target (extended): {pct}%",cover_position_actual:"Actual: {pct}%",blind_spot:"Blind spot: {from} – {to}",elev_suffix:" · elev {min}–{max}"},covers:{placeholder:"No covers reported by the integration.",title:"Covers",target:"Target: {pct}",target_solar:"Solar target: {pct}",click_to_set:"Click to set position",moving_to:"Moving to {pct}%",position_slider_label:"Cover position slider",position_open_value:"{pct} open",opening:"Opening…",closing:"Closing…",target_tooltip:"Target {pct}%",target_tooltip_override:"Would-be solar target {pct}% — cover is held by manual override",target_tooltip_motor:"Motor: {pct}% (before calibration)",position_title:"Position",tilt_title:"Tilt",tilt_target:"Tilt: {pct}",tilt_click_to_set:"Click to set tilt",tilt_target_tooltip:"Tilt target {pct}%",goto_target:"Move to target ({pct}%) — keeps automatic control"},decision:{placeholder:"Decision trace not yet populated.",pipeline:"Pipeline",winner:"Winner: {name}",summary_tooltip:"Why this position?",not_evaluated:"not evaluated",floor_suffix:" floor",outside_schedule:"Outside schedule — automatic control paused",outside_schedule_tooltip:"The configured schedule window is not active, so automatic positioning is paused.",solar_would_be:"solar {pct}",next_change_in:"Next adjustment allowed in {time}"},solar:{title:"Solar Calculation",axis_position:"Position axis",axis_tilt:"Tilt axis",group_inputs:"Inputs",group_intermediates:"Intermediates",group_output:"Output",show_all:"Show all {count} values",show_less:"Show less",no_target:"No solar target — {status}",status:{direct_sun:"Direct sun",fov_exit:"Default · SAA exit",elevation_limit:"Default · elevation limit",sunset_offset:"Default · sunset offset",blind_spot:"Default · blind spot",default:"Default"},field:{sol_elev_deg:"Sun elevation",gamma_deg:"Relative azimuth (γ)",position_pct:"Position",effective_distance_m:"Effective distance",adjusted_height_m:"Adjusted height",safety_margin:"Safety margin",awn_angle_deg:"Awning angle",vertical_position_m:"Vertical position",length_m:"Extension length",slat_angle_raw_deg:"Slat angle",tilt_mode:"Tilt mode",max_degrees:"Max angle"}},header:{on:"ON",off:"OFF",integration_enabled:"Integration Enabled",auto:"Auto",automatic_control:"Automatic Control"},tile:{motion_pending:"Occupancy timeout pending",motion_detected:"Occupancy detected",battery_low:"Low battery — {level}%",battery_unknown:"Battery level unknown",icon_action_label:"Cover icon action",open:"Open",stop:"Stop",close:"Close",resume_aria:"Resume automatic control",extend_aria:"Extend manual override",registry_failed:"Registry fetch failed: {error}",loading:"Loading…",entry_not_found:"Adaptive Cover Pro entry {entry} not found.",unavailable:"Unavailable",rails_layered:"{count} rails of one cover",rails_separate:"{count} covers",rails_layered_hint:"Rails of one cover"},formatters:{expired:"expired"},elevation:{title:"Sun today",fov_window:"SAA: {from} → {to}",fov_windows:"SAA: {windows}",fov_window_named:"{name}: {windows}",no_fov_today:"Sun does not enter SAA today",placeholder:"Sun elevation chart unavailable.",schedule:"Schedule {from} – {to}",schedule_from:"Schedule from {from}",schedule_until:"Schedule until {to}",schedule_start_tooltip:"Schedule start",schedule_end_tooltip:"Schedule end"},control_status:{active:"Active",outside_time_window:"Outside time window",position_delta_too_small:"Position change too small",time_delta_too_small:"Too soon since last move",manual_override:"Manual override",automatic_control_off:"Automatic control off",sun_not_visible:"Sun not visible",force_override_active:"Force override",weather_override_active:"Weather safety",motion_timeout:"Occupancy timeout"},history:{title:"History",open:"History",close:"Close",refresh:"Refresh",loading:"Loading history…",no_data:"No recorded data",window_label:"History window",window_hours:"{hours}h",show_more:"Show more",expand:"Expand to full view",collapse:"Back to history",today:"Today",yesterday:"Yesterday",section_tracks:"Timeline",track_position:"Position",track_who_won:"Who won",track_control_status:"Control status",track_enabled:"Integration",track_auto:"Automatic control",track_sun:"Sun in SAA",track_glare:"Glare",track_manual:"Manual override",track_mismatch:"Position mismatch",legend_target:"Target",legend_actual:"Actual",legend_per_cover:"Per cover",legend_saa:"Sun in SAA",legend_night:"Night",stat_moves:"moves",stat_travel:"pts travelled",stat_override:"in manual override",copy_diagnostics:"Copy diagnostics",copied:"Copied",no_recorder_data:"Not recorded — check your recorder settings",activity_title:"Activity",activity_empty:"No recorded activity in this window.",advanced:"Advanced — event buffer",events_search:"Filter events…",events_count:"{shown} of {total} events",events_empty:"No events match the filter.",events_unavailable:"Event buffer unavailable — the integration did not return diagnostics.",buffer_size:"Buffer size: {size}",data_window:"Buffer window: {from} → {to}"},root:{loading_registry:"Loading Adaptive Cover Pro registry…",no_entities_title:"No Adaptive Cover Pro entities found",footer_version:"adaptive-cover-pro-card v{version}",compass_no_match:"No matching Adaptive Cover Pro entities",compass_configured:"Configured entries: {entries}",compass_not_found:"Entries not found: {entries}"},editor:{common:{entry_id:"Adaptive Cover Pro instance",support_alt:"Buy me a coffee",title_optional:"Title (optional)",title_placeholder:"e.g. West-facing windows",north_offset:"Compass north offset (°)",north_offset_hint:'Rotate the compass clockwise so "up" matches your map. Default: 0.',loading_entries:"Loading Adaptive Cover Pro config entries…",load_failed:"Failed to load config entries: {error}",no_entries:"No Adaptive Cover Pro config entries found. Add an instance under",no_entries_path:"Settings → Devices & Services",no_entries_then:", then come back.",entry_id_manual_placeholder:"Enter config entry ID manually",entry_id_fallback_label:"Entry ID",unknown_entry:"(unknown: {entry})",reset:"Reset"},main:{sections:"Sections",sections_hint:"Toggle which parts of the card are shown.",section_sky_label:"Sky compass",section_sky_desc:"Sun vs. window SAA, polar plot",section_elevation_label:"Sun today",section_elevation_desc:"Elevation-vs-time chart with SAA band and current-time cursor",section_decision_label:"Decision strip",section_decision_desc:"All 10 pipeline handlers with the winning row highlighted",section_covers_label:"Cover positions",section_covers_desc:"Per-cover live vs. target bars; click to set position",section_overrides_label:"Overrides panel",section_overrides_desc:"Manual, force, occupancy tiles + reset button",section_climate_label:"Climate panel",section_climate_desc:"Summer/winter/intermediate strategy; shows standby when climate mode is off or inactive",section_solar_label:"Solar calculation",section_solar_desc:"Raw solar geometry breakdown (inputs → intermediates → output); requires the integration’s solar_calculation sensor",controls:"Controls",controls_hint:"Render as read-only (visible but not clickable).",integration_pill_label:"Integration ON/OFF pill",integration_pill_desc:"Allow toggling the integration from the card header.",automatic_pill_label:"Automatic Control pill",automatic_pill_desc:"Allow toggling automatic control from the card header.",reset_button_label:"Reset Manual Override button",reset_button_desc:"Allow pressing the reset tile in the overrides panel.",display:"Display",compact_label:"Compact mode",compact_desc:"Tighter spacing between sections.",show_compass_stats_label:"Show compass stats",show_compass_stats_desc:"Azi, Elev, ∠, and Window angle below the sky compass.",show_compass_legend_label:"Show compass legend",show_compass_legend_desc:"Color key below the sky compass.",show_moon_label:"Show moon on compass",show_moon_desc:"Moon position and phase overlay on the sky compass.",hide_inactive_label:"Hide inactive handlers",hide_inactive_desc:"Show only the winner and actively matched pipeline handlers.",state_color_label:"Color icon by state",state_color_desc:"Header cover icon takes on the theme’s open/closed/active color."},tile:{name:"Title override",icon:"Icon override",cover:"Cover entity",layout:"Layout",show_position:"Show position %",show_state:"Show state (Open/Closed)",show_decision_summary:"Show decision summary",show_controls:"Show ↑ ■ ↓ controls",covers:"Position bars (order)",covers_hint:"Drag a row, or use the arrows, to set the order the position bars appear in. The eye hides a bar without unbinding the cover.",member_names:"Members",member_names_hint:"Drag a row, or use the arrows, to set the order members appear in. The eye hides a member from this card without removing it from the group. Type to rename a member here; leave blank to use the entry’s own name.",members_hide:"Hide this member",members_show:"Show this member",covers_move_up:"Move up",covers_move_down:"Move down",covers_hide:"Hide this bar",covers_show:"Show this bar",controls_cover:"Cover driven by ↑ ■ ↓",controls_axis:"Axis driven by ↑ ■ ↓",show_badge:"Show contextual badge",show_position_bar:"Show position bar",show_tilt:"Show tilt bar",content_section:"Content",controls_section:"Controls",dialog_section:"Dialog sections",group_row_section:"Group controls",show_scene_select:"Show scene selector",show_lock:"Show group lock",show_automation:"Show member automation toggle",show_clear_overrides:"Show clear-overrides button",show_member_badges:"Show member override badges",badge_section:"Badges",badge_auto:"Auto",badge_solar:"Solar tracking",badge_force:"Force override",badge_weather:"Weather safety",badge_manual:"Manual override",badge_custom_position:"Custom position",badge_motion:"Occupancy",badge_climate:"Climate",badge_glare_zone:"Glare zone",badge_cloud:"Cloud suppression",show_compass:"Show sun compass in dialog",show_elevation_chart:"Show sun-today chart in dialog",show_solar_calc:"Show solar calculation in dialog",show_motion_icon:"Show occupancy indicator",state_color:"Color icon by state",interactions_section:"Interactions",tap_action:"Tap action",icon_tap_action:"Icon tap behavior",hold_action:"Hold action",double_tap_action:"Double-tap action",cover_blank_hint:"Leave blank to use the first managed cover automatically.",name_composed_hint:"A composed name is set in YAML. Type a new title here to replace it with plain text.",layout_option_one_line:"One line (compact)",layout_option_detailed:"Detailed (title, state, indicators)"},compass:{instances:"Adaptive Cover Pro instances",instances_hint:"Pick one or more. Each selected entry adds an overlay to the compass.",cover_colors:"Cover colors",cover_colors_hint:"Override the default palette color for each overlay.",default_color:"default",display:"Display",toggle_compact_label:"Compact mode",toggle_compact_desc:"Smaller SVG, legend hidden.",toggle_legend_label:"Legend",toggle_legend_desc:"Color swatches + entry labels below compass.",toggle_stats_label:"Stats",toggle_stats_desc:"Sun + per-window numeric rows.",toggle_moon_label:"Moon",toggle_moon_desc:"Render moon position and phase.",toggle_cardinals_label:"Cardinal labels",toggle_cardinals_desc:"N/E/S/W letters around the compass.",toggle_blind_spot_label:"Blind spots",toggle_blind_spot_desc:"Hatched wedges for each window’s blind range.",toggle_sun_path_label:"Sun path",toggle_sun_path_desc:"Today’s sun arc across the sky.",toggle_sunrise_sunset_label:"Sunrise / sunset markers",toggle_sunrise_sunset_desc:"Small dots at rise and set azimuths.",toggle_cover_fill_label:"Cover closure fill",toggle_cover_fill_desc:"Inner wedge showing how closed each cover is.",toggle_window_arrow_label:"Window-normal arrow",toggle_window_arrow_desc:"Line from center toward each window’s azimuth.",toggle_elevation_chart_label:"Sun-today chart",toggle_elevation_chart_desc:"Elevation-vs-time chart below the compass, with SAA band and elevation limits."},decision:{title:"Title (optional)",compact_label:"Compact mode",compact_desc:"Tighter rows; also hides inactive handlers.",hide_inactive_handlers_label:"Hide inactive handlers",hide_inactive_handlers_desc:"Show only the winner and actively matched pipeline handlers.",show_decision_summary_label:"Show decision summary",show_decision_summary_desc:'Render a plain-English "Why this position?" sentence above the strip.'},solar_chart:{instances:"Adaptive Cover Pro instances",instances_hint:"Pick one or more. Each selected entry adds a SAA overlay to the chart.",cover_colors:"Cover colors",cover_colors_hint:"Override the default palette color for each overlay.",default_color:"default",display:"Display",toggle_compact_label:"Compact mode",toggle_compact_desc:"Smaller chart, tighter spacing."},history:{title:"Title (optional)",hours_label:"History window",hours_desc:"How far back the tracks reach, counting from now.",track_position_label:"Position track",track_position_desc:"Recorded cover position over the window.",track_who_won_label:"Who-won track",track_who_won_desc:"Banded strip of the winning pipeline handler over time.",track_context_label:"Context tracks",track_context_desc:"Sun-in-SAA, glare and manual-override spans.",track_actions_label:"Cover actions list",track_actions_desc:"Recorded cover actions and skipped actions, newest first.",advanced_open_label:"Start with Advanced open",advanced_open_desc:"Expand the event-buffer section on load.",hide_advanced_label:"Hide Advanced section",hide_advanced_desc:"Never show the diagnostic event buffer on this card."}}},fr:{handler:{force:"Dérogation forcée",weather:"Sécurité météo",group_scene:"Scène de groupe",manual:"Dérogation manuelle",group_lock:"Verrouillage de groupe",custom_position:"Position personnalisée",motion:"Délai d'occupation",cloud:"Désactivation par temps nuageux",climate:"Climatique",glare_zone:"Zone d'éblouissement",solar:"Suivi solaire",default:"Par défaut",floor_clamp:"Plancher"},badge:{auto:"Auto",manual:"Manuel",force:"Forcé",weather:"Sécurité météo",glare_zone:"Éblouissement",climate:"Climatique",cloud:"Nuageux",custom_position:"Personnalisé",solar:"Suivi solaire",motion:"Occupation inactive",off:"Off",off_schedule:"Hors planning",floor_suffix:" ↥",safety:"Sécurité",group:"Groupe",tip:{auto:"Le contrôle automatique est actif et aucun gestionnaire ne le remplace — le volet suit le résultat du pipeline.",manual:"Une dérogation manuelle est active — le volet reste où vous l'avez placé et le contrôle automatique est en pause.",manual_until:"Une dérogation manuelle est active jusqu'à {time} — le volet reste où vous l'avez placé jusque-là.",force:"Une position forcée remplace tous les autres gestionnaires.",weather:"La sécurité météo pilote la position.",glare_zone:"Le soleil se trouve dans une zone d'éblouissement configurée, et le gestionnaire d'éblouissement pilote la position.",climate:"Le contrôle climatique pilote la position.",cloud:"La couverture nuageuse désactive le suivi solaire.",custom_position:"Un emplacement de position personnalisée pilote ce volet.",custom_position_slot:"Emplacement : {name}.",custom_position_value:"Sa position est de {pct} %.",custom_position_floor:"Il agit comme un plancher : il relève la position au-dessus du calcul brut au lieu de le remplacer.",solar:"Suivi solaire — la position suit la course du soleil devant la fenêtre.",motion:"La pièce est considérée comme inoccupée, le gestionnaire d'occupation maintient donc la position.",off:"L'intégration est désactivée pour ce volet — rien n'est piloté.",off_schedule:"En dehors de la plage horaire configurée, le contrôle automatique est donc en pause.",group:"Le groupe de volets décide actuellement de cette position.",safety:"Une position de sécurité remplace tous les autres gestionnaires."}},group:{title:"Groupe de couvertures",scene:"Scène",scene_auto:"Auto",scene_all_open:"Tout ouvrir",scene_all_closed:"Tout fermer",scene_privacy:"Intimité",state_open:"Ouvert",state_closed:"Fermé",state_mixed:"Mixte",state_unknown:"Inconnu",lock:"Verrouiller le groupe",unlock:"Déverrouiller le groupe",automation:"Automatisation",automation_count:"{count} membre(s) sur {total} automatisé(s)",clear_overrides:"Effacer les dérogations",clear_overrides_none:"Aucune dérogation de membre à effacer",who_won:"{count} membre(s) sur {total} sont pilotés par le groupe — une scène de groupe ou le verrouillage du groupe détermine actuellement leur position",members:"Membres",member_placeholder:"Aucun membre signalé par l'intégration.",position:"Position",open:"Ouvrir le groupe",close:"Fermer le groupe",stop:"Arrêter le groupe",position_slider_label:"Position du groupe",range:"{min}–{max} %",exception_held:"{count} maintenu(s)",exception_unavailable:"{count} indisponible(s)",drag_to_set_all:"Glisser pour régler les {count} stores",spread_value:"de {min} % à {max} % sur {count} stores"},forecast:{event:{sunrise:"Lever du soleil",sunset:"Coucher du soleil",fov_enter:"Le soleil entre dans l'angle d'acceptation solaire de la fenêtre",fov_exit:"Le soleil quitte l'angle d'acceptation solaire de la fenêtre"},hover_hint:"Survolez la courbe pour voir l'heure et la position prévue ; survolez une ligne colorée pour voir l'événement qu'elle indique.",solar_only_note:"Géométrie solaire uniquement — ne tient pas compte des dérogations manuelles, des positions personnalisées, de la désactivation par temps nuageux ni des conditions météo.",legend_forecast:"Prévision",legend_actual:"Réel"},dialog:{battery:"Batterie {level}%",battery_named:"{name} : {level}%",battery_unknown:"Niveau de batterie inconnu",battery_history:"Ouvrir l'historique de la batterie",extend:{title:"Prolonger la dérogation manuelle",presets_label:"Jusqu'à",relative_label:"Ajouter du temps",absolute_label:"Fin à",preview:"Dérogation jusqu'à {time}",confirm:"Prolonger",cancel:"Annuler",tomorrow_suffix:" (demain)"},configure_integration:"Configurer l'intégration",open_device_page:"Ouvrir la page de l'appareil",close:"Fermer",target:"Cible",resume_auto:"Reprendre l'automatique",hide_advanced:"▼ Masquer les options avancées",show_advanced:"▶ Afficher les options avancées",custom_positions:"Positions personnalisées",floor_tooltip:"Plancher — cette valeur force une position minimale au-dessus du calcul automatique",floor:"↥",disable_slot:"Désactiver le créneau {slot}",enable_slot:"Activer le créneau {slot}",on:"Activé",off:"Désactivé",controls:"Commandes",automatic:"Automatique",climate:"Climatique",motion:"Occupation",toggle_hint:"{label} {state} — appuyez pour basculer",state_on:"activé",state_off:"désactivé",todays_forecast:"Prévisions du jour"},overrides:{title:"Dérogations",manual:"Manuel",force:"Forcé",motion:"Occupation",active:"Actif",off:"Désactivé",ends_in:"se termine dans {time}",active_count:"{count} dérogation(s) active(s)",timeout:"expire dans {time}",reset_manual:"Réinitialiser le mode manuel"},climate:{title:"Climatique",active:"Actif : {strategy}",indoor:"Intérieur",outdoor:"Extérieur",presence:"Présence",sunny:"Ensoleillé",lux:"Lux",irradiance:"Irradiance",mode_off:"Mode climatique désactivé",standby:"En veille",threshold_low:"bas",threshold_high:"haut",threshold_summer_outside:"été",reason:{outside_time_window:"En dehors de la plage horaire de fonctionnement",thresholds_not_met:"Températures dans la plage de confort — aucune action requise",other_mode_active:"Un autre mode de contrôle est actuellement actif",readings_unavailable:"Relevés de température indisponibles",mode_off:"Le mode climatique est désactivé"}},compass:{placeholder_no_entries:"Aucune instance Adaptive Cover Pro sélectionnée.",placeholder_no_sun:"Le capteur solaire n'est pas encore renseigné.",sun_tooltip:"Soleil : {az} az / {el} él",sunrise_tooltip:"Lever du soleil : {time}",sunset_tooltip:"Coucher du soleil : {time}",moon_tooltip:"Lune : {phase} ({pct}%)",sun_path_tooltip:"Trajectoire solaire (aujourd'hui)",in_fov_check:"✓ dans le SAA",in_fov:"dans le SAA",in_fov_tooltip:"Le soleil est actuellement dans l'angle d'acceptation solaire de cette fenêtre",none:"—",sun:"Soleil",moon:"Lune",sun_up_not_hitting:"Soleil (levé, ne frappe pas)",sun_below_horizon:"Soleil (sous l’horizon)",window_fov:"SAA de la fenêtre",sun_path:"Trajectoire solaire",sunrise:"Lever du soleil",sunset:"Coucher du soleil",cover_target:"Cible du store",cover_held:"Position du store (maintenue)",window_normal:"Azimut de la fenêtre",stat_sun:"Soleil : ",stat_azi:"Azi : ",stat_elev:"Élév : ",stat_window:"Fenêtre : ",active_sun_arc:"Arc solaire actif {from} – {to}{elev}",fov_arc:"SAA {left} gauche / {right} droite{elev}",window_normal_tooltip:"Azimut de la fenêtre : {bearing}",cover_position_target:"Cible : {pct}%",cover_position_target_awning:"Cible (déployé) : {pct}%",cover_position_actual:"Réel : {pct}%",blind_spot:"Soleil masqué : {from} - {to}",elev_suffix:" · élév {min}–{max}"},covers:{placeholder:"Aucun store signalé par l'intégration.",title:"Stores",target:"Cible : {pct}",target_solar:"Cible solaire : {pct}",click_to_set:"Cliquer pour définir la position",moving_to:"En route vers {pct}%",position_slider_label:"Curseur de position du store",position_open_value:"{pct} ouvert",opening:"Ouverture…",closing:"Fermeture…",target_tooltip:"Cible {pct}%",target_tooltip_override:"Cible solaire théorique {pct}% — le store est maintenu par la commande manuelle",target_tooltip_motor:"Moteur : {pct}% (avant étalonnage)",position_title:"Position",tilt_title:"Inclinaison",tilt_target:"Inclinaison : {pct}",tilt_click_to_set:"Cliquer pour définir l'inclinaison",tilt_target_tooltip:"Cible inclinaison {pct}%",goto_target:"Aller à la cible ({pct}%) — le contrôle automatique est conservé"},decision:{placeholder:"La trace de décision n'est pas encore renseignée.",pipeline:"Pipeline",winner:"Actif : {name}",summary_tooltip:"Pourquoi cette position ?",not_evaluated:"non évalué",floor_suffix:" plancher",outside_schedule:"Hors planning — contrôle automatique en pause",outside_schedule_tooltip:"La fenêtre de planning configurée n'est pas active, le positionnement automatique est donc en pause.",solar_would_be:"solaire {pct}",next_change_in:"Prochain ajustement autorisé dans {time}"},solar:{title:"Calcul solaire",axis_position:"Axe de position",axis_tilt:"Axe d'inclinaison",group_inputs:"Entrées",group_intermediates:"Intermédiaires",group_output:"Sortie",show_all:"Afficher les {count} valeurs",show_less:"Afficher moins",no_target:"Pas de cible solaire — {status}",status:{direct_sun:"Soleil direct",fov_exit:"Par défaut · sortie du SAA",elevation_limit:"Par défaut · limite d'élévation",sunset_offset:"Par défaut · décalage coucher du soleil",blind_spot:"Par défaut · angle mort",default:"Par défaut"},field:{sol_elev_deg:"Élévation du soleil",gamma_deg:"Azimut relatif (γ)",position_pct:"Position",effective_distance_m:"Distance effective",adjusted_height_m:"Hauteur ajustée",safety_margin:"Marge de sécurité",awn_angle_deg:"Angle du store",vertical_position_m:"Position verticale",length_m:"Longueur d'extension",slat_angle_raw_deg:"Angle des lamelles",tilt_mode:"Mode d'inclinaison",max_degrees:"Angle maximal"}},header:{on:"ON",off:"OFF",integration_enabled:"Intégration activée",auto:"Auto",automatic_control:"Contrôle automatique"},tile:{motion_pending:"Délai d'occupation en cours",motion_detected:"Occupation détectée",battery_low:"Batterie faible — {level}%",battery_unknown:"Niveau de batterie inconnu",icon_action_label:"Action de l'icône du store",open:"Ouvrir",stop:"Arrêter",close:"Fermer",resume_aria:"Reprendre le contrôle automatique",extend_aria:"Prolonger la dérogation manuelle",registry_failed:"Échec de la récupération du registre : {error}",loading:"Chargement…",entry_not_found:"Instance Adaptive Cover Pro {entry} introuvable.",unavailable:"Indisponible",rails_layered:"{count} toiles d’un même store",rails_separate:"{count} stores",rails_layered_hint:"Toiles d’un même store"},formatters:{expired:"expiré"},elevation:{title:"Soleil aujourd'hui",fov_window:"SAA : {from} → {to}",fov_windows:"SAA : {windows}",fov_window_named:"{name} : {windows}",no_fov_today:"Le soleil n'entre pas dans le SAA aujourd'hui",placeholder:"Graphique d'élévation solaire indisponible.",schedule:"Programmation {from} – {to}",schedule_from:"Programmation à partir de {from}",schedule_until:"Programmation jusqu'à {to}",schedule_start_tooltip:"Début de programmation",schedule_end_tooltip:"Fin de programmation"},control_status:{active:"Actif",outside_time_window:"Hors plage horaire",position_delta_too_small:"Changement de position trop faible",time_delta_too_small:"Trop tôt depuis le dernier mouvement",manual_override:"Dérogation manuelle",automatic_control_off:"Contrôle automatique désactivé",sun_not_visible:"Soleil non visible",force_override_active:"Dérogation forcée",weather_override_active:"Sécurité météo",motion_timeout:"Délai d'occupation"},history:{title:"Historique",open:"Historique",close:"Fermer",refresh:"Actualiser",loading:"Chargement de l'historique…",no_data:"Aucune donnée enregistrée",window_label:"Fenêtre d'historique",window_hours:"{hours} h",show_more:"Afficher plus",expand:"Afficher en plein écran",collapse:"Retour à l'historique",today:"Aujourd'hui",yesterday:"Hier",section_tracks:"Chronologie",track_position:"Position",track_who_won:"Gagnant",track_control_status:"État du contrôle",track_enabled:"Intégration",track_auto:"Contrôle automatique",track_sun:"Soleil dans SAA",track_glare:"Éblouissement",track_manual:"Dérogation manuelle",track_mismatch:"Écart de position",legend_target:"Cible",legend_actual:"Réel",legend_per_cover:"Par store",legend_saa:"Soleil dans SAA",legend_night:"Nuit",stat_moves:"mouvements",stat_travel:"pts parcourus",stat_override:"en dérogation manuelle",copy_diagnostics:"Copier les diagnostics",copied:"Copié",no_recorder_data:"Non enregistré — vérifiez la configuration du recorder",activity_title:"Activité",activity_empty:"Aucune activité enregistrée sur cette période.",advanced:"Avancé — tampon d'événements",events_search:"Filtrer les événements…",events_count:"{shown} événements sur {total}",events_empty:"Aucun événement ne correspond au filtre.",events_unavailable:"Tampon d'événements indisponible — l'intégration n'a pas renvoyé de diagnostics.",buffer_size:"Taille du tampon : {size}",data_window:"Fenêtre du tampon : {from} → {to}"},root:{loading_registry:"Chargement du registre Adaptive Cover Pro…",no_entities_title:"Aucune entité Adaptive Cover Pro trouvée",footer_version:"adaptive-cover-pro-card v{version}",compass_no_match:"Aucune entité Adaptive Cover Pro correspondante",compass_configured:"Instances configurées : {entries}",compass_not_found:"Instances introuvables : {entries}"},editor:{common:{entry_id:"Instance Adaptive Cover Pro",support_alt:"Offrez-moi un café",title_optional:"Titre (facultatif)",title_placeholder:"ex. Fenêtres côté ouest",north_offset:"Décalage nord de la boussole (°)",north_offset_hint:"Faites pivoter la boussole dans le sens horaire pour que « haut » corresponde à votre carte. Par défaut : 0.",loading_entries:"Chargement des entrées de configuration Adaptive Cover Pro…",load_failed:"Échec du chargement des entrées de configuration : {error}",no_entries:"Aucune entrée de configuration Adaptive Cover Pro trouvée. Ajoutez une instance sous",no_entries_path:"Paramètres → Appareils et services",no_entries_then:", puis revenez ici.",entry_id_manual_placeholder:"Saisir manuellement l'ID d'entrée de configuration",entry_id_fallback_label:"ID d'entrée",unknown_entry:"(inconnu : {entry})",reset:"Réinitialiser"},main:{sections:"Sections",sections_hint:"Activer ou désactiver les parties de la carte affichées.",section_sky_label:"Boussole céleste",section_sky_desc:"Soleil par rapport au SAA de la fenêtre, tracé polaire",section_elevation_label:"Soleil aujourd'hui",section_elevation_desc:"Graphique élévation/temps avec bande SAA et curseur temps réel",section_decision_label:"Bande de décision",section_decision_desc:"Les 10 gestionnaires du pipeline avec la ligne gagnante mise en évidence",section_covers_label:"Positions des stores",section_covers_desc:"Barres position réelle/cible par store ; cliquer pour définir la position",section_overrides_label:"Panneau des dérogations",section_overrides_desc:"Tuiles Manuel, Forcé, Occupation + bouton de réinitialisation",section_climate_label:"Panneau climatique",section_climate_desc:"Stratégie été/hiver/intermédiaire ; affiche le mode veille si le mode climatique est désactivé ou inactif",section_solar_label:"Calcul solaire",section_solar_desc:"Décomposition de la géométrie solaire brute (entrées → intermédiaires → sortie) ; nécessite le capteur solar_calculation de l’intégration",controls:"Commandes",controls_hint:"Afficher en lecture seule (visible mais non cliquable).",integration_pill_label:"Bouton ON/OFF de l'intégration",integration_pill_desc:"Permettre de basculer l'intégration depuis l'en-tête de la carte.",automatic_pill_label:"Bouton contrôle automatique",automatic_pill_desc:"Permettre de basculer le contrôle automatique depuis l'en-tête de la carte.",reset_button_label:"Bouton de réinitialisation de la dérogation manuelle",reset_button_desc:"Permettre d'appuyer sur la tuile de réinitialisation dans le panneau des dérogations.",display:"Affichage",compact_label:"Mode compact",compact_desc:"Espacement réduit entre les sections.",show_compass_stats_label:"Afficher les statistiques de la boussole",show_compass_stats_desc:"Azi, Élév, ∠ et angle de fenêtre sous la boussole céleste.",show_compass_legend_label:"Afficher la légende de la boussole",show_compass_legend_desc:"Clé de couleur sous la boussole céleste.",show_moon_label:"Afficher la lune sur la boussole",show_moon_desc:"Position et phase de la lune en superposition sur la boussole céleste.",hide_inactive_label:"Masquer les gestionnaires inactifs",hide_inactive_desc:"Afficher uniquement le gestionnaire sélectionné et les gestionnaires du pipeline actifs.",state_color_label:"Colorer l'icône selon l'état",state_color_desc:"L'icône d'en-tête prend la couleur ouvert/fermé/actif du thème."},tile:{name:"Titre personnalisé",icon:"Icône personnalisée",cover:"Entité de store",layout:"Disposition",show_position:"Afficher la position %",show_state:"Afficher l'état (Ouvert/Fermé)",show_decision_summary:"Afficher le résumé de décision",show_controls:"Afficher les commandes ↑ ■ ↓",covers:"Barres de position (ordre)",covers_hint:"Faites glisser une ligne, ou utilisez les flèches, pour définir l'ordre des barres de position. L'œil masque une barre sans dissocier le volet.",member_names:"Membres",member_names_hint:"Faites glisser une ligne, ou utilisez les flèches, pour définir l'ordre des membres. L'œil masque un membre sur cette carte sans le retirer du groupe. Saisissez un texte pour renommer un membre ; laisser vide pour utiliser le nom de l'instance.",members_hide:"Masquer ce membre",members_show:"Afficher ce membre",covers_move_up:"Monter",covers_move_down:"Descendre",covers_hide:"Masquer cette barre",covers_show:"Afficher cette barre",controls_cover:"Volet piloté par ↑ ■ ↓",controls_axis:"Axe piloté par ↑ ■ ↓",show_badge:"Afficher le badge contextuel",show_position_bar:"Afficher la barre de position",show_tilt:"Afficher la barre d'inclinaison",content_section:"Contenu",controls_section:"Commandes",dialog_section:"Sections de la boîte de dialogue",group_row_section:"Commandes de groupe",show_scene_select:"Afficher le sélecteur de scène",show_lock:"Afficher le verrouillage du groupe",show_automation:"Afficher l'interrupteur d'automatisation des membres",show_clear_overrides:"Afficher le bouton d’effacement des dérogations",show_member_badges:"Afficher les badges de dérogation des membres",badge_section:"Badges",badge_auto:"Auto",badge_solar:"Suivi solaire",badge_force:"Dérogation forcée",badge_weather:"Sécurité météo",badge_manual:"Dérogation manuelle",badge_custom_position:"Position personnalisée",badge_motion:"Occupation",badge_climate:"Climatique",badge_glare_zone:"Zone d'éblouissement",badge_cloud:"Suppression nuageuse",show_compass:"Afficher la boussole solaire dans le dialogue",show_elevation_chart:"Afficher le graphique du soleil dans le dialogue",show_solar_calc:"Afficher le calcul solaire dans le dialogue",show_motion_icon:"Afficher l'indicateur d'occupation",state_color:"Colorer l'icône selon l'état",interactions_section:"Interactions",tap_action:"Action au toucher",icon_tap_action:"Action au toucher de l'icône",hold_action:"Action au maintien",double_tap_action:"Action au double toucher",cover_blank_hint:"Laisser vide pour utiliser automatiquement le premier store géré.",name_composed_hint:"Un titre composé est défini en YAML. Saisissez un nouveau titre ici pour le remplacer par du texte simple.",layout_option_one_line:"Une ligne (compact)",layout_option_detailed:"Détaillé (titre, état, indicateurs)"},compass:{instances:"Instances Adaptive Cover Pro",instances_hint:"Sélectionnez une ou plusieurs instances. Chaque instance sélectionnée ajoute une superposition à la boussole.",cover_colors:"Couleurs des stores",cover_colors_hint:"Remplacer la couleur de palette par défaut pour chaque superposition.",default_color:"par défaut",display:"Affichage",toggle_compact_label:"Mode compact",toggle_compact_desc:"SVG plus petit, légende masquée.",toggle_legend_label:"Légende",toggle_legend_desc:"Échantillons de couleur et étiquettes d'instance sous la boussole.",toggle_stats_label:"Statistiques",toggle_stats_desc:"Soleil + lignes numériques par fenêtre.",toggle_moon_label:"Lune",toggle_moon_desc:"Afficher la position et la phase de la lune.",toggle_cardinals_label:"Points cardinaux",toggle_cardinals_desc:"Lettres N/E/S/O autour de la boussole.",toggle_blind_spot_label:"Zones de soleil masqué",toggle_blind_spot_desc:"Secteurs hachurés pour la plage où le soleil est masqué de chaque fenêtre.",toggle_sun_path_label:"Trajectoire solaire",toggle_sun_path_desc:"Arc solaire du jour dans le ciel.",toggle_sunrise_sunset_label:"Repères lever / coucher du soleil",toggle_sunrise_sunset_desc:"Petits points aux azimuts de lever et coucher du soleil.",toggle_cover_fill_label:"Remplissage de fermeture du store",toggle_cover_fill_desc:"Secteur intérieur indiquant le taux de fermeture de chaque store.",toggle_window_arrow_label:"Flèche de normale de fenêtre",toggle_window_arrow_desc:"Ligne du centre vers l'azimut de chaque fenêtre.",toggle_elevation_chart_label:"Graphique du soleil",toggle_elevation_chart_desc:"Graphique élévation/temps sous la boussole, avec bande SAA et limites d'élévation."},decision:{title:"Titre (facultatif)",compact_label:"Mode compact",compact_desc:"Lignes plus serrées ; masque aussi les gestionnaires inactifs.",hide_inactive_handlers_label:"Masquer les gestionnaires inactifs",hide_inactive_handlers_desc:"Afficher uniquement le gestionnaire sélectionné et les gestionnaires du pipeline actifs.",show_decision_summary_label:"Afficher le résumé de décision",show_decision_summary_desc:"Afficher une phrase explicite « Pourquoi cette position ? » au-dessus de la bande."},solar_chart:{instances:"Instances Adaptive Cover Pro",instances_hint:"Sélectionnez une ou plusieurs instances. Chaque instance sélectionnée ajoute une superposition SAA au graphique.",cover_colors:"Couleurs des stores",cover_colors_hint:"Remplacer la couleur de palette par défaut pour chaque superposition.",default_color:"par défaut",display:"Affichage",toggle_compact_label:"Mode compact",toggle_compact_desc:"Graphique plus petit, espacement plus serré."},history:{title:"Titre (facultatif)",hours_label:"Fenêtre d'historique",hours_desc:"Profondeur de l'historique affiché, à partir de maintenant.",track_position_label:"Piste Position",track_position_desc:"Position enregistrée du store sur la période.",track_who_won_label:"Piste Gagnant",track_who_won_desc:"Bandes du gestionnaire de pipeline gagnant au fil du temps.",track_context_label:"Pistes de contexte",track_context_desc:"Périodes soleil-dans-SAA, éblouissement et dérogation manuelle.",track_actions_label:"Liste des actions",track_actions_desc:"Actions de store enregistrées et ignorées, les plus récentes en premier.",advanced_open_label:"Ouvrir Avancé au démarrage",advanced_open_desc:"Déplier la section du tampon d'événements au chargement.",hide_advanced_label:"Masquer la section Avancé",hide_advanced_desc:"Ne jamais afficher le tampon d'événements de diagnostic sur cette carte."}}},de:{handler:{force:"Zwangsübersteuerung",weather:"Wettersicherheit",group_scene:"Gruppenszene",manual:"Manuelle Übersteuerung",group_lock:"Gruppensperre",custom_position:"Benutzerdefinierte Position",motion:"Anwesenheits-Timeout",cloud:"Wolkenunterdrückung",climate:"Klima",glare_zone:"Blendungszone",solar:"Sonnenverfolgung",default:"Standard",floor_clamp:"Mindestposition"},badge:{auto:"Auto",manual:"Manuell",force:"Zwang",weather:"Wettersicherheit",glare_zone:"Blendung",climate:"Klima",cloud:"Bewölkt",custom_position:"Benutzerdefiniert",solar:"Sonnenverfolgung",motion:"Anwesenheit inaktiv",off:"Aus",off_schedule:"Außerhalb des Zeitplans",floor_suffix:" ↥",safety:"Sicherheit",group:"Gruppe",tip:{auto:"Die Automatiksteuerung ist aktiv und kein Handler übersteuert — die Abdeckung folgt dem Ergebnis der Pipeline.",manual:"Eine manuelle Übersteuerung ist aktiv — die Abdeckung bleibt dort, wo Sie sie eingestellt haben, und die Automatik pausiert.",manual_until:"Eine manuelle Übersteuerung ist bis {time} aktiv — bis dahin bleibt die Abdeckung dort, wo Sie sie eingestellt haben.",force:"Eine erzwungene Position übersteuert alle anderen Handler.",weather:"Die Wettersicherheit steuert die Position.",glare_zone:"Die Sonne steht in einer konfigurierten Blendungszone, und der Blendungs-Handler steuert die Position.",climate:"Die Klimasteuerung steuert die Position.",cloud:"Bewölkung unterdrückt die Sonnenverfolgung.",custom_position:"Ein benutzerdefinierter Positions-Slot steuert diese Abdeckung.",custom_position_slot:"Slot: {name}.",custom_position_value:"Seine Position beträgt {pct} %.",custom_position_floor:"Er wirkt als Mindestposition: Er hebt die Position über den Rohwert der Berechnung an, statt ihn zu ersetzen.",solar:"Sonnenverfolgung — die Position folgt der Sonne über das Fenster.",motion:"Der Raum gilt als nicht belegt, daher hält der Anwesenheits-Handler die Position.",off:"Die Integration ist für diese Abdeckung deaktiviert — es wird nichts gesteuert.",off_schedule:"Außerhalb des konfigurierten Zeitfensters, daher pausiert die Automatiksteuerung.",group:"Die Abdeckungsgruppe bestimmt derzeit diese Position.",safety:"Eine Sicherheitsposition übersteuert alle anderen Handler."}},group:{title:"Abdeckungsgruppe",scene:"Szene",scene_auto:"Auto",scene_all_open:"Alle öffnen",scene_all_closed:"Alle schließen",scene_privacy:"Sichtschutz",state_open:"Offen",state_closed:"Geschlossen",state_mixed:"Gemischt",state_unknown:"Unbekannt",lock:"Gruppe sperren",unlock:"Gruppe entsperren",automation:"Automatisierung",automation_count:"{count} von {total} Mitgliedern automatisiert",clear_overrides:"Übersteuerungen löschen",clear_overrides_none:"Keine Mitglieder-Übersteuerungen zum Löschen",who_won:"{count} von {total} Mitgliedern sind gruppengesteuert — eine Gruppenszene oder die Gruppensperre bestimmt derzeit ihre Position",members:"Mitglieder",member_placeholder:"Keine Mitglieder von der Integration gemeldet.",position:"Position",open:"Gruppe öffnen",close:"Gruppe schließen",stop:"Gruppe stoppen",position_slider_label:"Gruppenposition",range:"{min}–{max} %",exception_held:"{count} gehalten",exception_unavailable:"{count} nicht verfügbar",drag_to_set_all:"Ziehen, um alle {count} Behänge zu setzen",spread_value:"{min} % bis {max} % über {count} Behänge"},forecast:{event:{sunrise:"Sonnenaufgang",sunset:"Sonnenuntergang",fov_enter:"Sonne tritt in den Sonnenakzeptanzwinkel des Fensters ein",fov_exit:"Sonne verlässt den Sonnenakzeptanzwinkel des Fensters"},hover_hint:"Kurve überfahren für Uhrzeit und prognostizierte Position; farbige Linie überfahren für das markierte Ereignis.",solar_only_note:"Nur Sonnengeometrie — berücksichtigt keine manuellen Übersteuerungen, benutzerdefinierten Positionen, Wolkenunterdrückung oder Wetter.",legend_forecast:"Prognose",legend_actual:"Ist"},dialog:{battery:"Batterie {level}%",battery_named:"{name}: {level}%",battery_unknown:"Batteriestand unbekannt",battery_history:"Batterieverlauf öffnen",extend:{title:"Manuelle Übersteuerung verlängern",presets_label:"Bis",relative_label:"Zeit hinzufügen",absolute_label:"Ende um",preview:"Übersteuerung bis {time}",confirm:"Verlängern",cancel:"Abbrechen",tomorrow_suffix:" (morgen)"},configure_integration:"Integration konfigurieren",open_device_page:"Geräteseite öffnen",close:"Schließen",target:"Ziel",resume_auto:"Automatik fortsetzen",hide_advanced:"▼ Erweitert ausblenden",show_advanced:"▶ Erweitert",custom_positions:"Benutzerdefinierte Positionen",floor_tooltip:"Mindestposition — hebt die Position über den berechneten Wert",floor:"↥",disable_slot:"Slot {slot} deaktivieren",enable_slot:"Slot {slot} aktivieren",on:"An",off:"Aus",controls:"Steuerung",automatic:"Automatisch",climate:"Klima",motion:"Anwesenheit",toggle_hint:"{label} {state} — tippen zum Umschalten",state_on:"an",state_off:"aus",todays_forecast:"Heutige Prognose"},overrides:{title:"Übersteuerungen",manual:"Manuell",force:"Zwang",motion:"Anwesenheit",active:"Aktiv",off:"Aus",ends_in:"endet in {time}",active_count:"{count} aktiv",timeout:"läuft in {time} ab",reset_manual:"Manuell zurücksetzen"},climate:{title:"Klima",active:"Aktiv: {strategy}",indoor:"Innen",outdoor:"Außen",presence:"Anwesenheit",sunny:"Sonnig",lux:"Lux",irradiance:"Einstrahlung",mode_off:"Klimamodus deaktiviert",standby:"Bereitschaft",threshold_low:"niedrig",threshold_high:"hoch",threshold_summer_outside:"Sommer",reason:{outside_time_window:"Außerhalb des Betriebszeitfensters",thresholds_not_met:"Temperaturen im Komfortbereich — keine Maßnahme erforderlich",other_mode_active:"Ein anderer Steuermodus ist derzeit aktiv",readings_unavailable:"Temperaturwerte nicht verfügbar",mode_off:"Klimamodus ist deaktiviert"}},compass:{placeholder_no_entries:"Kein Adaptive Cover Pro-Eintrag ausgewählt.",placeholder_no_sun:"Sonnensensor noch nicht befüllt.",sun_tooltip:"Sonne: {az} az / {el} el",sunrise_tooltip:"Sonnenaufgang: {time}",sunset_tooltip:"Sonnenuntergang: {time}",moon_tooltip:"Mond: {phase} ({pct}%)",sun_path_tooltip:"Sonnenbahn (heute)",in_fov_check:"✓ im SAA",in_fov:"im SAA",in_fov_tooltip:"Sonne befindet sich derzeit im Sonnenakzeptanzwinkel dieses Fensters",none:"—",sun:"Sonne",moon:"Mond",sun_up_not_hitting:"Sonne (aufgegangen, trifft nicht)",sun_below_horizon:"Sonne (unter dem Horizont)",window_fov:"Fenster-SAA",sun_path:"Sonnenbahn",sunrise:"Sonnenaufgang",sunset:"Sonnenuntergang",cover_target:"Beschattungsziel",cover_held:"Beschattungsposition (gehalten)",window_normal:"Fensterazimut",stat_sun:"Sonne: ",stat_azi:"Azi: ",stat_elev:"Elev: ",stat_window:"Fenster: ",active_sun_arc:"Aktiver Sonnenbogen {from} – {to}{elev}",fov_arc:"SAA {left} links / {right} rechts{elev}",window_normal_tooltip:"Fensterazimut: {bearing}",cover_position_target:"Ziel: {pct}%",cover_position_target_awning:"Ziel (ausgefahren): {pct}%",cover_position_actual:"Aktuell: {pct}%",blind_spot:"Blindfleck: {from} – {to}",elev_suffix:" · Elev {min}–{max}"},covers:{placeholder:"Keine Beschattungen von der Integration gemeldet.",title:"Beschattungen",target:"Ziel: {pct}",target_solar:"Sonnenziel: {pct}",click_to_set:"Klicken zum Festlegen der Position",moving_to:"Fährt auf {pct}%",position_slider_label:"Positionsschieberegler",position_open_value:"{pct} offen",opening:"Öffnet…",closing:"Schließt…",target_tooltip:"Ziel {pct}%",target_tooltip_override:"Theoretisches Sonnenziel {pct}% — Beschattung wird durch manuelle Übersteuerung gehalten",target_tooltip_motor:"Motor: {pct}% (vor Kalibrierung)",position_title:"Position",tilt_title:"Neigung",tilt_target:"Neigung: {pct}",tilt_click_to_set:"Klicken zum Festlegen der Neigung",tilt_target_tooltip:"Neigungsziel {pct}%",goto_target:"Auf Ziel fahren ({pct}%) — automatische Steuerung bleibt aktiv"},decision:{placeholder:"Entscheidungsprotokoll noch nicht befüllt.",pipeline:"Pipeline",winner:"Gewinner: {name}",summary_tooltip:"Warum diese Position?",not_evaluated:"nicht ausgewertet",floor_suffix:" Mindestposition",outside_schedule:"Außerhalb des Zeitplans — automatische Steuerung pausiert",outside_schedule_tooltip:"Das konfigurierte Zeitplanfenster ist nicht aktiv, daher ist die automatische Positionierung pausiert.",solar_would_be:"solar {pct}",next_change_in:"Nächste Anpassung erlaubt in {time}"},solar:{title:"Sonnenberechnung",axis_position:"Positionsachse",axis_tilt:"Neigungsachse",group_inputs:"Eingaben",group_intermediates:"Zwischenwerte",group_output:"Ausgabe",show_all:"Alle {count} Werte anzeigen",show_less:"Weniger anzeigen",no_target:"Kein Sonnenziel — {status}",status:{direct_sun:"Direkte Sonne",fov_exit:"Standard · SAA-Austritt",elevation_limit:"Standard · Höhengrenze",sunset_offset:"Standard · Sonnenuntergangs-Versatz",blind_spot:"Standard · Blindfleck",default:"Standard"},field:{sol_elev_deg:"Sonnenhöhe",gamma_deg:"Relativer Azimut (γ)",position_pct:"Position",effective_distance_m:"Effektive Distanz",adjusted_height_m:"Angepasste Höhe",safety_margin:"Sicherheitsabstand",awn_angle_deg:"Markisenwinkel",vertical_position_m:"Vertikale Position",length_m:"Ausfahrlänge",slat_angle_raw_deg:"Lamellenwinkel",tilt_mode:"Neigungsmodus",max_degrees:"Maximaler Winkel"}},header:{on:"ON",off:"OFF",integration_enabled:"Integration aktiviert",auto:"Auto",automatic_control:"Automatische Steuerung"},tile:{motion_pending:"Anwesenheits-Timeout läuft",motion_detected:"Anwesenheit erkannt",battery_low:"Batterie schwach — {level}%",battery_unknown:"Batteriestand unbekannt",icon_action_label:"Aktion des Beschattungssymbols",open:"Öffnen",stop:"Stopp",close:"Schließen",resume_aria:"Automatische Steuerung fortsetzen",extend_aria:"Manuelle Übersteuerung verlängern",registry_failed:"Registry-Abruf fehlgeschlagen: {error}",loading:"Wird geladen…",entry_not_found:"Adaptive Cover Pro-Eintrag {entry} nicht gefunden.",unavailable:"Nicht verfügbar",rails_layered:"{count} Behänge einer Beschattung",rails_separate:"{count} Beschattungen",rails_layered_hint:"Behänge einer Beschattung"},formatters:{expired:"abgelaufen"},elevation:{title:"Sonne heute",fov_window:"SAA: {from} → {to}",fov_windows:"SAA: {windows}",fov_window_named:"{name}: {windows}",no_fov_today:"Sonne tritt heute nicht in den SAA ein",placeholder:"Sonnenhöhen-Diagramm nicht verfügbar.",schedule:"Zeitplan {from} – {to}",schedule_from:"Zeitplan ab {from}",schedule_until:"Zeitplan bis {to}",schedule_start_tooltip:"Zeitplanstart",schedule_end_tooltip:"Zeitplanende"},control_status:{active:"Aktiv",outside_time_window:"Außerhalb des Zeitfensters",position_delta_too_small:"Positionsänderung zu gering",time_delta_too_small:"Zu kurz seit der letzten Bewegung",manual_override:"Manuelle Übersteuerung",automatic_control_off:"Automatische Steuerung aus",sun_not_visible:"Sonne nicht sichtbar",force_override_active:"Zwangsübersteuerung",weather_override_active:"Wettersicherheit",motion_timeout:"Anwesenheits-Timeout"},history:{title:"Verlauf",open:"Verlauf",close:"Schließen",refresh:"Aktualisieren",loading:"Verlauf wird geladen…",no_data:"Keine aufgezeichneten Daten",window_label:"Verlaufszeitraum",window_hours:"{hours} Std.",show_more:"Mehr anzeigen",expand:"Vollansicht öffnen",collapse:"Zurück zum Verlauf",today:"Heute",yesterday:"Gestern",section_tracks:"Zeitverlauf",track_position:"Position",track_who_won:"Gewinner",track_control_status:"Steuerungsstatus",track_enabled:"Integration",track_auto:"Automatische Steuerung",track_sun:"Sonne im SAA",track_glare:"Blendung",track_manual:"Manuelle Übersteuerung",track_mismatch:"Positionsabweichung",legend_target:"Ziel",legend_actual:"Ist",legend_per_cover:"Pro Beschattung",legend_saa:"Sonne im SAA",legend_night:"Nacht",stat_moves:"Bewegungen",stat_travel:"Pkt. zurückgelegt",stat_override:"in manueller Übersteuerung",copy_diagnostics:"Diagnose kopieren",copied:"Kopiert",no_recorder_data:"Nicht aufgezeichnet — Recorder-Einstellungen prüfen",activity_title:"Aktivität",activity_empty:"Keine aufgezeichnete Aktivität in diesem Zeitraum.",advanced:"Erweitert — Ereignispuffer",events_search:"Ereignisse filtern…",events_count:"{shown} von {total} Ereignissen",events_empty:"Keine Ereignisse entsprechen dem Filter.",events_unavailable:"Ereignispuffer nicht verfügbar — die Integration hat keine Diagnose zurückgegeben.",buffer_size:"Puffergröße: {size}",data_window:"Pufferzeitraum: {from} → {to}"},root:{loading_registry:"Adaptive Cover Pro-Registry wird geladen…",no_entities_title:"Keine Adaptive Cover Pro-Entitäten gefunden",footer_version:"adaptive-cover-pro-card v{version}",compass_no_match:"Keine passenden Adaptive Cover Pro-Entitäten",compass_configured:"Konfigurierte Einträge: {entries}",compass_not_found:"Einträge nicht gefunden: {entries}"},editor:{common:{entry_id:"Adaptive Cover Pro-Instanz",support_alt:"Kauf mir einen Kaffee",title_optional:"Titel (optional)",title_placeholder:"z. B. Fenster Westseite",north_offset:"Kompass-Nordversatz (°)",north_offset_hint:'Kompass im Uhrzeigersinn drehen, sodass „oben" Ihrer Karte entspricht. Standard: 0.',loading_entries:"Adaptive Cover Pro-Konfigurationseinträge werden geladen…",load_failed:"Konfigurationseinträge konnten nicht geladen werden: {error}",no_entries:"Keine Adaptive Cover Pro-Konfigurationseinträge gefunden. Fügen Sie eine Instanz unter",no_entries_path:"Einstellungen → Geräte & Dienste",no_entries_then:" hinzu und kehren Sie dann zurück.",entry_id_manual_placeholder:"Konfigurations-Eintrags-ID manuell eingeben",entry_id_fallback_label:"Eintrags-ID",unknown_entry:"(unbekannt: {entry})",reset:"Zurücksetzen"},main:{sections:"Abschnitte",sections_hint:"Sichtbare Bereiche der Karte ein- oder ausblenden.",section_sky_label:"Himmelskompass",section_sky_desc:"Sonne vs. Fenster-SAA, Polardiagramm",section_elevation_label:"Sonne heute",section_elevation_desc:"Höhen-Zeit-Diagramm mit SAA-Bereich und aktuellem Zeitcursor",section_decision_label:"Entscheidungsleiste",section_decision_desc:"Alle 10 Pipeline-Handler mit hervorgehobener Gewinnerzeile",section_covers_label:"Beschattungspositionen",section_covers_desc:"Aktuelle und Zielposition je Beschattung; klicken zum Festlegen der Position",section_overrides_label:"Übersteuerungsbereich",section_overrides_desc:"Kacheln für Manuell, Zwang, Anwesenheit + Zurücksetzen-Schaltfläche",section_climate_label:"Klimabereich",section_climate_desc:"Sommer-/Winter-/Übergangsstrategie; zeigt Bereitschaft, wenn Klimamodus deaktiviert oder inaktiv ist",section_solar_label:"Sonnenberechnung",section_solar_desc:"Aufschlüsselung der Sonnengeometrie (Eingaben → Zwischenwerte → Ausgabe); erfordert den solar_calculation-Sensor der Integration",controls:"Steuerung",controls_hint:"Als schreibgeschützt anzeigen (sichtbar, aber nicht klickbar).",integration_pill_label:"Integration EIN/AUS-Schalter",integration_pill_desc:"Integration über den Karten-Header umschalten.",automatic_pill_label:"Automatische Steuerung-Schalter",automatic_pill_desc:"Automatische Steuerung über den Karten-Header umschalten.",reset_button_label:'Schaltfläche „Manuelle Übersteuerung zurücksetzen"',reset_button_desc:"Zurücksetzen-Kachel im Übersteuerungsbereich betätigen lassen.",display:"Anzeige",compact_label:"Kompaktmodus",compact_desc:"Engerer Abstand zwischen Abschnitten.",show_compass_stats_label:"Kompassstatistiken anzeigen",show_compass_stats_desc:"Azi, Elev, ∠ und Fensterwinkel unterhalb des Himmelskompasses.",show_compass_legend_label:"Kompasslegende anzeigen",show_compass_legend_desc:"Farbschlüssel unterhalb des Himmelskompasses.",show_moon_label:"Mond auf Kompass anzeigen",show_moon_desc:"Mondposition und Mondphase als Überlagerung auf dem Himmelskompass.",hide_inactive_label:"Inaktive Handler ausblenden",hide_inactive_desc:"Nur den Gewinner und aktiv übereinstimmende Pipeline-Handler anzeigen.",state_color_label:"Symbol nach Status einfärben",state_color_desc:"Kopfzeilen-Symbol nimmt die Offen/Geschlossen/Aktiv-Farbe des Themes an."},tile:{name:"Titel überschreiben",icon:"Symbol überschreiben",cover:"Beschattungsentität",layout:"Layout",show_position:"Position % anzeigen",show_state:"Status anzeigen (Offen/Geschlossen)",show_decision_summary:"Entscheidungszusammenfassung anzeigen",show_controls:"Steuerung ↑ ■ ↓ anzeigen",covers:"Positionsleisten (Reihenfolge)",covers_hint:"Ziehen Sie eine Zeile oder verwenden Sie die Pfeile, um die Reihenfolge der Positionsleisten festzulegen. Das Auge blendet eine Leiste aus, ohne den Behang zu entfernen.",member_names:"Mitglieder",member_names_hint:"Ziehen Sie eine Zeile oder verwenden Sie die Pfeile, um die Reihenfolge der Mitglieder festzulegen. Das Auge blendet ein Mitglied auf dieser Karte aus, ohne es aus der Gruppe zu entfernen. Tippen Sie, um ein Mitglied umzubenennen; leer lassen, um den Namen des Eintrags zu verwenden.",members_hide:"Dieses Mitglied ausblenden",members_show:"Dieses Mitglied anzeigen",covers_move_up:"Nach oben",covers_move_down:"Nach unten",covers_hide:"Diese Leiste ausblenden",covers_show:"Diese Leiste anzeigen",controls_cover:"Von ↑ ■ ↓ gesteuerter Behang",controls_axis:"Von ↑ ■ ↓ gesteuerte Achse",show_badge:"Kontextbadge anzeigen",show_position_bar:"Positionsleiste anzeigen",show_tilt:"Neigungsleiste anzeigen",content_section:"Inhalt",controls_section:"Bedienelemente",dialog_section:"Dialogbereiche",group_row_section:"Gruppensteuerung",show_scene_select:"Szenenauswahl anzeigen",show_lock:"Gruppensperre anzeigen",show_automation:"Umschalter für Mitglieder-Automatisierung anzeigen",show_clear_overrides:"Schaltfläche „Übersteuerungen löschen“ anzeigen",show_member_badges:"Mitglieder-Übersteuerungs-Badges anzeigen",badge_section:"Badges",badge_auto:"Auto",badge_solar:"Sonnenverfolgung",badge_force:"Zwangsübersteuerung",badge_weather:"Wettersicherheit",badge_manual:"Manuelle Übersteuerung",badge_custom_position:"Benutzerdefinierte Position",badge_motion:"Anwesenheit",badge_climate:"Klima",badge_glare_zone:"Blendungszone",badge_cloud:"Wolkenunterdrückung",show_compass:"Sonnenkompass im Dialog anzeigen",show_elevation_chart:"Sonne-heute-Diagramm im Dialog anzeigen",show_solar_calc:"Sonnenberechnung im Dialog anzeigen",show_motion_icon:"Anwesenheitsanzeige einblenden",state_color:"Symbol nach Status einfärben",interactions_section:"Interaktionen",tap_action:"Tipp-Aktion",icon_tap_action:"Tipp-Aktion für Symbol",hold_action:"Gedrückthalten-Aktion",double_tap_action:"Doppeltippen-Aktion",cover_blank_hint:"Leer lassen, um automatisch die erste verwaltete Beschattung zu verwenden.",name_composed_hint:"In YAML ist ein zusammengesetzter Titel festgelegt. Hier einen neuen Titel eingeben, um ihn durch einfachen Text zu ersetzen.",layout_option_one_line:"Eine Zeile (kompakt)",layout_option_detailed:"Detailliert (Titel, Status, Indikatoren)"},compass:{instances:"Adaptive Cover Pro-Instanzen",instances_hint:"Eine oder mehrere auswählen. Jeder gewählte Eintrag fügt dem Kompass eine Überlagerung hinzu.",cover_colors:"Beschattungsfarben",cover_colors_hint:"Standardpalettenfarbe für jede Überlagerung überschreiben.",default_color:"Standard",display:"Anzeige",toggle_compact_label:"Kompaktmodus",toggle_compact_desc:"Kleineres SVG, Legende ausgeblendet.",toggle_legend_label:"Legende",toggle_legend_desc:"Farbmuster und Eintragsbezeichnungen unterhalb des Kompasses.",toggle_stats_label:"Statistiken",toggle_stats_desc:"Sonne + numerische Zeilen je Fenster.",toggle_moon_label:"Mond",toggle_moon_desc:"Mondposition und Mondphase anzeigen.",toggle_cardinals_label:"Himmelsrichtungen",toggle_cardinals_desc:"N/O/S/W-Buchstaben rund um den Kompass.",toggle_blind_spot_label:"Blindflecke",toggle_blind_spot_desc:"Schraffierte Sektoren für den Blindfleckbereich jedes Fensters.",toggle_sun_path_label:"Sonnenbahn",toggle_sun_path_desc:"Heutiger Sonnenbogen am Himmel.",toggle_sunrise_sunset_label:"Sonnenaufgangs-/Untergangsmarkierungen",toggle_sunrise_sunset_desc:"Kleine Punkte bei Aufgangs- und Untergangsazimut.",toggle_cover_fill_label:"Schlussfüllbereich der Beschattung",toggle_cover_fill_desc:"Innerer Sektor, der zeigt, wie weit jede Beschattung geschlossen ist.",toggle_window_arrow_label:"Fenster-Normalenpfeil",toggle_window_arrow_desc:"Linie vom Mittelpunkt zum Azimut jedes Fensters.",toggle_elevation_chart_label:"Sonne-heute-Diagramm",toggle_elevation_chart_desc:"Höhen-Zeit-Diagramm unterhalb des Kompasses, mit SAA-Bereich und Höhengrenzen."},decision:{title:"Titel (optional)",compact_label:"Kompaktmodus",compact_desc:"Engere Zeilen; blendet inaktive Handler ebenfalls aus.",hide_inactive_handlers_label:"Inaktive Handler ausblenden",hide_inactive_handlers_desc:"Nur den Gewinner und aktiv übereinstimmende Pipeline-Handler anzeigen.",show_decision_summary_label:"Entscheidungszusammenfassung anzeigen",show_decision_summary_desc:'Einen verständlichen Satz „Warum diese Position?" oberhalb der Leiste anzeigen.'},solar_chart:{instances:"Adaptive Cover Pro-Instanzen",instances_hint:"Eine oder mehrere auswählen. Jeder gewählte Eintrag fügt dem Diagramm eine SAA-Überlagerung hinzu.",cover_colors:"Beschattungsfarben",cover_colors_hint:"Standardpalettenfarbe für jede Überlagerung überschreiben.",default_color:"Standard",display:"Anzeige",toggle_compact_label:"Kompaktmodus",toggle_compact_desc:"Kleineres Diagramm, engerer Abstand."},history:{title:"Titel (optional)",hours_label:"Verlaufszeitraum",hours_desc:"Wie weit die Spuren zurückreichen, gerechnet ab jetzt.",track_position_label:"Positionsspur",track_position_desc:"Aufgezeichnete Beschattungsposition im Zeitraum.",track_who_won_label:"Gewinner-Spur",track_who_won_desc:"Bänder des jeweils gewinnenden Pipeline-Handlers im Zeitverlauf.",track_context_label:"Kontextspuren",track_context_desc:"Zeiträume für Sonne-im-SAA, Blendung und manuelle Übersteuerung.",track_actions_label:"Aktionsliste",track_actions_desc:"Aufgezeichnete und übersprungene Beschattungsaktionen, neueste zuerst.",advanced_open_label:"Erweitert beim Start öffnen",advanced_open_desc:"Den Ereignispuffer-Abschnitt beim Laden ausklappen.",hide_advanced_label:"Erweitert-Abschnitt ausblenden",hide_advanced_desc:"Den Diagnose-Ereignispuffer auf dieser Karte nie anzeigen."}}}};function ot(e,t){const o=t.split(".");let i=e;for(const e of o){if("object"!=typeof i||null===i)return;i=i[e]}return"string"==typeof i?i:void 0}function it(e,t){return t?e.replace(/\{(\w+)\}/g,(e,o)=>Object.prototype.hasOwnProperty.call(t,o)?String(t[o]):e):e}function st(e,t,o){const i=function(e){const t=(e?.locale?.language??e?.language??"en").toLowerCase().split("-")[0];return t in tt?t:"en"}(t),s=ot(tt[i],e);if(void 0!==s)return it(s,o);if("en"!==i){const t=ot(tt.en,e);if(void 0!==t)return it(t,o)}return e}function nt(e){return null==e||Number.isNaN(e)?"—":`${Math.round(e)}%`}function rt(e){return!e||"unavailable"===e||"unknown"===e}function at(e){return!e||"unavailable"===e}function lt(e,t,o){if(!e||!t)return null;const i=e.states[t];if(!i||at(i.state))return null;const s=o?{...i,state:o}:i;if("function"==typeof e.formatEntityState){const t=e.formatEntityState(s);if(t)return t}if("function"==typeof e.localize){const t=e.localize(`component.cover.entity_component._.state.${s.state}`);if(t)return t}return s.state.charAt(0).toUpperCase()+s.state.slice(1)}function ct(e){return null==e||Number.isNaN(e)?"—":`${e.toFixed(1)}°`}function dt(e,t){if(!e)return"—";const o=new Date(e);return Number.isNaN(o.getTime())?"—":o.toLocaleTimeString([],{hour:"2-digit",minute:"2-digit",timeZone:t})}function ht(e,t){if(!e)return"—";const o=new Date(e).getTime();if(Number.isNaN(o))return"—";const i=Math.round((o-Date.now())/1e3);return i<=0?t?st("formatters.expired",t):"expired":function(e){if(null==e||Number.isNaN(e))return"—";const t=Math.max(0,Math.round(e));if(t<60)return`${t}s`;const o=Math.floor(t/60);return o<60?`${o}m ${t%60}s`:`${Math.floor(o/60)}h ${o%60}m`}(i)}function pt(e,t){if(null!==t&&!Number.isNaN(t)){if(t>=95)return e.open;if(t<=5)return e.closed}return e.partial}function ut(e){const{explicitIcon:t,deviceClass:o,coverType:i,position:s}=e;if("string"==typeof t&&t.length>0)return t;if(o){const e=Be[o];if(e)return pt(e,s)}return function(e,t){return pt({open:De[e]??"mdi:window-shutter-open",partial:Ne[e]??"mdi:window-shutter",closed:Fe[e]??"mdi:window-shutter"},t)}(i,s)}function _t(e){return e&&Re.has(e)?"mdi:arrow-expand-horizontal":"mdi:arrow-up"}function gt(e){return e&&Re.has(e)?"mdi:arrow-collapse-horizontal":"mdi:arrow-down"}const mt="var(--state-cover-active-color, var(--state-cover-color, var(--state-active-color, var(--primary-color))))";function vt(e){if(at(e)||!e)return"var(--state-unavailable-color)";const t=e.toLowerCase(),o="closed"!==t&&"unknown"!==t?"active":"inactive";return`var(--state-cover-${t}-color, var(--state-cover-${o}-color, var(--state-cover-color, var(--state-${o}-color))))`}function ft(e,t){return t.openBlocksSun?e:t.min+t.max-e}const bt=100,yt="%",wt=new Set(["cover_awning","cover_oscillating_awning"]);function xt(e,t){return"position"===t&&wt.has(e.cover_type)}function $t(e){return e.charAt(0).toUpperCase()+e.slice(1)}function kt(e){const t=e.discovery?.axes;if(Array.isArray(t))return t.filter(e=>!!e&&"string"==typeof e.id&&!1!==e.supported).map(t=>({id:t.id,label:t.label??$t(t.id),min:"number"==typeof t.min?t.min:0,max:"number"==typeof t.max?t.max:bt,unit:"string"==typeof t.unit?t.unit:yt,stateAttr:"string"==typeof t.state_attr?t.state_attr:void 0,targetRole:Ue[t.id],inverted:!0===t.inverted,openBlocksSun:"boolean"==typeof t.open_blocks_sun?t.open_blocks_sun:xt(e,t.id)}));const o=[{id:"position",label:$t("position"),min:0,max:bt,unit:yt,stateAttr:"current_position",targetRole:"target_position_sensor",inverted:!1,openBlocksSun:xt(e,"position")}];return e.entities.target_tilt_sensor&&o.push({id:"tilt",label:$t("tilt"),min:0,max:bt,unit:yt,stateAttr:"current_tilt_position",targetRole:"target_tilt_sensor",inverted:!1,openBlocksSun:!1}),o}function At(e){return kt(e).find(e=>"position"===e.id)??{id:"position",label:"Position",min:0,max:bt,unit:yt,stateAttr:"current_position",targetRole:"target_position_sensor",inverted:!1,openBlocksSun:xt(e,"position")}}function St(e){return kt(e).find(e=>"position"===e.id)?.inverted??!1}const Ct=[12,16];function Et(e,t,o=0){const i=(e-90+o)*Math.PI/180;return{x:t*Math.cos(i),y:t*Math.sin(i)}}function zt(e){return 1-Math.max(0,Math.min(90,e))/90}function Mt(e,t,o,i=0,s=0){const n=e=>(e%360+360)%360,r=n(e),a=n(t);let l=a-r;l<0&&(l+=360);const c=l>180?1:0,d=Et(r,o,s),h=Et(a,o,s);if(i<=0)return`M 0 0 L ${d.x} ${d.y} A ${o} ${o} 0 ${c} 1 ${h.x} ${h.y} Z`;const p=Et(a,i,s),u=Et(r,i,s);return[`M ${d.x} ${d.y}`,`A ${o} ${o} 0 ${c} 1 ${h.x} ${h.y}`,`L ${p.x} ${p.y}`,`A ${i} ${i} 0 ${c} 0 ${u.x} ${u.y}`,"Z"].join(" ")}function Tt(e,t,o=0){return Et(e,zt(t),o)}function It(e){return(e%360+360)%360}function Pt(e,t,o,i){const s=i??0;let n=-1,r=-1;for(let i=t;i<=o&&i<e.length;i++)e[i].elevation>s&&(-1===n&&(n=i),r=i);return-1===n?null:{wedgeStart:e[n].azimuth,wedgeEnd:e[r].azimuth}}function Ot(e,t,o){const i=(e-t)/864e5;return Math.max(0,Math.min(o,i*o))}function Nt(e,t,o){return t+(1-(Number.isNaN(e)?0:Math.max(0,Math.min(100,e)))/100)*o}function Dt(e,t,o){return((e-t)%360+360)%360<=((o-t)%360+360)%360}function Ft(e,t,o,i){return Dt(o,e,t)||Dt(i,e,t)||Dt(e,o,i)||Dt(t,o,i)}function Bt(e){const t=Object.values(e).filter(e=>"number"==typeof e);return 0===t.length?null:t.reduce((e,t)=>e+t,0)/t.length}function Rt(e,t,o,i){const s=t?e/100:1-e/100;return Math.min(o*s,i)}function jt(e,t,o){return e&&null!=t&&Number.isFinite(t)?t===o?null:t:null}function Kt(e,t){return e<.5?-4*t*e:4*t*(1-e)}function Lt(e,t,o,i,s){const n=Et(o,1),r=-n.y,a=n.x,l=e-n.x*i,c=t-n.y*i;return`M ${e} ${t} L ${l+r*s} ${c+a*s} L ${l-r*s} ${c-a*s} Z`}function Gt(e,t){return[It(e-t[1]),It(e-t[0])]}function Wt(e,t){const o=t.entities.target_position_sensor;if(!o)return null;const i=parseFloat(e.states[o]?.state??"");return Number.isNaN(i)?null:i}function Ht(e,t){const o=t.entities.target_position_sensor;if(!o)return null;const i=e.states[o]?.attributes,s=i?.linear_position;return"number"==typeof s&&Number.isFinite(s)?s:null}function Ut(e,t){return Ht(e,t)??Wt(e,t)}function qt(e,t){const o=t.entities.target_position_sensor;if(!o)return null;const i=e.states[o]?.attributes,s=i?.raw_calculated_position;return"number"==typeof s&&Number.isFinite(s)?s:null}function Vt(e,t){const o=t.entities.target_position_sensor;if(!o)return{};const i=e.states[o]?.attributes,s=i?.linear_actual_positions;if(s&&"object"==typeof s)return s;const n=i?.actual_positions;return n?St(t)?Object.fromEntries(Object.entries(n).map(([e,t])=>[e,"number"==typeof t?100-t:null])):n:{}}function Yt(e,t,o){if(!o)return null;const i=e.states[o]?.attributes?.current_position;return"number"!=typeof i||Number.isNaN(i)?null:St(t)?100-i:i}function Zt(e,t,o){if(!o||!t.stateAttr)return null;const i=e.states[o]?.attributes?.[t.stateAttr];return"number"!=typeof i||Number.isNaN(i)?null:t.inverted?100-i:i}function Qt(e,t){return Bt(Vt(e,t))}function Xt(e,t){const o=t.entities.manual_override_binary;return!!o&&"on"===e.states[o]?.state}function Jt(e,t){const o=Ut(e,t);return jt(Xt(e,t),qt(e,t),o)??o}const{I:eo}=ae,to=e=>e,oo=()=>document.createComment(""),io=(e,t,o)=>{const i=e._$AA.parentNode,s=void 0===t?e._$AB:t._$AA;if(void 0===o){const t=i.insertBefore(oo(),s),n=i.insertBefore(oo(),s);o=new eo(t,n,e,e.options)}else{const t=o._$AB.nextSibling,n=o._$AM,r=n!==e;if(r){let t;o._$AQ?.(e),o._$AM=e,void 0!==o._$AP&&(t=e._$AU)!==n._$AU&&o._$AP(t)}if(t!==s||r){let e=o._$AA;for(;e!==t;){const t=to(e).nextSibling;to(i).insertBefore(e,s),e=t}}}return o},so=(e,t,o=e)=>(e._$AI(t,o),e),no={},ro=(e,t=no)=>e._$AH=t,ao=e=>{e._$AR(),e._$AA.remove()},lo=e=>(...t)=>({_$litDirective$:e,values:t});class co{constructor(e){}get _$AU(){return this._$AM._$AU}_$AT(e,t,o){this._$Ct=e,this._$AM=t,this._$Ci=o}_$AS(e,t){return this.update(e,t)}update(e,t){return this.render(...t)}}const ho=(e,t)=>{const o=e._$AN;if(void 0===o)return!1;for(const e of o)e._$AO?.(t,!1),ho(e,t);return!0},po=e=>{let t,o;do{if(void 0===(t=e._$AM))break;o=t._$AN,o.delete(e),e=t}while(0===o?.size)},uo=e=>{for(let t;t=e._$AM;e=t){let o=t._$AN;if(void 0===o)t._$AN=o=new Set;else if(o.has(e))break;o.add(e),mo(t)}};function _o(e){void 0!==this._$AN?(po(this),this._$AM=e,uo(this)):this._$AM=e}function go(e,t=!1,o=0){const i=this._$AH,s=this._$AN;if(void 0!==s&&0!==s.size)if(t)if(Array.isArray(i))for(let e=o;e<i.length;e++)ho(i[e],!1),po(i[e]);else null!=i&&(ho(i,!1),po(i));else ho(this,e)}const mo=e=>{2==e.type&&(e._$AP??=go,e._$AQ??=_o)};class vo extends co{constructor(){super(...arguments),this._$AN=void 0}_$AT(e,t,o){super._$AT(e,t,o),uo(this),this.isConnected=e._$AU}_$AO(e,t=!0){e!==this.isConnected&&(this.isConnected=e,e?this.reconnected?.():this.disconnected?.()),t&&(ho(this,e),po(this))}setValue(e){if((()=>void 0===this._$Ct.strings)())this._$Ct._$AI(e,this);else{const t=[...this._$Ct._$AH];t[this._$Ci]=e,this._$Ct._$AI(t,this,0)}}disconnected(){}reconnected(){}}let fo=class extends de{constructor(){super(...arguments),this.text="",this.cursorX=0,this.cursorY=0,this.offset=Ct,this.visible=!1,this._x=0,this._y=0}connectedCallback(){super.connectedCallback(),this.hasAttribute("role")||this.setAttribute("role","tooltip")}updated(){if(!this.visible)return;this.setAttribute("aria-hidden","false");const e=this.shadowRoot?.querySelector(".bubble"),t=e?.offsetWidth??0,o=e?.offsetHeight??0,i="undefined"!=typeof window?window.innerWidth:0,s="undefined"!=typeof window?window.innerHeight:0,{x:n,y:r}=function(e){const{cursorX:t,cursorY:o,ttW:i,ttH:s,vpW:n,vpH:r}=e,[a,l]=e.offset??Ct;let c=t+a,d=!1;c+i>n&&(c=t-a-i,d=!0),c<0&&(c=0);let h=o+l;return h+s>r&&(h=o-l-s),h<0&&(h=0),{x:c,y:h,flipped:d}}({cursorX:this.cursorX,cursorY:this.cursorY,ttW:t,ttH:o,vpW:i,vpH:s,offset:this.offset});n!==this._x&&(this._x=n),r!==this._y&&(this._y=r)}render(){return this.visible?H`<div class="bubble" style="transform: translate3d(${this._x}px, ${this._y}px, 0)">
       ${this.text}
-    </div>`:(this.setAttribute("aria-hidden","true"),V)}};vo.styles=a`
+    </div>`:(this.setAttribute("aria-hidden","true"),V)}};fo.styles=a`
     :host {
       position: fixed;
       top: 0;
@@ -28,17 +28,17 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
       white-space: normal;
       word-break: break-word;
     }
-  `,e([ge({type:String})],vo.prototype,"text",void 0),e([ge({type:Number})],vo.prototype,"cursorX",void 0),e([ge({type:Number})],vo.prototype,"cursorY",void 0),e([ge({attribute:!1})],vo.prototype,"offset",void 0),e([ge({type:Boolean,reflect:!0})],vo.prototype,"visible",void 0),e([me()],vo.prototype,"_x",void 0),e([me()],vo.prototype,"_y",void 0),vo=e([pe("acp-floating-tooltip")],vo);const fo={enabled:!0,offset:Ct,delay:400};function bo(e){void 0!==e.enabled&&(fo.enabled=e.enabled),void 0!==e.offset&&(fo.offset=e.offset),void 0!==e.delay&&(fo.delay=e.delay)}const yo="acp-floating-tooltip-bubble",wo=new class{constructor(){this._el=null,this._refs=0}get id(){return yo}retain(){this._refs+=1,this._ensure()}release(){this._refs=Math.max(0,this._refs-1)}_ensure(){if("undefined"==typeof document)return null;if(this._el&&this._el.isConnected)return this._el;const e=document.createElement("acp-floating-tooltip");return e.id=yo,document.body.appendChild(e),this._el=e,e}show(e,t,o,i){const s=this._ensure();s&&(s.text=e,s.cursorX=t,s.cursorY=o,s.offset=i,s.visible=!0)}move(e,t){this._el&&this._el.visible&&(this._el.cursorX=e,this._el.cursorY=t)}hide(){this._el&&(this._el.visible=!1)}_reset(){this._el&&this._el.parentNode&&this._el.parentNode.removeChild(this._el),this._el=null,this._refs=0}},xo=ao(class extends mo{constructor(e){if(super(e),this._el=null,this._text="",this._offset=Ct,this._delay=400,this._enabled=!0,this._openTimer=null,this._shown=!1,this._retained=!1,this._lastX=0,this._lastY=0,this._onEnter=e=>this._handleEnter(e),this._onMove=e=>this._handleMove(e),this._onLeave=()=>this._dismiss(),this._onFocus=()=>this._handleFocus(),this._onBlur=()=>this._dismiss(),this._onKey=e=>{"Escape"===e.key&&this._dismiss()},this._onScroll=()=>this._dismiss(),6!==e.type)throw new Error("tooltip() can only be used as an element-part directive")}render(e,t){return V}update(e,[t,o]){const i=e.element;return this._text=t??"",this._offset=o?.offset??fo.offset,this._delay=o?.delay??fo.delay,this._enabled=o?.enabled??fo.enabled,this._el!==i?(this._teardown(),this._el=i,this._wire()):this._applyAttributes(),this.render(t,o)}_wire(){const e=this._el;e&&(this._applyAttributes(),this._enabled&&(wo.retain(),this._retained=!0,e.addEventListener("pointerenter",this._onEnter),e.addEventListener("pointermove",this._onMove),e.addEventListener("pointerleave",this._onLeave),e.addEventListener("focusin",this._onFocus),e.addEventListener("focusout",this._onBlur),e.addEventListener("keydown",this._onKey),window.addEventListener("scroll",this._onScroll,!0)))}_applyAttributes(){const e=this._el;e&&(this._enabled?(e.removeAttribute("title"),e.setAttribute("data-tooltip",this._text),e.setAttribute("aria-describedby",wo.id)):(e.removeAttribute("data-tooltip"),e.removeAttribute("aria-describedby"),e.removeAttribute("acp-tt-shown"),e.setAttribute("title",this._text)))}_handleEnter(e){this._lastX=e.clientX,this._lastY=e.clientY,this._armOpen()}_handleFocus(){const e=this._el;if(e&&"function"==typeof e.getBoundingClientRect){const t=e.getBoundingClientRect();this._lastX=t.left+t.width/2,this._lastY=t.bottom}this._armOpen()}_armOpen(){null===this._openTimer&&(this._openTimer=setTimeout(()=>{this._openTimer=null,this._open()},this._delay))}_open(){this._el&&(wo.show(this._text,this._lastX,this._lastY,this._offset),this._shown=!0,this._el.setAttribute("acp-tt-shown",""))}_handleMove(e){this._lastX=e.clientX,this._lastY=e.clientY,this._shown&&wo.move(this._lastX,this._lastY)}_dismiss(){null!==this._openTimer&&(clearTimeout(this._openTimer),this._openTimer=null),this._shown&&(wo.hide(),this._shown=!1),this._el?.removeAttribute("acp-tt-shown")}_teardown(){const e=this._el;e&&(this._dismiss(),e.removeEventListener("pointerenter",this._onEnter),e.removeEventListener("pointermove",this._onMove),e.removeEventListener("pointerleave",this._onLeave),e.removeEventListener("focusin",this._onFocus),e.removeEventListener("focusout",this._onBlur),e.removeEventListener("keydown",this._onKey),"undefined"!=typeof window&&window.removeEventListener("scroll",this._onScroll,!0),this._retained&&(wo.release(),this._retained=!1),e.removeAttribute("data-tooltip"),e.removeAttribute("aria-describedby"),e.removeAttribute("acp-tt-shown"),this._el=null)}disconnected(){this._teardown()}reconnected(){this._wire()}});function $o(){let e=null;return(t,o,i)=>{const s=o.entry_id??"";if(!s)return e=null,null;const n=null!==e&&e.registry===i&&e.entryId===s,r=n?e.base:Ao(s,i);if(!r)return e={registry:i,entryId:s,base:null,devices:null,areas:null,posState:null,ctrlState:null,result:null},null;const a=t.devices,l=t.areas,c=r.entities.target_position_sensor??r.entities.group_position_sensor,d=r.entities.control_status_sensor,h=c?t.states[c]:void 0,p=d?t.states[d]:void 0;if(n&&null!==e&&null!==e.result&&e.devices===a&&e.areas===l&&e.posState===h&&e.ctrlState===p)return e.result;const u=So(t,s,r);return e={registry:i,entryId:s,base:r,devices:a,areas:l,posState:h,ctrlState:p,result:u},u}}function ko(){const e=new Map;let t=[],o=[],i={list:[],missing:[]};return(s,n,r,a)=>{const l=n.map(t=>{let o=e.get(t);return o||(o=$o(),e.set(t,o)),o(s,{type:a,entry_id:t},r)});if(e.size>n.length)for(const t of e.keys())n.includes(t)||e.delete(t);const c=t.length===n.length&&t.every((e,t)=>e===n[t])&&o.length===l.length&&o.every((e,t)=>e===l[t]);if(c)return i;t=n.slice(),o=l;const d=[],h=[];return n.forEach((e,t)=>{const o=l[t];o?d.push(o):h.push(e)}),i={list:d,missing:h},i}}function Ao(e,t){const o={},i=`${e}_`;let s,n=!1;for(const r of t){if(r.config_entry_id!==e)continue;if(r.platform!==Te)continue;if(n=!0,!s&&r.device_id&&(s=r.device_id),!r.unique_id.startsWith(i))continue;const t=r.unique_id.slice(i.length),a=r.entity_id.split(".")[0],l=et[`${a}:${t}`];l&&(o[l]=r.entity_id)}return n&&0!==Object.keys(o).length?{entities:o,deviceId:s}:null}function So(e,t,o){const{entities:i,deviceId:s}=o,n=e;let r=t;if(n.devices)for(const e of Object.values(n.devices))if(e.config_entries?.includes(t)){r=e.name_by_user??e.name??t;break}const a=s?n.devices?.[s]?.area_id:void 0,l=a?e.areas?.[a]?.name:void 0,c=!!i.group_active_scene_sensor,d=[];if(c){const t=i.group_position_sensor;if(t){const o=e.states[t]?.attributes?.member_positions;o&&d.push(...Object.keys(o))}}else{const t=i.target_position_sensor;if(t){const o=e.states[t]?.attributes?.actual_positions;o&&d.push(...Object.keys(o))}}let h,p="cover_blind";const u=i.control_status_sensor;if(u){const t=e.states[u]?.attributes;t?.cover_type&&(p=t.cover_type);const o=t?.cover_discovery;o&&"object"==typeof o&&Array.isArray(o.axes)&&(h=o)}return{entry_id:t,entry_title:r,cover_type:p,entities:i,managed_covers:d,device_id:s,is_group:c,...h?{discovery:h}:{},...l?{area_name:l}:{}}}function Co(e,t,o){const i=t.entry_id;if(!i)return null;const s=Ao(i,o);return s?So(e,i,s):null}async function Eo(e){return e.callWS({type:"config/entity_registry/list"})}function zo(e,t){let o=null,i=!1;return e.connection.subscribeEvents(e=>t(e.data),"entity_registry_updated").then(e=>{i?e():o=e}).catch(()=>{}),()=>{i=!0,o&&o()}}let Mo=null,To=null;function Io(){return Mo}function Po(e,t=!1){if(To)return To;if(!t&&Mo)return Promise.resolve(Mo);const o=Eo(e).then(e=>(Mo=e,To=null,e)).catch(e=>{throw To=null,e});return To=o,o}let Oo=null,No=null;function Do(e){if(Oo===e&&No)return No;const t=new Map;for(const o of e)t.set(o.entity_id,o);return Oo=e,No=t,t}function Bo(e,t,o){if(!t.startsWith("cover."))return null;const i=o??Io();if(!i)return null;const s=Do(i);if(s.get(t)?.platform===Te)return null;for(const[o,i]of Object.entries(e.states)){const e=i?.attributes?.actual_positions;if(!e||!(t in e))continue;const n=s.get(o);if(n?.platform===Te)return n.config_entry_id}return null}function Fo(e,t){return function(){if(Mo||To)return;const e=globalThis.hassConnection;e&&(To=e.then(({conn:e})=>e.sendMessagePromise({type:"config/entity_registry/list"})).then(e=>(Mo=e,To=null,e)).catch(e=>{throw To=null,e}),To.catch(()=>{}))}(),(o,i)=>{const s=function(e,t){const o=Io();if(!o)return e.callWS&&Po(e).catch(()=>{}),null;const i=Do(o),s=i.get(t);if(s?.platform===Te)return s.config_entry_id;if(!t.startsWith("cover."))return null;for(const[o,s]of Object.entries(e.states)){const e=s?.attributes,n=e?.actual_positions??e?.member_positions;if(!n||!(t in n))continue;const r=i.get(o);if(r?.platform===Te)return r.config_entry_id}return null}(o,i);return s?{config:"entry_ids"===t?{type:e,entry_ids:[s]}:{type:e,entry_id:s}}:null}}async function Ro(e){const[t,o]=await Promise.all([e.callWS({type:"config_entries/get",domain:Te}),Eo(e)]),i=new Set(o.filter(e=>e.platform===Te&&null!=e.config_entry_id).map(e=>e.config_entry_id));return t.filter(e=>e.domain===Te&&i.has(e.entry_id)).map(e=>({entry_id:e.entry_id,title:e.title}))}function jo(e){return`acp-card:registry:v1:${e}`}const Lo={get(e){try{const t=localStorage.getItem(jo(e));if(!t)return null;const o=JSON.parse(t);return 1!==o.schemaVersion?null:o.entries?.length?"number"==typeof o.fetchedAt&&Date.now()-o.fetchedAt>6e4?null:o:null}catch{return null}},set(e,t){if(0!==t.length)try{const o={schemaVersion:1,cardVersion:fe,fetchedAt:Date.now(),entries:t};localStorage.setItem(jo(e),JSON.stringify(o))}catch{}},invalidate(e){try{localStorage.removeItem(jo(e))}catch{}},clear(){try{const e="acp-card:registry:v1:",t=[];for(let o=0;o<localStorage.length;o++){const i=localStorage.key(o);i?.startsWith(e)&&t.push(i)}t.forEach(e=>localStorage.removeItem(e))}catch{}}};function Ko(e){return`${e.entity_id}|${e.unique_id}|${e.platform}|${e.config_entry_id??""}`}function Go(e,t,o){return e.filter(e=>e.config_entry_id===t&&void 0===o)}let Wo=class extends de{constructor(){super(...arguments),this.on=!1,this.readonly=!1,this.label="",this.title=""}_handleClick(){this.readonly||this.dispatchEvent(new CustomEvent("pill-click",{bubbles:!0,composed:!0}))}render(){return H`
+  `,e([ge({type:String})],fo.prototype,"text",void 0),e([ge({type:Number})],fo.prototype,"cursorX",void 0),e([ge({type:Number})],fo.prototype,"cursorY",void 0),e([ge({attribute:!1})],fo.prototype,"offset",void 0),e([ge({type:Boolean,reflect:!0})],fo.prototype,"visible",void 0),e([me()],fo.prototype,"_x",void 0),e([me()],fo.prototype,"_y",void 0),fo=e([pe("acp-floating-tooltip")],fo);const bo={enabled:!0,offset:Ct,delay:400};function yo(e){void 0!==e.enabled&&(bo.enabled=e.enabled),void 0!==e.offset&&(bo.offset=e.offset),void 0!==e.delay&&(bo.delay=e.delay)}const wo="acp-floating-tooltip-bubble",xo=new class{constructor(){this._el=null,this._refs=0}get id(){return wo}retain(){this._refs+=1,this._ensure()}release(){this._refs=Math.max(0,this._refs-1)}_ensure(){if("undefined"==typeof document)return null;if(this._el&&this._el.isConnected)return this._el;const e=document.createElement("acp-floating-tooltip");return e.id=wo,document.body.appendChild(e),this._el=e,e}show(e,t,o,i){const s=this._ensure();s&&(s.text=e,s.cursorX=t,s.cursorY=o,s.offset=i,s.visible=!0)}move(e,t){this._el&&this._el.visible&&(this._el.cursorX=e,this._el.cursorY=t)}hide(){this._el&&(this._el.visible=!1)}_reset(){this._el&&this._el.parentNode&&this._el.parentNode.removeChild(this._el),this._el=null,this._refs=0}},$o=lo(class extends vo{constructor(e){if(super(e),this._el=null,this._text="",this._offset=Ct,this._delay=400,this._enabled=!0,this._openTimer=null,this._shown=!1,this._retained=!1,this._lastX=0,this._lastY=0,this._onEnter=e=>this._handleEnter(e),this._onMove=e=>this._handleMove(e),this._onLeave=()=>this._dismiss(),this._onFocus=()=>this._handleFocus(),this._onBlur=()=>this._dismiss(),this._onKey=e=>{"Escape"===e.key&&this._dismiss()},this._onScroll=()=>this._dismiss(),6!==e.type)throw new Error("tooltip() can only be used as an element-part directive")}render(e,t){return V}update(e,[t,o]){const i=e.element;return this._text=t??"",this._offset=o?.offset??bo.offset,this._delay=o?.delay??bo.delay,this._enabled=o?.enabled??bo.enabled,this._el!==i?(this._teardown(),this._el=i,this._wire()):this._applyAttributes(),this.render(t,o)}_wire(){const e=this._el;e&&(this._applyAttributes(),this._enabled&&(xo.retain(),this._retained=!0,e.addEventListener("pointerenter",this._onEnter),e.addEventListener("pointermove",this._onMove),e.addEventListener("pointerleave",this._onLeave),e.addEventListener("focusin",this._onFocus),e.addEventListener("focusout",this._onBlur),e.addEventListener("keydown",this._onKey),window.addEventListener("scroll",this._onScroll,!0)))}_applyAttributes(){const e=this._el;e&&(this._enabled?(e.removeAttribute("title"),e.setAttribute("data-tooltip",this._text),e.setAttribute("aria-describedby",xo.id)):(e.removeAttribute("data-tooltip"),e.removeAttribute("aria-describedby"),e.removeAttribute("acp-tt-shown"),e.setAttribute("title",this._text)))}_handleEnter(e){this._lastX=e.clientX,this._lastY=e.clientY,this._armOpen()}_handleFocus(){const e=this._el;if(e&&"function"==typeof e.getBoundingClientRect){const t=e.getBoundingClientRect();this._lastX=t.left+t.width/2,this._lastY=t.bottom}this._armOpen()}_armOpen(){null===this._openTimer&&(this._openTimer=setTimeout(()=>{this._openTimer=null,this._open()},this._delay))}_open(){this._el&&(xo.show(this._text,this._lastX,this._lastY,this._offset),this._shown=!0,this._el.setAttribute("acp-tt-shown",""))}_handleMove(e){this._lastX=e.clientX,this._lastY=e.clientY,this._shown&&xo.move(this._lastX,this._lastY)}_dismiss(){null!==this._openTimer&&(clearTimeout(this._openTimer),this._openTimer=null),this._shown&&(xo.hide(),this._shown=!1),this._el?.removeAttribute("acp-tt-shown")}_teardown(){const e=this._el;e&&(this._dismiss(),e.removeEventListener("pointerenter",this._onEnter),e.removeEventListener("pointermove",this._onMove),e.removeEventListener("pointerleave",this._onLeave),e.removeEventListener("focusin",this._onFocus),e.removeEventListener("focusout",this._onBlur),e.removeEventListener("keydown",this._onKey),"undefined"!=typeof window&&window.removeEventListener("scroll",this._onScroll,!0),this._retained&&(xo.release(),this._retained=!1),e.removeAttribute("data-tooltip"),e.removeAttribute("aria-describedby"),e.removeAttribute("acp-tt-shown"),this._el=null)}disconnected(){this._teardown()}reconnected(){this._wire()}});function ko(){let e=null;return(t,o,i)=>{const s=o.entry_id??"";if(!s)return e=null,null;const n=null!==e&&e.registry===i&&e.entryId===s,r=n?e.base:So(s,i);if(!r)return e={registry:i,entryId:s,base:null,devices:null,areas:null,posState:null,ctrlState:null,result:null},null;const a=t.devices,l=t.areas,c=r.entities.target_position_sensor??r.entities.group_position_sensor,d=r.entities.control_status_sensor,h=c?t.states[c]:void 0,p=d?t.states[d]:void 0;if(n&&null!==e&&null!==e.result&&e.devices===a&&e.areas===l&&e.posState===h&&e.ctrlState===p)return e.result;const u=Co(t,s,r);return e={registry:i,entryId:s,base:r,devices:a,areas:l,posState:h,ctrlState:p,result:u},u}}function Ao(){const e=new Map;let t=[],o=[],i={list:[],missing:[]};return(s,n,r,a)=>{const l=n.map(t=>{let o=e.get(t);return o||(o=ko(),e.set(t,o)),o(s,{type:a,entry_id:t},r)});if(e.size>n.length)for(const t of e.keys())n.includes(t)||e.delete(t);const c=t.length===n.length&&t.every((e,t)=>e===n[t])&&o.length===l.length&&o.every((e,t)=>e===l[t]);if(c)return i;t=n.slice(),o=l;const d=[],h=[];return n.forEach((e,t)=>{const o=l[t];o?d.push(o):h.push(e)}),i={list:d,missing:h},i}}function So(e,t){const o={},i=`${e}_`;let s,n=!1;for(const r of t){if(r.config_entry_id!==e)continue;if(r.platform!==Te)continue;if(n=!0,!s&&r.device_id&&(s=r.device_id),!r.unique_id.startsWith(i))continue;const t=r.unique_id.slice(i.length),a=r.entity_id.split(".")[0],l=et[`${a}:${t}`];l&&(o[l]=r.entity_id)}return n&&0!==Object.keys(o).length?{entities:o,deviceId:s}:null}function Co(e,t,o){const{entities:i,deviceId:s}=o,n=e;let r=t;if(n.devices)for(const e of Object.values(n.devices))if(e.config_entries?.includes(t)){r=e.name_by_user??e.name??t;break}const a=s?n.devices?.[s]?.area_id:void 0,l=a?e.areas?.[a]?.name:void 0,c=!!i.group_active_scene_sensor,d=[];if(c){const t=i.group_position_sensor;if(t){const o=e.states[t]?.attributes?.member_positions;o&&d.push(...Object.keys(o))}}else{const t=i.target_position_sensor;if(t){const o=e.states[t]?.attributes?.actual_positions;o&&d.push(...Object.keys(o))}}let h,p="cover_blind";const u=i.control_status_sensor;if(u){const t=e.states[u]?.attributes;t?.cover_type&&(p=t.cover_type);const o=t?.cover_discovery;o&&"object"==typeof o&&Array.isArray(o.axes)&&(h=o)}return{entry_id:t,entry_title:r,cover_type:p,entities:i,managed_covers:d,device_id:s,is_group:c,...h?{discovery:h}:{},...l?{area_name:l}:{}}}function Eo(e,t,o){const i=t.entry_id;if(!i)return null;const s=So(i,o);return s?Co(e,i,s):null}async function zo(e){return e.callWS({type:"config/entity_registry/list"})}function Mo(e,t){let o=null,i=!1;return e.connection.subscribeEvents(e=>t(e.data),"entity_registry_updated").then(e=>{i?e():o=e}).catch(()=>{}),()=>{i=!0,o&&o()}}let To=null,Io=null;function Po(){return To}function Oo(e,t=!1){if(Io)return Io;if(!t&&To)return Promise.resolve(To);const o=zo(e).then(e=>(To=e,Io=null,e)).catch(e=>{throw Io=null,e});return Io=o,o}let No=null,Do=null;function Fo(e){if(No===e&&Do)return Do;const t=new Map;for(const o of e)t.set(o.entity_id,o);return No=e,Do=t,t}function Bo(e,t,o){if(!t.startsWith("cover."))return null;const i=o??Po();if(!i)return null;const s=Fo(i);if(s.get(t)?.platform===Te)return null;for(const[o,i]of Object.entries(e.states)){const e=i?.attributes?.actual_positions;if(!e||!(t in e))continue;const n=s.get(o);if(n?.platform===Te)return n.config_entry_id}return null}function Ro(e,t){return function(){if(To||Io)return;const e=globalThis.hassConnection;e&&(Io=e.then(({conn:e})=>e.sendMessagePromise({type:"config/entity_registry/list"})).then(e=>(To=e,Io=null,e)).catch(e=>{throw Io=null,e}),Io.catch(()=>{}))}(),(o,i)=>{const s=function(e,t){const o=Po();if(!o)return e.callWS&&Oo(e).catch(()=>{}),null;const i=Fo(o),s=i.get(t);if(s?.platform===Te)return s.config_entry_id;if(!t.startsWith("cover."))return null;for(const[o,s]of Object.entries(e.states)){const e=s?.attributes,n=e?.actual_positions??e?.member_positions;if(!n||!(t in n))continue;const r=i.get(o);if(r?.platform===Te)return r.config_entry_id}return null}(o,i);return s?{config:"entry_ids"===t?{type:e,entry_ids:[s]}:{type:e,entry_id:s}}:null}}async function jo(e){const[t,o]=await Promise.all([e.callWS({type:"config_entries/get",domain:Te}),zo(e)]),i=new Set(o.filter(e=>e.platform===Te&&null!=e.config_entry_id).map(e=>e.config_entry_id));return t.filter(e=>e.domain===Te&&i.has(e.entry_id)).map(e=>({entry_id:e.entry_id,title:e.title}))}function Ko(e){return`acp-card:registry:v1:${e}`}const Lo={get(e){try{const t=localStorage.getItem(Ko(e));if(!t)return null;const o=JSON.parse(t);return 1!==o.schemaVersion?null:o.entries?.length?"number"==typeof o.fetchedAt&&Date.now()-o.fetchedAt>6e4?null:o:null}catch{return null}},set(e,t){if(0!==t.length)try{const o={schemaVersion:1,cardVersion:fe,fetchedAt:Date.now(),entries:t};localStorage.setItem(Ko(e),JSON.stringify(o))}catch{}},invalidate(e){try{localStorage.removeItem(Ko(e))}catch{}},clear(){try{const e="acp-card:registry:v1:",t=[];for(let o=0;o<localStorage.length;o++){const i=localStorage.key(o);i?.startsWith(e)&&t.push(i)}t.forEach(e=>localStorage.removeItem(e))}catch{}}};function Go(e){return`${e.entity_id}|${e.unique_id}|${e.platform}|${e.config_entry_id??""}`}function Wo(e,t,o){return e.filter(e=>e.config_entry_id===t&&void 0===o)}let Ho=class extends de{constructor(){super(...arguments),this.on=!1,this.readonly=!1,this.label="",this.title=""}_handleClick(){this.readonly||this.dispatchEvent(new CustomEvent("pill-click",{bubbles:!0,composed:!0}))}render(){return H`
       <button
         class="pill ${this.on?"on":"off"} ${this.readonly?"readonly":""}"
-        ${xo(this.title)}
+        ${$o(this.title)}
         aria-disabled=${this.readonly?"true":V}
         tabindex=${this.readonly?"-1":"0"}
         @click=${this._handleClick}
       >
         ${this.label}
       </button>
-    `}};Wo.styles=a`
+    `}};Ho.styles=a`
     .pill {
       padding: 2px 10px;
       border-radius: 999px;
@@ -73,7 +73,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
     .pill.on.readonly {
       opacity: 0.85;
     }
-  `,e([ge({type:Boolean})],Wo.prototype,"on",void 0),e([ge({type:Boolean})],Wo.prototype,"readonly",void 0),e([ge({type:String})],Wo.prototype,"label",void 0),e([ge({type:String})],Wo.prototype,"title",void 0),Wo=e([pe("acp-header-pill")],Wo);const Ho=ao(class extends lo{constructor(e){if(super(e),1!==e.type||"class"!==e.name||e.strings?.length>2)throw Error("`classMap()` can only be used in the `class` attribute and must be the only part in the attribute.")}render(e){return" "+Object.keys(e).filter(t=>e[t]).join(" ")+" "}update(e,[t]){if(void 0===this.st){this.st=new Set,void 0!==e.strings&&(this.nt=new Set(e.strings.join(" ").split(/\s/).filter(e=>""!==e)));for(const e in t)t[e]&&!this.nt?.has(e)&&this.st.add(e);return this.render(t)}const o=e.element.classList;for(const e of this.st)e in t||(o.remove(e),this.st.delete(e));for(const e in t){const i=!!t[e];i===this.st.has(e)||this.nt?.has(e)||(i?(o.add(e),this.st.add(e)):(o.remove(e),this.st.delete(e)))}return q}});function Uo(e){return e&&e.__esModule&&Object.prototype.hasOwnProperty.call(e,"default")?e.default:e}var qo,Vo,Yo={exports:{}},Zo=(qo||(qo=1,Vo=Yo,function(){var e=Math.PI,t=Math.sin,o=Math.cos,i=Math.tan,s=Math.asin,n=Math.atan2,r=Math.acos,a=e/180,l=864e5,c=2440588,d=2451545;function h(e){return new Date((e+.5-c)*l)}function p(e){return function(e){return e.valueOf()/l-.5+c}(e)-d}var u=23.4397*a;function _(e,s){return n(t(e)*o(u)-i(s)*t(u),o(e))}function g(e,i){return s(t(i)*o(u)+o(i)*t(u)*t(e))}function m(e,s,r){return n(t(e),o(e)*t(s)-i(r)*o(s))}function v(e,i,n){return s(t(i)*t(n)+o(i)*o(n)*o(e))}function f(e,t){return a*(280.16+360.9856235*e)-t}function b(e){return a*(357.5291+.98560028*e)}function y(o){return o+a*(1.9148*t(o)+.02*t(2*o)+3e-4*t(3*o))+102.9372*a+e}function w(e){var t=y(b(e));return{dec:g(t,0),ra:_(t,0)}}var x={getPosition:function(e,t,o){var i=a*-o,s=a*t,n=p(e),r=w(n),l=f(n,i)-r.ra;return{azimuth:m(l,s,r.dec),altitude:v(l,s,r.dec)}}},$=x.times=[[-.833,"sunrise","sunset"],[-.3,"sunriseEnd","sunsetStart"],[-6,"dawn","dusk"],[-12,"nauticalDawn","nauticalDusk"],[-18,"nightEnd","night"],[6,"goldenHourEnd","goldenHour"]];x.addTime=function(e,t,o){$.push([e,t,o])};var k=9e-4;function A(t,o,i){return k+(t+o)/(2*e)+i}function S(e,o,i){return d+e+.0053*t(o)-.0069*t(2*i)}function C(e,i,s,n,a,l,c){var d=function(e,i,s){return r((t(e)-t(i)*t(s))/(o(i)*o(s)))}(e,s,n);return S(A(d,i,a),l,c)}function E(e){var i=a*(134.963+13.064993*e),s=a*(93.272+13.22935*e),n=a*(218.316+13.176396*e)+6.289*a*t(i),r=5.128*a*t(s),l=385001-20905*o(i);return{ra:_(n,r),dec:g(n,r),dist:l}}function z(e,t){return new Date(e.valueOf()+t*l/24)}x.getTimes=function(t,o,i,s){var n,r,l,c,d,u=a*-i,_=a*o,m=function(e){return-2.076*Math.sqrt(e)/60}(s=s||0),v=function(t,o){return Math.round(t-k-o/(2*e))}(p(t),u),f=A(0,u,v),w=b(f),x=y(w),E=g(x,0),z=S(f,w,x),M={solarNoon:h(z),nadir:h(z-.5)};for(n=0,r=$.length;n<r;n+=1)d=z-((c=C(((l=$[n])[0]+m)*a,u,_,E,v,w,x))-z),M[l[1]]=h(d),M[l[2]]=h(c);return M},x.getMoonPosition=function(e,s,r){var l=a*-r,c=a*s,d=p(e),h=E(d),u=f(d,l)-h.ra,_=v(u,c,h.dec),g=n(t(u),i(c)*o(h.dec)-t(h.dec)*o(u));return _+=function(e){return e<0&&(e=0),2967e-7/Math.tan(e+.00312536/(e+.08901179))}(_),{azimuth:m(u,c,h.dec),altitude:_,distance:h.dist,parallacticAngle:g}},x.getMoonIllumination=function(e){var i=p(e||new Date),s=w(i),a=E(i),l=149598e3,c=r(t(s.dec)*t(a.dec)+o(s.dec)*o(a.dec)*o(s.ra-a.ra)),d=n(l*t(c),a.dist-l*o(c)),h=n(o(s.dec)*t(s.ra-a.ra),t(s.dec)*o(a.dec)-o(s.dec)*t(a.dec)*o(s.ra-a.ra));return{fraction:(1+o(d))/2,phase:.5+.5*d*(h<0?-1:1)/Math.PI,angle:h}},x.getMoonTimes=function(e,t,o,i){var s=new Date(e);i?s.setUTCHours(0,0,0,0):s.setHours(0,0,0,0);for(var n,r,l,c,d,h,p,u,_,g,m,v,f,b=.133*a,y=x.getMoonPosition(s,t,o).altitude-b,w=1;w<=24&&(n=x.getMoonPosition(z(s,w),t,o).altitude-b,u=((d=(y+(r=x.getMoonPosition(z(s,w+1),t,o).altitude-b))/2-n)*(p=-(h=(r-y)/2)/(2*d))+h)*p+n,g=0,(_=h*h-4*d*n)>=0&&(m=p-(f=Math.sqrt(_)/(2*Math.abs(d))),v=p+f,Math.abs(m)<=1&&g++,Math.abs(v)<=1&&g++,m<-1&&(m=v)),1===g?y<0?l=w+m:c=w+m:2===g&&(l=w+(u<0?v:m),c=w+(u<0?m:v)),!l||!c);w+=2)y=r;var $={};return l&&($.rise=z(s,l)),c&&($.set=z(s,c)),l||c||($[u>0?"alwaysUp":"alwaysDown"]=!0),$},Vo.exports=x}()),Yo.exports),Qo=Uo(Zo);const Xo=new Map;function Jo(e,t,o,i=10){const s=`${e},${t},${o.getTime()},${i}`,n=Xo.get(s);if(n)return Xo.delete(s),Xo.set(s,n),n;const r=[],a=o.getTime()+864e5;for(let s=o.getTime();s<=a;s+=60*i*1e3){const o=new Date(s),i=Qo.getPosition(o,e,t);r.push({t:o,elevation:180*i.altitude/Math.PI,azimuth:((180*i.azimuth/Math.PI+180)%360+360)%360})}if(Xo.set(s,r),Xo.size>4){const e=Xo.keys().next().value;void 0!==e&&Xo.delete(e)}return r}function ei(e=new Date){const t=new Date(e);return t.setHours(0,0,0,0),t}function ti(e,t=new Date){if(!e)return ei(t);const o=new Intl.DateTimeFormat("en-CA",{timeZone:e,year:"numeric",month:"2-digit",day:"2-digit"}).format(t),[i,s,n]=o.split("-").map(Number),r=Date.UTC(i,s-1,n,0,0,0),a=function(e,t){const o=new Intl.DateTimeFormat("en-US",{timeZone:e,year:"numeric",month:"2-digit",day:"2-digit",hour:"2-digit",minute:"2-digit",second:"2-digit",hourCycle:"h23"}).formatToParts(t),i={};for(const e of o)"literal"!==e.type&&(i[e.type]=Number(e.value));return Date.UTC(i.year,i.month-1,i.day,i.hour,i.minute,i.second)-t.getTime()}(e,new Date(r));return new Date(r-a)}function oi(e,t,o,i){const s=((t-o)%360+360)%360;return((e-s)%360+360)%360<=((((t+i)%360+360)%360-s)%360+360)%360}function ii(e,t,o,i){const s=[];let n=-1;for(let r=0;r<e.length;r++){const a=e[r];a.elevation>0&&oi(a.azimuth,t,o,i)?-1===n&&(n=r):-1!==n&&(s.push({startIdx:n,endIdx:r-1}),n=-1)}return-1!==n&&s.push({startIdx:n,endIdx:e.length-1}),s}function si(e){const t=[];let o=-1;for(let i=0;i<e.length;i++)e[i].elevation>0?-1===o&&(o=i):-1!==o&&(t.push({startIdx:o,endIdx:i-1}),o=-1);return-1!==o&&t.push({startIdx:o,endIdx:e.length-1}),t}function ni(e,t,o=new Date){const i=Qo.getMoonPosition(o,e,t),s=Qo.getMoonIllumination(o);return{azimuth:((180*i.azimuth/Math.PI+180)%360+360)%360,elevation:180*i.altitude/Math.PI,phase:s.phase,fraction:s.fraction,phaseName:ri(s.phase)}}function ri(e){return e<.0625||e>=.9375?"New Moon":e<.1875?"Waxing Crescent":e<.3125?"First Quarter":e<.4375?"Waxing Gibbous":e<.5625?"Full Moon":e<.6875?"Waning Gibbous":e<.8125?"Last Quarter":"Waning Crescent"}const ai=new Set(["outside_fov","in_fov_not_valid","hitting"]),li={night:"sun night",hitting:"sun valid",in_fov_not_valid:"sun in-fov",outside_fov:"sun up"};function ci(e){return e.belowHorizon?"night":e.sunState&&ai.has(e.sunState)?e.sunState:e.directSunValid?"hitting":e.inFov?"in_fov_not_valid":"outside_fov"}const di=["#1f77b4","#ff7f0e","#2ca02c","#d62728","#9467bd","#17becf","#e377c2"];function hi(e){const t=di.length;return di[(e%t+t)%t]}function pi(e,t){return"string"==typeof e&&e.length>0?{color:e,isOverride:!0}:{color:hi(t),isOverride:!1}}const ui="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAYAAADimHc4AABBS0lEQVR42tW9aaymWX4f9Dvbs7/7e9fqrrV7pmdpezw9nhnjOJETbI+3xEY4sUJEPgRiS5bhS1DAIghLkQgKwQEiJYCI+RCCIWAgibHHtohjj21m72Wmu6eX6aWqbt31XZ/9OQsfzjnPvdXu2ReHklrV03Or7nvP8l9+y/8Q/DH/IoSAANQA1BhjAKir//9wOMR0MknnO/Pd6XS6uzOfz6bT6WSQDQZCCFFVJdq2lVKp7XqzWebb/GK73Z4dPTg6OT4+yZfLJexf2/+ilFJKCNFaa/3H/vP/MS48AcCMMQqAAYAgCLC/tze+cf36ux9//LH3z2az982mkyfGo/EjYRjOGWMp4wyMMnRdB0IItNbQWoNSCq01OOcYDoelUvqiqIp76/XmxTfefPOZl1955TMvPP/C519/441FXdf9x2CUMhCijTFfcjPesoH//90Au+agxhjiT/pwOMD+3v4T+/t7P/iOxx77wTu3b38wy7Idxhjy7RZKK0ipoJSCEAJKKVNVlSGEmK7rQCmFEAKMMZIkCUnTlABAFEUYj8fI0hRRkoALDkLpxdHR0adeePHF3/z4xz/xm5/61Kc/d3Jy4j8e45zDGKO+3IJ/szeDfBsXn7kQo6MowiPXrl07vHbwb4xHoz/PGfvQeDgSo9EQUiq0XWuaplEwAKWUSClJJyXRxpAwCBAGAYIggJQSlFI0TYMgCMAYQzYYgBJigiCA1lrP5nPjvp6NpxMym8+RJgkMoO7dvffJj3/i4//kYx/7g//9M599+o2qKgGAcM7pt2sjyLdh4an7sHo8HuP2rVsfvnZ48FeDMPjJpmnGxhgYY8Apk2VZkrptaBRFhDGGQAjszncgpURelVBKgVIKow1mkwmGwyG22y3quoZSCmVVgVCCKAghhAClFEmSYDqdIo5jDAYDMxqP9SDLTFVV3BgDxhjatt0ePTj+p7//B3/w3/3+H/7h7y6XSwCg7kbob+VGkG9ljDfGUAAqS1PcvnX7+69ff/SvdbL9kaqq4GK+YoxBcE7bpiVlXYESAkop4iTBdDLB4f4B2qYFYRSj4RB1XUNrjSAIUNc1tpstKKOo6xpt20JKibZtEQQBKKVo2xZpmmI4GoEAGI/HGA6HAGC01sYYo9u25aPRCGma4uTs9Lc/9enP/Be/+3u/99HFYglCwBjjWmttvhWbQL6F4UZxIfDOxx//rv39/f9Edt1PFGUBxqhhjGshOOWcE2OAKAqhtca1g0NQQkAIQZKm4JwjS1N0bYsoitBJicVi0Sddn3iVUmjbFuPRCAbA+cUFOOdgjEFrha7tcHZ+Dm00hoMhRsMhxuMxoigC5xxaa5MkiW6ahgIgw+EAZVX/+u//wR/+4u/87u9+vCxLcM7ZlwtLX+8mkG/Vqb927XD8HU8++R83TfPvrVcbQSjRlBLDOWPEnXIpFYwGpJI4PNjD/u4eRCAQiAB1U2M8GqNpGhwdHYExBgMDpTQGWQbGGMIwxDrfwkgFEKBpGuzv7+Pw4BDL5RJd10FwAaUVqqrCcrlE23UQnINzjul0CiklAGAwGCCOY2y3WyWEIMPhkAoh9DbP/8H//Rsf/U8/8clPnrlE/SVvw9ezCeybHOtNGIbmyfe+58fe9cQTv7rZbH50vVozxpiy34tQQgiMMdBKA7Bl5Gw2RZImaLsObdehqipQQgEAz7/4Ak7OzrDNc9RNg9V6DUoolFK4f/8eVus1jDbIywJn5+fIiwLr9RqMMbz40hdwsbhAmiRgjGE6nWI8GqGuKtR1jaqq7GcxBuvNGkopGGNo27ak6zpVliVlhHzwwx/+0E/fvn3n3hdeeulzVVXBJWnzJaq8b/8GEAJuDNT+/l70Xe973y+FQfB3jx+cTLu2k4xxQimljDEwTiE7BYCAcVvLp1mKvf1dUGoXvG1aRGGIJEnwxr27WG82IIT0IUVKidV6g/PzC5R1AwJ7g9ziYTwaAQA2mw2CIMRoNAbn9sdM0xSHh4dYLBfY5jkiWymBc46mbuD7A0opGKVUCEGSNJVlWU7u3L71U0899f7rp2dn/+LBg+OGUsoJIfob3QT2TajrOQD53ve855137tz+Z6vl6iebptGUUiOEYFxwYtyNVVKBEoowEgAMoijEZDJGVVVo2xZJHMPAYLvd4vjkFF0n0dQN2k6h6zp0nYSSGkpq2JtkgyhjdvMYY1BaIxIB2qZF27aomhqMMgyyDNyFnuFgCMY5hBAoyxJd1/WbK5XCerVC3bao6xrGGBoEga7rWu/M50/9xJ/7cz/GRfCHTz/99BEh5BveBPaNLL4xhgsh5FPv/64fGY9Hv3Z+fvFYGAbSNpiUEEKgpD2ZWttFEyEHIYBSCmEY2g9BKZTWtoJpGjw4OUXbdpBK9n/WaBu2/G3QWoMxCgICQolLuBrGGJR1BSY4GGeo6xp104AxijTLQClF13VIkgRSSlRVhdFohK7r0CoJ1dneou5aVFWJxWqJPC+IlJICkEKIgw9+8AN/aTAYvPLZzz79Oa01p5R+3ZvAvpHFj+NYPvX+p35GK/WPV8tVMhqNlDaaN3Xz0AcwxriOlYExCillDyPUTQ0YQHCB5XKN9WZjQwCjAMHlSTcPJznOmU3MxoAQgBB7AxhjoNTmCP99OOdYbzfQSkMIgbquEYYhjDFo2xZlWYIQgjAIsbuzgyiK7OYDkFqjrErkeY66biinVFFKoyff/e6funbtWv7008/8ftu2zH+Wr3UT2Ne7+GmSyg889f5fAPQvNU1jhAhM27asbVpQSh+K25xzcMFA6cOborUGAQEIsNnkaNsWlDEwSkEZBYy7Qdr0OcJu5uVpJ4TY3oFRcM5tHmnbhzbefo39/+M4hupkXwEpZWGOJElAAGRZhiRJwKgNScZhTdoYFGWBuq5pwIUJwkBff/TRj9y6eTN89rnnfruqKsYYxVtT81faBPb1nvzvfN93/I0wFH8TxEjKGJVSUX8ajbFfGwQCXHAYGAQBhzH2lPpE52OyVhpSKnDBIdw/AKBcyPE1/+Wi2pAjuIA2GpSRK3X/lY1xiy8CgYAHaLsW08kUURih7dq+WyaE9CFpsVigaewN1kpBcPs1YRAChKBtG2itifulDg/2/9Rjjz+Wfvozn/3Npmk4pdR8S5KwX/woiuQHnvrAL0Drv9k0raSUsbKoiFLKfw04ZwjCAIQCWitQan9AIUTfOBFCYDRAr2yIb8IoJairFkrZW+K/v2/ALIRAAdjf/Yb4729DFEcQBOCcg1KKNIkRcIHNdgN/SoQQEEKgbVswxhDHMXZ2dgAAcRwjjmNwzpHEMeI4creIYTgcgjFGpJTUAN1oOPi+69evR08/8+xvKSk5eUtO+HK34Gu5AVwIIb/nwx/6GSXlLwkhZNu1rCzt4vsT6k8eYwRKKQyHIxweHqIoCrRt6zaIwxiDrpVQUoJQIAgDGBhobSClBiG0X3QA/e+++6WUggsGwJ72vr/Q2t4KQvvwl6UpwjCChgbc1+3M58iLAkIIEEIQxzEYY4iiCFEU9ZuS57mt0poWbdP0KKsPsXVds7pu5CBN/+SdO48Vn/7MZz72paqjr3sDCCGMEKI+/OEPfSSKwl8BjCKMsHyTkz8SHggFEwyc2xM1HA4RRRGKooCHiT2CSQjABUeSJP2fV1LCaPSb5OM6ZaQvNwHiFoBBSVsd+bCjtd1YEQikaYqmaUAZQ9006KQEJRRN10F1EmVVIgxDzKZTAMB2u0VZlj2453NEURQ2RxCC1EEkUso+nEopiTFGPfHOd3xkMBw+/8wzz36OUsoB6K90C77iBlBKqTFGP/XU+x/b3939aF7kYV01qKqaCiFgjC0zjXFhxIWEJE1w8+ZNfO/3fi+effbZPuwQQlBVle0JGIVWBl0n0bUS2thS1Bi72Iy7asgAjNsQJaWGEBxc2GqKc1tu+vhvN1L38V1rjTC0WFMURdhsNhBCYDAYIAojzKZTdF1nYQ3XQYdhCCll3yMEQYCmaSCCAFEYYrlawgAYDgb+kBAAZLlcmsfv3PlxbfQ/f/mVVx8wxt62Y/6qN8BjO7dv3Qq+88knP3r/6N6tump0VdVsOMiglEJdty7zX8beKA6QJAmUUrh37x7atu1PlK31W9i1IpBSQisDqWyTZrRx3SmDEMxtHGx4UvaWJGkEQuyf9TfDw9qXOJP9XlEUwRiDNE0xn8/RNA2apkErJUaDIRhjqKoKeZ5ju932Ycj/+YvlAk3bgDOO2WyGOAxtz9A2PfoqhMBwOCRlWer7R0fBhz70oT99/+jofzw+Pu7erjz9qjbAJ93xeKR+/Md/9L++e/fun12vt1JJyT2MUNcNKChAAUZZfyUNgK5rsd1usVquQaiN5fYDK7StfOhDMW5Di7CsFZRSYA4+aBsJQm1iVlL34cjnAZ98lVKuObMneDQaIY5je+so6WlMD1sbYyA4w97OHo6Oj/HyKy/j9Owc5xfnMACiMEQYhqjbFkVRuF7E9KUy5wLakkdXN4GenZ1JQsjOO594x/XPfPbpX3WVkf5SYejLbQADoH7wB37gI4Tgvzp+cCK11tyfsKZuQQgAYkBAH0rCAEAoAQEDpTZR2ripoJVGNsgAA1BGITgDdUjnI48eom3txnJuF1YIbsMRY2ibDkEoEAS2ctnZ2cF8Pndhy1Y1cRwjy7I+KY+GI8RhhDiM+jBFCEEURYjjBNsyx73791DVNYIwQCcllusVpFRglEJrhW2eW26h69DKDkkco+vafvM9lMEYQ9d1dLFYyL3dnfft7++/8Nmnn3mO+kX4am+ACz1473vfk73j8cd+/fU33hzKThGpFLFViuqRbEIIOGMghD7cZLnE6OHeKI76/20xHF9CWk43y2xIAwClbQyPosiGLiXBGYfSCpZqVP0NMsb0CzCdTjHIMiRxgk7ZBayqCoILhEEADQPKGIqiQBiGoJTi5OQEeZ73TZsF4lh/spMoRpamUFqDcQ5KLONW1hXKqkQaJ5jNZ33z5/+O8/OFef/73vf92zz/5dffeKNijJG3ywfsbZBNAITFcaz/zJ/5/r+13W4/srhYqqapmdIKBJcNDrHBGbjy3/yHeLgnED0G40+hkgpaGVuPB6IHwyz5biufuq5tmQjSM1z+6/ziN03T9xaj0cguEoAkidG0rY3XXYsojpAlCVarFbQxKMvS8gMuHNV1Cym7h34ObQzKuoZUNiHnRQHq4Imu67DZbtF1LaaTCYzjFNzPTZIkVmenp4Nbd27NX/zCF/6voijp2zVp7Evh+h/+8Ifes7sz/4f3798H44w1dUuM0f7cQxsFGANjQRoQQmGM7kORvx1hZBc/CIK+6ek6hTAMAKD/3dOU/hbEcdQDZZzzPpEHwoYJf3t8pdN1nf1zUeS6VwbK7WY3TYOz83PAALu7uxgMhyiLAlVV9QfFaINAiL7n0B4cdCfbh7lACIyGIxRVCSk7MMqwv7/vuWUEQYDVaoXJZEKbrlOM0vfv7uz+xrPPPXf37UIRfZvESyaTsblz5/Z/Xte1YIyhqRvCGe9xm/7vIBZ6sN2p7jfAnyBj0CdOKSUGAxeb3aJwbhcwDMO+EfLcrJQKWZZhsVj0i0sIgTb6ocUnBOg6G9byPLfAGiUo6wpa2ZDlw0tVV+CEoipKBEHQV1KccwShhTX8AfBNXd80dh1AACEEkiRBFIaWNCIEi9USQggURYHVaoUsy1BVlaNTO/Lkk+/927dv34ZSylw9oH/kBvjE+699z4f+xGg4+M+6rlNVVTEQY+FhqUAcoGZgQTECCs7FQ+EnDENXyVCXRC8rpO02ByEUs9nEQRQprl+/jizLeniaM4bG4fFhGPaLEMdxX+v7/6aUre8Zo33TtM1zZGmKyWiMMLAV0f7OLg7291HVNeqmRlXX2Gw2fVK2+UmDUtI3fxbPsvIXf8t2d3exv7sHzjmKssBsMkNe5FBK49FHHnGfhfl/KOdcBSK4OZvPP/mpT336pSvynIc3wJ/+2XRqPvjdH/jvtTZ3ABhCCG27DnleoK8xYdFFQigMdA8V+03wp8qDZB6/Jz3WAy+yAiEEo9EIbdvaMpJQDLMBNKxkxDZ7pg9jHsTzUPNgMIDW+uFwYgxmkykG2QCTyRjXDg9hjEGe5xgOh1iuVlit16jrGgQUSnm8G67EtP2H32QL8AGysyXx3s6ubda6DvP5HOPRCF3bYjab9TnKN3CDwcBst1sym83uvPnm3X/oBAP9HrC3nH79we/+wFM3b9z4W0mcmG1RsK5tURQ23mltwLnoKT5i8bCHsJhe58MZiDtNk8kEAJAkCbSWqOsWVVljMMiws7Njr7cBuq6DUgrTyRSc254giqKeNHdiq35D/K3y3S3nHGmaYm9vD5PRyIUr1sfz9XqNzWaD9WaD5WLVA4J+MykjPf7keQVjLKAoO9uh11WNpmsQhxEyx7INh0OkSQJyRSTmk3scx9QYY5q6enQwGv3OM888+9rVW8CvnH6kaYo7t2/9PACSF7mq65pa0qJzXShBmiboZAelalDCQK50oT3rJQSE4LbyyLI+dNhrbulFfysAgBGCvb09rDdrrLdbFFWJ8XiMwJ0ySokNfwSWWhQCy+XSbpLb/N3d3f5WAUBeFkijGMvV0pawSqGTHYqyRNt1oIygbTobRgn5I4ir31ytLV9AKAFxZXRRFGiaBmEYIssyaK0hXK7pug6DwQBKqf5Wjsdj/frrr9O9+fzfPzw8/J2jo6NLVNfFbWKM0e9597v3nnjnO/7+tiiCPC9oKAISBAHKskRbt1b60baQnQSl7KHW/yrGH4YhuLAJdTK2cVgbuzn5NgfnHIOBPT1plvZ9hJIK0AadlAjjCMzBxl654GGCqqoRRha7uaIZBee8Z7cmozGKsoSBwcnpKYwBNvnWUpZFaZuuTsEYm0+oC6daayRJ0sMZNs/Y72EAi9Z2EsPREHu7u0jT1JI6RoNRiizLEARBH4odJE6qqgJj9LY25n965ZVXFw5jM9SVXYwxhife+Y6fyotiUNe1CgQnURBAuqsEAigt+yZIa3UleclLqTkhALGNVBAEYIQiiSKMhqMeRqCU9CqG1dJ2nevNBlJJZIMB3vmOx3H98Bp2dndRNw3g/l7GONrOcsU+bFRVhYuLC6xWq55IaZoGy80ay/UKy9UKddPYA2Bsb0H7BpAjjkOX2nSPvvoiQil7W/0Np46rGAxTGJ+kXffNnFTGwyJN01iRgFLIi4JIKZXWJnz3E0/8xTiOoZSi9tDa66f39/eRpslfrOsagnFCtLEVgFKoKyvXMNrTXeaheO8xdR+GPC1YVRW2ZYG261A75QPnwuFCVv9T1zXyPAcjAGdWLHXt8BCj8Riz2QwGBlVVgjFLsPsKoyiKPjH7xHdxftEzWuv1GsvlEufn5yjLEmfn52hl5z6rlb9kgxRpliAIBGSn+q7cw9FXAT5jjLsBtiM2WluZpDGYTqc9FpXnOYqiwO7uLrIsQ1mW4IEAoZRuNhvMZ7OfvnXzJgWgKKXgvoO6cf3Rx9uu/QBjzDBCaSMtXr7Z5mjbru+SLSalQMGu1PsGSkkbRhyqKYTAdpsjSRK0ssPR8QO0bYswDC2hAYIojrDdbu0PBqAoC7z0yssoihyz2Qxnp2c9jtR1dvGapuk3ug8R2vLG69UWlALZwOadq4tX1zWKougBOqU1urYDFxyj8RBSKUjZ9pXPVU75Mk9qF64YGOdYbdbgVxg1IQRWq5X9MwQoisLmEm1ACaGGwBhj3vPe977nO59/4YXPAmDMGMMopfrDH/7gXzLG/CilTGmtGYitSk5OT1yj466hpxAJ7ROJ0qqvhrTWiJMInDNsNznSLEVVVlguV31J6iUp/n8HQQDuTjgIwfnFBY5PTnC+uLChT1kk1Td5Np7azrNtW8A1fBaWMIjCCEo7dNQ1a5ZftnDI7Vu38K53PYG6rnol3nw+eyiHXD39lns20EpBawMhAsxnU1BC0TUW9Y2TpG8YDYDTk9O+kjo5OUEYhoiiSAFgg0F2///9+Cd+V2vNKQAzn8+QZdkPtU2LuqkJ4wxJHOPk9NRWBK7stOSIRT/txbmMjR4ZBACtDJQyyAYpKKU4PT0DAelPX9u2WC6XPQiWJAm021wfh71KrSxL5PnWlo/rNbqug9YaZVlaYkepvtT0IUUErA9LVd2gaTqXPDW00lit1hYhjWNUZQ3Z2b7lhz/yERzs7/e5TEoFJRW6TkJ2ClLaG5AN0r5h7JTEg9MTPDg5Rufq/3t37/ah1VdDnZQYjUZEK43ZZPqDj1y7BmOMYgDM448/Ptzf3/3bm80m2W42ZDKekG2eO9xGuhpY2yrBaBhirCDKbYK/rn4DfLzmnKOqyp4p8yHDg2f+avsFjMIIVVmhaRvH6XK78KstkiQBd0IrrTXaxn42zjiSJEYYBpjNZhgMrKwkTVNEUYi6bno7U9dasE1phYvFha2IygrZIEPXdVgtVxgMh9BaYzAYQEqNsqxgtKVStdYIoxBRFCJNUhRFAWUUNtscSkncuHkTR0dHPXVZliWkUoijCEpKNE1DAE1Go/H8+OTkf3j9jTdyBgDf9b7vfH8QBD/ftp0ZDodESoltnmMymaDrLBndNJ0lymEXjAsOrT0VSUAIXIVkc4VW2glwLWbkQS6P2fuFj+O4T2iDLEMYBCjK0oUYu3haaUjV9d3lcrnCdpPDuA7cwC7YcDi0iVlwJHHibqVr8KTuu+0sS9G2LfKiRJLFGA1HiOIYnep6maTsFPK8wN7erm3EpMWVytKaQEQgUNUVttscjFKMRmPs7+1hs91g5LwIjDG0ssNgOEBdNyjKgmilNaUk6JT67Weffe5VzjnHaDR6SisNxpiijPHXXnsNhFAwzi3q4zSYHv0MQ4u9VLIGiAYItUkYFFEUALAJy5/ygAgoI8EoR1XVPXRcliXKsuwBLsYZmq7tgTYPTw9HGZTSveJNSVuv24WwOSSOYxweHmKz2WC5uMD+7j7KqkJZlkjSBEgskGiMpT+11piMRiDMAmq78zneePNNrFZrGKOx3RTQ2oYrT6f6217kBRacIY5idF0HKSXu378PQggO9/YBWKl8FEXQMLh7717fs+zv7mmlND3c3/uAEOKjfDwaIY3j923yHGEYom0brFZrXDs8xCBNkW+3lhjRCm3XgFGGpq0QhSEIJTCy5xDAGHehRrmumPa1P7S9+oEQaNum52uvlpMnp6cIggC3b9/Gm2++CcYotDZomrYnUOq6RuRqdxEwhGHQh7DtZoOqqhAEIaq6Rte2mIzGSJIEVV1DCN4nyjRJsL+7h052AKWo68aWxVXtum6ruvDd7NUwawn7qj9kbWtzzNGDBzg8OMAgzfoEfO/oPt68e7fvCWazGYqqRBLF79vZ2QENoxBSqXe5xolIqWCMxs2bNzBy8VAqCaMNGLElmi1BLYEeRzEIKAIRuiaovQw9DraWTvC6u7sDpTVGo3GfoHyy9Ak2z3Os12unarAL7NHIS4iYIY5DBEGAruuseqHtsNlsbBJnDKvVCnlVYjabYTQYwmiNIAwxm80cHRljMBwiCiMUeY7FcoE0TSy/4dBWzsVDDeal1JHCKUNQVzYXMcbwyLVrWC6WSNMUOzs7vfyGst7JiXv37tPX33gDlNJ3XDs8JOz6o48mh9cOfiEIgtF2uyWEEDKfzxFFEdbrNVrZucaqgwU+bcyllFsFg7EuFx8eBBcIQ+EALSsBJy5HNC4hDoaDvsWXUvaNj+86xRVixFtRPUlySeTb/OGVCVEcoaprMEIwGY/BuUAUhrh96xYE5+iktB6x4QjDwQCUsT5Op1mGsiqxXm/Q1E3fhPnfgyBAFDkvgWAgznum3EHzHoXBYADOGbTSuHHzJighuHf/Hlary+qtrmvEcUzGoxFdbde/zHd25nuUsnnpmobLK1aCcY4wCCHdDnPG0bZ138RQSiGVje0exCJOKOuVDmEkoJVG07QIQoHJdILFYtEDXk3T9qJd5QiUtm17GHo4HFoZiWt2uq5DFEW9UIrSqzIUBaMV6rrGdDTBcDTE2dkZiqJAlqS4eeMmjGvgfLeutcZ6u3Hls+r1qFd/Htv/cHBuemWHXyerIdXgAbNeBcpwfnZmDSJhgDhO+twhpUTXSrJeraGNng4Hw0POOd9VSiVaaxiAcMogdWe19VXtEEf74QCHdIJAqUvI1vt1ewmhoVBS9wtGQMC5cCfEwg11XfccMWAwm02x3eaI47iHNjximqZpj/H4EnNnZweqk1hvObpOIs8vXE8RW6+BUZeCKqdJJcZgPJ0iDAPcv3f/UqfUdbaI8CwbtawdCIVwPYnaWrKm62Qfkq5uQtO06FrbrddSYrVcuhvcOnOK7hV9ZVWZbZ6z4XC4x9M0mdd1DUKpIVoTxhniJAYBMBoMUVQlGPPyQIrpdIQir1yjZMPRVQxdCIamra+IZ1lfQ9+4cQNFUaCua6xWq76Rs7ShrbUHgwyd7BAFAYJA4Pz8AkmSYDwe9+GpLEucn51hmGXIkgR13fafQUqJ+XSKIAz6Djt0nILgAmlmFQ5pmqKqKjRNAyWl7fCdejuMAld6euEXcyGQPOQ/8EiAMbYvun/vCJRQjBzSG0VRn+u0hkvaGgzUEAPCGN2lXIix20VDKYXsJLTSKCoL2R7s7WMwyCACjigKkKaZVTFw+0GJK+2CIECchDDwBD2gjY3hTdMgjmOcnZ2BEILz83NUVe2qB6tgWK/XIJZEhlEGdd1gsVjAGIPFYoHJaIR3v/MJXH/kUcynU+zv7eHGjRsIRYj5fIa9vT2Mx2PszGaIoxjX9g8tg8Y5RBAgdFWblgqccYRRZD0AWkMq1XMGYRhAdhZyACjapr3s+N0N8ainr4zCMESaJqiqGl987TW0bYeLiwsQQhxQZ28PDHE4lLLDGoAxrapq6CTcJnaCI2W0hXCdnpJQitlshiRJ0DS1UyRbWnE0GmEwSBFGAgcHBxablx2M0X3p2DSNxeCDAMvlEttt3uNJjBFUVW2FukGAVmkEgiEIhCX1nQd4sVpBwSCJYyRxgjAI7c10He5sMsXB/j64I1jatu1FU7WDLPw/VVGgriokaQIhOAaDAXZ3dxHFUV/XK6XtYdTGWWSdH43Thxbf34K6aTAeDzGfz3B6cY6VY9+yLEOaJrZYgf364XDg/9yQvfvd7/reQIiPSCmNMYYqJyHkzMa+siz6+tdXRoSQno6z8KyVgfvmSkoJLji6VqKXRzhf2Gq1gtZWRU0Z7f1iPrFlgwH2d/ZRlAWKokRRFOCcYz6doqnqvkLyUPZ4PLYIptZWVuKk5v0QD0eSeJ6WUooiz7FypS6jDGVZYutwKenMgN6Vc1X9zRmznT+jUFpCcNFXS4NhhoPDfQTOyHGwt29tUFpjm+dYLtdgztlz89YNMxwM6Wa7+T3u3Yk+kXad5YD39/fROEm3pxqvWv+jyJ4Wr2iztKOysbWsoKQBY9yqoKl1yxR5ASkVojBCWdagFNAwPQnetjaR5UWOoiit8KnpIESA9WaDNrmUhCdJgjAMwTjDKBmCrEivnCOEuI49BGMMQRD0Dnsv/LLYkuWQ67pG09pGzKu7CWEQAXN07KWggHHb/9AwBGe8L5WF4Dg7O0cYhijLEscnx0jiGABwsL+P09NTyM4ChqNsYI2JUoE9+sgjTyVJ8qMAjFKKEuelGqXZQ2MAoiBE09QwQE9a+B/WY+GjwRClNTJbH7DsXFNmnKGC91ZTY7TTFD3c5HRS9mT8drvtw11VVYiiCFmaXpV9uN7h0ivsu+VsMICBQV3VTg4vEcUxGOdgjk71Ja+bV4EoiSGVRFVZWJwx6j6rQRAIxEnkyskOYRj0OiVKieNMTB92t9stUndIpJTIBhlGIxui4jAyjezoZrP9Ld517cblAOLxCwszUPu7+yZSK2hjkGXZZdKNIxRFiSzL0DgX+3q1htIah4cH+OKrr/fanapskKSW1LdKBwI4T/BVJJUAGKQptDGIHGjXdR3SJAWjFFIphM7kcX52Csqs8c5z0v5QhGGIqiyRpGlvc/WqCsaYy3N1z0kIIRBnqU3WINhsNla24sphQijKssRkMkGWZTg/P4cQAl0rEcVhD6sPh0NwznF6eor1Zu34Zasv8gyZ1hqcUnDONpwQugrDAHm+te0zIairCjBAGEXQNnk7OpH3BPhkPEbXtRhkAyh96d8NwgBFUWCz2YBQg8P9PaxXGxRFBc4F0ixBFEbY39/Hq6++2ocJT9CcnZ2hccxZ09Rw/Ckm00mvxUmzFFoq1E2NIHB4EiGY7+5eiraUxmA0xGg8BiUE6+Wql4psS6u68CSPMgaz+RyUEEBpRI89houLC9y7dx9FXjgjiW3Mrj/6KLI0w+f18zg9OXNhViPNrJ9ss9n0zpyTs3NMp1PbxBHa61LbtiXCMm8rXhTFuYWQGa3qGmmcIImTPuZXVeUSU9d7riiA6XgCQgle+eKrOD+/QBiEyAZ2h/0PRqnlbpVW7noGiKMYURihLktsNlvAAGmW9MIpIQTarsNqvYZWGovFAnEco2kaTMYjEEOwWq6scS5JnN+gxXg8RlPXvTKDcYYojDCfz3vr03a9AXNSlrIskcQxCKXY391B0zSAAabTKTSs0ODo6AgisOWpCDju3LmD9z75JI6PjzEZT9C1HerGqveSJAXnDBcXC+R57nCtAps8x2gwsNUko1hvNthuczKbTVEUxSnPi+IsTZJKShm3TWO0lOT6I4+AEntNlbb20eVq1cdqIQQuLi5QNTXOzs9R5hVW3QbHx6cw0AiDAGdnZwiDCIxxjMcJZCb70NXJDqv1CsbYuT9VVfWmbcEFzs/PnQulQxhGSJMEbdvi6MExAOD2jZtQSmE+2+m9Zz4ZegmJ5xru371nkdy66SsjSinW6zV4EGB3fw9JkuD87Az5ZotOdlgsFn31BQBSKdy8cQMH+wd45eVXQCnB7s4O0iTB6flZXwldXFz0hYzsLGx+cnKKOIysSE0ISNnh/PycjMcjlRfFCa/K6riu6nOt9aOXBLvGbG8HVVn2KGKSJLg4v3AK5Bjr7RaL1QKNsyj5ephSjq5TSMMAB4e2FNtut716QSmFxWJhdfsunF3Vk3oOwecDzmkfLjbbDSi5lLE3TYMsy6yq4gosst1uMRqNemfmVX0npTaWe/tqWZZW5l43yPMc948f4Pj4uD8UWZZhxDnSNENbVWgdVRonFjnd2dlBWZZ47bXXHF/MXddrDYOLxQK7u3NQ6p39MEkSE631Ks+LI9pJWWiY+65j1UrbUx+GIUAJttuNtZISgvlsBjjOdjQaQXYSSnYPeXl9DG4beakRpRR5bhUSZWlHjw0Gg76+vioF8Z6qIAjABUeel7h77x5aN99hNp0iSZJeE+orNW8vZYxhPp+7sFX3jaAQAtPptK+2sixD2zRYLZbYbDbI8y3Oz87ACUXgbpD3Ng+yDEkSQ2rnqKcUneog3SE4Ojrq+wTvArLGcYq26fDiiy/j/PzclvVdZ3Z2djAcDh/k2+0FdbN5XqS2cjCccywWSywWFzYuwo4LaOum520XywXGY+vB4s7s7BskpRWUklDK9hWr1aq/zuv1um/db9++jclk0oc1f/KbpsFms0VVVlaGThxZUpaIwgjj0ahXRHhq0/sOtNa90XqxWGCz2fbjzezfa0ff3Lh1E9dv3rAYj1QOSkgRhKH9mQlBlg0cWmvFXoxQGIegts435gsFf3BAiIM0NJS6VNXJTlo0wB4+bf9c8/JqvdFMKYXHHrtzM03SjxgYXVUVbZoadVU70rpA13auycowHA2RlwXWmw3yPLennPG+DiYgV/Q4ThzrkNPFYtEvlg8JtjKxfHLjcJcotPCHFYZJTCcTvOdd78Z4NO4bQd97+LDiRVLK/b1+Dmni8ocIAlBCEEYhxpMp8nwLzhkGg4GbqqWhpERdVwijCJ20/HCaphgOBmAO7BtkmZ1R19TW85ANsNlsHPRh5S92Qgx6uDxJIoRRhMVigeFwqGEMXa3Xv/Lsc5/7l1xKifOLi09nNzLU25r1DNV2Y4l3Y+UoYRj1P0ySJNhst3bQkROpWtKEALDEuzYaW/c1nHPked6PACCE9JKUq6a5trWEjMVb0NuPptMpErfoHrKwSmv7PebzOYbjEWTbocgLxIkVA8dx1COkXdeBM4Y4SXDv3l1IBx0zxqAd2JYNB0iyFNv1prcxCcFBDCDc7UgGGcazGbZ5jvVqgZVDVi21SqC1QhAIC+YRgDHiOVtfalOpJE5Pzz7Vtq0V52Zpujk8OPjZpmliKaWhlJIwDFHWNZI4dkOT7OkcZhmatoOBAae0HwmQbwsIwfoGazwZ9ZTh/v5+nwe8G8Y3JLKTqJsao9EIQjBrfaUMSlnSJ01ThFGEJI6glUKaxn3euCpzeeTR6wjDoJeHDwYDBGGIKIl7GCFNU1vFMYG6rdHUjYOfQyRp0hNChBCcnp32c4iUtg0ojMF4MkEgBMqiQBCGOL+4cDZWO2bhcrwCAReX8vrQ2l6NUooKEVQvvfTSf7RcrnIGgAkhqkcfeeRPd7K7QwjRXjgquw6BsJi6MgZRHPW6GsFtTa+cSLdpG3tyKQGIjfN7+/uQzoXuT71XDGuX7KVUgCGoyqqHFYwbDyM4xyOPPmIFs0GA6WRqySFjsNlssNls+h+udoR6kiS98yUIQwyHQ6xXa8RJYrmIpkHdNKjKqid/xpMJ9g8PsTy/QNd2aOoaZVni2uEhlNI4enCEqiwxm00hO4myKDCaTnDv/n3Udd2jpwQUUlroJQh532QaY6ulJIk1ANo0zaeffe7zf7dtW8oA8Kqu9c2b13fjOP4hpZTWWtOeMmztDDdjDBihtos9OICWErLrsFyvoLTFQ5xZ2VYZadorh7052lct3kVvnZANiLE8hIFx/mJ7i4SwamhCCLLEhqAoju0os6a2MkSny/dmaWMMlsulrTgcUa+UgnYVi3EchfctAECSpaAGvSYoLwoEQYCLs/MejLxYWMc8jEESJ67et2ivN4DbIYSqHyIShiEaZ7NK0wRaG00Ioefn57/88suv/gtCCaeEENV1HY6Pj3/d/TvzpSN1LvNNkWO9XmGbb3F+cY6zkxOLghqDwXCIwXCALMsQRVFvWhiOhjg4OEBZljg9PevpRF8OpqmVLXLGrGeY096Rcnn19UOlJmcMWikYrREGIWazKQaj0UMqu+PjYygpEYSBg7uJ8xRYMK9rOzs7dDTqhb6bzQanZ6eI0wSznR0QQvDg+Bh5WeD8wvK7fqQBnLA3CqP+sCVJAhjTj1gTQiAMrcc5CEMrGKhqNE3DCCE4PT39584voRkhxACgjPOzGzeu/1jbtteCIFCEEFpWFRi1wiVQaofhdS3W220/CNVOJwz6crJpGtvOa43ziwucnp4hCARu3LhhS70g6En1zWbjJBteXhj2RgutVT9Z5WBvHzeuXwdxKKOvTjzdaZm8rm+wwjBCmqY9E+Z1pt5T5qWTVgHXIUkTJGmKyWSCxeICxw8eYLFcYuPGIrdt50wXBEVRYu/A2lLv3n0Ty+XSNpBa9s5+b5fane/gzu07tuAAtJSSMsZefPqZ5/6G0xtp7hh7enT0QG+3219J0/S7y7I0HnfPiwKz2cxOHFEKAWeQ7hQqN/QOsBhKFEXWAOFkJEVRglHb/Z6cnGLo5CgA8Njjj4NSajfB8Qxt22KQZYiTBK1TOhsYDAeD3vpjwa4Ek9kUWZpBqw5VVTqyHH3H7UtUb7jwidvN/exhi+F4jKqsHI9Roior1E3zkOkkisLLRd3ZgVEKb7z2GpIo7jlqawG2PUUQBIijCPt7e5jNZlislmjbVksp6dHR0f+6Wq0UpZQbYyRz38QopZCmyZvj8fhntdaBg3RJURSYTqcIg8ASzFIhSxJkgwyFUyj75OqxFv9hN5s12rbBwcEBANOTImmS4pFr1xAlCeIwhJKql5BwxnD9kUcxHo+QpRmuXTvEbD5Hmlktz2A4wNzRozwQeOO111EVJaIkRhRFmM1mvcbf5owILBAgAMqi7OXxPiR6AkVrjaaqcbFY9DnEQx6+r0mSBIeH12zYtPg3wiBAlqbY5FsEIgCBhe/n0yn29/exdspupRQxxsiXX3n1Z8/PLxYOujHsCoTAuq5bX7/+6JMG5klKieKcU84ZNps10iRF6VQEeZGjKAsHAdgfwN8Co7TrEexoL3+CoiiCATAaDLC3s4s4jrG3v9eXbFEYYpBlVtrnEuR8OsV0PsPAjgjrMZgkSdA2NWTbIk5TqxUKQ+wfHCBKE0jnqKcAgsASIpRQbLcb11xaOCTLMjQO8/dCYM44mq5F0zQoXDL2ne/tW7cwHo2wzXMQRnF6dobQhSZf2bVuiEcgAgDGTvqlVEopmVLyoy+88IX/pixLSinVvUnPu+arqjbj8fhoPBr9Fa0Vuk4Sf0rqtgFjHFJ2jgWjjniPEMUx4CCG4XDYn740STCfzW3YSFLcunEDjFJwxt0YgjHCKMRysUAQBBiPx0jTFJPpFNP5HEmWgjuNUJ7nWC2WiJMYQRSBEMtXxEmCqizBOQMXDMOR7T+0M81VVYWmsofGGOO0o8FD9irOuR0QwsXlsKa66oE9i2kx3L55C5QQPPu558AYw96OhbHjNEEgApyenlq4Jo7dZK726jQVcnx88vPPP//Cq9SCYOatPmFjjKFt1949ONj/fiHErSAQqm1bSt2iOY07giCwC++qnoAz2+pTO65skA2cas5WJ6PB0Dohr/h9PblvGzBr6BNhYG/JcAhohSAKIUTQl7ej0QhBGAJOsWBLUadH8oinlKirGsvFAnVd4/z83BIq2iDfbgE3mtKDbWlqWbDDgwMbUssSr7/+BvJenm8PXJokyJIEi+XCfsbRCHlRYLlcQiuN9XqN9Xp9OQKNwA9+UlJKqrX67HOf+/x/uF6viT39bz+qgJZlZfZ2d+8Oh8N/283Xp/60KKWwXq97r5UnZwIRgBCKUAirdnCWgFZ2WG/WKOvKIYpJDxtbVJEgFAFAgGwwQF3XODw8RBiF/aIOh0McHh7aGUAO87k4O0UcJ9YW1DTgrjNVSqEs3Mw3VyBcpTq9koMxhtlshp29PVuuUktBnp6eIs9zSzhNbZI/PDjAaDhCWVUwTvHtGcD1et1P4PKL733DfuOapjFSSrparn7uuec+/wIIaG/Lf5sNMMYYVpblq3u7u3+CMfZYGIaqLEvq5/d496MvA7fb3E4OUQppliEUdtGEEBCcIxACYRTh5OwUIgiAK6LXruswdPW4n+WfJgmEm1aV53n/tkBd11gsFlheLJCkKcLASukZoyjKClxwVKWVsXjBrxCXg/uiMMLB4SGiKASjzMISMCjyAtt8i8XFRa8JmrohfkIIiDDE8clxP9w1zVKcn58jyzJst9sehrg6RuHi4gIDW7kpKSXjnH/iuc99/j9YrpbkrWOO33ZcTVGUZjqZfn48Hv27buogUVISWynZqYEgBAxucqGSPeYurkg1PLYym88gGO9nr40nE4wmY1DYhxrCMAQxwHA0vALs6X7EjTGWvM/z3E7UddMXpVLwk3qLsgTnl3OHPMlT1zXGkwkG46EVGTjf2Wq1QpHnqMoSxGteXUXjlSBSSuR5jsVyiUGW2T5htbRiZc5QlZUV/maZq/TQ+w/ciB0TRRG9++bdf+v5F158/Wrs/3IbYACw9WZztLszPxCCfzCKIkUpoXVtzQ+BO8neHVi7WdGxSz7aESS+RlbGQMoO0/EEaZrC6RYtKcOYUy6onjErygKMMleBWCjc88y+I22qCoPBEGtn0O7aS856MB71dfxkMsFwPIJWCsuLBc7OzpDnOUajUc96+c0KHEMnpV3g1WaNum3w+OOPI4pjbDcbBEJgPB5bA7bjsK9fv957hb1cJ89zxThjlND/+ROf+vR/Wdc1o5Sqr3pkWdM0RHbyD6bT6V9mjA3sCx4gUkqEIkAoBAI3DtIPNfLYTdO1vXOy6zrnLUbPpjWNddqEUWQhb2nlgltLWPcL7U1+vnb3eYgx1mM0xiXhZJABzpsWhSGybIB0OHAzoQk2q3Wv7IjC6OFZFU6W74XDXdehazsYbZBkKaIwhGzsMyqD0RCV66w9M+iZvtVq5dV3xoWl9Ruvv/ETX3zttcKBcuarHdpnCCF0vdmU49Hoi3Ec/fRwOFKEgJal9db6RORBNsu92g0JvLsliuzQjihCXuQg1L6MNJlMbJnohmkvFguAADfu3AZ18ySiOOr1PZd6ffSmD0oI2rpBvt1iPt9BwDnKukYQhVZR13aANjg/O7daUJcTJpMJojjqp2E1TQPlNrJwifzqABM/mMniOyHatkOaJOjcDfMCMd8rOApUcc5Z23Y/+5nPPvOxtm3p1Um6D02M/DJTE40xhm822+fns/lNSsn7hQik1ppeVQp7RUJv2lYKjNqSM3aJtSzK/uQGruT0IBlzuA8XArPZHFwInJ+e2a9xSc3yBm3vSVBOPUcoAeMcZVEg32wguw7b9cZ6xWo7lEkrq7bwrJmHj9u2Rd3UUO6RuKq2w/3i2HbUZekEZ10LAiBK7aJzYbVPnl71+c7xvdBaS0op11r/H5/81Kd/4fzinDPGvuTjP19pcKtp25Zpo39zOBz8JKV0j3OuqqqiQgiMsoFbBNY7TkaDAQi85ND0VtIotCdaw9iBfVqDC4HReAQYg6aqsVouUeQ5tFLggeiTmoeTa/cqxna1Rp7n4ELAKH2ZB1wVMxqNMB6PIYR4aCKiVXc3PcLaNm1vBumkRBRG2Nvb6wFG7ae0EIr5zk7/tVfJIJ/rqqpC13VaSsmEEG+8+OJLP/Laa6+1jLGH3iF760awr+ZlpM1m0w4Hw385HA7+MiFEuJhMDAwoAQhoP3OZC4E4jOzcTXY5UrgsS9hX8MI+zk5ndoa/7CTi1Iqz2qZFmmVu+jpxfHML7QbmMcYQBgESR6bIrgNhtAfAvMzF5x+vpDbG2JLREU29Ks5504jTh3pYJa9KKzjgHJzxPhTFadK/KeCFCK70NVJKo7VWDx4c/8gzzz77CrE2Uf2NDu82APjFxcXxeDz+QhxHf4Expuz4dkUCEVoYgFslcdu2yJLUScTZlXmaViHteYC9g307w3ObO/kgRZTESLMM2iVrX47aAX8cFASNyzVGKxAYLBZLa12NIsRRhJ3dXWw2m94G68FByxHHFsk1GlEQ9okcxjjDxuU86rKuoNoOlBDM5jPsHRxABLbh82MS9GXeME3TqNVqxVer9b/zmc88/WtSSf52Vc/XOz1dK6X4+cXF53d3d/MoCj8ihFAOUQLjHIM0BSEUTdtAwyYvj+1zLtxERdsFTx2RcnZ6hiAKkQ4y61p0Sd2LbH1P4DeDUDscoypKNK4hrGurY63KEuPJBJWrRqjnMRxGNR6P/etIyNIMgdOiWr9xAM5Fr38ihCBwXW0Qhtg/PEAcxTh6cNRrjzz04D6zXCwWQmv9i08/89zf3eZbzhiTbw03b5cHvpYHHHTXdTzP89/f29sN4zj+U1mWdW3bMGMM0jjBaDhEGIV2sd00FT8uwGM6YRgiSzOcOOYqzdK+C27bFmVu3Sv+pvgwVpZ2TJi84s1arzfIczv/U7rxOkVeeCsooihE11qp4Xq9RlVVvZdYOlzL9wudVm4sgoWqeSAQxwnSLMNiucB6vcJ0aqHuu3fvoixL/5Zld3R0JAD8vRde+MJff3B8/LaL/816wsQUZcnLqvqt27dvpQC+L4piCYB0XUdCZ4qLoxiz2RxJErvFsU7yOI4wGI5wcX4OKSXSNEUSJ9BKo6qry4mInexni959/Q0QYt+WjB3qyjjDarXuN6JX5uHKHNAg6DtVf6u8wNiT8UmSWFMGtTeXuIJhW+QglCLkwqK+AAYOXrl//36fJ5bLRXd6eiKU0v/gpZde/bnXXn+dvTXpfqVX9r7mR3woJWaz2bKyqn5zOMgizsWfDIJAcyEIASFBGIJxDumMyT2fKzgm47ErBSuEocWM4KqofGNfOfKLJASDURpcBCAA0ixFuc3R1DU26w1GkzEEF3148tiS3wAPJ3jfgC+XPVzu//FvCwRhiCSOoY0d/LGzswshuC1nqwrnFxe4d+8eLi4uYIwxp6enum07XlXN33v6mWd+7t69e37xzdfyxOHXvAFe8bVYLFjbdL+1M98pKCU/xDknURwpbQytyhKEWo+tlXbbYRp+8CshFHGcQEmFsWvKysJOSNnmue08lcJms0Xj3pTUrvX3vUZTNz0Q5rWefmzYVYd9mqYYDAYYjUY9NtQp2XMCfsKXd/T4A7RZrXFydgpOmR1z6Z5G32w2uigKopSiq9X6F59//sW//uDBgy+5+N/Kh9zMcrXieVF8bGc2f5FS8sNVXYcwRjJKqTIa3MEJQgioTqKTHbLBoDc/CyGQpElvsEiHAzsI2xg0bWsH4UmLzXj5n6+/PbnimyrP9V7O+zT9v191z1gOm/SOmSCwcLjXJBVFgbOzMywdrOAhcLdZsq5rppXu7t2//1c/+alP/9Jyufyyi/+V9uQbfcpQr9dr/uabd58bjUa/MRwOvq9pmr04TRS3b0iSQAR20qFDKI024MJqMQmltgRlDJOpHQG2Wi5R1fbRHI+3XJ3Ie1Wa7k+xV7x5EZSHE/yE3aujZuI47pHNMIpQlCXKqoRsO6zdlEXf2fuNbdvWaK1VVVW8LMtX7987+slnn/vcP+267st2ud+WxzwJIbrtWv7mm3fvR2H4jyaTyTVK6XelaUomk4lsmoZ6elC62XKM2mcF0yy1g7qVncROCcHiYgHZ2fEBnfP6+mmJo9GohxL8Lz+czymO+5N+tY/wIclPXDHGoHLj6/MiR11Wlu/uLkXDHt9pmkbmec601vTiYvG/feELL/3ky6+++gUDwxn90tXOt6QK+nKboLVm9+7fr5fL1f/Zdd1LnPPvCYJglGWZkUpppRXV2jiYgvZ+rSAQ1pN8Zc6mksq9rGSJoziJ+5DlnyD0Md9rfPw03u122wOEvo8Qwjr7tdZo6hr5NsditcLF4gLnFxdou7bngH1FpZRSbmgJq6r6/OjBg59/6aVXfuFicVEyqxBQ34wXtr9p7wk7BJVsNht29+69Z2Un/3EUhWPG2FOd7CghRHPGNBeC1u79RsE5GPHvghGURQmj/XsEjkg0ph81czUM9bV82/Qhp21b27Zz3tOfvsz0Uw83+RZ1W1vewt0cpTWiOPILr40xuus6tlwuyWa9/Uf3Hzz4C1/84hd/p2kb6sKc/mY9b/7N3ICHCJ3z8/Pt/ftH/4xz8f9EYXhdKXVHa02DMNScc13XNSGEEMoo2taaIpSU0I4Q8S4THz7smwJ2brP/b1fHwLRdZ8fruAFPHgNabzZYrdfgzDJYm+0GVdNAKYnxcOSFA4YQot07YjTPc3p2ev6xs7Pzv/LG3bt/5+zsbE0pZV5K8s18W/5b8qa8+4uJtY5R9c53vhN3bt/+s/P57K8Zo7/P25OEEDJJEhqGIdVSomlaJFHUi2MBWFtQmiKJYrRN079s5yGBpmn6mt8/BOpnD0kpEYQhus6OXijK0j7s4ObNqU7q1Wql267j3mIqO/Xx1Wb9d85Oz//JerOGMYYxSrX5Eo/w/Cv1pvyXeAqLAjBCCHN4eIi9vd0feOzO7Z8ZjUY/KoSIKKV+yqDknBOjNQ1FQFrXkHmnzNZBCIwxO//N3w53a/yQJ1+C9hJE2bmBrS1a633QZVkaKSVbLBakLEsoqbumaX5js93+t+vN5teWdtYPofZRZPXNPvXftg14y0YwB82a8XiE97z7PY/v7+39+dF4+G/O5/P3eetRlmUYDAaaEKKbuibGGNK1HVFSEo+7+yTuu2z/uxf+1nWNwupbTde2RkppKGO0VR21CjlL8J8cn34uL4pfzYvif7m4uHj+CkfMvtUL/23dgLfZCANAZ1mGvd1dzOfzD9y6eeOH9/b3/vUkSd4/GAwyr6/J3Rteggs0bWOqsjKAMdQNu6ibGhQEYRyBghCtNVFaEeWM3/k2dy9rVwiCsNxut0/fu3f/ty8Wi19frzefKIpCO5k6pXZ2mvpWhJp/JTbgLQ9bUheepJ9mNd+ZY3dn52A0Hn3HZDL+wCAbfOd8PnuHEOLQGDPpuo774RqEEnRNC6mUraauzJ6WXafarlu2bfugKIqXi7J85vT09FNFXj67WC7vVWUJfbmQ/qU7/e1a9D/2DXjLRhC3Gf70mSsPieLg4ACj0XDOKD24fv36/s58Z77ebKZFsR0QSgNnA+2MMVtjzGK73Z5LKU9W6/WDzWZ7VlWV8aDclZ+ZuTe9vi785pv56/8Dwh2X/Ffkm08AAAAASUVORK5CYII=",_i=110;let gi=0,mi=class extends de{constructor(){super(...arguments),this.discovered_list=[],this.compact=!1,this.showStats=!0,this.showLegend=!0,this.showMoon=!1,this.showCardinals=!0,this.showBlindSpot=!0,this.showSunPath=!0,this.showSunriseSunset=!0,this.showCoverFill=!0,this.showWindowArrow=!0,this.coverColors=[],this.northOffsetDeg=0,this._hiddenEntries=new Set,this._legendMoonMaskId="acp-legend-moon-"+gi++}shouldUpdate(e){return e.size>1||!e.has("hass")||ve(e.get("hass"),this.hass,this._relevantIds())}_relevantIds(){const e=[];for(const t of this.discovered_list){const o=t.entities;e.push(o.sun_sensor,o.target_position_sensor,o.manual_override_binary,o.sun_infront_binary,o.decision_trace_sensor,o.start_sensor,o.end_sensor)}return e}_toggleEntry(e){const t=new Set(this._hiddenEntries);t.has(e)?t.delete(e):t.add(e),this._hiddenEntries=t}_sunFor(e){const t=e.entities.sun_sensor;if(!t)return null;const o=this.hass.states[t];if(!o)return null;const i=parseFloat(o.state);return Number.isNaN(i)?null:{...o.attributes,window_azimuth:o.attributes.window_azimuth}}_sunInfrontFor(e){const t=e.entities.sun_infront_binary;return!!t&&"on"===this.hass.states[t]?.state}_sunDotStateFor(e,t){const o=e.entities.decision_trace_sensor?this.hass.states[e.entities.decision_trace_sensor]?.attributes:void 0;return ci({belowHorizon:t.elevation<=0,sunState:o?.sun_state??null,directSunValid:o?.direct_sun_valid??!1,inFov:!0===t.in_fov})}_readActiveAzimuth(e){if(!e)return null;const t=this.hass.states[e];if(!t)return null;if("unavailable"===t.state||"unknown"===t.state)return null;const o=t.attributes.azimuth;return"number"==typeof o&&Number.isFinite(o)?o:null}_buildOverlays(){const e=[];return this.discovered_list.forEach((t,o)=>{const i=this._sunFor(t);if(!i)return;const s=t.entities.sun_sensor,n=parseFloat(this.hass.states[s]?.state??"0"),{color:r,isOverride:a}=pi(this.coverColors?.[o],o);e.push({d:t,sun:i,sunAzi:n,sunInfront:this._sunInfrontFor(t),dotState:this._sunDotStateFor(t,i),coverPos:Xt(this.hass,t),actualPos:Zt(this.hass,t),coverType:t.cover_type,openBlocksSun:At(t).openBlocksSun,color:r,isOverride:a,index:o})}),e}render(){if(!this.hass)return V;if(!this.discovered_list||0===this.discovered_list.length)return H`<div class="placeholder">${st("compass.placeholder_no_entries",this.hass)}</div>`;const e=this._buildOverlays();if(0===e.length)return H`<div class="placeholder">${st("compass.placeholder_no_sun",this.hass)}</div>`;const t=e.filter(e=>!this._hiddenEntries.has(e.d.entry_id)),o=It(this.northOffsetDeg),i=e.length>1,s=e[0],n=s.sunAzi,r=s.sun.elevation,a=Tt(n,r,o),l={night:-1,outside_fov:0,in_fov_not_valid:1,hitting:2},c=r<=0?"night":e.reduce((e,t)=>l[t.dotState]>l[e]?t.dotState:e,"outside_fov"),d=li[c],{latitude:h,longitude:p,time_zone:u}=this.hass.config,_=void 0!==h&&void 0!==p?Jo(h,p,ti(u)):[],g=this.showMoon&&void 0!==h&&void 0!==p?ni(h,p):null,m=null!==g&&g.elevation>0,v=g?Lt(g.phase,6):0,f=m?Tt(g.azimuth,g.elevation,o):null,b=f?f.x*_i:0,y=f?f.y*_i:0,w=this.showSunPath?si(_).map(e=>_.slice(e.startIdx,e.endIdx+1).map(e=>{const t=Tt(e.azimuth,e.elevation,o);return{x:t.x*_i,y:t.y*_i,elev:e.elevation}})):[],x=[122,127,135],$=[245,197,24],k=e=>{const t=Math.sqrt(Math.max(0,Math.min(1,e/90))),o=x.map((e,o)=>Math.round(e+($[o]-e)*t));return`rgb(${o[0]},${o[1]},${o[2]})`},A=this.showSunPath&&this.showSunriseSunset?w.filter(e=>e.length>1).map((e,t)=>{const o=e[0],i=e[e.length-1],s=i.x-o.x,n=i.y-o.y,r=s*s+n*n||1,a=e.filter((t,o)=>o%6==0||o===e.length-1).map(e=>({offset:100*Math.max(0,Math.min(1,((e.x-o.x)*s+(e.y-o.y)*n)/r)),color:k(e.elev)}));return{id:`sun-path-grad-${t}`,x1:o.x,y1:o.y,x2:i.x,y2:i.y,stops:a}}):[],S=e=>this.showSunriseSunset?`url(#sun-path-grad-${e})`:"var(--warning-color, gold)",C=Et(0,124,o),E=Et(90,124,o),z=Et(180,124,o),M=Et(270,124,o),T=Et(0,_i,o),I=Et(180,_i,o),P=Et(90,_i,o),O=Et(270,_i,o),N=st("compass.sun_tooltip",this.hass,{az:ct(n),el:ct(r)}),D=null!==g?st("compass.moon_tooltip",this.hass,{phase:g.phaseName,pct:Math.round(100*g.fraction)}):"",B=st("compass.sun_path_tooltip",this.hass);return H`
+  `,e([ge({type:Boolean})],Ho.prototype,"on",void 0),e([ge({type:Boolean})],Ho.prototype,"readonly",void 0),e([ge({type:String})],Ho.prototype,"label",void 0),e([ge({type:String})],Ho.prototype,"title",void 0),Ho=e([pe("acp-header-pill")],Ho);const Uo=lo(class extends co{constructor(e){if(super(e),1!==e.type||"class"!==e.name||e.strings?.length>2)throw Error("`classMap()` can only be used in the `class` attribute and must be the only part in the attribute.")}render(e){return" "+Object.keys(e).filter(t=>e[t]).join(" ")+" "}update(e,[t]){if(void 0===this.st){this.st=new Set,void 0!==e.strings&&(this.nt=new Set(e.strings.join(" ").split(/\s/).filter(e=>""!==e)));for(const e in t)t[e]&&!this.nt?.has(e)&&this.st.add(e);return this.render(t)}const o=e.element.classList;for(const e of this.st)e in t||(o.remove(e),this.st.delete(e));for(const e in t){const i=!!t[e];i===this.st.has(e)||this.nt?.has(e)||(i?(o.add(e),this.st.add(e)):(o.remove(e),this.st.delete(e)))}return q}});function qo(e){return e&&e.__esModule&&Object.prototype.hasOwnProperty.call(e,"default")?e.default:e}var Vo,Yo,Zo={exports:{}},Qo=(Vo||(Vo=1,Yo=Zo,function(){var e=Math.PI,t=Math.sin,o=Math.cos,i=Math.tan,s=Math.asin,n=Math.atan2,r=Math.acos,a=e/180,l=864e5,c=2440588,d=2451545;function h(e){return new Date((e+.5-c)*l)}function p(e){return function(e){return e.valueOf()/l-.5+c}(e)-d}var u=23.4397*a;function _(e,s){return n(t(e)*o(u)-i(s)*t(u),o(e))}function g(e,i){return s(t(i)*o(u)+o(i)*t(u)*t(e))}function m(e,s,r){return n(t(e),o(e)*t(s)-i(r)*o(s))}function v(e,i,n){return s(t(i)*t(n)+o(i)*o(n)*o(e))}function f(e,t){return a*(280.16+360.9856235*e)-t}function b(e){return a*(357.5291+.98560028*e)}function y(o){return o+a*(1.9148*t(o)+.02*t(2*o)+3e-4*t(3*o))+102.9372*a+e}function w(e){var t=y(b(e));return{dec:g(t,0),ra:_(t,0)}}var x={getPosition:function(e,t,o){var i=a*-o,s=a*t,n=p(e),r=w(n),l=f(n,i)-r.ra;return{azimuth:m(l,s,r.dec),altitude:v(l,s,r.dec)}}},$=x.times=[[-.833,"sunrise","sunset"],[-.3,"sunriseEnd","sunsetStart"],[-6,"dawn","dusk"],[-12,"nauticalDawn","nauticalDusk"],[-18,"nightEnd","night"],[6,"goldenHourEnd","goldenHour"]];x.addTime=function(e,t,o){$.push([e,t,o])};var k=9e-4;function A(t,o,i){return k+(t+o)/(2*e)+i}function S(e,o,i){return d+e+.0053*t(o)-.0069*t(2*i)}function C(e,i,s,n,a,l,c){var d=function(e,i,s){return r((t(e)-t(i)*t(s))/(o(i)*o(s)))}(e,s,n);return S(A(d,i,a),l,c)}function E(e){var i=a*(134.963+13.064993*e),s=a*(93.272+13.22935*e),n=a*(218.316+13.176396*e)+6.289*a*t(i),r=5.128*a*t(s),l=385001-20905*o(i);return{ra:_(n,r),dec:g(n,r),dist:l}}function z(e,t){return new Date(e.valueOf()+t*l/24)}x.getTimes=function(t,o,i,s){var n,r,l,c,d,u=a*-i,_=a*o,m=function(e){return-2.076*Math.sqrt(e)/60}(s=s||0),v=function(t,o){return Math.round(t-k-o/(2*e))}(p(t),u),f=A(0,u,v),w=b(f),x=y(w),E=g(x,0),z=S(f,w,x),M={solarNoon:h(z),nadir:h(z-.5)};for(n=0,r=$.length;n<r;n+=1)d=z-((c=C(((l=$[n])[0]+m)*a,u,_,E,v,w,x))-z),M[l[1]]=h(d),M[l[2]]=h(c);return M},x.getMoonPosition=function(e,s,r){var l=a*-r,c=a*s,d=p(e),h=E(d),u=f(d,l)-h.ra,_=v(u,c,h.dec),g=n(t(u),i(c)*o(h.dec)-t(h.dec)*o(u));return _+=function(e){return e<0&&(e=0),2967e-7/Math.tan(e+.00312536/(e+.08901179))}(_),{azimuth:m(u,c,h.dec),altitude:_,distance:h.dist,parallacticAngle:g}},x.getMoonIllumination=function(e){var i=p(e||new Date),s=w(i),a=E(i),l=149598e3,c=r(t(s.dec)*t(a.dec)+o(s.dec)*o(a.dec)*o(s.ra-a.ra)),d=n(l*t(c),a.dist-l*o(c)),h=n(o(s.dec)*t(s.ra-a.ra),t(s.dec)*o(a.dec)-o(s.dec)*t(a.dec)*o(s.ra-a.ra));return{fraction:(1+o(d))/2,phase:.5+.5*d*(h<0?-1:1)/Math.PI,angle:h}},x.getMoonTimes=function(e,t,o,i){var s=new Date(e);i?s.setUTCHours(0,0,0,0):s.setHours(0,0,0,0);for(var n,r,l,c,d,h,p,u,_,g,m,v,f,b=.133*a,y=x.getMoonPosition(s,t,o).altitude-b,w=1;w<=24&&(n=x.getMoonPosition(z(s,w),t,o).altitude-b,u=((d=(y+(r=x.getMoonPosition(z(s,w+1),t,o).altitude-b))/2-n)*(p=-(h=(r-y)/2)/(2*d))+h)*p+n,g=0,(_=h*h-4*d*n)>=0&&(m=p-(f=Math.sqrt(_)/(2*Math.abs(d))),v=p+f,Math.abs(m)<=1&&g++,Math.abs(v)<=1&&g++,m<-1&&(m=v)),1===g?y<0?l=w+m:c=w+m:2===g&&(l=w+(u<0?v:m),c=w+(u<0?m:v)),!l||!c);w+=2)y=r;var $={};return l&&($.rise=z(s,l)),c&&($.set=z(s,c)),l||c||($[u>0?"alwaysUp":"alwaysDown"]=!0),$},Yo.exports=x}()),Zo.exports),Xo=qo(Qo);const Jo=new Map;function ei(e,t,o,i=10){const s=`${e},${t},${o.getTime()},${i}`,n=Jo.get(s);if(n)return Jo.delete(s),Jo.set(s,n),n;const r=[],a=o.getTime()+864e5;for(let s=o.getTime();s<=a;s+=60*i*1e3){const o=new Date(s),i=Xo.getPosition(o,e,t);r.push({t:o,elevation:180*i.altitude/Math.PI,azimuth:((180*i.azimuth/Math.PI+180)%360+360)%360})}if(Jo.set(s,r),Jo.size>4){const e=Jo.keys().next().value;void 0!==e&&Jo.delete(e)}return r}function ti(e=new Date){const t=new Date(e);return t.setHours(0,0,0,0),t}function oi(e,t=new Date){if(!e)return ti(t);const o=new Intl.DateTimeFormat("en-CA",{timeZone:e,year:"numeric",month:"2-digit",day:"2-digit"}).format(t),[i,s,n]=o.split("-").map(Number),r=Date.UTC(i,s-1,n,0,0,0),a=function(e,t){const o=new Intl.DateTimeFormat("en-US",{timeZone:e,year:"numeric",month:"2-digit",day:"2-digit",hour:"2-digit",minute:"2-digit",second:"2-digit",hourCycle:"h23"}).formatToParts(t),i={};for(const e of o)"literal"!==e.type&&(i[e.type]=Number(e.value));return Date.UTC(i.year,i.month-1,i.day,i.hour,i.minute,i.second)-t.getTime()}(e,new Date(r));return new Date(r-a)}function ii(e,t,o,i){const s=((t-o)%360+360)%360;return((e-s)%360+360)%360<=((((t+i)%360+360)%360-s)%360+360)%360}function si(e,t,o,i){const s=[];let n=-1;for(let r=0;r<e.length;r++){const a=e[r];a.elevation>0&&ii(a.azimuth,t,o,i)?-1===n&&(n=r):-1!==n&&(s.push({startIdx:n,endIdx:r-1}),n=-1)}return-1!==n&&s.push({startIdx:n,endIdx:e.length-1}),s}function ni(e){const t=[];let o=-1;for(let i=0;i<e.length;i++)e[i].elevation>0?-1===o&&(o=i):-1!==o&&(t.push({startIdx:o,endIdx:i-1}),o=-1);return-1!==o&&t.push({startIdx:o,endIdx:e.length-1}),t}function ri(e,t,o=new Date){const i=Xo.getMoonPosition(o,e,t),s=Xo.getMoonIllumination(o);return{azimuth:((180*i.azimuth/Math.PI+180)%360+360)%360,elevation:180*i.altitude/Math.PI,phase:s.phase,fraction:s.fraction,phaseName:ai(s.phase)}}function ai(e){return e<.0625||e>=.9375?"New Moon":e<.1875?"Waxing Crescent":e<.3125?"First Quarter":e<.4375?"Waxing Gibbous":e<.5625?"Full Moon":e<.6875?"Waning Gibbous":e<.8125?"Last Quarter":"Waning Crescent"}const li=new Set(["outside_fov","in_fov_not_valid","hitting"]),ci={night:"sun night",hitting:"sun valid",in_fov_not_valid:"sun in-fov",outside_fov:"sun up"};function di(e){return e.belowHorizon?"night":e.sunState&&li.has(e.sunState)?e.sunState:e.directSunValid?"hitting":e.inFov?"in_fov_not_valid":"outside_fov"}const hi=["#1f77b4","#ff7f0e","#2ca02c","#d62728","#9467bd","#17becf","#e377c2"];function pi(e){const t=hi.length;return hi[(e%t+t)%t]}function ui(e,t){return"string"==typeof e&&e.length>0?{color:e,isOverride:!0}:{color:pi(t),isOverride:!1}}const _i="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAYAAADimHc4AABBS0lEQVR42tW9aaymWX4f9Dvbs7/7e9fqrrV7pmdpezw9nhnjOJETbI+3xEY4sUJEPgRiS5bhS1DAIghLkQgKwQEiJYCI+RCCIWAgibHHtohjj21m72Wmu6eX6aWqbt31XZ/9OQsfzjnPvdXu2ReHklrV03Or7nvP8l9+y/8Q/DH/IoSAANQA1BhjAKir//9wOMR0MknnO/Pd6XS6uzOfz6bT6WSQDQZCCFFVJdq2lVKp7XqzWebb/GK73Z4dPTg6OT4+yZfLJexf2/+ilFJKCNFaa/3H/vP/MS48AcCMMQqAAYAgCLC/tze+cf36ux9//LH3z2az982mkyfGo/EjYRjOGWMp4wyMMnRdB0IItNbQWoNSCq01OOcYDoelUvqiqIp76/XmxTfefPOZl1955TMvPP/C519/441FXdf9x2CUMhCijTFfcjPesoH//90Au+agxhjiT/pwOMD+3v4T+/t7P/iOxx77wTu3b38wy7Idxhjy7RZKK0ipoJSCEAJKKVNVlSGEmK7rQCmFEAKMMZIkCUnTlABAFEUYj8fI0hRRkoALDkLpxdHR0adeePHF3/z4xz/xm5/61Kc/d3Jy4j8e45zDGKO+3IJ/szeDfBsXn7kQo6MowiPXrl07vHbwb4xHoz/PGfvQeDgSo9EQUiq0XWuaplEwAKWUSClJJyXRxpAwCBAGAYIggJQSlFI0TYMgCMAYQzYYgBJigiCA1lrP5nPjvp6NpxMym8+RJgkMoO7dvffJj3/i4//kYx/7g//9M599+o2qKgGAcM7pt2sjyLdh4an7sHo8HuP2rVsfvnZ48FeDMPjJpmnGxhgYY8Apk2VZkrptaBRFhDGGQAjszncgpURelVBKgVIKow1mkwmGwyG22y3quoZSCmVVgVCCKAghhAClFEmSYDqdIo5jDAYDMxqP9SDLTFVV3BgDxhjatt0ePTj+p7//B3/w3/3+H/7h7y6XSwCg7kbob+VGkG9ljDfGUAAqS1PcvnX7+69ff/SvdbL9kaqq4GK+YoxBcE7bpiVlXYESAkop4iTBdDLB4f4B2qYFYRSj4RB1XUNrjSAIUNc1tpstKKOo6xpt20JKibZtEQQBKKVo2xZpmmI4GoEAGI/HGA6HAGC01sYYo9u25aPRCGma4uTs9Lc/9enP/Be/+3u/99HFYglCwBjjWmttvhWbQL6F4UZxIfDOxx//rv39/f9Edt1PFGUBxqhhjGshOOWcE2OAKAqhtca1g0NQQkAIQZKm4JwjS1N0bYsoitBJicVi0Sddn3iVUmjbFuPRCAbA+cUFOOdgjEFrha7tcHZ+Dm00hoMhRsMhxuMxoigC5xxaa5MkiW6ahgIgw+EAZVX/+u//wR/+4u/87u9+vCxLcM7ZlwtLX+8mkG/Vqb927XD8HU8++R83TfPvrVcbQSjRlBLDOWPEnXIpFYwGpJI4PNjD/u4eRCAQiAB1U2M8GqNpGhwdHYExBgMDpTQGWQbGGMIwxDrfwkgFEKBpGuzv7+Pw4BDL5RJd10FwAaUVqqrCcrlE23UQnINzjul0CiklAGAwGCCOY2y3WyWEIMPhkAoh9DbP/8H//Rsf/U8/8clPnrlE/SVvw9ezCeybHOtNGIbmyfe+58fe9cQTv7rZbH50vVozxpiy34tQQgiMMdBKA7Bl5Gw2RZImaLsObdehqipQQgEAz7/4Ak7OzrDNc9RNg9V6DUoolFK4f/8eVus1jDbIywJn5+fIiwLr9RqMMbz40hdwsbhAmiRgjGE6nWI8GqGuKtR1jaqq7GcxBuvNGkopGGNo27ak6zpVliVlhHzwwx/+0E/fvn3n3hdeeulzVVXBJWnzJaq8b/8GEAJuDNT+/l70Xe973y+FQfB3jx+cTLu2k4xxQimljDEwTiE7BYCAcVvLp1mKvf1dUGoXvG1aRGGIJEnwxr27WG82IIT0IUVKidV6g/PzC5R1AwJ7g9ziYTwaAQA2mw2CIMRoNAbn9sdM0xSHh4dYLBfY5jkiWymBc46mbuD7A0opGKVUCEGSNJVlWU7u3L71U0899f7rp2dn/+LBg+OGUsoJIfob3QT2TajrOQD53ve855137tz+Z6vl6iebptGUUiOEYFxwYtyNVVKBEoowEgAMoijEZDJGVVVo2xZJHMPAYLvd4vjkFF0n0dQN2k6h6zp0nYSSGkpq2JtkgyhjdvMYY1BaIxIB2qZF27aomhqMMgyyDNyFnuFgCMY5hBAoyxJd1/WbK5XCerVC3bao6xrGGBoEga7rWu/M50/9xJ/7cz/GRfCHTz/99BEh5BveBPaNLL4xhgsh5FPv/64fGY9Hv3Z+fvFYGAbSNpiUEEKgpD2ZWttFEyEHIYBSCmEY2g9BKZTWtoJpGjw4OUXbdpBK9n/WaBu2/G3QWoMxCgICQolLuBrGGJR1BSY4GGeo6xp104AxijTLQClF13VIkgRSSlRVhdFohK7r0CoJ1dneou5aVFWJxWqJPC+IlJICkEKIgw9+8AN/aTAYvPLZzz79Oa01p5R+3ZvAvpHFj+NYPvX+p35GK/WPV8tVMhqNlDaaN3Xz0AcwxriOlYExCillDyPUTQ0YQHCB5XKN9WZjQwCjAMHlSTcPJznOmU3MxoAQgBB7AxhjoNTmCP99OOdYbzfQSkMIgbquEYYhjDFo2xZlWYIQgjAIsbuzgyiK7OYDkFqjrErkeY66biinVFFKoyff/e6funbtWv7008/8ftu2zH+Wr3UT2Ne7+GmSyg889f5fAPQvNU1jhAhM27asbVpQSh+K25xzcMFA6cOborUGAQEIsNnkaNsWlDEwSkEZBYy7Qdr0OcJu5uVpJ4TY3oFRcM5tHmnbhzbefo39/+M4hupkXwEpZWGOJElAAGRZhiRJwKgNScZhTdoYFGWBuq5pwIUJwkBff/TRj9y6eTN89rnnfruqKsYYxVtT81faBPb1nvzvfN93/I0wFH8TxEjKGJVSUX8ajbFfGwQCXHAYGAQBhzH2lPpE52OyVhpSKnDBIdw/AKBcyPE1/+Wi2pAjuIA2GpSRK3X/lY1xiy8CgYAHaLsW08kUURih7dq+WyaE9CFpsVigaewN1kpBcPs1YRAChKBtG2itifulDg/2/9Rjjz+Wfvozn/3Npmk4pdR8S5KwX/woiuQHnvrAL0Drv9k0raSUsbKoiFLKfw04ZwjCAIQCWitQan9AIUTfOBFCYDRAr2yIb8IoJairFkrZW+K/v2/ALIRAAdjf/Yb4729DFEcQBOCcg1KKNIkRcIHNdgN/SoQQEEKgbVswxhDHMXZ2dgAAcRwjjmNwzpHEMeI4creIYTgcgjFGpJTUAN1oOPi+69evR08/8+xvKSk5eUtO+HK34Gu5AVwIIb/nwx/6GSXlLwkhZNu1rCzt4vsT6k8eYwRKKQyHIxweHqIoCrRt6zaIwxiDrpVQUoJQIAgDGBhobSClBiG0X3QA/e+++6WUggsGwJ72vr/Q2t4KQvvwl6UpwjCChgbc1+3M58iLAkIIEEIQxzEYY4iiCFEU9ZuS57mt0poWbdP0KKsPsXVds7pu5CBN/+SdO48Vn/7MZz72paqjr3sDCCGMEKI+/OEPfSSKwl8BjCKMsHyTkz8SHggFEwyc2xM1HA4RRRGKooCHiT2CSQjABUeSJP2fV1LCaPSb5OM6ZaQvNwHiFoBBSVsd+bCjtd1YEQikaYqmaUAZQ9006KQEJRRN10F1EmVVIgxDzKZTAMB2u0VZlj2453NEURQ2RxCC1EEkUso+nEopiTFGPfHOd3xkMBw+/8wzz36OUsoB6K90C77iBlBKqTFGP/XU+x/b3939aF7kYV01qKqaCiFgjC0zjXFhxIWEJE1w8+ZNfO/3fi+effbZPuwQQlBVle0JGIVWBl0n0bUS2thS1Bi72Iy7asgAjNsQJaWGEBxc2GqKc1tu+vhvN1L38V1rjTC0WFMURdhsNhBCYDAYIAojzKZTdF1nYQ3XQYdhCCll3yMEQYCmaSCCAFEYYrlawgAYDgb+kBAAZLlcmsfv3PlxbfQ/f/mVVx8wxt62Y/6qN8BjO7dv3Qq+88knP3r/6N6tump0VdVsOMiglEJdty7zX8beKA6QJAmUUrh37x7atu1PlK31W9i1IpBSQisDqWyTZrRx3SmDEMxtHGx4UvaWJGkEQuyf9TfDw9qXOJP9XlEUwRiDNE0xn8/RNA2apkErJUaDIRhjqKoKeZ5ju932Ycj/+YvlAk3bgDOO2WyGOAxtz9A2PfoqhMBwOCRlWer7R0fBhz70oT99/+jofzw+Pu7erjz9qjbAJ93xeKR+/Md/9L++e/fun12vt1JJyT2MUNcNKChAAUZZfyUNgK5rsd1usVquQaiN5fYDK7StfOhDMW5Di7CsFZRSYA4+aBsJQm1iVlL34cjnAZ98lVKuObMneDQaIY5je+so6WlMD1sbYyA4w97OHo6Oj/HyKy/j9Owc5xfnMACiMEQYhqjbFkVRuF7E9KUy5wLakkdXN4GenZ1JQsjOO594x/XPfPbpX3WVkf5SYejLbQADoH7wB37gI4Tgvzp+cCK11tyfsKZuQQgAYkBAH0rCAEAoAQEDpTZR2ripoJVGNsgAA1BGITgDdUjnI48eom3txnJuF1YIbsMRY2ibDkEoEAS2ctnZ2cF8Pndhy1Y1cRwjy7I+KY+GI8RhhDiM+jBFCEEURYjjBNsyx73791DVNYIwQCcllusVpFRglEJrhW2eW26h69DKDkkco+vafvM9lMEYQ9d1dLFYyL3dnfft7++/8Nmnn3mO+kX4am+ACz1473vfk73j8cd+/fU33hzKThGpFLFViuqRbEIIOGMghD7cZLnE6OHeKI76/20xHF9CWk43y2xIAwClbQyPosiGLiXBGYfSCpZqVP0NMsb0CzCdTjHIMiRxgk7ZBayqCoILhEEADQPKGIqiQBiGoJTi5OQEeZ73TZsF4lh/spMoRpamUFqDcQ5KLONW1hXKqkQaJ5jNZ33z5/+O8/OFef/73vf92zz/5dffeKNijJG3ywfsbZBNAITFcaz/zJ/5/r+13W4/srhYqqapmdIKBJcNDrHBGbjy3/yHeLgnED0G40+hkgpaGVuPB6IHwyz5biufuq5tmQjSM1z+6/ziN03T9xaj0cguEoAkidG0rY3XXYsojpAlCVarFbQxKMvS8gMuHNV1Cym7h34ObQzKuoZUNiHnRQHq4Imu67DZbtF1LaaTCYzjFNzPTZIkVmenp4Nbd27NX/zCF/6voijp2zVp7Evh+h/+8Ifes7sz/4f3798H44w1dUuM0f7cQxsFGANjQRoQQmGM7kORvx1hZBc/CIK+6ek6hTAMAKD/3dOU/hbEcdQDZZzzPpEHwoYJf3t8pdN1nf1zUeS6VwbK7WY3TYOz83PAALu7uxgMhyiLAlVV9QfFaINAiL7n0B4cdCfbh7lACIyGIxRVCSk7MMqwv7/vuWUEQYDVaoXJZEKbrlOM0vfv7uz+xrPPPXf37UIRfZvESyaTsblz5/Z/Xte1YIyhqRvCGe9xm/7vIBZ6sN2p7jfAnyBj0CdOKSUGAxeb3aJwbhcwDMO+EfLcrJQKWZZhsVj0i0sIgTb6ocUnBOg6G9byPLfAGiUo6wpa2ZDlw0tVV+CEoipKBEHQV1KccwShhTX8AfBNXd80dh1AACEEkiRBFIaWNCIEi9USQggURYHVaoUsy1BVlaNTO/Lkk+/927dv34ZSylw9oH/kBvjE+699z4f+xGg4+M+6rlNVVTEQY+FhqUAcoGZgQTECCs7FQ+EnDENXyVCXRC8rpO02ByEUs9nEQRQprl+/jizLeniaM4bG4fFhGPaLEMdxX+v7/6aUre8Zo33TtM1zZGmKyWiMMLAV0f7OLg7291HVNeqmRlXX2Gw2fVK2+UmDUtI3fxbPsvIXf8t2d3exv7sHzjmKssBsMkNe5FBK49FHHnGfhfl/KOdcBSK4OZvPP/mpT336pSvynIc3wJ/+2XRqPvjdH/jvtTZ3ABhCCG27DnleoK8xYdFFQigMdA8V+03wp8qDZB6/Jz3WAy+yAiEEo9EIbdvaMpJQDLMBNKxkxDZ7pg9jHsTzUPNgMIDW+uFwYgxmkykG2QCTyRjXDg9hjEGe5xgOh1iuVlit16jrGgQUSnm8G67EtP2H32QL8AGysyXx3s6ubda6DvP5HOPRCF3bYjab9TnKN3CDwcBst1sym83uvPnm3X/oBAP9HrC3nH79we/+wFM3b9z4W0mcmG1RsK5tURQ23mltwLnoKT5i8bCHsJhe58MZiDtNk8kEAJAkCbSWqOsWVVljMMiws7Njr7cBuq6DUgrTyRSc254giqKeNHdiq35D/K3y3S3nHGmaYm9vD5PRyIUr1sfz9XqNzWaD9WaD5WLVA4J+MykjPf7keQVjLKAoO9uh11WNpmsQhxEyx7INh0OkSQJyRSTmk3scx9QYY5q6enQwGv3OM888+9rVW8CvnH6kaYo7t2/9PACSF7mq65pa0qJzXShBmiboZAelalDCQK50oT3rJQSE4LbyyLI+dNhrbulFfysAgBGCvb09rDdrrLdbFFWJ8XiMwJ0ySokNfwSWWhQCy+XSbpLb/N3d3f5WAUBeFkijGMvV0pawSqGTHYqyRNt1oIygbTobRgn5I4ir31ytLV9AKAFxZXRRFGiaBmEYIssyaK0hXK7pug6DwQBKqf5Wjsdj/frrr9O9+fzfPzw8/J2jo6NLVNfFbWKM0e9597v3nnjnO/7+tiiCPC9oKAISBAHKskRbt1b60baQnQSl7KHW/yrGH4YhuLAJdTK2cVgbuzn5NgfnHIOBPT1plvZ9hJIK0AadlAjjCMzBxl654GGCqqoRRha7uaIZBee8Z7cmozGKsoSBwcnpKYwBNvnWUpZFaZuuTsEYm0+oC6daayRJ0sMZNs/Y72EAi9Z2EsPREHu7u0jT1JI6RoNRiizLEARBH4odJE6qqgJj9LY25n965ZVXFw5jM9SVXYwxhife+Y6fyotiUNe1CgQnURBAuqsEAigt+yZIa3UleclLqTkhALGNVBAEYIQiiSKMhqMeRqCU9CqG1dJ2nevNBlJJZIMB3vmOx3H98Bp2dndRNw3g/l7GONrOcsU+bFRVhYuLC6xWq55IaZoGy80ay/UKy9UKddPYA2Bsb0H7BpAjjkOX2nSPvvoiQil7W/0Np46rGAxTGJ+kXffNnFTGwyJN01iRgFLIi4JIKZXWJnz3E0/8xTiOoZSi9tDa66f39/eRpslfrOsagnFCtLEVgFKoKyvXMNrTXeaheO8xdR+GPC1YVRW2ZYG261A75QPnwuFCVv9T1zXyPAcjAGdWLHXt8BCj8Riz2QwGBlVVgjFLsPsKoyiKPjH7xHdxftEzWuv1GsvlEufn5yjLEmfn52hl5z6rlb9kgxRpliAIBGSn+q7cw9FXAT5jjLsBtiM2WluZpDGYTqc9FpXnOYqiwO7uLrIsQ1mW4IEAoZRuNhvMZ7OfvnXzJgWgKKXgvoO6cf3Rx9uu/QBjzDBCaSMtXr7Z5mjbru+SLSalQMGu1PsGSkkbRhyqKYTAdpsjSRK0ssPR8QO0bYswDC2hAYIojrDdbu0PBqAoC7z0yssoihyz2Qxnp2c9jtR1dvGapuk3ug8R2vLG69UWlALZwOadq4tX1zWKougBOqU1urYDFxyj8RBSKUjZ9pXPVU75Mk9qF64YGOdYbdbgVxg1IQRWq5X9MwQoisLmEm1ACaGGwBhj3vPe977nO59/4YXPAmDMGMMopfrDH/7gXzLG/CilTGmtGYitSk5OT1yj466hpxAJ7ROJ0qqvhrTWiJMInDNsNznSLEVVVlguV31J6iUp/n8HQQDuTjgIwfnFBY5PTnC+uLChT1kk1Td5Np7azrNtW8A1fBaWMIjCCEo7dNQ1a5ZftnDI7Vu38K53PYG6rnol3nw+eyiHXD39lns20EpBawMhAsxnU1BC0TUW9Y2TpG8YDYDTk9O+kjo5OUEYhoiiSAFgg0F2///9+Cd+V2vNKQAzn8+QZdkPtU2LuqkJ4wxJHOPk9NRWBK7stOSIRT/txbmMjR4ZBACtDJQyyAYpKKU4PT0DAelPX9u2WC6XPQiWJAm021wfh71KrSxL5PnWlo/rNbqug9YaZVlaYkepvtT0IUUErA9LVd2gaTqXPDW00lit1hYhjWNUZQ3Z2b7lhz/yERzs7/e5TEoFJRW6TkJ2ClLaG5AN0r5h7JTEg9MTPDg5Rufq/3t37/ah1VdDnZQYjUZEK43ZZPqDj1y7BmOMYgDM448/Ptzf3/3bm80m2W42ZDKekG2eO9xGuhpY2yrBaBhirCDKbYK/rn4DfLzmnKOqyp4p8yHDg2f+avsFjMIIVVmhaRvH6XK78KstkiQBd0IrrTXaxn42zjiSJEYYBpjNZhgMrKwkTVNEUYi6bno7U9dasE1phYvFha2IygrZIEPXdVgtVxgMh9BaYzAYQEqNsqxgtKVStdYIoxBRFCJNUhRFAWUUNtscSkncuHkTR0dHPXVZliWkUoijCEpKNE1DAE1Go/H8+OTkf3j9jTdyBgDf9b7vfH8QBD/ftp0ZDodESoltnmMymaDrLBndNJ0lymEXjAsOrT0VSUAIXIVkc4VW2glwLWbkQS6P2fuFj+O4T2iDLEMYBCjK0oUYu3haaUjV9d3lcrnCdpPDuA7cwC7YcDi0iVlwJHHibqVr8KTuu+0sS9G2LfKiRJLFGA1HiOIYnep6maTsFPK8wN7erm3EpMWVytKaQEQgUNUVttscjFKMRmPs7+1hs91g5LwIjDG0ssNgOEBdNyjKgmilNaUk6JT67Weffe5VzjnHaDR6SisNxpiijPHXXnsNhFAwzi3q4zSYHv0MQ4u9VLIGiAYItUkYFFEUALAJy5/ygAgoI8EoR1XVPXRcliXKsuwBLsYZmq7tgTYPTw9HGZTSveJNSVuv24WwOSSOYxweHmKz2WC5uMD+7j7KqkJZlkjSBEgskGiMpT+11piMRiDMAmq78zneePNNrFZrGKOx3RTQ2oYrT6f6217kBRacIY5idF0HKSXu378PQggO9/YBWKl8FEXQMLh7717fs+zv7mmlND3c3/uAEOKjfDwaIY3j923yHGEYom0brFZrXDs8xCBNkW+3lhjRCm3XgFGGpq0QhSEIJTCy5xDAGHehRrmumPa1P7S9+oEQaNum52uvlpMnp6cIggC3b9/Gm2++CcYotDZomrYnUOq6RuRqdxEwhGHQh7DtZoOqqhAEIaq6Rte2mIzGSJIEVV1DCN4nyjRJsL+7h052AKWo68aWxVXtum6ruvDd7NUwawn7qj9kbWtzzNGDBzg8OMAgzfoEfO/oPt68e7fvCWazGYqqRBLF79vZ2QENoxBSqXe5xolIqWCMxs2bNzBy8VAqCaMNGLElmi1BLYEeRzEIKAIRuiaovQw9DraWTvC6u7sDpTVGo3GfoHyy9Ak2z3Os12unarAL7NHIS4iYIY5DBEGAruuseqHtsNlsbBJnDKvVCnlVYjabYTQYwmiNIAwxm80cHRljMBwiCiMUeY7FcoE0TSy/4dBWzsVDDeal1JHCKUNQVzYXMcbwyLVrWC6WSNMUOzs7vfyGst7JiXv37tPX33gDlNJ3XDs8JOz6o48mh9cOfiEIgtF2uyWEEDKfzxFFEdbrNVrZucaqgwU+bcyllFsFg7EuFx8eBBcIQ+EALSsBJy5HNC4hDoaDvsWXUvaNj+86xRVixFtRPUlySeTb/OGVCVEcoaprMEIwGY/BuUAUhrh96xYE5+iktB6x4QjDwQCUsT5Op1mGsiqxXm/Q1E3fhPnfgyBAFDkvgWAgznum3EHzHoXBYADOGbTSuHHzJighuHf/Hlary+qtrmvEcUzGoxFdbde/zHd25nuUsnnpmobLK1aCcY4wCCHdDnPG0bZ138RQSiGVje0exCJOKOuVDmEkoJVG07QIQoHJdILFYtEDXk3T9qJd5QiUtm17GHo4HFoZiWt2uq5DFEW9UIrSqzIUBaMV6rrGdDTBcDTE2dkZiqJAlqS4eeMmjGvgfLeutcZ6u3Hls+r1qFd/Htv/cHBuemWHXyerIdXgAbNeBcpwfnZmDSJhgDhO+twhpUTXSrJeraGNng4Hw0POOd9VSiVaaxiAcMogdWe19VXtEEf74QCHdIJAqUvI1vt1ewmhoVBS9wtGQMC5cCfEwg11XfccMWAwm02x3eaI47iHNjximqZpj/H4EnNnZweqk1hvObpOIs8vXE8RW6+BUZeCKqdJJcZgPJ0iDAPcv3f/UqfUdbaI8CwbtawdCIVwPYnaWrKm62Qfkq5uQtO06FrbrddSYrVcuhvcOnOK7hV9ZVWZbZ6z4XC4x9M0mdd1DUKpIVoTxhniJAYBMBoMUVQlGPPyQIrpdIQir1yjZMPRVQxdCIamra+IZ1lfQ9+4cQNFUaCua6xWq76Rs7ShrbUHgwyd7BAFAYJA4Pz8AkmSYDwe9+GpLEucn51hmGXIkgR13fafQUqJ+XSKIAz6Djt0nILgAmlmFQ5pmqKqKjRNAyWl7fCdejuMAld6euEXcyGQPOQ/8EiAMbYvun/vCJRQjBzSG0VRn+u0hkvaGgzUEAPCGN2lXIix20VDKYXsJLTSKCoL2R7s7WMwyCACjigKkKaZVTFw+0GJK+2CIECchDDwBD2gjY3hTdMgjmOcnZ2BEILz83NUVe2qB6tgWK/XIJZEhlEGdd1gsVjAGIPFYoHJaIR3v/MJXH/kUcynU+zv7eHGjRsIRYj5fIa9vT2Mx2PszGaIoxjX9g8tg8Y5RBAgdFWblgqccYRRZD0AWkMq1XMGYRhAdhZyACjapr3s+N0N8ainr4zCMESaJqiqGl987TW0bYeLiwsQQhxQZ28PDHE4lLLDGoAxrapq6CTcJnaCI2W0hXCdnpJQitlshiRJ0DS1UyRbWnE0GmEwSBFGAgcHBxablx2M0X3p2DSNxeCDAMvlEttt3uNJjBFUVW2FukGAVmkEgiEIhCX1nQd4sVpBwSCJYyRxgjAI7c10He5sMsXB/j64I1jatu1FU7WDLPw/VVGgriokaQIhOAaDAXZ3dxHFUV/XK6XtYdTGWWSdH43Thxbf34K6aTAeDzGfz3B6cY6VY9+yLEOaJrZYgf364XDg/9yQvfvd7/reQIiPSCmNMYYqJyHkzMa+siz6+tdXRoSQno6z8KyVgfvmSkoJLji6VqKXRzhf2Gq1gtZWRU0Z7f1iPrFlgwH2d/ZRlAWKokRRFOCcYz6doqnqvkLyUPZ4PLYIptZWVuKk5v0QD0eSeJ6WUooiz7FypS6jDGVZYutwKenMgN6Vc1X9zRmznT+jUFpCcNFXS4NhhoPDfQTOyHGwt29tUFpjm+dYLtdgztlz89YNMxwM6Wa7+T3u3Yk+kXad5YD39/fROEm3pxqvWv+jyJ4Wr2iztKOysbWsoKQBY9yqoKl1yxR5ASkVojBCWdagFNAwPQnetjaR5UWOoiit8KnpIESA9WaDNrmUhCdJgjAMwTjDKBmCrEivnCOEuI49BGMMQRD0Dnsv/LLYkuWQ67pG09pGzKu7CWEQAXN07KWggHHb/9AwBGe8L5WF4Dg7O0cYhijLEscnx0jiGABwsL+P09NTyM4ChqNsYI2JUoE9+sgjTyVJ8qMAjFKKEuelGqXZQ2MAoiBE09QwQE9a+B/WY+GjwRClNTJbH7DsXFNmnKGC91ZTY7TTFD3c5HRS9mT8drvtw11VVYiiCFmaXpV9uN7h0ivsu+VsMICBQV3VTg4vEcUxGOdgjk71Ja+bV4EoiSGVRFVZWJwx6j6rQRAIxEnkyskOYRj0OiVKieNMTB92t9stUndIpJTIBhlGIxui4jAyjezoZrP9Ld517cblAOLxCwszUPu7+yZSK2hjkGXZZdKNIxRFiSzL0DgX+3q1htIah4cH+OKrr/fanapskKSW1LdKBwI4T/BVJJUAGKQptDGIHGjXdR3SJAWjFFIphM7kcX52Csqs8c5z0v5QhGGIqiyRpGlvc/WqCsaYy3N1z0kIIRBnqU3WINhsNla24sphQijKssRkMkGWZTg/P4cQAl0rEcVhD6sPh0NwznF6eor1Zu34Zasv8gyZ1hqcUnDONpwQugrDAHm+te0zIairCjBAGEXQNnk7OpH3BPhkPEbXtRhkAyh96d8NwgBFUWCz2YBQg8P9PaxXGxRFBc4F0ixBFEbY39/Hq6++2ocJT9CcnZ2hccxZ09Rw/Ckm00mvxUmzFFoq1E2NIHB4EiGY7+5eiraUxmA0xGg8BiUE6+Wql4psS6u68CSPMgaz+RyUEEBpRI89houLC9y7dx9FXjgjiW3Mrj/6KLI0w+f18zg9OXNhViPNrJ9ss9n0zpyTs3NMp1PbxBHa61LbtiXCMm8rXhTFuYWQGa3qGmmcIImTPuZXVeUSU9d7riiA6XgCQgle+eKrOD+/QBiEyAZ2h/0PRqnlbpVW7noGiKMYURihLktsNlvAAGmW9MIpIQTarsNqvYZWGovFAnEco2kaTMYjEEOwWq6scS5JnN+gxXg8RlPXvTKDcYYojDCfz3vr03a9AXNSlrIskcQxCKXY391B0zSAAabTKTSs0ODo6AgisOWpCDju3LmD9z75JI6PjzEZT9C1HerGqveSJAXnDBcXC+R57nCtAps8x2gwsNUko1hvNthuczKbTVEUxSnPi+IsTZJKShm3TWO0lOT6I4+AEntNlbb20eVq1cdqIQQuLi5QNTXOzs9R5hVW3QbHx6cw0AiDAGdnZwiDCIxxjMcJZCb70NXJDqv1CsbYuT9VVfWmbcEFzs/PnQulQxhGSJMEbdvi6MExAOD2jZtQSmE+2+m9Zz4ZegmJ5xru371nkdy66SsjSinW6zV4EGB3fw9JkuD87Az5ZotOdlgsFn31BQBSKdy8cQMH+wd45eVXQCnB7s4O0iTB6flZXwldXFz0hYzsLGx+cnKKOIysSE0ISNnh/PycjMcjlRfFCa/K6riu6nOt9aOXBLvGbG8HVVn2KGKSJLg4v3AK5Bjr7RaL1QKNsyj5ephSjq5TSMMAB4e2FNtut716QSmFxWJhdfsunF3Vk3oOwecDzmkfLjbbDSi5lLE3TYMsy6yq4gosst1uMRqNemfmVX0npTaWe/tqWZZW5l43yPMc948f4Pj4uD8UWZZhxDnSNENbVWgdVRonFjnd2dlBWZZ47bXXHF/MXddrDYOLxQK7u3NQ6p39MEkSE631Ks+LI9pJWWiY+65j1UrbUx+GIUAJttuNtZISgvlsBjjOdjQaQXYSSnYPeXl9DG4beakRpRR5bhUSZWlHjw0Gg76+vioF8Z6qIAjABUeel7h77x5aN99hNp0iSZJeE+orNW8vZYxhPp+7sFX3jaAQAtPptK+2sixD2zRYLZbYbDbI8y3Oz87ACUXgbpD3Ng+yDEkSQ2rnqKcUneog3SE4Ojrq+wTvArLGcYq26fDiiy/j/PzclvVdZ3Z2djAcDh/k2+0FdbN5XqS2cjCccywWSywWFzYuwo4LaOum520XywXGY+vB4s7s7BskpRWUklDK9hWr1aq/zuv1um/db9++jclk0oc1f/KbpsFms0VVVlaGThxZUpaIwgjj0ahXRHhq0/sOtNa90XqxWGCz2fbjzezfa0ff3Lh1E9dv3rAYj1QOSkgRhKH9mQlBlg0cWmvFXoxQGIegts435gsFf3BAiIM0NJS6VNXJTlo0wB4+bf9c8/JqvdFMKYXHHrtzM03SjxgYXVUVbZoadVU70rpA13auycowHA2RlwXWmw3yPLennPG+DiYgV/Q4ThzrkNPFYtEvlg8JtjKxfHLjcJcotPCHFYZJTCcTvOdd78Z4NO4bQd97+LDiRVLK/b1+Dmni8ocIAlBCEEYhxpMp8nwLzhkGg4GbqqWhpERdVwijCJ20/HCaphgOBmAO7BtkmZ1R19TW85ANsNlsHPRh5S92Qgx6uDxJIoRRhMVigeFwqGEMXa3Xv/Lsc5/7l1xKifOLi09nNzLU25r1DNV2Y4l3Y+UoYRj1P0ySJNhst3bQkROpWtKEALDEuzYaW/c1nHPked6PACCE9JKUq6a5trWEjMVb0NuPptMpErfoHrKwSmv7PebzOYbjEWTbocgLxIkVA8dx1COkXdeBM4Y4SXDv3l1IBx0zxqAd2JYNB0iyFNv1prcxCcFBDCDc7UgGGcazGbZ5jvVqgZVDVi21SqC1QhAIC+YRgDHiOVtfalOpJE5Pzz7Vtq0V52Zpujk8OPjZpmliKaWhlJIwDFHWNZI4dkOT7OkcZhmatoOBAae0HwmQbwsIwfoGazwZ9ZTh/v5+nwe8G8Y3JLKTqJsao9EIQjBrfaUMSlnSJ01ThFGEJI6glUKaxn3euCpzeeTR6wjDoJeHDwYDBGGIKIl7GCFNU1vFMYG6rdHUjYOfQyRp0hNChBCcnp32c4iUtg0ojMF4MkEgBMqiQBCGOL+4cDZWO2bhcrwCAReX8vrQ2l6NUooKEVQvvfTSf7RcrnIGgAkhqkcfeeRPd7K7QwjRXjgquw6BsJi6MgZRHPW6GsFtTa+cSLdpG3tyKQGIjfN7+/uQzoXuT71XDGuX7KVUgCGoyqqHFYwbDyM4xyOPPmIFs0GA6WRqySFjsNlssNls+h+udoR6kiS98yUIQwyHQ6xXa8RJYrmIpkHdNKjKqid/xpMJ9g8PsTy/QNd2aOoaZVni2uEhlNI4enCEqiwxm00hO4myKDCaTnDv/n3Udd2jpwQUUlroJQh532QaY6ulJIk1ANo0zaeffe7zf7dtW8oA8Kqu9c2b13fjOP4hpZTWWtOeMmztDDdjDBihtos9OICWErLrsFyvoLTFQ5xZ2VYZadorh7052lct3kVvnZANiLE8hIFx/mJ7i4SwamhCCLLEhqAoju0os6a2MkSny/dmaWMMlsulrTgcUa+UgnYVi3EchfctAECSpaAGvSYoLwoEQYCLs/MejLxYWMc8jEESJ67et2ivN4DbIYSqHyIShiEaZ7NK0wRaG00Ioefn57/88suv/gtCCaeEENV1HY6Pj3/d/TvzpSN1LvNNkWO9XmGbb3F+cY6zkxOLghqDwXCIwXCALMsQRVFvWhiOhjg4OEBZljg9PevpRF8OpqmVLXLGrGeY096Rcnn19UOlJmcMWikYrREGIWazKQaj0UMqu+PjYygpEYSBg7uJ8xRYMK9rOzs7dDTqhb6bzQanZ6eI0wSznR0QQvDg+Bh5WeD8wvK7fqQBnLA3CqP+sCVJAhjTj1gTQiAMrcc5CEMrGKhqNE3DCCE4PT39584voRkhxACgjPOzGzeu/1jbtteCIFCEEFpWFRi1wiVQaofhdS3W220/CNVOJwz6crJpGtvOa43ziwucnp4hCARu3LhhS70g6En1zWbjJBteXhj2RgutVT9Z5WBvHzeuXwdxKKOvTjzdaZm8rm+wwjBCmqY9E+Z1pt5T5qWTVgHXIUkTJGmKyWSCxeICxw8eYLFcYuPGIrdt50wXBEVRYu/A2lLv3n0Ty+XSNpBa9s5+b5fane/gzu07tuAAtJSSMsZefPqZ5/6G0xtp7hh7enT0QG+3219J0/S7y7I0HnfPiwKz2cxOHFEKAWeQ7hQqN/QOsBhKFEXWAOFkJEVRglHb/Z6cnGLo5CgA8Njjj4NSajfB8Qxt22KQZYiTBK1TOhsYDAeD3vpjwa4Ek9kUWZpBqw5VVTqyHH3H7UtUb7jwidvN/exhi+F4jKqsHI9Roior1E3zkOkkisLLRd3ZgVEKb7z2GpIo7jlqawG2PUUQBIijCPt7e5jNZlislmjbVksp6dHR0f+6Wq0UpZQbYyRz38QopZCmyZvj8fhntdaBg3RJURSYTqcIg8ASzFIhSxJkgwyFUyj75OqxFv9hN5s12rbBwcEBANOTImmS4pFr1xAlCeIwhJKql5BwxnD9kUcxHo+QpRmuXTvEbD5Hmlktz2A4wNzRozwQeOO111EVJaIkRhRFmM1mvcbf5owILBAgAMqi7OXxPiR6AkVrjaaqcbFY9DnEQx6+r0mSBIeH12zYtPg3wiBAlqbY5FsEIgCBhe/n0yn29/exdspupRQxxsiXX3n1Z8/PLxYOujHsCoTAuq5bX7/+6JMG5klKieKcU84ZNps10iRF6VQEeZGjKAsHAdgfwN8Co7TrEexoL3+CoiiCATAaDLC3s4s4jrG3v9eXbFEYYpBlVtrnEuR8OsV0PsPAjgjrMZgkSdA2NWTbIk5TqxUKQ+wfHCBKE0jnqKcAgsASIpRQbLcb11xaOCTLMjQO8/dCYM44mq5F0zQoXDL2ne/tW7cwHo2wzXMQRnF6dobQhSZf2bVuiEcgAgDGTvqlVEopmVLyoy+88IX/pixLSinVvUnPu+arqjbj8fhoPBr9Fa0Vuk4Sf0rqtgFjHFJ2jgWjjniPEMUx4CCG4XDYn740STCfzW3YSFLcunEDjFJwxt0YgjHCKMRysUAQBBiPx0jTFJPpFNP5HEmWgjuNUJ7nWC2WiJMYQRSBEMtXxEmCqizBOQMXDMOR7T+0M81VVYWmsofGGOO0o8FD9irOuR0QwsXlsKa66oE9i2kx3L55C5QQPPu558AYw96OhbHjNEEgApyenlq4Jo7dZK726jQVcnx88vPPP//Cq9SCYOatPmFjjKFt1949ONj/fiHErSAQqm1bSt2iOY07giCwC++qnoAz2+pTO65skA2cas5WJ6PB0Dohr/h9PblvGzBr6BNhYG/JcAhohSAKIUTQl7ej0QhBGAJOsWBLUadH8oinlKirGsvFAnVd4/z83BIq2iDfbgE3mtKDbWlqWbDDgwMbUssSr7/+BvJenm8PXJokyJIEi+XCfsbRCHlRYLlcQiuN9XqN9Xp9OQKNwA9+UlJKqrX67HOf+/x/uF6viT39bz+qgJZlZfZ2d+8Oh8N/283Xp/60KKWwXq97r5UnZwIRgBCKUAirdnCWgFZ2WG/WKOvKIYpJDxtbVJEgFAFAgGwwQF3XODw8RBiF/aIOh0McHh7aGUAO87k4O0UcJ9YW1DTgrjNVSqEs3Mw3VyBcpTq9koMxhtlshp29PVuuUktBnp6eIs9zSzhNbZI/PDjAaDhCWVUwTvHtGcD1et1P4PKL733DfuOapjFSSrparn7uuec+/wIIaG/Lf5sNMMYYVpblq3u7u3+CMfZYGIaqLEvq5/d496MvA7fb3E4OUQppliEUdtGEEBCcIxACYRTh5OwUIgiAK6LXruswdPW4n+WfJgmEm1aV53n/tkBd11gsFlheLJCkKcLASukZoyjKClxwVKWVsXjBrxCXg/uiMMLB4SGiKASjzMISMCjyAtt8i8XFRa8JmrohfkIIiDDE8clxP9w1zVKcn58jyzJst9sehrg6RuHi4gIDW7kpKSXjnH/iuc99/j9YrpbkrWOO33ZcTVGUZjqZfn48Hv27buogUVISWynZqYEgBAxucqGSPeYurkg1PLYym88gGO9nr40nE4wmY1DYhxrCMAQxwHA0vALs6X7EjTGWvM/z3E7UddMXpVLwk3qLsgTnl3OHPMlT1zXGkwkG46EVGTjf2Wq1QpHnqMoSxGteXUXjlSBSSuR5jsVyiUGW2T5htbRiZc5QlZUV/maZq/TQ+w/ciB0TRRG9++bdf+v5F158/Wrs/3IbYACw9WZztLszPxCCfzCKIkUpoXVtzQ+BO8neHVi7WdGxSz7aESS+RlbGQMoO0/EEaZrC6RYtKcOYUy6onjErygKMMleBWCjc88y+I22qCoPBEGtn0O7aS856MB71dfxkMsFwPIJWCsuLBc7OzpDnOUajUc96+c0KHEMnpV3g1WaNum3w+OOPI4pjbDcbBEJgPB5bA7bjsK9fv957hb1cJ89zxThjlND/+ROf+vR/Wdc1o5Sqr3pkWdM0RHbyD6bT6V9mjA3sCx4gUkqEIkAoBAI3DtIPNfLYTdO1vXOy6zrnLUbPpjWNddqEUWQhb2nlgltLWPcL7U1+vnb3eYgx1mM0xiXhZJABzpsWhSGybIB0OHAzoQk2q3Wv7IjC6OFZFU6W74XDXdehazsYbZBkKaIwhGzsMyqD0RCV66w9M+iZvtVq5dV3xoWl9Ruvv/ETX3zttcKBcuarHdpnCCF0vdmU49Hoi3Ec/fRwOFKEgJal9db6RORBNsu92g0JvLsliuzQjihCXuQg1L6MNJlMbJnohmkvFguAADfu3AZ18ySiOOr1PZd6ffSmD0oI2rpBvt1iPt9BwDnKukYQhVZR13aANjg/O7daUJcTJpMJojjqp2E1TQPlNrJwifzqABM/mMniOyHatkOaJOjcDfMCMd8rOApUcc5Z23Y/+5nPPvOxtm3p1Um6D02M/DJTE40xhm822+fns/lNSsn7hQik1ppeVQp7RUJv2lYKjNqSM3aJtSzK/uQGruT0IBlzuA8XArPZHFwInJ+e2a9xSc3yBm3vSVBOPUcoAeMcZVEg32wguw7b9cZ6xWo7lEkrq7bwrJmHj9u2Rd3UUO6RuKq2w/3i2HbUZekEZ10LAiBK7aJzYbVPnl71+c7xvdBaS0op11r/H5/81Kd/4fzinDPGvuTjP19pcKtp25Zpo39zOBz8JKV0j3OuqqqiQgiMsoFbBNY7TkaDAQi85ND0VtIotCdaw9iBfVqDC4HReAQYg6aqsVouUeQ5tFLggeiTmoeTa/cqxna1Rp7n4ELAKH2ZB1wVMxqNMB6PIYR4aCKiVXc3PcLaNm1vBumkRBRG2Nvb6wFG7ae0EIr5zk7/tVfJIJ/rqqpC13VaSsmEEG+8+OJLP/Laa6+1jLGH3iF760awr+ZlpM1m0w4Hw385HA7+MiFEuJhMDAwoAQhoP3OZC4E4jOzcTXY5UrgsS9hX8MI+zk5ndoa/7CTi1Iqz2qZFmmVu+jpxfHML7QbmMcYQBgESR6bIrgNhtAfAvMzF5x+vpDbG2JLREU29Ks5504jTh3pYJa9KKzjgHJzxPhTFadK/KeCFCK70NVJKo7VWDx4c/8gzzz77CrE2Uf2NDu82APjFxcXxeDz+QhxHf4Expuz4dkUCEVoYgFslcdu2yJLUScTZlXmaViHteYC9g307w3ObO/kgRZTESLMM2iVrX47aAX8cFASNyzVGKxAYLBZLa12NIsRRhJ3dXWw2m94G68FByxHHFsk1GlEQ9okcxjjDxuU86rKuoNoOlBDM5jPsHRxABLbh82MS9GXeME3TqNVqxVer9b/zmc88/WtSSf52Vc/XOz1dK6X4+cXF53d3d/MoCj8ihFAOUQLjHIM0BSEUTdtAwyYvj+1zLtxERdsFTx2RcnZ6hiAKkQ4y61p0Sd2LbH1P4DeDUDscoypKNK4hrGurY63KEuPJBJWrRqjnMRxGNR6P/etIyNIMgdOiWr9xAM5Fr38ihCBwXW0Qhtg/PEAcxTh6cNRrjzz04D6zXCwWQmv9i08/89zf3eZbzhiTbw03b5cHvpYHHHTXdTzP89/f29sN4zj+U1mWdW3bMGMM0jjBaDhEGIV2sd00FT8uwGM6YRgiSzOcOOYqzdK+C27bFmVu3Sv+pvgwVpZ2TJi84s1arzfIczv/U7rxOkVeeCsooihE11qp4Xq9RlVVvZdYOlzL9wudVm4sgoWqeSAQxwnSLMNiucB6vcJ0aqHuu3fvoixL/5Zld3R0JAD8vRde+MJff3B8/LaL/816wsQUZcnLqvqt27dvpQC+L4piCYB0XUdCZ4qLoxiz2RxJErvFsU7yOI4wGI5wcX4OKSXSNEUSJ9BKo6qry4mInexni959/Q0QYt+WjB3qyjjDarXuN6JX5uHKHNAg6DtVf6u8wNiT8UmSWFMGtTeXuIJhW+QglCLkwqK+AAYOXrl//36fJ5bLRXd6eiKU0v/gpZde/bnXXn+dvTXpfqVX9r7mR3woJWaz2bKyqn5zOMgizsWfDIJAcyEIASFBGIJxDumMyT2fKzgm47ErBSuEocWM4KqofGNfOfKLJASDURpcBCAA0ixFuc3R1DU26w1GkzEEF3148tiS3wAPJ3jfgC+XPVzu//FvCwRhiCSOoY0d/LGzswshuC1nqwrnFxe4d+8eLi4uYIwxp6enum07XlXN33v6mWd+7t69e37xzdfyxOHXvAFe8bVYLFjbdL+1M98pKCU/xDknURwpbQytyhKEWo+tlXbbYRp+8CshFHGcQEmFsWvKysJOSNnmue08lcJms0Xj3pTUrvX3vUZTNz0Q5rWefmzYVYd9mqYYDAYYjUY9NtQp2XMCfsKXd/T4A7RZrXFydgpOmR1z6Z5G32w2uigKopSiq9X6F59//sW//uDBgy+5+N/Kh9zMcrXieVF8bGc2f5FS8sNVXYcwRjJKqTIa3MEJQgioTqKTHbLBoDc/CyGQpElvsEiHAzsI2xg0bWsH4UmLzXj5n6+/PbnimyrP9V7O+zT9v191z1gOm/SOmSCwcLjXJBVFgbOzMywdrOAhcLdZsq5rppXu7t2//1c/+alP/9Jyufyyi/+V9uQbfcpQr9dr/uabd58bjUa/MRwOvq9pmr04TRS3b0iSQAR20qFDKI024MJqMQmltgRlDJOpHQG2Wi5R1fbRHI+3XJ3Ie1Wa7k+xV7x5EZSHE/yE3aujZuI47pHNMIpQlCXKqoRsO6zdlEXf2fuNbdvWaK1VVVW8LMtX7987+slnn/vcP+267st2ud+WxzwJIbrtWv7mm3fvR2H4jyaTyTVK6XelaUomk4lsmoZ6elC62XKM2mcF0yy1g7qVncROCcHiYgHZ2fEBnfP6+mmJo9GohxL8Lz+czymO+5N+tY/wIclPXDHGoHLj6/MiR11Wlu/uLkXDHt9pmkbmec601vTiYvG/feELL/3ky6+++gUDwxn90tXOt6QK+nKboLVm9+7fr5fL1f/Zdd1LnPPvCYJglGWZkUpppRXV2jiYgvZ+rSAQ1pN8Zc6mksq9rGSJoziJ+5DlnyD0Md9rfPw03u122wOEvo8Qwjr7tdZo6hr5NsditcLF4gLnFxdou7bngH1FpZRSbmgJq6r6/OjBg59/6aVXfuFicVEyqxBQ34wXtr9p7wk7BJVsNht29+69Z2Un/3EUhWPG2FOd7CghRHPGNBeC1u79RsE5GPHvghGURQmj/XsEjkg0ph81czUM9bV82/Qhp21b27Zz3tOfvsz0Uw83+RZ1W1vewt0cpTWiOPILr40xuus6tlwuyWa9/Uf3Hzz4C1/84hd/p2kb6sKc/mY9b/7N3ICHCJ3z8/Pt/ftH/4xz8f9EYXhdKXVHa02DMNScc13XNSGEEMoo2taaIpSU0I4Q8S4THz7smwJ2brP/b1fHwLRdZ8fruAFPHgNabzZYrdfgzDJYm+0GVdNAKYnxcOSFA4YQot07YjTPc3p2ev6xs7Pzv/LG3bt/5+zsbE0pZV5K8s18W/5b8qa8+4uJtY5R9c53vhN3bt/+s/P57K8Zo7/P25OEEDJJEhqGIdVSomlaJFHUi2MBWFtQmiKJYrRN079s5yGBpmn6mt8/BOpnD0kpEYQhus6OXijK0j7s4ObNqU7q1Wql267j3mIqO/Xx1Wb9d85Oz//JerOGMYYxSrX5Eo/w/Cv1pvyXeAqLAjBCCHN4eIi9vd0feOzO7Z8ZjUY/KoSIKKV+yqDknBOjNQ1FQFrXkHmnzNZBCIwxO//N3w53a/yQJ1+C9hJE2bmBrS1a633QZVkaKSVbLBakLEsoqbumaX5js93+t+vN5teWdtYPofZRZPXNPvXftg14y0YwB82a8XiE97z7PY/v7+39+dF4+G/O5/P3eetRlmUYDAaaEKKbuibGGNK1HVFSEo+7+yTuu2z/uxf+1nWNwupbTde2RkppKGO0VR21CjlL8J8cn34uL4pfzYvif7m4uHj+CkfMvtUL/23dgLfZCANAZ1mGvd1dzOfzD9y6eeOH9/b3/vUkSd4/GAwyr6/J3Rteggs0bWOqsjKAMdQNu6ibGhQEYRyBghCtNVFaEeWM3/k2dy9rVwiCsNxut0/fu3f/ty8Wi19frzefKIpCO5k6pXZ2mvpWhJp/JTbgLQ9bUheepJ9mNd+ZY3dn52A0Hn3HZDL+wCAbfOd8PnuHEOLQGDPpuo774RqEEnRNC6mUraauzJ6WXafarlu2bfugKIqXi7J85vT09FNFXj67WC7vVWUJfbmQ/qU7/e1a9D/2DXjLRhC3Gf70mSsPieLg4ACj0XDOKD24fv36/s58Z77ebKZFsR0QSgNnA+2MMVtjzGK73Z5LKU9W6/WDzWZ7VlWV8aDclZ+ZuTe9vi785pv56/8Dwh2X/Ffkm08AAAAASUVORK5CYII=",gi=110;let mi=0,vi=class extends de{constructor(){super(...arguments),this.discovered_list=[],this.compact=!1,this.showStats=!0,this.showLegend=!0,this.showMoon=!1,this.showCardinals=!0,this.showBlindSpot=!0,this.showSunPath=!0,this.showSunriseSunset=!0,this.showCoverFill=!0,this.showWindowArrow=!0,this.coverColors=[],this.northOffsetDeg=0,this._hiddenEntries=new Set,this._legendMoonMaskId="acp-legend-moon-"+mi++}shouldUpdate(e){return e.size>1||!e.has("hass")||ve(e.get("hass"),this.hass,this._relevantIds())}_relevantIds(){const e=[];for(const t of this.discovered_list){const o=t.entities;e.push(o.sun_sensor,o.target_position_sensor,o.manual_override_binary,o.sun_infront_binary,o.decision_trace_sensor,o.start_sensor,o.end_sensor)}return e}_toggleEntry(e){const t=new Set(this._hiddenEntries);t.has(e)?t.delete(e):t.add(e),this._hiddenEntries=t}_sunFor(e){const t=e.entities.sun_sensor;if(!t)return null;const o=this.hass.states[t];if(!o)return null;const i=parseFloat(o.state);return Number.isNaN(i)?null:{...o.attributes,window_azimuth:o.attributes.window_azimuth}}_sunInfrontFor(e){const t=e.entities.sun_infront_binary;return!!t&&"on"===this.hass.states[t]?.state}_sunDotStateFor(e,t){const o=e.entities.decision_trace_sensor?this.hass.states[e.entities.decision_trace_sensor]?.attributes:void 0;return di({belowHorizon:t.elevation<=0,sunState:o?.sun_state??null,directSunValid:o?.direct_sun_valid??!1,inFov:!0===t.in_fov})}_readActiveAzimuth(e){if(!e)return null;const t=this.hass.states[e];if(!t)return null;if("unavailable"===t.state||"unknown"===t.state)return null;const o=t.attributes.azimuth;return"number"==typeof o&&Number.isFinite(o)?o:null}_buildOverlays(){const e=[];return this.discovered_list.forEach((t,o)=>{const i=this._sunFor(t);if(!i)return;const s=t.entities.sun_sensor,n=parseFloat(this.hass.states[s]?.state??"0"),{color:r,isOverride:a}=ui(this.coverColors?.[o],o);e.push({d:t,sun:i,sunAzi:n,sunInfront:this._sunInfrontFor(t),dotState:this._sunDotStateFor(t,i),coverPos:Jt(this.hass,t),actualPos:Qt(this.hass,t),coverType:t.cover_type,openBlocksSun:At(t).openBlocksSun,color:r,isOverride:a,index:o})}),e}render(){if(!this.hass)return V;if(!this.discovered_list||0===this.discovered_list.length)return H`<div class="placeholder">${st("compass.placeholder_no_entries",this.hass)}</div>`;const e=this._buildOverlays();if(0===e.length)return H`<div class="placeholder">${st("compass.placeholder_no_sun",this.hass)}</div>`;const t=e.filter(e=>!this._hiddenEntries.has(e.d.entry_id)),o=It(this.northOffsetDeg),i=e.length>1,s=e[0],n=s.sunAzi,r=s.sun.elevation,a=Tt(n,r,o),l={night:-1,outside_fov:0,in_fov_not_valid:1,hitting:2},c=r<=0?"night":e.reduce((e,t)=>l[t.dotState]>l[e]?t.dotState:e,"outside_fov"),d=ci[c],{latitude:h,longitude:p,time_zone:u}=this.hass.config,_=void 0!==h&&void 0!==p?ei(h,p,oi(u)):[],g=this.showMoon&&void 0!==h&&void 0!==p?ri(h,p):null,m=null!==g&&g.elevation>0,v=g?Kt(g.phase,6):0,f=m?Tt(g.azimuth,g.elevation,o):null,b=f?f.x*gi:0,y=f?f.y*gi:0,w=this.showSunPath?ni(_).map(e=>_.slice(e.startIdx,e.endIdx+1).map(e=>{const t=Tt(e.azimuth,e.elevation,o);return{x:t.x*gi,y:t.y*gi,elev:e.elevation}})):[],x=[122,127,135],$=[245,197,24],k=e=>{const t=Math.sqrt(Math.max(0,Math.min(1,e/90))),o=x.map((e,o)=>Math.round(e+($[o]-e)*t));return`rgb(${o[0]},${o[1]},${o[2]})`},A=this.showSunPath&&this.showSunriseSunset?w.filter(e=>e.length>1).map((e,t)=>{const o=e[0],i=e[e.length-1],s=i.x-o.x,n=i.y-o.y,r=s*s+n*n||1,a=e.filter((t,o)=>o%6==0||o===e.length-1).map(e=>({offset:100*Math.max(0,Math.min(1,((e.x-o.x)*s+(e.y-o.y)*n)/r)),color:k(e.elev)}));return{id:`sun-path-grad-${t}`,x1:o.x,y1:o.y,x2:i.x,y2:i.y,stops:a}}):[],S=e=>this.showSunriseSunset?`url(#sun-path-grad-${e})`:"var(--warning-color, gold)",C=Et(0,124,o),E=Et(90,124,o),z=Et(180,124,o),M=Et(270,124,o),T=Et(0,gi,o),I=Et(180,gi,o),P=Et(90,gi,o),O=Et(270,gi,o),N=st("compass.sun_tooltip",this.hass,{az:ct(n),el:ct(r)}),D=null!==g?st("compass.moon_tooltip",this.hass,{phase:g.phaseName,pct:Math.round(100*g.fraction)}):"",F=st("compass.sun_path_tooltip",this.hass);return H`
       <div class="compass">
         <svg viewBox="${-140} ${-140} ${280} ${280}">
           ${U`
@@ -92,15 +92,15 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
               `)}
             </defs>
 
-            <circle class="grid" r=${_i}></circle>
+            <circle class="grid" r=${gi}></circle>
             <circle class="grid" r=${220/3}></circle>
-            <circle class="grid" r=${_i/3}></circle>
+            <circle class="grid" r=${gi/3}></circle>
             <line class="grid thin" x1=${T.x} y1=${T.y} x2=${I.x} y2=${I.y}></line>
             <line class="grid thin" x1=${P.x} y1=${P.y} x2=${O.x} y2=${O.y}></line>
 
             ${t.map(e=>this._renderEntryLayers(e,i,o,_))}
 
-            ${this.showSunPath&&w.length?U`<g ${xo(B)}>${w.filter(e=>e.length>1).flatMap((e,t)=>{const o=e.map(e=>`${e.x},${e.y}`).join(" "),i=U`<polyline class="sun-path-line" points=${o}
+            ${this.showSunPath&&w.length?U`<g ${$o(F)}>${w.filter(e=>e.length>1).flatMap((e,t)=>{const o=e.map(e=>`${e.x},${e.y}`).join(" "),i=U`<polyline class="sun-path-line" points=${o}
                         style="stroke:${S(t)}"></polyline>`,s=[];for(let t=0;t<e.length;t+=10){const o=e[t],i=e[Math.max(0,t-1)],n=e[Math.min(e.length-1,t+1)],r=180*Math.atan2(n.y-i.y,n.x-i.x)/Math.PI,a=this.showSunriseSunset?k(o.elev):"var(--warning-color, gold)";s.push(U`<path class="sun-path-chevron"
                           transform=${`translate(${o.x} ${o.y}) rotate(${r})`}
                           d="M -2.4 -3 L 1.8 0 L -2.4 3 L -0.7 0 Z"
@@ -114,11 +114,11 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
             `:V}
 
             ${m?U`
-              <g ${xo(D)}>
+              <g ${$o(D)}>
                 <circle class="moon-outline" cx=${b} cy=${y} r=${6}></circle>
                 <image
                   class="moon-img"
-                  href=${ui}
+                  href=${_i}
                   x=${b-6}
                   y=${y-6}
                   width=${12}
@@ -128,43 +128,43 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
               </g>
             `:V}
 
-            <g ${xo(N)}>
-              <circle class=${d} cx=${a.x*_i} cy=${a.y*_i} r="7"></circle>
+            <g ${$o(N)}>
+              <circle class=${d} cx=${a.x*gi} cy=${a.y*gi} r="7"></circle>
             </g>
           `}
         </svg>
         ${this.showLegend?this._renderLegend(e,i,d,g):V}
         ${this.showStats?this._renderStats(e,i):V}
       </div>
-    `}_renderEntryLayers(e,t,o=0,i=[]){const s=It(e.sun.window_azimuth),n=It(s-e.sun.fov_left),r=It(s+e.sun.fov_right),a=this._readActiveAzimuth(e.d.entities.start_sensor),l=this._readActiveAzimuth(e.d.entities.end_sensor),c=null!==a&&null!==l;let d,h;if(c)({wedgeStart:d,wedgeEnd:h}=function(e,t,o,i,s){const n=((o-i)%360+360)%360,r=i+s,a=((t-n)%360+360)%360,l=e=>e<=r?e:e-r<360-e?r:0,c=l(((e-n)%360+360)%360),d=l(a);return c===d?{wedgeStart:n,wedgeEnd:((n+r)%360+360)%360}:{wedgeStart:((n+Math.min(c,d))%360+360)%360,wedgeEnd:((n+Math.max(c,d))%360+360)%360}}(It(a),It(l),s,e.sun.fov_left,e.sun.fov_right));else{const t=function(e,t,o,i,s){if(void 0===s)return null;const n=It(t-o),r=o+i,a=e.filter(e=>((e.azimuth-n)%360+360)%360<=r&&e.elevation>s);return 0===a.length?null:{wedgeStart:a[0].azimuth,wedgeEnd:a[a.length-1].azimuth}}(i,s,e.sun.fov_left,e.sun.fov_right,e.sun.min_elevation);d=t?t.wedgeStart:n,h=t?t.wedgeEnd:r}const p=Et(s,_i,o),{outer:u,inner:_}=(g=e.sun.min_elevation,m=e.sun.max_elevation,v=_i,void 0!==g&&void 0!==m&&g>m?{outer:v,inner:0}:{outer:void 0!==g?v*zt(g):v,inner:void 0!==m?v*zt(m):0});var g,m,v;const f=null!==e.coverPos?Rt(e.coverPos,e.openBlocksSun,_i,u):null,b=null!==e.actualPos?Rt(e.actualPos,e.openBlocksSun,_i,u):null,y=e.sun.blind_spot_range?[It((w=s)-(x=e.sun.blind_spot_range)[1]),It(w-x[0])]:null;var w,x;const $=y?Mt(y[0],y[1],_i,0,o):null,k=Mt(d,h,u,_,o),A=c&&(d!==n||h!==r),S=A?Mt(n,r,u,_,o):"",C=null!==f&&f>_?Mt(d,h,f,_,o):"",E=null!==b&&b>_?Mt(d,h,b,_,o):"",z=[];for(const t of ii(i,s,e.sun.fov_left,e.sun.fov_right)){const s=Pt(i,t.startIdx,t.endIdx,e.sun.min_elevation);s&&!Bt(s.wedgeStart,s.wedgeEnd,d,h)&&z.push({fov:Mt(s.wedgeStart,s.wedgeEnd,u,_,o),cover:this.showCoverFill&&null!==f&&f>_?Mt(s.wedgeStart,s.wedgeEnd,f,_,o):"",actual:this.showCoverFill&&null!==b&&b>_?Mt(s.wedgeStart,s.wedgeEnd,b,_,o):"",from:s.wedgeStart,to:s.wedgeEnd})}const M=t?`${e.d.entry_title}: `:"",T=void 0!==e.sun.min_elevation||void 0!==e.sun.max_elevation?st("compass.elev_suffix",this.hass,{min:ct(e.sun.min_elevation??0),max:ct(e.sun.max_elevation??90)}):"",I=c?`${M}${st("compass.active_sun_arc",this.hass,{from:ct(d),to:ct(h),elev:T})}`:`${M}${st("compass.fov_arc",this.hass,{left:ct(e.sun.fov_left),right:ct(e.sun.fov_right),elev:T})}`,P=`${M}${st("compass.window_normal_tooltip",this.hass,{bearing:ct(s)})}`,O=[];if(null!==e.coverPos){const t=e.openBlocksSun?"compass.cover_position_target_awning":"compass.cover_position_target";O.push(`${M}${st(t,this.hass,{pct:e.coverPos})}`),null!==e.actualPos&&O.push(st("compass.cover_position_actual",this.hass,{pct:Math.round(e.actualPos)}))}const N=O.join("\n"),D=y?`${M}${st("compass.blind_spot",this.hass,{from:ct(y[0]),to:ct(y[1])})}`:"",B=t||e.isOverride,F=t||e.isOverride,R=B?`fill: ${e.color}; stroke: ${e.color};`:"",j=F?`fill: ${e.color}; stroke: ${e.color};`:"",L=B?`fill: ${e.color}; stroke: ${e.color};`:"",K=B?`stroke: ${e.color};`:"",G=B?`fill: ${e.color};`:"",W=this.showCoverFill&&""!==C,H=this.showBlindSpot&&!!$,q=this.showWindowArrow,Y=`M 0 0 L ${p.x} ${p.y}`,Z=B?`fill: ${e.color}; stroke: ${e.color};`:"",Q=Kt(p.x,p.y,s+o,9,5),X="display: none;",J=`${M}${st("compass.fov_arc",this.hass,{left:ct(e.sun.fov_left),right:ct(e.sun.fov_right),elev:T})}`;return U`<g class="entry-overlay">
-      ${A?U`<g ${xo(J)}>
-              <path class="fov fov-static" style=${R} d=${S}></path>
+    `}_renderEntryLayers(e,t,o=0,i=[]){const s=It(e.sun.window_azimuth),n=It(s-e.sun.fov_left),r=It(s+e.sun.fov_right),a=this._readActiveAzimuth(e.d.entities.start_sensor),l=this._readActiveAzimuth(e.d.entities.end_sensor),c=null!==a&&null!==l;let d,h;if(c)({wedgeStart:d,wedgeEnd:h}=function(e,t,o,i,s){const n=((o-i)%360+360)%360,r=i+s,a=((t-n)%360+360)%360,l=e=>e<=r?e:e-r<360-e?r:0,c=l(((e-n)%360+360)%360),d=l(a);return c===d?{wedgeStart:n,wedgeEnd:((n+r)%360+360)%360}:{wedgeStart:((n+Math.min(c,d))%360+360)%360,wedgeEnd:((n+Math.max(c,d))%360+360)%360}}(It(a),It(l),s,e.sun.fov_left,e.sun.fov_right));else{const t=function(e,t,o,i,s){if(void 0===s)return null;const n=It(t-o),r=o+i,a=e.filter(e=>((e.azimuth-n)%360+360)%360<=r&&e.elevation>s);return 0===a.length?null:{wedgeStart:a[0].azimuth,wedgeEnd:a[a.length-1].azimuth}}(i,s,e.sun.fov_left,e.sun.fov_right,e.sun.min_elevation);d=t?t.wedgeStart:n,h=t?t.wedgeEnd:r}const p=Et(s,gi,o),{outer:u,inner:_}=(g=e.sun.min_elevation,m=e.sun.max_elevation,v=gi,void 0!==g&&void 0!==m&&g>m?{outer:v,inner:0}:{outer:void 0!==g?v*zt(g):v,inner:void 0!==m?v*zt(m):0});var g,m,v;const f=null!==e.coverPos?Rt(e.coverPos,e.openBlocksSun,gi,u):null,b=null!==e.actualPos?Rt(e.actualPos,e.openBlocksSun,gi,u):null,y=function(e,t,o){const i=t?.length?t:o?[o]:[],s=[];for(const t of i){if(!t||2!==t.length)continue;const[o,i]=t;Number.isFinite(o)&&Number.isFinite(i)&&o!==i&&s.push(Gt(e,[o,i]))}return s}(s,e.sun.blind_spot_ranges,e.sun.blind_spot_range).map(([e,t])=>({from:e,to:t,path:Mt(e,t,gi,0,o)})),w=Mt(d,h,u,_,o),x=c&&(d!==n||h!==r),$=x?Mt(n,r,u,_,o):"",k=null!==f&&f>_?Mt(d,h,f,_,o):"",A=null!==b&&b>_?Mt(d,h,b,_,o):"",S=[];for(const t of si(i,s,e.sun.fov_left,e.sun.fov_right)){const s=Pt(i,t.startIdx,t.endIdx,e.sun.min_elevation);s&&!Ft(s.wedgeStart,s.wedgeEnd,d,h)&&S.push({fov:Mt(s.wedgeStart,s.wedgeEnd,u,_,o),cover:this.showCoverFill&&null!==f&&f>_?Mt(s.wedgeStart,s.wedgeEnd,f,_,o):"",actual:this.showCoverFill&&null!==b&&b>_?Mt(s.wedgeStart,s.wedgeEnd,b,_,o):"",from:s.wedgeStart,to:s.wedgeEnd})}const C=t?`${e.d.entry_title}: `:"",E=void 0!==e.sun.min_elevation||void 0!==e.sun.max_elevation?st("compass.elev_suffix",this.hass,{min:ct(e.sun.min_elevation??0),max:ct(e.sun.max_elevation??90)}):"",z=c?`${C}${st("compass.active_sun_arc",this.hass,{from:ct(d),to:ct(h),elev:E})}`:`${C}${st("compass.fov_arc",this.hass,{left:ct(e.sun.fov_left),right:ct(e.sun.fov_right),elev:E})}`,M=`${C}${st("compass.window_normal_tooltip",this.hass,{bearing:ct(s)})}`,T=[];if(null!==e.coverPos){const t=e.openBlocksSun?"compass.cover_position_target_awning":"compass.cover_position_target";T.push(`${C}${st(t,this.hass,{pct:e.coverPos})}`),null!==e.actualPos&&T.push(st("compass.cover_position_actual",this.hass,{pct:Math.round(e.actualPos)}))}const I=T.join("\n"),P=y.map((e,t)=>{const o=st("compass.blind_spot",this.hass,{from:ct(e.from),to:ct(e.to)});return 0===t?`${C}${o}`:o}).join("\n"),O=t||e.isOverride,N=t||e.isOverride,D=O?`fill: ${e.color}; stroke: ${e.color};`:"",F=N?`fill: ${e.color}; stroke: ${e.color};`:"",B=O?`fill: ${e.color}; stroke: ${e.color};`:"",R=O?`stroke: ${e.color};`:"",j=O?`fill: ${e.color};`:"",K=this.showCoverFill&&""!==k,L=this.showBlindSpot&&y.length>0,G=this.showWindowArrow,W=`M 0 0 L ${p.x} ${p.y}`,H=O?`fill: ${e.color}; stroke: ${e.color};`:"",q=Lt(p.x,p.y,s+o,9,5),Y="display: none;",Z=`${C}${st("compass.fov_arc",this.hass,{left:ct(e.sun.fov_left),right:ct(e.sun.fov_right),elev:E})}`;return U`<g class="entry-overlay">
+      ${x?U`<g ${$o(Z)}>
+              <path class="fov fov-static" style=${D} d=${$}></path>
             </g>`:V}
-      <g ${xo(I)}>
-        <path class="fov" style=${R} d=${k}></path>
+      <g ${$o(z)}>
+        <path class="fov" style=${D} d=${w}></path>
       </g>
-      ${z.map(e=>{const t=`${M}${st("compass.active_sun_arc",this.hass,{from:ct(e.from),to:ct(e.to),elev:T})}`;return U`<g ${xo(t)}>
-          <path class="fov-extra" style=${R} d=${e.fov}></path>
-          ${e.cover?U`<path class="cover-fill-extra" style=${j} d=${e.cover}></path>`:V}
-          ${e.actual?U`<path class="cover-actual-extra" style=${j} d=${e.actual}></path>`:V}
+      ${S.map(e=>{const t=`${C}${st("compass.active_sun_arc",this.hass,{from:ct(e.from),to:ct(e.to),elev:E})}`;return U`<g ${$o(t)}>
+          <path class="fov-extra" style=${D} d=${e.fov}></path>
+          ${e.cover?U`<path class="cover-fill-extra" style=${F} d=${e.cover}></path>`:V}
+          ${e.actual?U`<path class="cover-actual-extra" style=${F} d=${e.actual}></path>`:V}
         </g>`})}
-      <g class="arrow-group" style=${q?"":X} ${xo(P)}>
-        <path class="window" style=${K} d=${Y}></path>
-        <path class="window-head" style=${Z} d=${Q}></path>
-        <circle class="window-base" style=${G} cx="0" cy="0" r="4"></circle>
+      <g class="arrow-group" style=${G?"":Y} ${$o(M)}>
+        <path class="window" style=${R} d=${W}></path>
+        <path class="window-head" style=${H} d=${q}></path>
+        <circle class="window-base" style=${j} cx="0" cy="0" r="4"></circle>
       </g>
-      <g class="cover-group" style=${W?"":X} ${xo(N)}>
-        <path class="cover-fill" style=${j} d=${C}></path>
-        ${this.showCoverFill&&E?U`<path class="cover-actual" style=${j} d=${E}></path>`:V}
+      <g class="cover-group" style=${K?"":Y} ${$o(I)}>
+        <path class="cover-fill" style=${F} d=${k}></path>
+        ${this.showCoverFill&&A?U`<path class="cover-actual" style=${F} d=${A}></path>`:V}
       </g>
-      <g class="blind-group" style=${H?"":X} ${xo(D)}>
-        <path class="blind-spot" style=${L} d=${$??""}></path>
+      <g class="blind-group" style=${L?"":Y} ${$o(P)}>
+        ${y.map(e=>U`<path class="blind-spot" style=${B} d=${e.path}></path>`)}
       </g>
     </g>`}_legendSunGlyph(e){return H`<span class="glyph"
       ><svg viewBox="-8 -8 16 16" width="20" height="20">
         ${U`<circle class=${e} cx="0" cy="0" r="5"></circle>`}
       </svg></span
-    >`}_legendMoonGlyph(e){const t=e?Lt(e.phase,4):0,o=this._legendMoonMaskId;return H`<span class="glyph"
+    >`}_legendMoonGlyph(e){const t=e?Kt(e.phase,4):0,o=this._legendMoonMaskId;return H`<span class="glyph"
       ><svg viewBox="-5 -5 10 10" width="11" height="11">
         ${U`
           <defs>
@@ -176,7 +176,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
           <circle class="moon-outline" cx="0" cy="0" r=${4}></circle>
           <image
             class="moon-img"
-            href=${ui}
+            href=${_i}
             x=${-4}
             y=${-4}
             width=${8}
@@ -185,7 +185,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
           ></image>
         `}
       </svg></span
-    >`}_legendWindowGlyph(e){const t=e?`stroke: ${e};`:"",o=e?`fill: ${e};`:"",i=Kt(5,0,90,4,2);return H`<span class="glyph"
+    >`}_legendWindowGlyph(e){const t=e?`stroke: ${e};`:"",o=e?`fill: ${e};`:"",i=Lt(5,0,90,4,2);return H`<span class="glyph"
       ><svg class="window-glyph" viewBox="-6 -6 12 12" width="13" height="13">
         ${U`
           <line class="window" style=${t} x1="-5" y1="0" x2="1.5" y2="0"></line>
@@ -199,7 +199,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
           ${e.map(e=>H`
               <button
                 type="button"
-                class=${Ho({"entry-toggle":!0,hidden:this._hiddenEntries.has(e.d.entry_id)})}
+                class=${Uo({"entry-toggle":!0,hidden:this._hiddenEntries.has(e.d.entry_id)})}
                 aria-pressed=${!this._hiddenEntries.has(e.d.entry_id)}
                 @click=${()=>this._toggleEntry(e.d.entry_id)}
               >
@@ -244,7 +244,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
       ${this.showWindowArrow?H`<div>
             ${this._legendWindowGlyph(s)} ${st("compass.window_normal",this.hass)}
           </div>`:V}
-    </div>`}_renderStats(e,t){const o=e[0],i=o.sunAzi,s=o.sun.elevation,{latitude:n,longitude:r}=this.hass.config,a=this.showMoon&&void 0!==n&&void 0!==r?ni(n,r):null;return t?H`
+    </div>`}_renderStats(e,t){const o=e[0],i=o.sunAzi,s=o.sun.elevation,{latitude:n,longitude:r}=this.hass.config,a=this.showMoon&&void 0!==n&&void 0!==r?ri(n,r):null;return t?H`
         <div class="stats dim">
           <div class="stats-row">
             <span
@@ -261,7 +261,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
                 <span>W ${ct(It(e.sun.window_azimuth))}</span>
                 ${e.sun.in_fov?H`<span
                       class="status in-fov"
-                      ${xo(st("compass.in_fov_tooltip",this.hass))}
+                      ${$o(st("compass.in_fov_tooltip",this.hass))}
                       >✓</span
                     >`:V}
               </div>
@@ -275,7 +275,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
         >${st("compass.stat_window",this.hass)}${ct(It(o.sun.window_azimuth))}</span
       >
       ${this.showMoon&&a?H`<span>${a.phaseName} ${Math.round(100*a.fraction)}%</span>`:V}
-    </div>`}};function vi(e){let t=null,o=null;const i=6e4-Date.now()%6e4;return t=setTimeout(()=>{t=null,e(),o=setInterval(e,6e4)},i),()=>{null!==t&&(clearTimeout(t),t=null),null!==o&&(clearInterval(o),o=null)}}mi.styles=a`
+    </div>`}};function fi(e){let t=null,o=null;const i=6e4-Date.now()%6e4;return t=setTimeout(()=>{t=null,e(),o=setInterval(e,6e4)},i),()=>{null!==t&&(clearTimeout(t),t=null),null!==o&&(clearInterval(o),o=null)}}vi.styles=a`
     :host {
       display: block;
       width: 100%;
@@ -627,7 +627,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
     [data-tooltip][acp-tt-shown] {
       cursor: default;
     }
-  `,e([ge({attribute:!1})],mi.prototype,"hass",void 0),e([ge({attribute:!1})],mi.prototype,"discovered_list",void 0),e([ge({type:Boolean,reflect:!0})],mi.prototype,"compact",void 0),e([ge({attribute:!1})],mi.prototype,"showStats",void 0),e([ge({attribute:!1})],mi.prototype,"showLegend",void 0),e([ge({attribute:!1})],mi.prototype,"showMoon",void 0),e([ge({attribute:!1})],mi.prototype,"showCardinals",void 0),e([ge({attribute:!1})],mi.prototype,"showBlindSpot",void 0),e([ge({attribute:!1})],mi.prototype,"showSunPath",void 0),e([ge({attribute:!1})],mi.prototype,"showSunriseSunset",void 0),e([ge({attribute:!1})],mi.prototype,"showCoverFill",void 0),e([ge({attribute:!1})],mi.prototype,"showWindowArrow",void 0),e([ge({attribute:!1})],mi.prototype,"coverColors",void 0),e([ge({attribute:!1})],mi.prototype,"northOffsetDeg",void 0),e([me()],mi.prototype,"_hiddenEntries",void 0),mi=e([pe("acp-sky-compass")],mi);const fi=32,bi=864e5;function yi(e){if(!e)return null;const t=new Date(e);return Number.isNaN(t.getTime())?null:t}let wi=class extends de{constructor(){super(...arguments),this.discoveredList=[],this.coverColors=[],this.compact=!1,this._cancelMinuteTimer=null}connectedCallback(){super.connectedCallback(),this._cancelMinuteTimer=vi(()=>this.requestUpdate())}disconnectedCallback(){super.disconnectedCallback(),this._cancelMinuteTimer?.(),this._cancelMinuteTimer=null}shouldUpdate(e){if(e.size>1||!e.has("hass"))return!0;const t=e.get("hass"),o=[];for(const e of this.discoveredList){const t=e.entities;o.push(t.sun_sensor,t.decision_trace_sensor,t.control_status_sensor)}return ve(t,this.hass,o)}_sunAttrsFor(e){const t=e.entities.sun_sensor;if(!t)return null;const o=this.hass.states[t];return o?o.attributes:null}_sunDotTraceInputs(){const e=this.discoveredList[0]?.entities.decision_trace_sensor,t=e?this.hass.states[e]?.attributes:void 0;return{sunState:t?.sun_state??null,directSunValid:t?.direct_sun_valid??!1}}_scheduleBounds(){const e=this.discoveredList[0]?.entities.control_status_sensor;if(!e)return null;const t=this.hass.states[e]?.attributes;return t?{start:yi(t.schedule_start),end:yi(t.schedule_end)}:null}render(){if(!this.hass||0===this.discoveredList.length)return V;const e=this._sunAttrsFor(this.discoveredList[0]),{latitude:t,longitude:o,time_zone:i}=this.hass.config??{};if(void 0===t||void 0===o||!e)return H`<div class="placeholder">${st("elevation.placeholder",this.hass)}</div>`;const s=ti(i),n=Jo(t,o,s),r=new Date,a=e=>{const t=e.getTime()-s.getTime();return fi+t/864e5*360},l=e=>138-(e- -10)/100*128,c=n.map(e=>`${a(e.t).toFixed(1)},${l(e.elevation).toFixed(1)}`).join(" "),d=l(0),h=a(r),p=this._interpAt(n,r),u=p?l(p.elevation):null,_=!p||p.elevation<=0,g=this._sunDotTraceInputs(),m=li[ci({belowHorizon:_,sunState:g.sunState,directSunValid:g.directSunValid,inFov:!0===e.in_fov})].replace(/^sun /,""),v=e=>138-128*e,f=this.discoveredList.length>1,b=this._scheduleBounds(),y=b?function(e,t,o,i){if(!e&&!t)return{offSchedule:[],bars:[]};const s=e=>(e.getTime()-o)/i,n=e=>Math.max(0,Math.min(1,e)),r=e=>n(e),a=e=>e>1?e-Math.floor(e):n(e),l=e=>e>0&&e<1?[e]:[];if(e&&!t){const t=s(e);return{offSchedule:[{x0:0,x1:r(t)}],bars:l(t)}}if(!e&&t){const e=s(t);return{offSchedule:[{x0:a(e),x1:1}],bars:l(e)}}const c=s(e),d=s(t),h=r(c),p=a(d),u=[...l(c),...l(d)];if(h>p)return{offSchedule:[{x0:p,x1:h}],bars:u};const _=[];return h>0&&_.push({x0:0,x1:h}),p<1&&_.push({x0:p,x1:1}),{offSchedule:_,bars:u}}(b.start,b.end,s.getTime(),bi):{offSchedule:[],bars:[]},w=e=>fi+360*e,x=y.offSchedule.map(e=>({x:w(e.x0),width:w(e.x1)-w(e.x0)})),$=b?.start&&s?(b.start.getTime()-s.getTime())/bi:null,k=y.bars.map(e=>{const t=null!==$&&Math.abs(e-$)<1e-9?b.start.toISOString():b.end.toISOString(),o=null!==$&&Math.abs(e-$)<1e-9,s=w(e);return{x:s,anchor:s>=391?"end":s<=33?"start":"middle",label:dt(t,i),tooltip:st(o?"elevation.schedule_start_tooltip":"elevation.schedule_end_tooltip",this.hass)}}),A=(()=>{if(!b)return null;const e=b.start?dt(b.start.toISOString(),i):null,t=b.end?dt(b.end.toISOString(),i):null;return e&&t?st("elevation.schedule",this.hass,{from:e,to:t}):e?st("elevation.schedule_from",this.hass,{from:e}):t?st("elevation.schedule_until",this.hass,{to:t}):null})(),S=this.discoveredList.map((e,t)=>{const o=this._sunAttrsFor(e),{color:s,isOverride:r}=pi(this.coverColors?.[t],t),l=r;if(!o)return{d:e,runs:[],inPlotBands:[],runBars:[],label:"",color:s,inlineFill:l};const c=ii(n,o.window_azimuth,o.fov_left,o.fov_right),d="number"==typeof o.min_elevation,h="number"==typeof o.max_elevation,{loFrac:p,hiFrac:u}=function(e,t){if(void 0!==e&&void 0!==t&&e>t)return{loFrac:0,hiFrac:1};const o=e=>Math.max(0,Math.min(1,(e- -10)/100));return{loFrac:void 0!==e?o(e):0,hiFrac:void 0!==t?o(t):1}}(o.min_elevation,o.max_elevation),_=d||h?v(u):10,g=d||h?v(p):138,m=_,b=Math.max(0,g-_),y=c.map(e=>({x0:a(n[e.startIdx].t),x1:a(n[e.endIdx].t),y:m,height:b})),w=c.map(e=>({x0:a(n[e.startIdx].t),x1:a(n[e.endIdx].t),range:`${dt(n[e.startIdx].t.toISOString(),i)} → ${dt(n[e.endIdx].t.toISOString(),i)}`})),x=c.map(e=>`${dt(n[e.startIdx].t.toISOString(),i)} → ${dt(n[e.endIdx].t.toISOString(),i)}`).join(", "),$=[];return f||(d&&$.push(g),h&&$.push(_)),{d:e,runs:c,inPlotBands:y,runBars:w,label:x,color:s,inlineFill:l,limitLines:$}}),C=S.some(e=>e.runs.length>0),E=f?function(e){if(e<=0)return{rows:[],height:0};const t=Array.from({length:e},(e,t)=>({y:0+11*t,height:8}));return{rows:t,height:0+8*e+3*(e-1)+0}}(S.length):{rows:[],height:0},z=138-E.height-3;return H`
+  `,e([ge({attribute:!1})],vi.prototype,"hass",void 0),e([ge({attribute:!1})],vi.prototype,"discovered_list",void 0),e([ge({type:Boolean,reflect:!0})],vi.prototype,"compact",void 0),e([ge({attribute:!1})],vi.prototype,"showStats",void 0),e([ge({attribute:!1})],vi.prototype,"showLegend",void 0),e([ge({attribute:!1})],vi.prototype,"showMoon",void 0),e([ge({attribute:!1})],vi.prototype,"showCardinals",void 0),e([ge({attribute:!1})],vi.prototype,"showBlindSpot",void 0),e([ge({attribute:!1})],vi.prototype,"showSunPath",void 0),e([ge({attribute:!1})],vi.prototype,"showSunriseSunset",void 0),e([ge({attribute:!1})],vi.prototype,"showCoverFill",void 0),e([ge({attribute:!1})],vi.prototype,"showWindowArrow",void 0),e([ge({attribute:!1})],vi.prototype,"coverColors",void 0),e([ge({attribute:!1})],vi.prototype,"northOffsetDeg",void 0),e([me()],vi.prototype,"_hiddenEntries",void 0),vi=e([pe("acp-sky-compass")],vi);const bi=32,yi=864e5;function wi(e){if(!e)return null;const t=new Date(e);return Number.isNaN(t.getTime())?null:t}let xi=class extends de{constructor(){super(...arguments),this.discoveredList=[],this.coverColors=[],this.compact=!1,this._cancelMinuteTimer=null}connectedCallback(){super.connectedCallback(),this._cancelMinuteTimer=fi(()=>this.requestUpdate())}disconnectedCallback(){super.disconnectedCallback(),this._cancelMinuteTimer?.(),this._cancelMinuteTimer=null}shouldUpdate(e){if(e.size>1||!e.has("hass"))return!0;const t=e.get("hass"),o=[];for(const e of this.discoveredList){const t=e.entities;o.push(t.sun_sensor,t.decision_trace_sensor,t.control_status_sensor)}return ve(t,this.hass,o)}_sunAttrsFor(e){const t=e.entities.sun_sensor;if(!t)return null;const o=this.hass.states[t];return o?o.attributes:null}_sunDotTraceInputs(){const e=this.discoveredList[0]?.entities.decision_trace_sensor,t=e?this.hass.states[e]?.attributes:void 0;return{sunState:t?.sun_state??null,directSunValid:t?.direct_sun_valid??!1}}_scheduleBounds(){const e=this.discoveredList[0]?.entities.control_status_sensor;if(!e)return null;const t=this.hass.states[e]?.attributes;return t?{start:wi(t.schedule_start),end:wi(t.schedule_end)}:null}render(){if(!this.hass||0===this.discoveredList.length)return V;const e=this._sunAttrsFor(this.discoveredList[0]),{latitude:t,longitude:o,time_zone:i}=this.hass.config??{};if(void 0===t||void 0===o||!e)return H`<div class="placeholder">${st("elevation.placeholder",this.hass)}</div>`;const s=oi(i),n=ei(t,o,s),r=new Date,a=e=>{const t=e.getTime()-s.getTime();return bi+t/864e5*360},l=e=>138-(e- -10)/100*128,c=n.map(e=>`${a(e.t).toFixed(1)},${l(e.elevation).toFixed(1)}`).join(" "),d=l(0),h=a(r),p=this._interpAt(n,r),u=p?l(p.elevation):null,_=!p||p.elevation<=0,g=this._sunDotTraceInputs(),m=ci[di({belowHorizon:_,sunState:g.sunState,directSunValid:g.directSunValid,inFov:!0===e.in_fov})].replace(/^sun /,""),v=e=>138-128*e,f=this.discoveredList.length>1,b=this._scheduleBounds(),y=b?function(e,t,o,i){if(!e&&!t)return{offSchedule:[],bars:[]};const s=e=>(e.getTime()-o)/i,n=e=>Math.max(0,Math.min(1,e)),r=e=>n(e),a=e=>e>1?e-Math.floor(e):n(e),l=e=>e>0&&e<1?[e]:[];if(e&&!t){const t=s(e);return{offSchedule:[{x0:0,x1:r(t)}],bars:l(t)}}if(!e&&t){const e=s(t);return{offSchedule:[{x0:a(e),x1:1}],bars:l(e)}}const c=s(e),d=s(t),h=r(c),p=a(d),u=[...l(c),...l(d)];if(h>p)return{offSchedule:[{x0:p,x1:h}],bars:u};const _=[];return h>0&&_.push({x0:0,x1:h}),p<1&&_.push({x0:p,x1:1}),{offSchedule:_,bars:u}}(b.start,b.end,s.getTime(),yi):{offSchedule:[],bars:[]},w=e=>bi+360*e,x=y.offSchedule.map(e=>({x:w(e.x0),width:w(e.x1)-w(e.x0)})),$=b?.start&&s?(b.start.getTime()-s.getTime())/yi:null,k=y.bars.map(e=>{const t=null!==$&&Math.abs(e-$)<1e-9?b.start.toISOString():b.end.toISOString(),o=null!==$&&Math.abs(e-$)<1e-9,s=w(e);return{x:s,anchor:s>=391?"end":s<=33?"start":"middle",label:dt(t,i),tooltip:st(o?"elevation.schedule_start_tooltip":"elevation.schedule_end_tooltip",this.hass)}}),A=(()=>{if(!b)return null;const e=b.start?dt(b.start.toISOString(),i):null,t=b.end?dt(b.end.toISOString(),i):null;return e&&t?st("elevation.schedule",this.hass,{from:e,to:t}):e?st("elevation.schedule_from",this.hass,{from:e}):t?st("elevation.schedule_until",this.hass,{to:t}):null})(),S=this.discoveredList.map((e,t)=>{const o=this._sunAttrsFor(e),{color:s,isOverride:r}=ui(this.coverColors?.[t],t),l=r;if(!o)return{d:e,runs:[],inPlotBands:[],runBars:[],label:"",color:s,inlineFill:l};const c=si(n,o.window_azimuth,o.fov_left,o.fov_right),d="number"==typeof o.min_elevation,h="number"==typeof o.max_elevation,{loFrac:p,hiFrac:u}=function(e,t){if(void 0!==e&&void 0!==t&&e>t)return{loFrac:0,hiFrac:1};const o=e=>Math.max(0,Math.min(1,(e- -10)/100));return{loFrac:void 0!==e?o(e):0,hiFrac:void 0!==t?o(t):1}}(o.min_elevation,o.max_elevation),_=d||h?v(u):10,g=d||h?v(p):138,m=_,b=Math.max(0,g-_),y=c.map(e=>({x0:a(n[e.startIdx].t),x1:a(n[e.endIdx].t),y:m,height:b})),w=c.map(e=>({x0:a(n[e.startIdx].t),x1:a(n[e.endIdx].t),range:`${dt(n[e.startIdx].t.toISOString(),i)} → ${dt(n[e.endIdx].t.toISOString(),i)}`})),x=c.map(e=>`${dt(n[e.startIdx].t.toISOString(),i)} → ${dt(n[e.endIdx].t.toISOString(),i)}`).join(", "),$=[];return f||(d&&$.push(g),h&&$.push(_)),{d:e,runs:c,inPlotBands:y,runBars:w,label:x,color:s,inlineFill:l,limitLines:$}}),C=S.some(e=>e.runs.length>0),E=f?function(e){if(e<=0)return{rows:[],height:0};const t=Array.from({length:e},(e,t)=>({y:0+11*t,height:8}));return{rows:t,height:0+8*e+3*(e-1)+0}}(S.length):{rows:[],height:0},z=138-E.height-3;return H`
       <div class="wrap">
         <div class="head">
           <span class="label">${st("elevation.title",this.hass)}</span>
@@ -642,15 +642,15 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
           ${U`
             <!-- y-axis gridlines -->
             ${[0,30,60,90].map(e=>U`
-              <line class="grid" x1=${fi} y1=${l(e)} x2=${392} y2=${l(e)} />
+              <line class="grid" x1=${bi} y1=${l(e)} x2=${392} y2=${l(e)} />
               <text class="tick" x=${28} y=${l(e)+3} text-anchor="end">${e}°</text>
             `)}
 
             <!-- horizon -->
-            <line class="horizon" x1=${fi} y1=${d} x2=${392} y2=${d} />
+            <line class="horizon" x1=${bi} y1=${d} x2=${392} y2=${d} />
 
             <!-- elevation limit gridlines (single-window legacy path only) -->
-            ${S.flatMap(e=>(e.limitLines??[]).map(e=>U`<line class="limit-line" x1=${fi} y1=${e} x2=${392} y2=${e} />`))}
+            ${S.flatMap(e=>(e.limitLines??[]).map(e=>U`<line class="limit-line" x1=${bi} y1=${e} x2=${392} y2=${e} />`))}
 
             <!-- In-plot FOV bands: single-window legacy path only. -->
             ${f?V:S.flatMap(e=>e.inPlotBands.map(t=>U`<rect
@@ -669,12 +669,12 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
                  curve stays crisp on top. -->
             ${E.rows.flatMap((e,t)=>{const o=S[t],i=z+e.y,s=o.runs.length?o.d.entry_title:st("elevation.fov_window_named",this.hass,{name:o.d.entry_title,windows:st("elevation.no_fov_today",this.hass)}),n=U`<rect
                 class="ribbon-track"
-                x=${fi}
+                x=${bi}
                 y=${i}
                 width=${360}
                 height=${e.height}
                 rx="2"
-                ${xo(s)}
+                ${$o(s)}
               ></rect>`,r=o.runBars.map(t=>U`<rect
                   class="ribbon-bar"
                   x=${t.x0}
@@ -683,7 +683,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
                   height=${e.height}
                   rx="2"
                   style=${`fill:${o.color}`}
-                  ${xo(st("elevation.fov_window_named",this.hass,{name:o.d.entry_title,windows:t.range}))}
+                  ${$o(st("elevation.fov_window_named",this.hass,{name:o.d.entry_title,windows:t.range}))}
                 ></rect>`);return[n,...r]})}
 
             <!-- Schedule window overlay (issue #128): faint off-schedule gray
@@ -704,7 +704,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
                 y1=${10}
                 x2=${e.x}
                 y2=${138}
-                ${xo(e.tooltip)}
+                ${$o(e.tooltip)}
               ></line>`,U`<text
                 class="schedule-tick"
                 x=${e.x}
@@ -718,7 +718,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
             <!-- current-time cursor + sun dot, drawn last so they sit on top of
                  the curve AND the ribbon bars. A wide transparent hit-line widens
                  the hover target so the thin now-line is easy to tooltip. -->
-            <g class="now-group" ${xo(dt(r.toISOString(),i))}>
+            <g class="now-group" ${$o(dt(r.toISOString(),i))}>
               <line class="now-hit" x1=${h} y1=${10} x2=${h} y2=${138} />
               <line class="now" x1=${h} y1=${10} x2=${h} y2=${138} />
             </g>
@@ -735,7 +735,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
           `}
         </svg>
       </div>
-    `}_interpAt(e,t){if(0===e.length)return null;const o=t.getTime();if(o<=e[0].t.getTime())return e[0];if(o>=e[e.length-1].t.getTime())return e[e.length-1];for(let i=1;i<e.length;i++)if(e[i].t.getTime()>=o){const s=e[i-1],n=e[i],r=(o-s.t.getTime())/(n.t.getTime()-s.t.getTime());return{t:t,elevation:s.elevation+(n.elevation-s.elevation)*r,azimuth:s.azimuth+(n.azimuth-s.azimuth)*r}}return e[e.length-1]}};function xi(e,t){if(!0===e?.custom_position_minimum_mode&&Array.isArray(e.custom_position_slots)&&void 0!==e.custom_position_active_slot){const t=e.custom_position_slots.find(t=>t.slot===e.custom_position_active_slot);if(void 0!==t&&null!==t.position&&void 0!==t.position)return t.position}return t}function $i(e){if(void 0===e?.custom_position_active_slot||!Array.isArray(e.custom_position_slots))return!1;const t=e.custom_position_slots.find(t=>t.slot===e.custom_position_active_slot);return 100===t?.priority}function ki(e){const t=e.replace(/Handler$/,"").replace(/([a-z])([A-Z])/g,"$1_$2").toLowerCase();if(/^custom_position_\d+$/.test(t))return"custom_position";switch(t){case"force_override":return"force";case"weather_override":return"weather";case"manual_override":return"manual";case"motion_timeout":return"motion";case"cloud_suppression":return"cloud";default:return t}}function Ai(e,t,o,i=Pe,s="Safety"){const n=new Map;for(const t of e){if(!t.matched)continue;const e=ki(t.handler);Ie.includes(e)&&n.set(e,t)}const r=[...Ie].reverse().filter(e=>n.has(e));return 0===r.length?t.reason??"":r.map(e=>function(e,t,o,i,s){const n=i[e]??e,r=t.position,a=null==r?"":` ${nt(r)}`;if("custom_position"!==e)return`${n}${a}`.trimEnd();return`${o.custom_position_active_slot_name?`${n} · ${o.custom_position_active_slot_name}`:o.custom_position_active_slot?`${n} #${o.custom_position_active_slot}`:n}${a}${!0===o.custom_position_minimum_mode?" floor":""}${$i(o)?` · ${s}`:""}`}(e,n.get(e),t,i,s)).join(" → ")}wi.styles=a`
+    `}_interpAt(e,t){if(0===e.length)return null;const o=t.getTime();if(o<=e[0].t.getTime())return e[0];if(o>=e[e.length-1].t.getTime())return e[e.length-1];for(let i=1;i<e.length;i++)if(e[i].t.getTime()>=o){const s=e[i-1],n=e[i],r=(o-s.t.getTime())/(n.t.getTime()-s.t.getTime());return{t:t,elevation:s.elevation+(n.elevation-s.elevation)*r,azimuth:s.azimuth+(n.azimuth-s.azimuth)*r}}return e[e.length-1]}};function $i(e,t){if(!0===e?.custom_position_minimum_mode&&Array.isArray(e.custom_position_slots)&&void 0!==e.custom_position_active_slot){const t=e.custom_position_slots.find(t=>t.slot===e.custom_position_active_slot);if(void 0!==t&&null!==t.position&&void 0!==t.position)return t.position}return t}function ki(e){if(void 0===e?.custom_position_active_slot||!Array.isArray(e.custom_position_slots))return!1;const t=e.custom_position_slots.find(t=>t.slot===e.custom_position_active_slot);return 100===t?.priority}function Ai(e){const t=e.replace(/Handler$/,"").replace(/([a-z])([A-Z])/g,"$1_$2").toLowerCase();if(/^custom_position_\d+$/.test(t))return"custom_position";switch(t){case"force_override":return"force";case"weather_override":return"weather";case"manual_override":return"manual";case"motion_timeout":return"motion";case"cloud_suppression":return"cloud";default:return t}}function Si(e,t,o,i=Pe,s="Safety"){const n=new Map;for(const t of e){if(!t.matched)continue;const e=Ai(t.handler);Ie.includes(e)&&n.set(e,t)}const r=[...Ie].reverse().filter(e=>n.has(e));return 0===r.length?t.reason??"":r.map(e=>function(e,t,o,i,s){const n=i[e]??e,r=t.position,a=null==r?"":` ${nt(r)}`;if("custom_position"!==e)return`${n}${a}`.trimEnd();return`${o.custom_position_active_slot_name?`${n} · ${o.custom_position_active_slot_name}`:o.custom_position_active_slot?`${n} #${o.custom_position_active_slot}`:n}${a}${!0===o.custom_position_minimum_mode?" floor":""}${ki(o)?` · ${s}`:""}`}(e,n.get(e),t,i,s)).join(" → ")}xi.styles=a`
     :host {
       display: block;
       width: 100%;
@@ -885,7 +885,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
       text-align: center;
       padding: 20px;
     }
-  `,e([ge({attribute:!1})],wi.prototype,"hass",void 0),e([ge({attribute:!1})],wi.prototype,"discoveredList",void 0),e([ge({attribute:!1})],wi.prototype,"coverColors",void 0),e([ge({type:Boolean,reflect:!0})],wi.prototype,"compact",void 0),wi=e([pe("acp-elevation-chart")],wi);let Si=class extends de{constructor(){super(...arguments),this.compact=!1,this.showSummary=!0,this._tick=null,this.hideInactive=!1}disconnectedCallback(){super.disconnectedCallback(),this._syncTimer(!1)}updated(){const e=Boolean(this.hass&&this.discovered&&this._throttleNextAllowedIso());this._syncTimer(e)}_syncTimer(e){e&&null===this._tick?this._tick=setInterval(()=>this.requestUpdate(),1e3):e||null===this._tick||(clearInterval(this._tick),this._tick=null)}shouldUpdate(e){if(e.size>1||!e.has("hass"))return!0;const t=e.get("hass"),o=this.discovered?.entities;return ve(t,this.hass,[o?.decision_trace_sensor,o?.last_skipped_sensor])}_throttleNextAllowedIso(){const e=this.discovered.entities.last_skipped_sensor;if(!e)return null;const t=this.hass.states[e];if(!t||"time_delta_too_small"!==t.state)return null;const o=t.attributes,i=function(e,t){if(!e)return null;if(null==t||Number.isNaN(t))return null;const o=new Date(e).getTime();return Number.isNaN(o)?null:new Date(o+6e4*t).toISOString()}(o?.timestamp,o?.time_threshold_minutes);return i?new Date(i).getTime()<=Date.now()?null:i:null}_trace(){const e=this.discovered.entities.decision_trace_sensor;if(!e)return null;const t=this.hass.states[e];if(!t)return null;const o=t.attributes;if(!o?.trace)return null;const i=new Map;for(const e of o.trace)i.set(ki(e.handler),{matched:e.matched,reason:e.reason,position:e.position,held_position:e.held_position});const s={};for(const[e,t]of Object.entries(Oe))s[e]=st(t,this.hass);return{winner:t.state,reason:o.reason??"",steps:i,enabledHandlers:o.enabled_handlers,summary:Ai(o.trace,o,t.state,s),inTimeWindow:o.in_time_window}}render(){if(!this.hass||!this.discovered)return V;const e=this._trace();if(!e)return H`<div class="placeholder">${st("decision.placeholder",this.hass)}</div>`;const t=this._throttleNextAllowedIso(),o=function(e){if(!e)return new Set;const t=new Set(e);return new Set(Ie.filter(e=>!t.has(e)))}(e.enabledHandlers),i=function(e,t,o,i,s=new Set){return e.filter(e=>e===o||!s.has(e)&&(!i||!0===t.get(e)?.matched))}(Ie,e.steps,e.winner,this.hideInactive,o);return H`
+  `,e([ge({attribute:!1})],xi.prototype,"hass",void 0),e([ge({attribute:!1})],xi.prototype,"discoveredList",void 0),e([ge({attribute:!1})],xi.prototype,"coverColors",void 0),e([ge({type:Boolean,reflect:!0})],xi.prototype,"compact",void 0),xi=e([pe("acp-elevation-chart")],xi);let Ci=class extends de{constructor(){super(...arguments),this.compact=!1,this.showSummary=!0,this._tick=null,this.hideInactive=!1}disconnectedCallback(){super.disconnectedCallback(),this._syncTimer(!1)}updated(){const e=Boolean(this.hass&&this.discovered&&this._throttleNextAllowedIso());this._syncTimer(e)}_syncTimer(e){e&&null===this._tick?this._tick=setInterval(()=>this.requestUpdate(),1e3):e||null===this._tick||(clearInterval(this._tick),this._tick=null)}shouldUpdate(e){if(e.size>1||!e.has("hass"))return!0;const t=e.get("hass"),o=this.discovered?.entities;return ve(t,this.hass,[o?.decision_trace_sensor,o?.last_skipped_sensor])}_throttleNextAllowedIso(){const e=this.discovered.entities.last_skipped_sensor;if(!e)return null;const t=this.hass.states[e];if(!t||"time_delta_too_small"!==t.state)return null;const o=t.attributes,i=function(e,t){if(!e)return null;if(null==t||Number.isNaN(t))return null;const o=new Date(e).getTime();return Number.isNaN(o)?null:new Date(o+6e4*t).toISOString()}(o?.timestamp,o?.time_threshold_minutes);return i?new Date(i).getTime()<=Date.now()?null:i:null}_trace(){const e=this.discovered.entities.decision_trace_sensor;if(!e)return null;const t=this.hass.states[e];if(!t)return null;const o=t.attributes;if(!o?.trace)return null;const i=new Map;for(const e of o.trace)i.set(Ai(e.handler),{matched:e.matched,reason:e.reason,position:e.position,held_position:e.held_position});const s={};for(const[e,t]of Object.entries(Oe))s[e]=st(t,this.hass);return{winner:t.state,reason:o.reason??"",steps:i,enabledHandlers:o.enabled_handlers,summary:Si(o.trace,o,t.state,s),inTimeWindow:o.in_time_window}}render(){if(!this.hass||!this.discovered)return V;const e=this._trace();if(!e)return H`<div class="placeholder">${st("decision.placeholder",this.hass)}</div>`;const t=this._throttleNextAllowedIso(),o=function(e){if(!e)return new Set;const t=new Set(e);return new Set(Ie.filter(e=>!t.has(e)))}(e.enabledHandlers),i=function(e,t,o,i,s=new Set){return e.filter(e=>e===o||!s.has(e)&&(!i||!0===t.get(e)?.matched))}(Ie,e.steps,e.winner,this.hideInactive,o);return H`
       <div class="wrap">
         <div class="head">
           <span class="label">${st("decision.pipeline",this.hass)}</span>
@@ -893,7 +893,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
         </div>
         ${!1===e.inTimeWindow?H`<div
               class="off-schedule"
-              ${xo(st("decision.outside_schedule_tooltip",this.hass))}
+              ${$o(st("decision.outside_schedule_tooltip",this.hass))}
             >
               ${st("decision.outside_schedule",this.hass)}
             </div>`:V}
@@ -903,7 +903,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
                 >${st("decision.next_change_in",this.hass,{time:ht(t,this.hass)})}</span
               >
             </div>`:V}
-        ${this.showSummary&&e.summary?H`<div class="summary" ${xo(st("decision.summary_tooltip",this.hass))}>
+        ${this.showSummary&&e.summary?H`<div class="summary" ${$o(st("decision.summary_tooltip",this.hass))}>
               ${e.summary}
             </div>`:V}
         <div class="rows">
@@ -919,7 +919,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
         <span class="reason-inline dim">${s}${c}</span>
         ${o?H`<span class="badge">✓</span>`:V}
       </div>
-    `}};var Ci,Ei;Si.styles=a`
+    `}};var Ei,zi;Ci.styles=a`
     :host {
       display: block;
     }
@@ -1065,7 +1065,70 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
       padding: 16px;
       text-align: center;
     }
-  `,e([ge({attribute:!1})],Si.prototype,"hass",void 0),e([ge({attribute:!1})],Si.prototype,"discovered",void 0),e([ge({type:Boolean,reflect:!0})],Si.prototype,"compact",void 0),e([ge({type:Boolean,reflect:!0,attribute:"show-summary"})],Si.prototype,"showSummary",void 0),e([ge({type:Boolean,reflect:!0,attribute:"hide-inactive"})],Si.prototype,"hideInactive",void 0),Si=e([pe("acp-decision-strip")],Si),function(e){e.language="language",e.system="system",e.comma_decimal="comma_decimal",e.decimal_comma="decimal_comma",e.space_comma="space_comma",e.none="none"}(Ci||(Ci={})),function(e){e.language="language",e.system="system",e.am_pm="12",e.twenty_four="24"}(Ei||(Ei={}));const zi=["closed","locked","off"],Mi=(e,t,o,i)=>{i=i||{},o=null==o?{}:o;const s=new Event(t,{bubbles:void 0===i.bubbles||i.bubbles,cancelable:Boolean(i.cancelable),composed:void 0===i.composed||i.composed});return s.detail=o,e.dispatchEvent(s),s},Ti=e=>{Mi(window,"haptic",e)},Ii=(e,t,o,i)=>{let s;"double_tap"===i&&o.double_tap_action?s=o.double_tap_action:"hold"===i&&o.hold_action?s=o.hold_action:"tap"===i&&o.tap_action&&(s=o.tap_action),((e,t,o,i)=>{if(i||(i={action:"more-info"}),!i.confirmation||i.confirmation.exemptions&&i.confirmation.exemptions.some(e=>e.user===t.user.id)||(Ti("warning"),confirm(i.confirmation.text||`Are you sure you want to ${i.action}?`)))switch(i.action){case"more-info":(o.entity||o.camera_image)&&Mi(e,"hass-more-info",{entityId:o.entity?o.entity:o.camera_image});break;case"navigate":i.navigation_path&&((e,t,o=!1)=>{o?history.replaceState(null,"",t):history.pushState(null,"",t),Mi(window,"location-changed",{replace:o})})(0,i.navigation_path);break;case"url":i.url_path&&window.open(i.url_path);break;case"toggle":o.entity&&(((e,t)=>{((e,t,o=!0)=>{const i=function(e){return e.substr(0,e.indexOf("."))}(t),s="group"===i?"homeassistant":i;let n;switch(i){case"lock":n=o?"unlock":"lock";break;case"cover":n=o?"open_cover":"close_cover";break;default:n=o?"turn_on":"turn_off"}e.callService(s,n,{entity_id:t})})(e,t,zi.includes(e.states[t].state))})(t,o.entity),Ti("success"));break;case"call-service":{if(!i.service)return void Ti("failure");const[e,o]=i.service.split(".",2);t.callService(e,o,i.service_data,i.target),Ti("success");break}case"fire-dom-event":Mi(e,"ll-custom",i)}})(e,t,o,s)};function Pi(e){return void 0!==e&&"none"!==e.action}function Oi(e,t){if(null==e)return t.entry_title;if("string"==typeof e)return e;if(Array.isArray(e)){const o=e.map(e=>function(e,t){if(e&&"object"==typeof e)switch(e.type){case"entry":return t.entry_title||void 0;case"area":return t.area_name||void 0;case"text":return e.text||void 0;default:return}}(e,t)).filter(e=>!!e);return o.length>0?o.join(" "):t.entry_title}return"object"==typeof e?t.entry_title:String(e)}function Ni(e){if(!e||"object"!=typeof e)return!1;const t=e.type;return"entry"===t||"area"===t||"text"===t&&"string"==typeof e.text}const Di=new Set(["cover_day_night_shade","cover_dual_panel"]);function Bi(e,t){if(!t)return!1;const o=e.states[t]?.attributes?.supported_features;return"number"==typeof o&&!!(128&o)}function Fi(e,t,o){return e.callService("switch",o?"turn_on":"turn_off",{},{entity_id:t})}const Ri={position:"set_position",tilt:"set_tilt"};function ji(e){const t=e.services;return!!t?.[Te]?.set_axes}function Li(e,t,o,i){if(ji(e)){const s={axes:o};return null!=i?.force&&(s.force=i.force),void e.callService(Te,"set_axes",s,{entity_id:t})}for(const[i,s]of Object.entries(o)){const o=Ri[i];o&&e.callService(Te,o,{[i]:s},{entity_id:t})}}const Ki=3;const Gi=[15,30,60,120];let Wi=class extends de{constructor(){super(...arguments),this.open=!1,this.presets=[],this._onBackdrop=e=>{e.target===e.currentTarget&&this._emitClose()},this._emitClose=()=>{this.dispatchEvent(new CustomEvent("acp-extend-close",{bubbles:!0,composed:!0}))},this._stop=e=>{e.stopPropagation()}}updated(e){e.has("open")&&this.open&&(this._endMs=void 0)}render(){if(!this.open)return V;const e=this._t("dialog.extend.title","Extend manual override");return H`
+  `,e([ge({attribute:!1})],Ci.prototype,"hass",void 0),e([ge({attribute:!1})],Ci.prototype,"discovered",void 0),e([ge({type:Boolean,reflect:!0})],Ci.prototype,"compact",void 0),e([ge({type:Boolean,reflect:!0,attribute:"show-summary"})],Ci.prototype,"showSummary",void 0),e([ge({type:Boolean,reflect:!0,attribute:"hide-inactive"})],Ci.prototype,"hideInactive",void 0),Ci=e([pe("acp-decision-strip")],Ci),function(e){e.language="language",e.system="system",e.comma_decimal="comma_decimal",e.decimal_comma="decimal_comma",e.space_comma="space_comma",e.none="none"}(Ei||(Ei={})),function(e){e.language="language",e.system="system",e.am_pm="12",e.twenty_four="24"}(zi||(zi={}));const Mi=["closed","locked","off"],Ti=(e,t,o,i)=>{i=i||{},o=null==o?{}:o;const s=new Event(t,{bubbles:void 0===i.bubbles||i.bubbles,cancelable:Boolean(i.cancelable),composed:void 0===i.composed||i.composed});return s.detail=o,e.dispatchEvent(s),s},Ii=e=>{Ti(window,"haptic",e)},Pi=(e,t,o,i)=>{let s;"double_tap"===i&&o.double_tap_action?s=o.double_tap_action:"hold"===i&&o.hold_action?s=o.hold_action:"tap"===i&&o.tap_action&&(s=o.tap_action),((e,t,o,i)=>{if(i||(i={action:"more-info"}),!i.confirmation||i.confirmation.exemptions&&i.confirmation.exemptions.some(e=>e.user===t.user.id)||(Ii("warning"),confirm(i.confirmation.text||`Are you sure you want to ${i.action}?`)))switch(i.action){case"more-info":(o.entity||o.camera_image)&&Ti(e,"hass-more-info",{entityId:o.entity?o.entity:o.camera_image});break;case"navigate":i.navigation_path&&((e,t,o=!1)=>{o?history.replaceState(null,"",t):history.pushState(null,"",t),Ti(window,"location-changed",{replace:o})})(0,i.navigation_path);break;case"url":i.url_path&&window.open(i.url_path);break;case"toggle":o.entity&&(((e,t)=>{((e,t,o=!0)=>{const i=function(e){return e.substr(0,e.indexOf("."))}(t),s="group"===i?"homeassistant":i;let n;switch(i){case"lock":n=o?"unlock":"lock";break;case"cover":n=o?"open_cover":"close_cover";break;default:n=o?"turn_on":"turn_off"}e.callService(s,n,{entity_id:t})})(e,t,Mi.includes(e.states[t].state))})(t,o.entity),Ii("success"));break;case"call-service":{if(!i.service)return void Ii("failure");const[e,o]=i.service.split(".",2);t.callService(e,o,i.service_data,i.target),Ii("success");break}case"fire-dom-event":Ti(e,"ll-custom",i)}})(e,t,o,s)};function Oi(e){return void 0!==e&&"none"!==e.action}function Ni(e,t){if(null==e)return t.entry_title;if("string"==typeof e)return e;if(Array.isArray(e)){const o=e.map(e=>function(e,t){if(e&&"object"==typeof e)switch(e.type){case"entry":return t.entry_title||void 0;case"area":return t.area_name||void 0;case"text":return e.text||void 0;default:return}}(e,t)).filter(e=>!!e);return o.length>0?o.join(" "):t.entry_title}return"object"==typeof e?t.entry_title:String(e)}function Di(e){if(!e||"object"!=typeof e)return!1;const t=e.type;return"entry"===t||"area"===t||"text"===t&&"string"==typeof e.text}const Fi=new Set(["cover_day_night_shade","cover_dual_panel"]);function Bi(e,t){return null!=e&&!Number.isNaN(e)&&Math.abs(e-t)<=2}function Ri(e,t){return null!==t&&!Bi(e,t)}const ji=new Set(["opening","closing"]);function Ki(e){return!!e&&ji.has(e)}class Li{constructor(e){this.moves=new Map,this.timers=new Map,this.host=e,e.addController(this)}start(e,t){const o=this.timers.get(e);o&&clearTimeout(o),this.moves.set(e,t),this.timers.set(e,setTimeout(()=>this.clear(e),6e4)),this.host.requestUpdate()}get(e){return this.moves.get(e)??null}clear(e){const t=this.timers.get(e);t&&clearTimeout(t),this.timers.delete(e),this.moves.delete(e)&&this.host.requestUpdate()}settle(e){for(const[t,o]of[...this.moves])Bi(e(t),o)&&this.clear(t)}hostDisconnected(){for(const e of this.timers.values())clearTimeout(e);this.timers.clear(),this.moves.clear()}}function Gi(e){const{hass:t,liveFrac:o,pendingFrac:i,pending:s}=e,n=e.prefix??"",r=function(e,t){return{left:Math.min(e,t),width:Math.abs(t-e)}}(o,i),a=st("covers.moving_to",t,{pct:s}),l=""===n?"pending-marker":`${n}pending`;return H`<div
+      class=${`${n}travel`}
+      style="left:${r.left}%;width:${r.width}%"
+      ${$o(a)}
+    ></div>
+    <div
+      class=${l}
+      style="left:clamp(1px, ${i}%, calc(100% - 1px))"
+      ${$o(a)}
+    ></div>`}const Wi=a`
+  .travel,
+  .pos-travel {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    height: 100%;
+    pointer-events: none;
+    border-radius: inherit;
+    background: repeating-linear-gradient(
+      135deg,
+      var(
+          --acp-rail-accent,
+          var(--acp-cover-color, var(--acp-pos-fill-color, var(--primary-color)))
+        )
+        0 4px,
+      transparent 4px 8px
+    );
+    opacity: 0.45;
+    transition:
+      left 0.3s ease,
+      width 0.3s ease;
+  }
+  .pending-marker,
+  .pos-pending {
+    position: absolute;
+    top: 50%;
+    width: 8px;
+    height: 8px;
+    pointer-events: none;
+    background: var(
+      --acp-rail-accent,
+      var(--acp-cover-color, var(--acp-pos-fill-color, var(--primary-color)))
+    );
+    border: 1px solid var(--card-background-color, #fff);
+    transform: translate(-50%, -50%) rotate(45deg);
+    transition: left 0.3s ease;
+  }
+  /* The dense tile rails are 6px tall; a full-size pip would overhang them. */
+  .pos-pending {
+    width: 7px;
+    height: 7px;
+  }
+  .pos-travel {
+    background: repeating-linear-gradient(
+      135deg,
+      var(
+          --acp-rail-accent,
+          var(--acp-cover-color, var(--acp-pos-fill-color, var(--primary-color)))
+        )
+        0 3px,
+      transparent 3px 6px
+    );
+  }
+`;function Hi(e,t){if(!t)return!1;const o=e.states[t]?.attributes?.supported_features;return"number"==typeof o&&!!(128&o)}function Ui(e,t,o){return e.callService("switch",o?"turn_on":"turn_off",{},{entity_id:t})}const qi={position:"set_position",tilt:"set_tilt"};function Vi(e){const t=e.services;return!!t?.[Te]?.set_axes}function Yi(e,t,o,i){if(Vi(e)){const s={axes:o};return null!=i?.force&&(s.force=i.force),void e.callService(Te,"set_axes",s,{entity_id:t})}for(const[i,s]of Object.entries(o)){const o=qi[i];o&&e.callService(Te,o,{[i]:s},{entity_id:t})}}const Zi=3;const Qi=[15,30,60,120];let Xi=class extends de{constructor(){super(...arguments),this.open=!1,this.presets=[],this._onBackdrop=e=>{e.target===e.currentTarget&&this._emitClose()},this._emitClose=()=>{this.dispatchEvent(new CustomEvent("acp-extend-close",{bubbles:!0,composed:!0}))},this._stop=e=>{e.stopPropagation()}}updated(e){e.has("open")&&this.open&&(this._endMs=void 0)}render(){if(!this.open)return V;const e=this._t("dialog.extend.title","Extend manual override");return H`
       <div class="backdrop" data-open @click=${this._onBackdrop}>
         <div class="dialog" @click=${this._stop} role="dialog" aria-modal="true">
           <div class="title">${e}</div>
@@ -1086,7 +1149,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
           <div class="section">
             <div class="label">${this._t("dialog.extend.relative_label","Add time")}</div>
             <div class="chips">
-              ${Gi.map(e=>H`<button
+              ${Qi.map(e=>H`<button
                     class="rel"
                     type="button"
                     data-mins=${e}
@@ -1119,7 +1182,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
           </div>
         </div>
       </div>
-    `}_t(e,t){if(!this.hass)return t;const o=st(e,this.hass);return o===e?t:o}_presetLabel(e){const t=`forecast.event.${e.kind}`,o=this.hass?st(t,this.hass):t;return o===t?e.label??e.kind:o}_previewText(){if(void 0===this._endMs)return"";const e=new Date(this._endMs).toISOString(),t=dt(e),o=new Date(this._endMs).getDate()!==(new Date).getDate()?this._t("dialog.extend.tomorrow_suffix"," (tomorrow)"):"";return`${this._t("dialog.extend.preview","Override until {time}").replace("{time}",`${t}${o}`)} · ${ht(e,this.hass)}`}_pick(e){this._endMs=e}_addRelative(e){const t=this._endMs??this.currentEndMs??Date.now();this._endMs=t+6e4*e}_onTimeChange(e){const t=e.target.value;if(!t)return;const[o,i]=t.split(":").map(Number);if(Number.isNaN(o)||Number.isNaN(i))return;const s=new Date,n=new Date(s);n.setHours(o,i,0,0),n.getTime()<=s.getTime()&&n.setDate(n.getDate()+1),this._endMs=n.getTime()}_onConfirm(){void 0!==this._endMs&&this.dispatchEvent(new CustomEvent("acp-extend-confirm",{detail:{endMs:this._endMs},bubbles:!0,composed:!0}))}};function Hi(e){if(null==e||""===e)return null;if("number"!=typeof e&&"string"!=typeof e)return null;const t="number"==typeof e?e:Number(e);return Number.isFinite(t)?Math.max(0,Math.min(100,t)):null}function Ui(e,t){if(!e||0===t.length)return[];const o=e.entities;let i=null;const s=()=>{const t=new Map;if(!o)return t;for(const[i,s]of Object.entries(o)){const o=s?.device_id;if(!o)continue;if(!i.startsWith("sensor."))continue;const n=e.states[i];if("battery"!==n?.attributes?.device_class)continue;const r=t.get(o);void 0!==r?null===Hi(e.states[r]?.state)&&null!==Hi(n.state)&&t.set(o,i):t.set(o,i)}return t},n=[];for(const r of t){const t=e.states[r];if(!t)continue;const a=Hi(t.attributes?.battery_level);if(null!==a){n.push({cover_id:r,source_id:r,level:a,charging:!0===t.attributes?.battery_charging});continue}const l=o?.[r]?.device_id;if(!l)continue;i??(i=s());const c=i.get(l);if(!c)continue;const d=e.states[c];n.push({cover_id:r,source_id:c,level:Hi(d?.state),charging:!0===d?.attributes?.battery_charging})}return n}function qi(e){return!!e&&(null===e.level||e.level<=20)}function Vi(e){let t=null;for(const o of e)t?null===o.level?t=null===t.level?t:o:null!==t.level&&o.level<t.level&&(t=o):t=o;return t}function Yi(e,t=!1){if(null===e)return"mdi:battery-alert-variant-outline";const o=Math.max(0,Math.min(10,Math.floor(e/10)));return 10===o?t?"mdi:battery-charging-100":"mdi:battery":0===o?t?"mdi:battery-charging-10":"mdi:battery-outline":t?"mdi:battery-charging-"+10*o:"mdi:battery-"+10*o}function Zi(e,t,o){return e.filter(e=>"off"===e||"group"===e||("solar"===e?function(e){return e.solarMatched&&!e.cloudIsWinner}(o)&&!1!==t?.solar:!1!==t?.[e]))}function Qi(e){return!!e&&e.some(e=>e.matched&&"solar"===ki(e.handler))}function Xi(e){const t=new Set;if(!e)return t;for(const o of e){if(!o.matched)continue;const e=ki(o.handler);Ie.includes(e)&&t.add(e)}return t}function Ji(e){return"cloud"===ki(e)}function es(e){if(!1===e.integrationEnabled)return"off";const t=ki(e.winner);return e.manualActive&&"force"!==t&&"custom_position"!==t?"manual":je[t]??"auto"}function ts(e,t){return{solarMatched:Qi(e),cloudIsWinner:Ji(t)}}Wi.styles=a`
+    `}_t(e,t){if(!this.hass)return t;const o=st(e,this.hass);return o===e?t:o}_presetLabel(e){const t=`forecast.event.${e.kind}`,o=this.hass?st(t,this.hass):t;return o===t?e.label??e.kind:o}_previewText(){if(void 0===this._endMs)return"";const e=new Date(this._endMs).toISOString(),t=dt(e),o=new Date(this._endMs).getDate()!==(new Date).getDate()?this._t("dialog.extend.tomorrow_suffix"," (tomorrow)"):"";return`${this._t("dialog.extend.preview","Override until {time}").replace("{time}",`${t}${o}`)} · ${ht(e,this.hass)}`}_pick(e){this._endMs=e}_addRelative(e){const t=this._endMs??this.currentEndMs??Date.now();this._endMs=t+6e4*e}_onTimeChange(e){const t=e.target.value;if(!t)return;const[o,i]=t.split(":").map(Number);if(Number.isNaN(o)||Number.isNaN(i))return;const s=new Date,n=new Date(s);n.setHours(o,i,0,0),n.getTime()<=s.getTime()&&n.setDate(n.getDate()+1),this._endMs=n.getTime()}_onConfirm(){void 0!==this._endMs&&this.dispatchEvent(new CustomEvent("acp-extend-confirm",{detail:{endMs:this._endMs},bubbles:!0,composed:!0}))}};function Ji(e){if(null==e||""===e)return null;if("number"!=typeof e&&"string"!=typeof e)return null;const t="number"==typeof e?e:Number(e);return Number.isFinite(t)?Math.max(0,Math.min(100,t)):null}function es(e,t){if(!e||0===t.length)return[];const o=e.entities;let i=null;const s=()=>{const t=new Map;if(!o)return t;for(const[i,s]of Object.entries(o)){const o=s?.device_id;if(!o)continue;if(!i.startsWith("sensor."))continue;const n=e.states[i];if("battery"!==n?.attributes?.device_class)continue;const r=t.get(o);void 0!==r?null===Ji(e.states[r]?.state)&&null!==Ji(n.state)&&t.set(o,i):t.set(o,i)}return t},n=[];for(const r of t){const t=e.states[r];if(!t)continue;const a=Ji(t.attributes?.battery_level);if(null!==a){n.push({cover_id:r,source_id:r,level:a,charging:!0===t.attributes?.battery_charging});continue}const l=o?.[r]?.device_id;if(!l)continue;i??(i=s());const c=i.get(l);if(!c)continue;const d=e.states[c];n.push({cover_id:r,source_id:c,level:Ji(d?.state),charging:!0===d?.attributes?.battery_charging})}return n}function ts(e){return!!e&&(null===e.level||e.level<=20)}function os(e){let t=null;for(const o of e)t?null===o.level?t=null===t.level?t:o:null!==t.level&&o.level<t.level&&(t=o):t=o;return t}function is(e,t=!1){if(null===e)return"mdi:battery-alert-variant-outline";const o=Math.max(0,Math.min(10,Math.floor(e/10)));return 10===o?t?"mdi:battery-charging-100":"mdi:battery":0===o?t?"mdi:battery-charging-10":"mdi:battery-outline":t?"mdi:battery-charging-"+10*o:"mdi:battery-"+10*o}function ss(e,t,o){return e.filter(e=>"off"===e||"group"===e||("solar"===e?function(e){return e.solarMatched&&!e.cloudIsWinner}(o)&&!1!==t?.solar:!1!==t?.[e]))}function ns(e){return!!e&&e.some(e=>e.matched&&"solar"===Ai(e.handler))}function rs(e){const t=new Set;if(!e)return t;for(const o of e){if(!o.matched)continue;const e=Ai(o.handler);Ie.includes(e)&&t.add(e)}return t}function as(e){return"cloud"===Ai(e)}function ls(e){if(!1===e.integrationEnabled)return"off";const t=Ai(e.winner);return e.manualActive&&"force"!==t&&"custom_position"!==t?"manual":je[t]??"auto"}function cs(e,t){return{solarMatched:ns(e),cloudIsWinner:as(t)}}Xi.styles=a`
     .backdrop {
       position: fixed;
       inset: 0;
@@ -1207,17 +1270,17 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
       opacity: 0.4;
       cursor: default;
     }
-  `,e([ge({attribute:!1})],Wi.prototype,"hass",void 0),e([ge({type:Boolean})],Wi.prototype,"open",void 0),e([ge({attribute:!1})],Wi.prototype,"presets",void 0),e([ge({type:Number,attribute:!1})],Wi.prototype,"currentEndMs",void 0),e([me()],Wi.prototype,"_endMs",void 0),Wi=e([pe("acp-extend-override-dialog")],Wi);const os=new Set(["group_scene","group_lock","solar","default","motion"]);function is(e){if(!e)return[];const t=new Set;for(const o of Object.values(e)){if(!o)continue;const e=ki(o);os.has(e)||e in je&&t.add(e)}return Ie.filter(e=>t.has(e))}let ss=class extends de{constructor(){super(...arguments),this.winner="default",this.compact=!1,this.integrationEnabled=!0,this.manualActive=!1,this.safetyActive=!1,this.resumable=!1,this.extendable=!1}render(){const e=this._kind(),t="custom_position"===e&&this.safetyActive,o=t?Ke.force:Ke[e],i=this.hass?st(Ge[e],this.hass):Ke[e].label,s=t?this.hass?st("badge.safety",this.hass):"Safety":this._label(e,i),n=t?We.force:We[e],r=this._hint(e,t);if(this.extendable){const t=this.hass?st("tile.extend_aria",this.hass):"Extend manual override",i=this.hass?st("tile.resume_aria",this.hass):"Resume automatic control",a=!!n&&!this.compact;return H`<span
+  `,e([ge({attribute:!1})],Xi.prototype,"hass",void 0),e([ge({type:Boolean})],Xi.prototype,"open",void 0),e([ge({attribute:!1})],Xi.prototype,"presets",void 0),e([ge({type:Number,attribute:!1})],Xi.prototype,"currentEndMs",void 0),e([me()],Xi.prototype,"_endMs",void 0),Xi=e([pe("acp-extend-override-dialog")],Xi);const ds=new Set(["group_scene","group_lock","solar","default","motion"]);function hs(e){if(!e)return[];const t=new Set;for(const o of Object.values(e)){if(!o)continue;const e=Ai(o);ds.has(e)||e in je&&t.add(e)}return Ie.filter(e=>t.has(e))}let ps=class extends de{constructor(){super(...arguments),this.winner="default",this.compact=!1,this.integrationEnabled=!0,this.manualActive=!1,this.safetyActive=!1,this.resumable=!1,this.extendable=!1}render(){const e=this._kind(),t="custom_position"===e&&this.safetyActive,o=t?Le.force:Le[e],i=this.hass?st(Ge[e],this.hass):Le[e].label,s=t?this.hass?st("badge.safety",this.hass):"Safety":this._label(e,i),n=t?We.force:We[e],r=this._hint(e,t);if(this.extendable){const t=this.hass?st("tile.extend_aria",this.hass):"Extend manual override",i=this.hass?st("tile.resume_aria",this.hass):"Resume automatic control",a=!!n&&!this.compact;return H`<span
         class="badge kind-${e} has-actions"
         style="background:${o.bg};color:${o.fg};"
         part="badge"
       >
         ${a?H`<ha-icon class="badge-icon" icon=${n}></ha-icon>`:V}
-        <span class="badge-label" ${r?xo(r):V}>${s}</span>
+        <span class="badge-label" ${r?$o(r):V}>${s}</span>
         <button
           class="act extend"
           type="button"
-          ${xo(t)}
+          ${$o(t)}
           aria-label=${t}
           @click=${this._onExtendClick}
           @pointerdown=${this._stop}
@@ -1227,7 +1290,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
         ${this.resumable?H`<button
               class="act resume"
               type="button"
-              ${xo(i)}
+              ${$o(i)}
               aria-label=${i}
               @click=${this._onResumeClick}
               @pointerdown=${this._stop}
@@ -1239,7 +1302,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
         style="background:${o.bg};color:${o.fg};"
         part="badge"
         type="button"
-        ${xo(i)}
+        ${$o(i)}
         aria-label=${t}
         @click=${this._onResumeClick}
         @pointerdown=${this._stop}
@@ -1249,9 +1312,9 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
       class="badge kind-${e}"
       style="background:${o.bg};color:${o.fg};"
       part="badge"
-      ${r?xo(r):V}
+      ${r?$o(r):V}
       >${a}</span
-    >`}_hint(e,t){if(t)return this._tip("safety");if("manual"===e){const e=this.manualEndIso?dt(this.manualEndIso):null;return e&&"—"!==e?this._tip("manual_until",{time:e}):this._tip("manual")}return"custom_position"===e?this._customPositionHint():"group"===e&&void 0!==this.groupCount&&void 0!==this.groupTotal?st("group.who_won",this.hass,{count:this.groupCount,total:this.groupTotal}):this._tip(e)}_customPositionHint(){const e=[this._tip("custom_position")],t=this.slotName??(void 0!==this.slotNumber?`#${this.slotNumber}`:null);return t&&e.push(this._tip("custom_position_slot",{name:t})),void 0!==this.pct&&null!==this.pct&&e.push(this._tip("custom_position_value",{pct:Math.round(this.pct)})),!0===this.minimumMode&&e.push(this._tip("custom_position_floor")),e.filter(e=>null!==e).join(" ")}_tip(e,t){const o=`badge.tip.${e}`,i=st(o,this.hass,t);return i===o?null:i}_stop(e){e.stopPropagation()}_onResumeClick(e){e.stopPropagation(),this.dispatchEvent(new CustomEvent("acp-resume",{bubbles:!0,composed:!0}))}_onExtendClick(e){e.stopPropagation(),this.dispatchEvent(new CustomEvent("acp-extend",{bubbles:!0,composed:!0}))}_kind(){return this.kindOverride??es({winner:this.winner,integrationEnabled:this.integrationEnabled,manualActive:this.manualActive})}_label(e,t){return"manual"===e?this.manualEndIso?dt(this.manualEndIso):t:"custom_position"===e?`${this.slotName?this.slotName:void 0!==this.slotNumber?`${t} #${this.slotNumber}`:t}${void 0!==this.pct&&null!==this.pct?` · ${Math.round(this.pct)}%`:""}${!0===this.minimumMode?this.hass?st("badge.floor_suffix",this.hass):" ↥":""}`:"group"===e?void 0===this.groupCount||void 0===this.groupTotal?t:`${this.groupCount}/${this.groupTotal}`:t}};ss.styles=a`
+    >`}_hint(e,t){if(t)return this._tip("safety");if("manual"===e){const e=this.manualEndIso?dt(this.manualEndIso):null;return e&&"—"!==e?this._tip("manual_until",{time:e}):this._tip("manual")}return"custom_position"===e?this._customPositionHint():"group"===e&&void 0!==this.groupCount&&void 0!==this.groupTotal?st("group.who_won",this.hass,{count:this.groupCount,total:this.groupTotal}):this._tip(e)}_customPositionHint(){const e=[this._tip("custom_position")],t=this.slotName??(void 0!==this.slotNumber?`#${this.slotNumber}`:null);return t&&e.push(this._tip("custom_position_slot",{name:t})),void 0!==this.pct&&null!==this.pct&&e.push(this._tip("custom_position_value",{pct:Math.round(this.pct)})),!0===this.minimumMode&&e.push(this._tip("custom_position_floor")),e.filter(e=>null!==e).join(" ")}_tip(e,t){const o=`badge.tip.${e}`,i=st(o,this.hass,t);return i===o?null:i}_stop(e){e.stopPropagation()}_onResumeClick(e){e.stopPropagation(),this.dispatchEvent(new CustomEvent("acp-resume",{bubbles:!0,composed:!0}))}_onExtendClick(e){e.stopPropagation(),this.dispatchEvent(new CustomEvent("acp-extend",{bubbles:!0,composed:!0}))}_kind(){return this.kindOverride??ls({winner:this.winner,integrationEnabled:this.integrationEnabled,manualActive:this.manualActive})}_label(e,t){return"manual"===e?this.manualEndIso?dt(this.manualEndIso):t:"custom_position"===e?`${this.slotName?this.slotName:void 0!==this.slotNumber?`${t} #${this.slotNumber}`:t}${void 0!==this.pct&&null!==this.pct?` · ${Math.round(this.pct)}%`:""}${!0===this.minimumMode?this.hass?st("badge.floor_suffix",this.hass):" ↥":""}`:"group"===e?void 0===this.groupCount||void 0===this.groupTotal?t:`${this.groupCount}/${this.groupTotal}`:t}};var us;ps.styles=a`
     :host {
       display: inline-flex;
     }
@@ -1394,12 +1457,12 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
     :host([compact]) .badge-icon {
       --mdc-icon-size: 12px;
     }
-  `,e([ge({attribute:!1})],ss.prototype,"hass",void 0),e([ge()],ss.prototype,"winner",void 0),e([ge({attribute:"manual-end-iso"})],ss.prototype,"manualEndIso",void 0),e([ge({type:Number,attribute:"slot-number"})],ss.prototype,"slotNumber",void 0),e([ge({attribute:"slot-name"})],ss.prototype,"slotName",void 0),e([ge({type:Number})],ss.prototype,"pct",void 0),e([ge({type:Boolean,attribute:"minimum-mode"})],ss.prototype,"minimumMode",void 0),e([ge({type:Boolean,reflect:!0})],ss.prototype,"compact",void 0),e([ge({type:Boolean,attribute:"integration-enabled"})],ss.prototype,"integrationEnabled",void 0),e([ge({type:Boolean,attribute:"manual-active"})],ss.prototype,"manualActive",void 0),e([ge({type:Boolean,attribute:"safety-active"})],ss.prototype,"safetyActive",void 0),e([ge({attribute:"kind-override"})],ss.prototype,"kindOverride",void 0),e([ge({type:Number,attribute:"group-count"})],ss.prototype,"groupCount",void 0),e([ge({type:Number,attribute:"group-total"})],ss.prototype,"groupTotal",void 0),e([ge({type:Boolean,reflect:!0})],ss.prototype,"resumable",void 0),e([ge({type:Boolean,reflect:!0})],ss.prototype,"extendable",void 0),ss=e([pe("acp-tile-badge")],ss);let ns=class extends de{constructor(){super(...arguments),this.actual=null,this.target=null,this.coverColor=null,this.compact=!1,this.disabled=!1,this.layout="cover",this.label=null,this.min=0,this.max=100,this.unit="%",this.hintKey=null,this.targetHintKey=null,this._dragValue=null,this.openBlocksSun=!0,this._onPointerDown=e=>{if(this.disabled)return;const t=e.currentTarget;t.setPointerCapture?.(e.pointerId),this._dragValue=this._valueFromEvent(e,t)},this._onPointerMove=e=>{this.disabled||null===this._dragValue||(this._dragValue=this._valueFromEvent(e,e.currentTarget))},this._onPointerEnd=()=>{this._dragValue=null}}_frac(e){if(null==e||Number.isNaN(e))return 0;const t=this.max-this.min;if(0===t)return 0;const o=(e-this.min)/t*100,i=Math.max(0,Math.min(100,o));return this.openBlocksSun?i:100-i}render(){if(!this.hass)return V;const e=null!==this._dragValue,t=this._dragValue??this.actual,o=this._frac(t),i=this._frac(this.target),s=this.label??st("covers.tilt_title",this.hass);return H`
+  `,e([ge({attribute:!1})],ps.prototype,"hass",void 0),e([ge()],ps.prototype,"winner",void 0),e([ge({attribute:"manual-end-iso"})],ps.prototype,"manualEndIso",void 0),e([ge({type:Number,attribute:"slot-number"})],ps.prototype,"slotNumber",void 0),e([ge({attribute:"slot-name"})],ps.prototype,"slotName",void 0),e([ge({type:Number})],ps.prototype,"pct",void 0),e([ge({type:Boolean,attribute:"minimum-mode"})],ps.prototype,"minimumMode",void 0),e([ge({type:Boolean,reflect:!0})],ps.prototype,"compact",void 0),e([ge({type:Boolean,attribute:"integration-enabled"})],ps.prototype,"integrationEnabled",void 0),e([ge({type:Boolean,attribute:"manual-active"})],ps.prototype,"manualActive",void 0),e([ge({type:Boolean,attribute:"safety-active"})],ps.prototype,"safetyActive",void 0),e([ge({attribute:"kind-override"})],ps.prototype,"kindOverride",void 0),e([ge({type:Number,attribute:"group-count"})],ps.prototype,"groupCount",void 0),e([ge({type:Number,attribute:"group-total"})],ps.prototype,"groupTotal",void 0),e([ge({type:Boolean,reflect:!0})],ps.prototype,"resumable",void 0),e([ge({type:Boolean,reflect:!0})],ps.prototype,"extendable",void 0),ps=e([pe("acp-tile-badge")],ps);let _s=us=class extends de{constructor(){super(...arguments),this.actual=null,this.target=null,this.coverColor=null,this.compact=!1,this.disabled=!1,this.layout="cover",this.label=null,this.min=0,this.max=100,this.unit="%",this.hintKey=null,this.targetHintKey=null,this._dragValue=null,this.movingTo=null,this._pending=new Li(this),this.openBlocksSun=!0,this._onPointerDown=e=>{if(this.disabled)return;const t=e.currentTarget;t.setPointerCapture?.(e.pointerId),this._dragValue=this._valueFromEvent(e,t)},this._onPointerMove=e=>{this.disabled||null===this._dragValue||(this._dragValue=this._valueFromEvent(e,e.currentTarget))},this._onPointerEnd=()=>{this._dragValue=null}}updated(e){e.has("actual")&&this._pending.settle(()=>this.actual)}_frac(e){if(null==e||Number.isNaN(e))return 0;const t=this.max-this.min;if(0===t)return 0;const o=(e-this.min)/t*100,i=Math.max(0,Math.min(100,o));return this.openBlocksSun?i:100-i}render(){if(!this.hass)return V;const e=null!==this._dragValue,t=this._dragValue??this.actual,o=this._frac(t),i=this._frac(this.target),s=e?null:this._pending.get(us.PENDING_KEY)??this.movingTo,n=Ri(t,s)?s:null,r=null===n?null:this._frac(n),a=this.label??st("covers.tilt_title",this.hass);return H`
       <div
         class="row ${this.layout}"
         style=${this.coverColor?`--acp-cover-color:${this.coverColor}`:V}
       >
-        <span class="label">${s}</span>
+        <span class="label">${a}</span>
         <span class="num">${nt(t)}</span>
         <div
           class="track ${this.disabled?"disabled":""}${e?" dragging":""}"
@@ -1410,36 +1473,37 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
           aria-valuemax=${this.max}
           aria-valuenow=${null===t?this.min:this.openBlocksSun?t:this.min+this.max-t}
           aria-valuetext=${nt(t)}
-          aria-label=${s}
+          aria-label=${a}
           @click=${this._onClick}
           @pointerdown=${this._onPointerDown}
           @pointermove=${this._onPointerMove}
           @pointerup=${this._onPointerEnd}
           @pointercancel=${this._onPointerEnd}
           @keydown=${this._onKeydown}
-          ${xo(st(this.hintKey??"covers.tilt_click_to_set",this.hass))}
+          ${$o(st(this.hintKey??"covers.tilt_click_to_set",this.hass))}
         >
           <div class="fill" style="width:${o}%"></div>
           <div class="fill-closed" style="width:${100-o}%"></div>
+          ${null!==n&&null!==r?Gi({hass:this.hass,liveFrac:o,pendingFrac:r,pending:n}):V}
           ${null!==this.target?H`<div
                 class="marker"
                 style="left:clamp(1px, ${i}%, calc(100% - 1px))"
-                ${xo(st(this.targetHintKey??"covers.tilt_target_tooltip",this.hass,{pct:this.target}))}
+                ${$o(st(this.targetHintKey??"covers.tilt_target_tooltip",this.hass,{pct:this.target}))}
               ></div>`:V}
         </div>
       </div>
-    `}_valueFromEvent(e,t){const o=t.getBoundingClientRect(),i=(e.clientX-o.left)/o.width,s=this.openBlocksSun?i:1-i,n=this.min+s*(this.max-this.min);return this._clamp(n)}_clamp(e){return Math.max(this.min,Math.min(this.max,Math.round(e)))}_commit(e){this.dispatchEvent(new CustomEvent("acp-tilt-set",{detail:e,bubbles:!0,composed:!0}))}_onClick(e){this.disabled||this._commit(this._valueFromEvent(e,e.currentTarget))}_onKeydown(e){if(this.disabled)return;const t=this.openBlocksSun?1:-1,o=this.openBlocksSun?this.min:this.max,i=this.openBlocksSun?this.max:this.min,s=this.actual??o;let n;switch(e.key){case"ArrowRight":case"ArrowUp":n=s+t;break;case"ArrowLeft":case"ArrowDown":n=s-t;break;case"PageUp":n=s+10*t;break;case"PageDown":n=s-10*t;break;case"Home":n=o;break;case"End":n=i;break;default:return}e.preventDefault(),this._commit(this._clamp(n))}};function rs(e,t){const o=[],i=[];for(const s of Object.values(e))"number"!=typeof s||Number.isNaN(s)||(o.push(ft(s,t)),i.push(s));if(0===o.length)return null;o.sort((e,t)=>e-t),i.sort((e,t)=>e-t);const s=o.filter((e,t)=>0===t||e!==o[t-1]);return{min:o[0],max:o[o.length-1],ticks:s,readable:o.length,aligned:o[0]===o[o.length-1],logicalMin:i[0],logicalMax:i[i.length-1]}}ns.styles=a`
-    :host {
-      display: block;
-    }
-    .row {
-      display: grid;
-      align-items: center;
-    }
-    /* Cover-bar variant: mirror .cover's grid so the track + percentage line up
+    `}_valueFromEvent(e,t){const o=t.getBoundingClientRect(),i=(e.clientX-o.left)/o.width,s=this.openBlocksSun?i:1-i,n=this.min+s*(this.max-this.min);return this._clamp(n)}_clamp(e){return Math.max(this.min,Math.min(this.max,Math.round(e)))}_commit(e){this._pending.start(us.PENDING_KEY,e),this.dispatchEvent(new CustomEvent("acp-tilt-set",{detail:e,bubbles:!0,composed:!0}))}_onClick(e){this.disabled||this._commit(this._valueFromEvent(e,e.currentTarget))}_onKeydown(e){if(this.disabled)return;const t=this.openBlocksSun?1:-1,o=this.openBlocksSun?this.min:this.max,i=this.openBlocksSun?this.max:this.min,s=this.actual??o;let n;switch(e.key){case"ArrowRight":case"ArrowUp":n=s+t;break;case"ArrowLeft":case"ArrowDown":n=s-t;break;case"PageUp":n=s+10*t;break;case"PageDown":n=s-10*t;break;case"Home":n=o;break;case"End":n=i;break;default:return}e.preventDefault(),this._commit(this._clamp(n))}};function gs(e,t){const o=[],i=[];for(const s of Object.values(e))"number"!=typeof s||Number.isNaN(s)||(o.push(ft(s,t)),i.push(s));if(0===o.length)return null;o.sort((e,t)=>e-t),i.sort((e,t)=>e-t);const s=o.filter((e,t)=>0===t||e!==o[t-1]);return{min:o[0],max:o[o.length-1],ticks:s,readable:o.length,aligned:o[0]===o[o.length-1],logicalMin:i[0],logicalMax:i[i.length-1]}}_s.PENDING_KEY="axis",_s.styles=[Wi,a`
+      :host {
+        display: block;
+      }
+      .row {
+        display: grid;
+        align-items: center;
+      }
+      /* Cover-bar variant: mirror .cover's grid so the track + percentage line up
        with the Position row directly above (name | num | track | warn-spacer). */
-    .row.cover {
-      /* Must stay identical to acp-cover-bar's .cover grid — these are two
+      .row.cover {
+        /* Must stay identical to acp-cover-bar's .cover grid — these are two
          separate grids stacked in one .cover-group, so any divergence offsets
          this track from the position track directly above it. Fixed, not
          minmax: an auto track resolves per-grid to its own content.
@@ -1448,89 +1512,97 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
          no counterpart — the button drives the POSITION axis, and a tilt target
          is a separate value — so the column is present here purely as a spacer
          to keep the two tracks aligned. */
-      grid-template-columns: minmax(80px, 1fr) 11ch 3fr 22px 16px;
-      gap: 8px;
-      font-size: 0.82rem;
-    }
-    :host([compact]) .row.cover {
-      gap: 6px;
-      font-size: 0.75rem;
-    }
-    /* Tile variant: inline "TILT 35% [track]" — label then % then the bar. */
-    .row.tile {
-      grid-template-columns: auto auto 1fr;
-      gap: 6px;
-      font-size: 0.75rem;
-    }
-    .label {
-      letter-spacing: 0.05em;
-      text-transform: uppercase;
-      color: var(--secondary-text-color);
-    }
-    .num {
-      font-variant-numeric: tabular-nums;
-      color: var(--secondary-text-color);
-    }
-    .row.cover .num {
-      text-align: right;
-    }
-    /* Track mirrors the position bar: the LEADING segment carries the
+        grid-template-columns: minmax(80px, 1fr) 11ch 3fr 22px 16px;
+        gap: 8px;
+        font-size: 0.82rem;
+      }
+      :host([compact]) .row.cover {
+        gap: 6px;
+        font-size: 0.75rem;
+      }
+      /* Tile variant: inline "TILT 35% [track]" — label then % then the bar. */
+      .row.tile {
+        grid-template-columns: auto auto 1fr;
+        gap: 6px;
+        font-size: 0.75rem;
+      }
+      .label {
+        letter-spacing: 0.05em;
+        text-transform: uppercase;
+        color: var(--secondary-text-color);
+      }
+      .num {
+        font-variant-numeric: tabular-nums;
+        color: var(--secondary-text-color);
+      }
+      .row.cover .num {
+        text-align: right;
+      }
+      /* Track mirrors the position bar: the LEADING segment carries the
        sun-blocking portion and is solid, the trailing clear portion is pale —
        same hue as the cover wedge. The leading segment is sized from the drawn
        fraction, so on a mirrored axis it is the closed end. */
-    .track {
-      position: relative;
-      display: flex;
-      height: 10px;
-      background: var(--secondary-background-color, rgba(0, 0, 0, 0.08));
-      border-radius: 6px;
-      cursor: pointer;
-      overflow: hidden;
-      /* A touch-drag must move the fill, not scroll the page — own the gesture. */
-      touch-action: none;
-    }
-    .track:focus-visible {
-      outline: 2px solid var(--primary-color);
-      outline-offset: 2px;
-    }
-    /* The 0.3s ease below smooths server-driven updates; during a drag it would
+      .track {
+        position: relative;
+        display: flex;
+        height: 10px;
+        background: var(--secondary-background-color, rgba(0, 0, 0, 0.08));
+        border-radius: 6px;
+        cursor: pointer;
+        overflow: hidden;
+        /* A touch-drag must move the fill, not scroll the page — own the gesture. */
+        touch-action: none;
+      }
+      .track:focus-visible {
+        outline: 2px solid var(--primary-color);
+        outline-offset: 2px;
+      }
+      /* The 0.3s ease below smooths server-driven updates; during a drag it would
        read as the fill lagging behind the finger, so drop it for the gesture. */
-    .track.dragging .fill,
-    .track.dragging .fill-closed {
-      transition: none;
-    }
-    :host([compact]) .track,
-    .row.tile .track {
-      height: 6px;
-    }
-    /* Unavailable cover (issue #212): non-interactive track — no click-to-set,
+      .track.dragging .fill,
+      .track.dragging .fill-closed {
+        transition: none;
+      }
+      :host([compact]) .track,
+      .row.tile .track {
+        height: 6px;
+      }
+      /* Unavailable cover (issue #212): non-interactive track — no click-to-set,
        matching the up/stop/down controls disabled elsewhere on the tile. */
-    .track.disabled {
-      cursor: default;
-      touch-action: auto;
-    }
-    .fill {
-      height: 100%;
-      flex-shrink: 0;
-      background: color-mix(in srgb, var(--acp-cover-color, var(--primary-color)) 50%, transparent);
-      transition: width 0.3s ease;
-    }
-    .fill-closed {
-      height: 100%;
-      flex-shrink: 0;
-      background: color-mix(in srgb, var(--acp-cover-color, var(--primary-color)) 18%, transparent);
-      transition: width 0.3s ease;
-    }
-    .marker {
-      position: absolute;
-      top: -2px;
-      width: 2px;
-      height: 14px;
-      background: var(--accent-color, red);
-      transform: translateX(-50%);
-      transition: left 0.3s ease;
-    }
-  `,e([ge({attribute:!1})],ns.prototype,"hass",void 0),e([ge({attribute:!1})],ns.prototype,"actual",void 0),e([ge({attribute:!1})],ns.prototype,"target",void 0),e([ge({attribute:!1})],ns.prototype,"coverColor",void 0),e([ge({type:Boolean,reflect:!0})],ns.prototype,"compact",void 0),e([ge({type:Boolean,reflect:!0})],ns.prototype,"disabled",void 0),e([ge({reflect:!0})],ns.prototype,"layout",void 0),e([ge({attribute:!1})],ns.prototype,"label",void 0),e([ge({type:Number})],ns.prototype,"min",void 0),e([ge({type:Number})],ns.prototype,"max",void 0),e([ge()],ns.prototype,"unit",void 0),e([ge({attribute:!1})],ns.prototype,"hintKey",void 0),e([ge({attribute:!1})],ns.prototype,"targetHintKey",void 0),e([me()],ns.prototype,"_dragValue",void 0),e([ge({type:Boolean})],ns.prototype,"openBlocksSun",void 0),ns=e([pe("acp-axis-bar")],ns),customElements.get("acp-tilt-bar")||customElements.define("acp-tilt-bar",class extends ns{});const as={status:"unknown",on:0,total:0};let ls=null,cs=null;function ds(e,t,o){if(!t||0===o.length)return as;const i=function(e){if(ls===e&&cs)return cs;const t=new Map;for(const o of e){if(o.platform!==Te)continue;const e=o.config_entry_id;if(!e)continue;const i=`${e}_`;if(!o.unique_id.startsWith(i))continue;const s=o.unique_id.slice(i.length),n=o.entity_id.split(".")[0],r=et[`${n}:${s}`];if("target_position_sensor"!==r&&"automatic_control_switch"!==r&&"integration_enabled_switch"!==r)continue;const a=t.get(e)??{};"target_position_sensor"===r?a.positionSensor=o.entity_id:"automatic_control_switch"===r?a.automaticControl=o.entity_id:a.integrationEnabled=o.entity_id,t.set(e,a)}return ls=e,cs=t,t}(t),s=new Map;for(const[t,o]of i){if(!o.positionSensor)continue;const i=e.states[o.positionSensor]?.attributes?.actual_positions;if(i)for(const e of Object.keys(i))s.set(e,t)}const n=new Map;let r=0,a=0;for(const t of new Set(o)){const o=s.get(t);if(!o)continue;let l=n.get(o);void 0===l&&(l=hs(e,i.get(o)),n.set(o,l)),null!==l&&(a++,l&&r++)}return 0===a?as:{status:r===a?"all":0===r?"none":"some",on:r,total:a}}function hs(e,t){if(!t?.automaticControl)return null;const o=e.states[t.automaticControl];if(!o)return null;const i=!t.integrationEnabled||"off"!==e.states[t.integrationEnabled]?.state;return"on"===o.state&&i}const ps=["auto","all_open","all_closed","privacy"],us=["open","closed","mixed","unknown"];function _s(e,t){const o=t.entities,i=o.group_position_sensor?e.states[o.group_position_sensor]:void 0,s=i?parseFloat(i.state):NaN,n=i?.attributes?.member_positions??{},r=o.group_who_won_sensor?e.states[o.group_who_won_sensor]:void 0,a=r?.attributes?.member_winners,l=o.group_state_sensor?e.states[o.group_state_sensor]?.state??"unknown":"unknown",c=o.group_scene_select?e.states[o.group_scene_select]:void 0,d=c?.attributes?.current_option??c?.state??"auto",h=new Set;for(const t of Object.keys(n)){const o=e.states[t]?.attributes?.device_class;o&&h.add(o)}const p=o.group_cover,u=Bi(e,p);return{position:Number.isNaN(s)?null:s,memberPositions:n,rosterTotal:Object.keys(n).length,whoWonCount:r?parseInt(r.state,10):NaN,memberWinners:a,aggregate:us.includes(l)?l:"unknown",scene:ps.includes(d)?d:"auto",locked:!!o.group_lock_switch&&"on"===e.states[o.group_lock_switch]?.state,automationOn:!o.group_automation_switch||"on"===e.states[o.group_automation_switch]?.state,memberAutomation:ds(e,Io(),Object.keys(a??{})),lockId:o.group_lock_switch,automationId:o.group_automation_switch,clearId:o.group_clear_overrides_button,target:p??o.group_position_sensor,deviceClass:1===h.size?[...h][0]:void 0,tilt:p&&u?{entityId:p,value:e.states[p]?.attributes?.current_tilt_position??null}:void 0}}function gs(e,t){return ut({deviceClass:e.deviceClass,coverType:"",position:t})}const ms=new Set(["manual","force"]),vs=new Set(["force","weather","group_scene","manual","group_lock","custom_position"]);function fs(e,t,o){t.target&&function(e,t,o){const i={position:o};e.callService(Te,"group_set_position",i,{entity_id:t})}(e,t.target,o)}function bs(e,t,o){o.target&&function(e,t,o=[]){const i=e.services;i?.[Te]?.group_stop?e.callService(Te,"group_stop",{},{entity_id:t}):0!==o.length&&e.callService("cover","stop_cover",{},{entity_id:o})}(e,o.target,t.managed_covers??[])}function ys(e,t,o){t.tilt&&function(e,t,o){e.callService("cover","set_cover_tilt_position",{tilt_position:o},{entity_id:t})}(e,t.tilt.entityId,o)}let ws=class extends de{constructor(){super(...arguments),this.position=null,this.enabled=!0,this.labels="tile",this.compact=!1,this.fill=!1}render(){const e=null!==this.position&&this.position>=100,t=null!==this.position&&this.position<=0;return H`
+      .track.disabled {
+        cursor: default;
+        touch-action: auto;
+      }
+      .fill {
+        height: 100%;
+        flex-shrink: 0;
+        background: color-mix(
+          in srgb,
+          var(--acp-cover-color, var(--primary-color)) 50%,
+          transparent
+        );
+        transition: width 0.3s ease;
+      }
+      .fill-closed {
+        height: 100%;
+        flex-shrink: 0;
+        background: color-mix(
+          in srgb,
+          var(--acp-cover-color, var(--primary-color)) 18%,
+          transparent
+        );
+        transition: width 0.3s ease;
+      }
+      .marker {
+        position: absolute;
+        top: -2px;
+        width: 2px;
+        height: 14px;
+        background: var(--accent-color, red);
+        transform: translateX(-50%);
+        transition: left 0.3s ease;
+      }
+    `],e([ge({attribute:!1})],_s.prototype,"hass",void 0),e([ge({attribute:!1})],_s.prototype,"actual",void 0),e([ge({attribute:!1})],_s.prototype,"target",void 0),e([ge({attribute:!1})],_s.prototype,"coverColor",void 0),e([ge({type:Boolean,reflect:!0})],_s.prototype,"compact",void 0),e([ge({type:Boolean,reflect:!0})],_s.prototype,"disabled",void 0),e([ge({reflect:!0})],_s.prototype,"layout",void 0),e([ge({attribute:!1})],_s.prototype,"label",void 0),e([ge({type:Number})],_s.prototype,"min",void 0),e([ge({type:Number})],_s.prototype,"max",void 0),e([ge()],_s.prototype,"unit",void 0),e([ge({attribute:!1})],_s.prototype,"hintKey",void 0),e([ge({attribute:!1})],_s.prototype,"targetHintKey",void 0),e([me()],_s.prototype,"_dragValue",void 0),e([ge({attribute:!1})],_s.prototype,"movingTo",void 0),e([ge({type:Boolean})],_s.prototype,"openBlocksSun",void 0),_s=us=e([pe("acp-axis-bar")],_s),customElements.get("acp-tilt-bar")||customElements.define("acp-tilt-bar",class extends _s{});const ms={status:"unknown",on:0,total:0};let vs=null,fs=null;function bs(e,t,o){if(!t||0===o.length)return ms;const i=function(e){if(vs===e&&fs)return fs;const t=new Map;for(const o of e){if(o.platform!==Te)continue;const e=o.config_entry_id;if(!e)continue;const i=`${e}_`;if(!o.unique_id.startsWith(i))continue;const s=o.unique_id.slice(i.length),n=o.entity_id.split(".")[0],r=et[`${n}:${s}`];if("target_position_sensor"!==r&&"automatic_control_switch"!==r&&"integration_enabled_switch"!==r)continue;const a=t.get(e)??{};"target_position_sensor"===r?a.positionSensor=o.entity_id:"automatic_control_switch"===r?a.automaticControl=o.entity_id:a.integrationEnabled=o.entity_id,t.set(e,a)}return vs=e,fs=t,t}(t),s=new Map;for(const[t,o]of i){if(!o.positionSensor)continue;const i=e.states[o.positionSensor]?.attributes?.actual_positions;if(i)for(const e of Object.keys(i))s.set(e,t)}const n=new Map;let r=0,a=0;for(const t of new Set(o)){const o=s.get(t);if(!o)continue;let l=n.get(o);void 0===l&&(l=ys(e,i.get(o)),n.set(o,l)),null!==l&&(a++,l&&r++)}return 0===a?ms:{status:r===a?"all":0===r?"none":"some",on:r,total:a}}function ys(e,t){if(!t?.automaticControl)return null;const o=e.states[t.automaticControl];if(!o)return null;const i=!t.integrationEnabled||"off"!==e.states[t.integrationEnabled]?.state;return"on"===o.state&&i}const ws=["auto","all_open","all_closed","privacy"],xs=["open","closed","mixed","unknown"];function $s(e,t){const o=t.entities,i=o.group_position_sensor?e.states[o.group_position_sensor]:void 0,s=i?parseFloat(i.state):NaN,n=i?.attributes?.member_positions??{},r=o.group_who_won_sensor?e.states[o.group_who_won_sensor]:void 0,a=r?.attributes?.member_winners,l=o.group_state_sensor?e.states[o.group_state_sensor]?.state??"unknown":"unknown",c=o.group_scene_select?e.states[o.group_scene_select]:void 0,d=c?.attributes?.current_option??c?.state??"auto",h=new Set;for(const t of Object.keys(n)){const o=e.states[t]?.attributes?.device_class;o&&h.add(o)}const p=o.group_cover,u=Hi(e,p);return{position:Number.isNaN(s)?null:s,memberPositions:n,rosterTotal:Object.keys(n).length,whoWonCount:r?parseInt(r.state,10):NaN,memberWinners:a,aggregate:xs.includes(l)?l:"unknown",scene:ws.includes(d)?d:"auto",locked:!!o.group_lock_switch&&"on"===e.states[o.group_lock_switch]?.state,automationOn:!o.group_automation_switch||"on"===e.states[o.group_automation_switch]?.state,memberAutomation:bs(e,Po(),Object.keys(a??{})),lockId:o.group_lock_switch,automationId:o.group_automation_switch,clearId:o.group_clear_overrides_button,target:p??o.group_position_sensor,deviceClass:1===h.size?[...h][0]:void 0,tilt:p&&u?{entityId:p,value:e.states[p]?.attributes?.current_tilt_position??null}:void 0}}const ks=new Set(["group_scene","group_lock"]);function As(e,t,o){if(0===o.size)return t;const i={};for(const[e,s]of Object.entries(t.memberPositions))o.has(e)||(i[e]=s);let s;if(t.memberWinners){s={};for(const[e,i]of Object.entries(t.memberWinners))o.has(e)||(s[e]=i)}const n=Object.keys(i),r=n.map(e=>i[e]).filter(e=>null!==e),a=r.length?r.reduce((e,t)=>e+t,0)/r.length:null,l=new Set(n.map(t=>e.states[t]?.state)),c=1===l.size&&(l.has("open")||l.has("closed"))?[...l][0]:0===n.length?"unknown":"mixed",d=new Set;for(const t of n){const o=e.states[t]?.attributes?.device_class;o&&d.add(o)}return{...t,memberPositions:i,memberWinners:s,position:a,aggregate:c,rosterTotal:n.length,whoWonCount:Number.isNaN(t.whoWonCount)?t.whoWonCount:Object.values(s??{}).filter(e=>e&&ks.has(Ai(e))).length,memberAutomation:bs(e,Po(),Object.keys(s??{})),deviceClass:1===d.size?[...d][0]:void 0}}function Ss(e,t){return ut({deviceClass:e.deviceClass,coverType:"",position:t})}const Cs=new Set(["manual","force"]),Es=new Set(["force","weather","group_scene","manual","group_lock","custom_position"]);function zs(e,t,o){t.target&&function(e,t,o){const i={position:o};e.callService(Te,"group_set_position",i,{entity_id:t})}(e,t.target,o)}function Ms(e,t,o){o.target&&function(e,t,o=[]){const i=e.services;i?.[Te]?.group_stop?e.callService(Te,"group_stop",{},{entity_id:t}):0!==o.length&&e.callService("cover","stop_cover",{},{entity_id:o})}(e,o.target,t.managed_covers??[])}function Ts(e,t,o){t.tilt&&function(e,t,o){e.callService("cover","set_cover_tilt_position",{tilt_position:o},{entity_id:t})}(e,t.tilt.entityId,o)}const Is=new Map;function Ps(e,t,o){return function(e,t){const o=[],i=new Map;for(const s of e){const e=t(s);if(!e){o.push({entryId:null,covers:[s]});continue}const n=i.get(e);if(n){n.covers.push(s);continue}const r={entryId:e,covers:[s]};i.set(e,r),o.push(r)}return o}(t,t=>{const i=Bo(e,t,o);return i?(Is.set(t,i),i):Is.get(t)??null})}function Os(){let e=null,t=null,o=[];return(i,s,n)=>{const r=s.join("|");return e===r&&t===n&&o.length>0||(e=r,t=n,o=Ps(i,s,n)),o}}function Ns(e){return e.entryId??`generic:${e.covers[0]}`}function Ds(e){return e.entryId??e.covers[0]}function Fs(e,t){const o=new Set;if(!Bs(e,t))return o;const i=new Set(t);for(const t of e)i.has(t)||o.add(t);return o}function Bs(e,t){if(!t?.length)return!1;const o=new Set(e);return t.some(e=>o.has(e))}function Rs(e,t){if(!Bs(e.flatMap(e=>e.covers),t))return e;const o=new Map(t.map((e,t)=>[e,t])),i=[];for(const t of e){const e=t.covers.filter(e=>o.has(e));0!==e.length&&i.push({row:{...t,covers:e},at:Math.min(...e.map(e=>o.get(e)))})}return i.sort((e,t)=>e.at-t.at).map(e=>e.row)}let js=class extends de{constructor(){super(...arguments),this.position=null,this.enabled=!0,this.labels="tile",this.compact=!1,this.fill=!1}render(){const e=null!==this.position&&this.position>=100,t=null!==this.position&&this.position<=0;return H`
       <div class="move-buttons">
         <button
           class="up"
@@ -1560,7 +1632,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
           <ha-icon icon=${gt(this.deviceClass)}></ha-icon>
         </button>
       </div>
-    `}_emit(e){this.dispatchEvent(new CustomEvent("acp-move",{detail:e,bubbles:!0,composed:!0}))}};ws.styles=a`
+    `}_emit(e){this.dispatchEvent(new CustomEvent("acp-move",{detail:e,bubbles:!0,composed:!0}))}};js.styles=a`
     :host {
       display: contents;
     }
@@ -1629,14 +1701,14 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
       opacity: 0.4;
       cursor: not-allowed;
     }
-  `,e([ge({attribute:!1})],ws.prototype,"hass",void 0),e([ge({attribute:!1})],ws.prototype,"position",void 0),e([ge({attribute:!1})],ws.prototype,"deviceClass",void 0),e([ge({type:Boolean})],ws.prototype,"enabled",void 0),e([ge()],ws.prototype,"labels",void 0),e([ge({type:Boolean,reflect:!0})],ws.prototype,"compact",void 0),e([ge({type:Boolean,reflect:!0})],ws.prototype,"fill",void 0),ws=e([pe("acp-cover-move-buttons")],ws);const xs={all:"mdi:robot",some:"mdi:robot-outline",none:"mdi:robot-off"};let $s=class extends de{constructor(){super(...arguments),this.showSceneSelect=!0,this.showLock=!0,this.showAutomation=!0,this.showClearOverrides=!0}render(){if(!this.hass||!this.discovered||!this.snapshot)return V;const e=this.snapshot,t=this.showClearOverrides?e.clearId:void 0,o=this.showLock&&!!e.lockId,i=this.showAutomation&&!!e.automationId,s=this.showSceneSelect&&!!this.discovered.entities.group_scene_select;if(!(s||o||i||t))return V;const n=function(e){if(!e)return!0;const t=Object.values(e);return 0!==t.length&&t.some(e=>!e||vs.has(ki(e)))}(e.memberWinners);return H`
+  `,e([ge({attribute:!1})],js.prototype,"hass",void 0),e([ge({attribute:!1})],js.prototype,"position",void 0),e([ge({attribute:!1})],js.prototype,"deviceClass",void 0),e([ge({type:Boolean})],js.prototype,"enabled",void 0),e([ge()],js.prototype,"labels",void 0),e([ge({type:Boolean,reflect:!0})],js.prototype,"compact",void 0),e([ge({type:Boolean,reflect:!0})],js.prototype,"fill",void 0),js=e([pe("acp-cover-move-buttons")],js);const Ks={all:"mdi:robot",some:"mdi:robot-outline",none:"mdi:robot-off"};let Ls=class extends de{constructor(){super(...arguments),this.showSceneSelect=!0,this.showLock=!0,this.showAutomation=!0,this.showClearOverrides=!0}render(){if(!this.hass||!this.discovered||!this.snapshot)return V;const e=this.snapshot,t=this.showClearOverrides?e.clearId:void 0,o=this.showLock&&!!e.lockId,i=this.showAutomation&&!!e.automationId,s=this.showSceneSelect&&!!this.discovered.entities.group_scene_select;if(!(s||o||i||t))return V;const n=function(e){if(!e)return!0;const t=Object.values(e);return 0!==t.length&&t.some(e=>!e||Es.has(Ai(e)))}(e.memberWinners);return H`
       <div class="group-row" @click=${this._stop} @pointerdown=${this._stop} @keydown=${this._stop}>
         ${s?H`<select
               class="scene-select"
               aria-label=${st("group.scene",this.hass)}
               @change=${this._onSceneChange}
             >
-              ${ps.map(t=>H`<option value=${t} ?selected=${t===e.scene}>
+              ${ws.map(t=>H`<option value=${t} ?selected=${t===e.scene}>
                     ${st(`group.scene_${t}`,this.hass)}
                   </option>`)}
             </select>`:V}
@@ -1645,8 +1717,8 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
               type="button"
               aria-pressed=${e.locked?"true":"false"}
               aria-label=${st(e.locked?"group.unlock":"group.lock",this.hass)}
-              ${xo(st(e.locked?"group.unlock":"group.lock",this.hass))}
-              @click=${()=>function(e,t,o){const i=t.entities.group_lock_switch;i&&Fi(e,i,!o)}(this.hass,this.discovered,e.locked)}
+              ${$o(st(e.locked?"group.unlock":"group.lock",this.hass))}
+              @click=${()=>function(e,t,o){const i=t.entities.group_lock_switch;i&&Ui(e,i,!o)}(this.hass,this.discovered,e.locked)}
             >
               <ha-icon icon=${e.locked?"mdi:lock":"mdi:lock-open-variant"}></ha-icon>
             </button>`:V}
@@ -1656,22 +1728,22 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
               type="button"
               aria-label=${st("group.clear_overrides",this.hass)}
               ?disabled=${!n}
-              ${xo(st(n?"group.clear_overrides":"group.clear_overrides_none",this.hass))}
+              ${$o(st(n?"group.clear_overrides":"group.clear_overrides_none",this.hass))}
               @click=${()=>{return e=this.hass,o=t,void e.callService("button","press",{},{entity_id:o});var e,o}}
             >
               <ha-icon icon="mdi:backup-restore"></ha-icon>
             </button>`:V}
       </div>
-    `}_automationView(e){const t=st("group.automation",this.hass),o=e.memberAutomation.status;if("unknown"===o)return{cls:e.automationOn?"active":"",icon:e.automationOn?xs.all:xs.none,ariaPressed:e.automationOn?"true":"false",label:t,on:e.automationOn};const i="all"===o,s=st("group.automation_count",this.hass,{count:e.memberAutomation.on,total:e.memberAutomation.total});return{cls:`auto-${o}`,icon:xs[o],ariaPressed:"some"===o?"mixed":i?"true":"false",label:`${t} — ${s}`,on:i}}_automationButton(e){return H`<button
+    `}_automationView(e){const t=st("group.automation",this.hass),o=e.memberAutomation.status;if("unknown"===o)return{cls:e.automationOn?"active":"",icon:e.automationOn?Ks.all:Ks.none,ariaPressed:e.automationOn?"true":"false",label:t,on:e.automationOn};const i="all"===o,s=st("group.automation_count",this.hass,{count:e.memberAutomation.on,total:e.memberAutomation.total});return{cls:`auto-${o}`,icon:Ks[o],ariaPressed:"some"===o?"mixed":i?"true":"false",label:`${t} — ${s}`,on:i}}_automationButton(e){return H`<button
       class="ctrl automation-toggle ${e.cls}"
       type="button"
       aria-pressed=${e.ariaPressed}
       aria-label=${e.label}
-      ${xo(e.label)}
-      @click=${()=>function(e,t,o){const i=t.entities.group_automation_switch;i&&Fi(e,i,!o)}(this.hass,this.discovered,e.on)}
+      ${$o(e.label)}
+      @click=${()=>function(e,t,o){const i=t.entities.group_automation_switch;i&&Ui(e,i,!o)}(this.hass,this.discovered,e.on)}
     >
       <ha-icon icon=${e.icon}></ha-icon>
-    </button>`}_onSceneChange(e){!function(e,t,o){const i=t.entities.group_scene_select;i&&function(e,t,o){e.callService("select","select_option",{option:o},{entity_id:t})}(e,i,o)}(this.hass,this.discovered,e.target.value)}_stop(e){e.stopPropagation()}};var ks;$s.styles=a`
+    </button>`}_onSceneChange(e){!function(e,t,o){const i=t.entities.group_scene_select;i&&function(e,t,o){e.callService("select","select_option",{option:o},{entity_id:t})}(e,i,o)}(this.hass,this.discovered,e.target.value)}_stop(e){e.stopPropagation()}};var Gs;Ls.styles=a`
     :host {
       display: block;
     }
@@ -1753,7 +1825,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
     .ctrl ha-icon {
       --mdc-icon-size: 20px;
     }
-  `,e([ge({attribute:!1})],$s.prototype,"hass",void 0),e([ge({attribute:!1})],$s.prototype,"discovered",void 0),e([ge({attribute:!1})],$s.prototype,"snapshot",void 0),e([ge({type:Boolean})],$s.prototype,"showSceneSelect",void 0),e([ge({type:Boolean})],$s.prototype,"showLock",void 0),e([ge({type:Boolean})],$s.prototype,"showAutomation",void 0),e([ge({type:Boolean})],$s.prototype,"showClearOverrides",void 0),$s=e([pe("acp-group-controls-row")],$s);let As=ks=class extends de{constructor(){super(...arguments),this.showControls=!0,this.showPositionBar=!0,this.showTilt=!0,this.showSceneSelect=!0,this.showLock=!0,this.showAutomation=!0,this.showClearOverrides=!0,this.showMemberBadges=!0,this.stateColor=!0,this.iconInteractive=!1,this._posDrag=null,this._openMoreInfo=()=>{this.dispatchEvent(new CustomEvent("acp-open-more-info",{bubbles:!0,composed:!0}))},this._onIconClick=e=>{this.iconInteractive&&(e.stopPropagation(),this.dispatchEvent(new CustomEvent("acp-icon-action",{bubbles:!0,composed:!0})))},this._onIconKeydown=e=>{this.iconInteractive&&("Enter"!==e.key&&" "!==e.key||(e.preventDefault(),this._onIconClick(e)))},this._onBodyKeydown=e=>{e.target===e.currentTarget&&("Enter"!==e.key&&" "!==e.key||(e.preventDefault(),this._openMoreInfo()))},this._posDownX=null,this._posMoved=!1,this._onPosPointerMove=e=>{null!==this._posDownX&&(e.stopPropagation(),Math.abs(e.clientX-this._posDownX)>=ks.DRAG_THRESHOLD_PX&&(this._posMoved=!0),this._posMoved&&(this._posDrag=ft(this._pctFromEvent(e,e.currentTarget),At(this.discovered))))},this._onPosPointerEnd=(e,t)=>{e.stopPropagation();const o=this._posDrag,i=this._posMoved;this._posDrag=null,this._posDownX=null,this._posMoved=!1,i&&null!==o&&t.target&&fs(this.hass,t,o)},this._onPosCancel=e=>{e.stopPropagation(),this._posDrag=null,this._posDownX=null,this._posMoved=!1}}render(){if(!this.hass||!this.discovered)return V;const e=_s(this.hass,this.discovered),t=st(`group.state_${e.aggregate}`,this.hass),o=this._posDrag??e.position,i=At(this.discovered),s=null===o?0:ft(o,i),n=this.stateColor?vt(e.aggregate):"",r=!!e.target,a=rs(e.memberPositions,i),l=null!==this._posDrag,c=function(e,t){let o=0;for(const[i,s]of Object.entries(t.memberPositions)){const t=e.states[i];(null===s||void 0!==t&&at(t.state))&&(o+=1)}if(o>0)return{kind:"unavailable",count:o};const i=t.memberWinners;if(!i)return null;let s=0;for(const e of Object.values(i))e&&ms.has(ki(e))&&(s+=1);return s>0?{kind:"held",count:s}:null}(this.hass,e),d=l?nt(o):c?st(`group.exception_${c.kind}`,this.hass,{count:c.count}):a?a.aligned?nt(a.logicalMin):st("group.range",this.hass,{min:Math.round(a.logicalMin),max:Math.round(a.logicalMax)}):nt(o),h=this.showMemberBadges?is(e.memberWinners):[];return H`
+  `,e([ge({attribute:!1})],Ls.prototype,"hass",void 0),e([ge({attribute:!1})],Ls.prototype,"discovered",void 0),e([ge({attribute:!1})],Ls.prototype,"snapshot",void 0),e([ge({type:Boolean})],Ls.prototype,"showSceneSelect",void 0),e([ge({type:Boolean})],Ls.prototype,"showLock",void 0),e([ge({type:Boolean})],Ls.prototype,"showAutomation",void 0),e([ge({type:Boolean})],Ls.prototype,"showClearOverrides",void 0),Ls=e([pe("acp-group-controls-row")],Ls);let Ws=Gs=class extends de{constructor(){super(...arguments),this.showControls=!0,this.showPositionBar=!0,this.showTilt=!0,this.showSceneSelect=!0,this.showLock=!0,this.showAutomation=!0,this.showClearOverrides=!0,this.showMemberBadges=!0,this.stateColor=!0,this.iconInteractive=!1,this._posDrag=null,this._pending=new Li(this),this._openMoreInfo=()=>{this.dispatchEvent(new CustomEvent("acp-open-more-info",{bubbles:!0,composed:!0}))},this._onIconClick=e=>{this.iconInteractive&&(e.stopPropagation(),this.dispatchEvent(new CustomEvent("acp-icon-action",{bubbles:!0,composed:!0})))},this._onIconKeydown=e=>{this.iconInteractive&&("Enter"!==e.key&&" "!==e.key||(e.preventDefault(),this._onIconClick(e)))},this._onBodyKeydown=e=>{e.target===e.currentTarget&&("Enter"!==e.key&&" "!==e.key||(e.preventDefault(),this._openMoreInfo()))},this._posDownX=null,this._posMoved=!1,this._onPosPointerMove=e=>{null!==this._posDownX&&(e.stopPropagation(),Math.abs(e.clientX-this._posDownX)>=Gs.DRAG_THRESHOLD_PX&&(this._posMoved=!0),this._posMoved&&(this._posDrag=ft(this._pctFromEvent(e,e.currentTarget),At(this.discovered))))},this._onPosPointerEnd=(e,t)=>{e.stopPropagation();const o=this._posDrag,i=this._posMoved;this._posDrag=null,this._posDownX=null,this._posMoved=!1,i&&null!==o&&t.target&&(this._pending.start(Gs.PENDING_KEY,o),zs(this.hass,t,o))},this._onPosCancel=e=>{e.stopPropagation(),this._posDrag=null,this._posDownX=null,this._posMoved=!1}}updated(){this.hass&&this.discovered&&this._pending.settle(()=>this._snapshot().position)}_snapshot(){const e=$s(this.hass,this.discovered);return this.members?.length?As(this.hass,e,Fs(Object.keys(e.memberPositions),this.members)):e}render(){if(!this.hass||!this.discovered)return V;const e=this._snapshot(),t=st(`group.state_${e.aggregate}`,this.hass),o=this._posDrag??e.position,i=At(this.discovered),s=null===o?0:ft(o,i),n=this.stateColor?vt(e.aggregate):"",r=!!e.target,a=gs(e.memberPositions,i),l=null!==this._posDrag,c=l?null:this._pending.get(Gs.PENDING_KEY),d=Ri(e.position,c)?c:null,h=null===d?null:ft(d,i),p=function(e,t){let o=0;for(const[i,s]of Object.entries(t.memberPositions)){const t=e.states[i];(void 0===t?null===s:at(t.state))&&(o+=1)}if(o>0)return{kind:"unavailable",count:o};const i=t.memberWinners;if(!i)return null;let s=0;for(const e of Object.values(i))e&&Cs.has(Ai(e))&&(s+=1);return s>0?{kind:"held",count:s}:null}(this.hass,e),u=l?nt(o):p?st(`group.exception_${p.kind}`,this.hass,{count:p.count}):a?a.aligned?nt(a.logicalMin):st("group.range",this.hass,{min:Math.round(a.logicalMin),max:Math.round(a.logicalMax)}):nt(o),_=this.showMemberBadges?hs(e.memberWinners):[];return H`
       <div
         class=${"group-tile"+(this.showControls?" has-controls":"")}
         role="button"
@@ -1772,14 +1844,14 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
         >
           <ha-icon
             class="cover-icon"
-            icon=${this.icon??gs(e,o)}
+            icon=${this.icon??Ss(e,o)}
             style=${n?`color: ${n}`:""}
           ></ha-icon>
         </div>
 
         <div class="label">
           <div class="title">${this.name??this.discovered.entry_title}</div>
-          <div class="state">${t} · ${d}</div>
+          <div class="state">${t} · ${u}</div>
         </div>
 
         ${this.showControls?H`<div
@@ -1806,7 +1878,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
                 .groupCount=${e.whoWonCount}
                 .groupTotal=${e.rosterTotal}
               ></acp-tile-badge>`}
-          ${h.map(e=>H`<acp-tile-badge .hass=${this.hass} .winner=${e}></acp-tile-badge>`)}
+          ${_.map(e=>H`<acp-tile-badge .hass=${this.hass} .winner=${e}></acp-tile-badge>`)}
           ${this.showPositionBar?H`<div
                 class="pos-slider${null!==this._posDrag?" dragging":""}${r?"":" disabled"}"
                 role="slider"
@@ -1817,7 +1889,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
                 aria-valuenow=${a&&!l?a.min:s}
                 aria-valuetext=${!a||a.aligned||l?st("covers.position_open_value",this.hass,{pct:nt(o)}):st("group.spread_value",this.hass,{min:Math.round(a.logicalMin),max:Math.round(a.logicalMax),count:a.readable})}
                 aria-label=${st("group.position_slider_label",this.hass)}
-                ${xo(st("group.drag_to_set_all",this.hass,{count:e.rosterTotal}))}
+                ${$o(st("group.drag_to_set_all",this.hass,{count:e.rosterTotal}))}
                 @click=${this._stop}
                 @pointerdown=${e=>this._onPosPointerDown(e,r)}
                 @pointermove=${this._onPosPointerMove}
@@ -1826,7 +1898,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
                 @keydown=${t=>this._onPosKeydown(t,e)}
               >
                 <div class="pos-bar">
-                  ${l||!a?H`<div class="pos-fill" style=${`width:${s}%`}></div>`:H`
+                  ${l||null!==d||!a?H`<div class="pos-fill" style=${`width:${s}%`}></div>`:H`
                         <!-- Solid to the LEAST-covered member: the coverage every
                              member has reached. Band on top spans to the most-
                              covered one, so the gap between them IS the disagreement
@@ -1841,6 +1913,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
                               style=${`left:clamp(1px, ${e}%, calc(100% - 1px))`}
                             ></div>`)}
                       `}
+                  ${null!==d&&null!==h?Gi({hass:this.hass,liveFrac:s,pendingFrac:h,pending:d,prefix:"pos-"}):V}
                 </div>
               </div>`:V}
         </div>
@@ -1857,7 +1930,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
                 .label=${st("covers.tilt_title",this.hass)}
                 .actual=${e.tilt.value}
                 .openBlocksSun=${!1}
-                @acp-tilt-set=${t=>ys(this.hass,e,t.detail)}
+                @acp-tilt-set=${t=>Ts(this.hass,e,t.detail)}
               ></acp-axis-bar>
             </div>`:V}
 
@@ -1871,251 +1944,285 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
           .showClearOverrides=${this.showClearOverrides}
         ></acp-group-controls-row>
       </div>
-    `}_move(e,t){"stop"===e.detail?bs(this.hass,this.discovered,t):fs(this.hass,t,"open"===e.detail?100:0)}_pctFromEvent(e,t){const o=t.getBoundingClientRect(),i=Math.round((e.clientX-o.left)/o.width*100);return Math.max(0,Math.min(100,i))}_onPosPointerDown(e,t){if(e.stopPropagation(),!t)return;const o=e.currentTarget;o.setPointerCapture?.(e.pointerId),this._posDownX=e.clientX,this._posMoved=!1}_onPosKeydown(e,t){const o=At(this.discovered),i=rs(t.memberPositions,o),s=i?.min??(null===t.position?0:ft(t.position,o));let n;switch(e.key){case"ArrowRight":case"ArrowUp":n=s+1;break;case"ArrowLeft":case"ArrowDown":n=s-1;break;case"PageUp":n=s+10;break;case"PageDown":n=s-10;break;case"Home":n=0;break;case"End":n=100;break;default:return}e.preventDefault(),e.stopPropagation(),t.target&&fs(this.hass,t,ft(Math.max(0,Math.min(100,n)),o))}_stop(e){e.stopPropagation()}};As.DRAG_THRESHOLD_PX=4,As.styles=a`
-    :host {
-      display: block;
-    }
-    /* Mirrors the cover tile's detailed grid: the glyph spans the label +
+    `}_move(e,t){if("stop"===e.detail)return this._pending.clear(Gs.PENDING_KEY),void Ms(this.hass,this.discovered,t);const o="open"===e.detail?100:0;this._pending.start(Gs.PENDING_KEY,o),zs(this.hass,t,o)}_pctFromEvent(e,t){const o=t.getBoundingClientRect(),i=Math.round((e.clientX-o.left)/o.width*100);return Math.max(0,Math.min(100,i))}_onPosPointerDown(e,t){if(e.stopPropagation(),!t)return;const o=e.currentTarget;o.setPointerCapture?.(e.pointerId),this._posDownX=e.clientX,this._posMoved=!1}_onPosKeydown(e,t){const o=At(this.discovered),i=gs(t.memberPositions,o),s=i?.min??(null===t.position?0:ft(t.position,o));let n;switch(e.key){case"ArrowRight":case"ArrowUp":n=s+1;break;case"ArrowLeft":case"ArrowDown":n=s-1;break;case"PageUp":n=s+10;break;case"PageDown":n=s-10;break;case"Home":n=0;break;case"End":n=100;break;default:return}if(e.preventDefault(),e.stopPropagation(),!t.target)return;const r=ft(Math.max(0,Math.min(100,n)),o);this._pending.start(Gs.PENDING_KEY,r),zs(this.hass,t,r)}_stop(e){e.stopPropagation()}};Ws.PENDING_KEY="group",Ws.DRAG_THRESHOLD_PX=4,Ws.styles=[Wi,a`
+      :host {
+        display: block;
+      }
+      /* Mirrors the cover tile's detailed grid: the glyph spans the label +
        chrome rows so it stays vertically centered, controls sit right. */
-    .group-tile {
-      display: grid;
-      grid-template-areas:
-        'icon label controls'
-        'icon chrome chrome'
-        'tilt tilt tilt'
-        'group group group';
-      grid-template-columns: 36px minmax(0, 1fr) auto;
-      /* HA's ha-tile-container .content: 10px gap, 56px row floor. */
-      column-gap: 10px;
-      min-height: var(--row-height, 56px);
-      row-gap: 2px;
-      align-items: center;
-      padding: 6px 4px;
-      cursor: pointer;
-    }
-    /* Same 50% controls track as the cover tile's detailed grid — HA's inline
+      .group-tile {
+        display: grid;
+        grid-template-areas:
+          'icon label controls'
+          'icon chrome chrome'
+          'tilt tilt tilt'
+          'group group group';
+        grid-template-columns: 36px minmax(0, 1fr) auto;
+        /* HA's ha-tile-container .content: 10px gap, 56px row floor. */
+        column-gap: 10px;
+        min-height: var(--row-height, 56px);
+        row-gap: 2px;
+        align-items: center;
+        padding: 6px 4px;
+        cursor: pointer;
+      }
+      /* Same 50% controls track as the cover tile's detailed grid — HA's inline
        features block is half the card. Gated so a show_controls: false tile
        doesn't reserve half its width for an empty area. */
-    .group-tile.has-controls {
-      grid-template-columns: 36px minmax(0, 1fr) calc(50% - 12px);
-    }
-    /* Unlike the cover tile this element has no reflow that moves the controls
+      .group-tile.has-controls {
+        grid-template-columns: 36px minmax(0, 1fr) calc(50% - 12px);
+      }
+      /* Unlike the cover tile this element has no reflow that moves the controls
        onto their own row, so the 50% track would keep squeezing the name all
        the way down. Below the cover tile's own narrow threshold, hand the track
        back to content and square the buttons off — flex-filling a content-sized
        track collapses them to the glyph width. The container is the host card's
        ha-card (container-type: inline-size); container queries resolve across
        the shadow boundary. */
-    @container (max-width: 340px) {
-      .group-tile.has-controls {
-        grid-template-columns: 36px minmax(0, 1fr) auto;
+      @container (max-width: 340px) {
+        .group-tile.has-controls {
+          grid-template-columns: 36px minmax(0, 1fr) auto;
+        }
+        acp-cover-move-buttons {
+          --acp-move-button-flex: 0 0 auto;
+          --acp-move-button-width: var(--control-button-group-thickness, 36px);
+        }
       }
-      acp-cover-move-buttons {
-        --acp-move-button-flex: 0 0 auto;
-        --acp-move-button-width: var(--control-button-group-thickness, 36px);
+      .group-tile:focus-visible {
+        outline: 2px solid var(--primary-color);
+        outline-offset: 2px;
+        border-radius: 8px;
       }
-    }
-    .group-tile:focus-visible {
-      outline: 2px solid var(--primary-color);
-      outline-offset: 2px;
-      border-radius: 8px;
-    }
-    .cover-icon-wrap {
-      grid-area: icon;
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      width: 36px;
-      height: 36px;
-    }
-    /* HA's ha-tile-icon shape, opt-in via icon_tap_action — see the matching
+      .cover-icon-wrap {
+        grid-area: icon;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 36px;
+        height: 36px;
+      }
+      /* HA's ha-tile-icon shape, opt-in via icon_tap_action — see the matching
        rule on the cover tile for the upstream trail. */
-    .cover-icon-wrap.background {
-      position: relative;
-      border-radius: var(--ha-border-radius-pill, 9999px);
-      overflow: hidden;
-      cursor: pointer;
-    }
-    .cover-icon-wrap.background::before {
-      content: '';
-      position: absolute;
-      inset: 0;
-      background-color: var(--acp-tile-icon-color, var(--disabled-color, #7f7f7f));
-      opacity: 0.2;
-      transition: opacity 180ms ease-in-out;
-    }
-    .cover-icon-wrap.background:hover::before {
-      opacity: 0.35;
-    }
-    .cover-icon-wrap.background:focus-visible {
-      outline: none;
-      box-shadow: 0 0 0 2px var(--acp-tile-icon-color, var(--primary-text-color));
-    }
-    .cover-icon-wrap.background .cover-icon {
-      position: relative;
-    }
-    .cover-icon {
-      --mdc-icon-size: 24px;
-    }
-    .label {
-      grid-area: label;
-      min-width: 0;
-      display: flex;
-      flex-direction: column;
-      justify-content: center;
-    }
-    /* Same theme tokens HA's ha-tile-info uses, matching the cover tile — see
+      .cover-icon-wrap.background {
+        position: relative;
+        border-radius: var(--ha-border-radius-pill, 9999px);
+        overflow: hidden;
+        cursor: pointer;
+      }
+      .cover-icon-wrap.background::before {
+        content: '';
+        position: absolute;
+        inset: 0;
+        background-color: var(--acp-tile-icon-color, var(--disabled-color, #7f7f7f));
+        opacity: 0.2;
+        transition: opacity 180ms ease-in-out;
+      }
+      .cover-icon-wrap.background:hover::before {
+        opacity: 0.35;
+      }
+      .cover-icon-wrap.background:focus-visible {
+        outline: none;
+        box-shadow: 0 0 0 2px var(--acp-tile-icon-color, var(--primary-text-color));
+      }
+      .cover-icon-wrap.background .cover-icon {
+        position: relative;
+      }
+      .cover-icon {
+        --mdc-icon-size: 24px;
+      }
+      .label {
+        grid-area: label;
+        min-width: 0;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+      }
+      /* Same theme tokens HA's ha-tile-info uses, matching the cover tile — see
        that rule for why the two lines take different line-heights. */
-    .title {
-      font-size: var(--ha-font-size-m, 0.875rem);
-      font-weight: var(--ha-font-weight-medium, 500);
-      line-height: var(--ha-line-height-normal, 1.6);
-      letter-spacing: 0.1px;
-      color: var(--primary-text-color);
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-    }
-    .state {
-      font-size: var(--ha-font-size-s, 0.75rem);
-      font-weight: var(--ha-font-weight-normal, 400);
-      line-height: var(--ha-line-height-condensed, 1.2);
-      letter-spacing: 0.4px;
-      color: var(--secondary-text-color);
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-    }
-    .controls {
-      grid-area: controls;
-      align-self: center;
-      display: inline-flex;
-    }
-    .chrome-line {
-      grid-area: chrome;
-      display: flex;
-      align-items: center;
-      gap: 6px;
-      min-width: 0;
-      /* Reserve the badge pill's height even with no badge, so the row keeps the
+      .title {
+        font-size: var(--ha-font-size-m, 0.875rem);
+        font-weight: var(--ha-font-weight-medium, 500);
+        line-height: var(--ha-line-height-normal, 1.6);
+        letter-spacing: 0.1px;
+        color: var(--primary-text-color);
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+      .state {
+        font-size: var(--ha-font-size-s, 0.75rem);
+        font-weight: var(--ha-font-weight-normal, 400);
+        line-height: var(--ha-line-height-condensed, 1.2);
+        letter-spacing: 0.4px;
+        color: var(--secondary-text-color);
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+      .controls {
+        grid-area: controls;
+        align-self: center;
+        display: inline-flex;
+      }
+      .chrome-line {
+        grid-area: chrome;
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        min-width: 0;
+        /* Reserve the badge pill's height even with no badge, so the row keeps the
          same height either way and the bar centers in it (cover tile parity). */
-      min-height: 22px;
-      /* The one deliberate divergence from the cover tile's nowrap: a group's
+        min-height: 22px;
+        /* The one deliberate divergence from the cover tile's nowrap: a group's
          badge count is unbounded (one per distinct member override), so the row
          wraps rather than crushing the slider. With the usual 0-1 badges the
          layout is identical. */
-      flex-wrap: wrap;
-    }
-    /* Badges hold their intrinsic width so the bar absorbs any shortage. */
-    .chrome-line acp-tile-badge {
-      overflow: visible;
-      flex: 0 0 auto;
-    }
-    /* Interactive wrapper carries the sizing; the visible rail below stays 6px.
+        flex-wrap: wrap;
+      }
+      /* Badges hold their intrinsic width so the bar absorbs any shortage. */
+      .chrome-line acp-tile-badge {
+        overflow: visible;
+        flex: 0 0 auto;
+      }
+      /* Interactive wrapper carries the sizing; the visible rail below stays 6px.
        Geometry is copied from the cover tile's .chrome-line .pos-slider rule so
        a group tile stacked under cover tiles lines its bar up with theirs,
        instead of stretching the full width of the row. */
-    .pos-slider {
-      margin-left: auto;
-      align-self: center;
-      position: relative;
-      flex: 0 1 170px;
-      max-width: 55%;
-      cursor: pointer;
-      /* A touch-drag must move the fill, not scroll the dashboard. */
-      touch-action: none;
-    }
-    /* The rail is too thin to grab on a phone — widen the hit area vertically
+      .pos-slider {
+        margin-left: auto;
+        align-self: center;
+        position: relative;
+        flex: 0 1 170px;
+        max-width: 55%;
+        cursor: pointer;
+        /* A touch-drag must move the fill, not scroll the dashboard. */
+        touch-action: none;
+      }
+      /* The rail is too thin to grab on a phone — widen the hit area vertically
        with an invisible absolute box, which adds no layout height. */
-    .pos-slider::before {
-      content: '';
-      position: absolute;
-      inset: -8px 0;
-    }
-    .pos-slider:focus-visible {
-      outline: 2px solid var(--primary-color);
-      outline-offset: 3px;
-      border-radius: 6px;
-    }
-    /* Nothing to drive: match the buttons rather than looking live and no-oping. */
-    .pos-slider.disabled {
-      cursor: default;
-      opacity: 0.4;
-      touch-action: auto;
-    }
-    .pos-bar {
-      position: relative;
-      width: 100%;
-      height: 6px;
-      border-radius: 6px;
-      background: var(--secondary-background-color, rgba(127, 127, 127, 0.15));
-      overflow: hidden;
-    }
-    .pos-fill {
-      position: absolute;
-      inset: 0 auto 0 0;
-      /* One constant color for every rail, never the cover's state color: a rail
+      .pos-slider::before {
+        content: '';
+        position: absolute;
+        inset: -8px 0;
+      }
+      .pos-slider:focus-visible {
+        outline: 2px solid var(--primary-color);
+        outline-offset: 3px;
+        border-radius: 6px;
+      }
+      /* Nothing to drive: match the buttons rather than looking live and no-oping. */
+      .pos-slider.disabled {
+        cursor: default;
+        opacity: 0.4;
+        touch-action: auto;
+      }
+      .pos-bar {
+        position: relative;
+        width: 100%;
+        height: 6px;
+        border-radius: 6px;
+        background: var(--secondary-background-color, rgba(127, 127, 127, 0.15));
+        overflow: hidden;
+      }
+      .pos-fill {
+        position: absolute;
+        inset: 0 auto 0 0;
+        /* One constant color for every rail, never the cover's state color: a rail
          that changed hue as it crossed open/closed read as a status light rather
          than a measurement. Overridable per-theme via --acp-pos-fill-color. */
-      background: var(--acp-pos-fill-color, ${r(mt)});
-      opacity: 0.55;
-      border-radius: 6px;
-      transition: width 0.3s ease;
-    }
-    /* Disagreement band: from the least-covered member to the most-covered one.
+        background: var(--acp-pos-fill-color, ${r(mt)});
+        opacity: 0.55;
+        border-radius: 6px;
+        transition: width 0.3s ease;
+      }
+      /* Disagreement band: from the least-covered member to the most-covered one.
        Same hue as the fill at a lower opacity, so it reads as "some of them are
        also this far" rather than as a second measurement. Zero-width when the
        members agree, which is why it isn't rendered at all in that case. */
-    .pos-band {
-      position: absolute;
-      top: 0;
-      bottom: 0;
-      background: var(--acp-pos-fill-color, ${r(mt)});
-      opacity: 0.22;
-      transition:
-        left 0.3s ease,
-        width 0.3s ease;
-    }
-    /* One tick per DISTINCT member value. Two clusters of covers draw two ticks,
+      .pos-band {
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        background: var(--acp-pos-fill-color, ${r(mt)});
+        opacity: 0.22;
+        transition:
+          left 0.3s ease,
+          width 0.3s ease;
+      }
+      /* One tick per DISTINCT member value. Two clusters of covers draw two ticks,
        which is the whole point: "Mixed" stops being a word and becomes a picture
        of where they actually are. Clamped inside the rail (inline) so the 2px box
        survives .pos-bar's overflow:hidden at either extreme, same as the cover
        bar's target marker. */
-    .pos-tick {
-      position: absolute;
-      top: -2px;
-      width: 2px;
-      height: 10px;
-      border-radius: 1px;
-      background: var(--acp-pos-fill-color, ${r(mt)});
-      transform: translateX(-50%);
-      transition: left 0.3s ease;
-    }
-    /* The rail has to show the ticks that overhang it. Only the FILL and BAND
+      .pos-tick {
+        position: absolute;
+        top: -2px;
+        width: 2px;
+        height: 10px;
+        border-radius: 1px;
+        background: var(--acp-pos-fill-color, ${r(mt)});
+        transform: translateX(-50%);
+        transition: left 0.3s ease;
+      }
+      /* The rail has to show the ticks that overhang it. Only the FILL and BAND
        need clipping to the rounded ends, so they round themselves instead. */
-    .pos-bar {
-      overflow: visible;
+      .pos-bar {
+        overflow: visible;
+      }
+      .pos-band {
+        border-radius: 6px;
+      }
+      /* The ease above smooths server-driven updates; mid-drag it reads as lag. */
+      .pos-slider.dragging .pos-fill {
+        transition: none;
+      }
+      .tilt-line {
+        grid-area: tilt;
+        min-width: 0;
+        cursor: default;
+      }
+      acp-group-controls-row {
+        grid-area: group;
+        margin-top: 4px;
+      }
+    `],e([ge({attribute:!1})],Ws.prototype,"hass",void 0),e([ge({attribute:!1})],Ws.prototype,"discovered",void 0),e([ge({type:Boolean})],Ws.prototype,"showControls",void 0),e([ge({type:Boolean})],Ws.prototype,"showPositionBar",void 0),e([ge({type:Boolean})],Ws.prototype,"showTilt",void 0),e([ge({type:Boolean})],Ws.prototype,"showSceneSelect",void 0),e([ge({type:Boolean})],Ws.prototype,"showLock",void 0),e([ge({type:Boolean})],Ws.prototype,"showAutomation",void 0),e([ge({type:Boolean})],Ws.prototype,"showClearOverrides",void 0),e([ge({type:Boolean})],Ws.prototype,"showMemberBadges",void 0),e([ge({type:Boolean})],Ws.prototype,"stateColor",void 0),e([ge({type:Boolean})],Ws.prototype,"iconInteractive",void 0),e([ge({attribute:!1})],Ws.prototype,"name",void 0),e([ge({attribute:!1})],Ws.prototype,"icon",void 0),e([ge({attribute:!1})],Ws.prototype,"members",void 0),e([me()],Ws.prototype,"_posDrag",void 0),Ws=Gs=e([pe("acp-group-tile")],Ws);const Hs=(e,t,o)=>{const i=new Map;for(let s=t;s<=o;s++)i.set(e[s],s);return i},Us=lo(class extends co{constructor(e){if(super(e),2!==e.type)throw Error("repeat() can only be used in text expressions")}dt(e,t,o){let i;void 0===o?o=t:void 0!==t&&(i=t);const s=[],n=[];let r=0;for(const t of e)s[r]=i?i(t,r):r,n[r]=o(t,r),r++;return{values:n,keys:s}}render(e,t,o){return this.dt(e,t,o).values}update(e,[t,o,i]){const s=(e=>e._$AH)(e),{values:n,keys:r}=this.dt(t,o,i);if(!Array.isArray(s))return this.ut=r,n;const a=this.ut??=[],l=[];let c,d,h=0,p=s.length-1,u=0,_=n.length-1;for(;h<=p&&u<=_;)if(null===s[h])h++;else if(null===s[p])p--;else if(a[h]===r[u])l[u]=so(s[h],n[u]),h++,u++;else if(a[p]===r[_])l[_]=so(s[p],n[_]),p--,_--;else if(a[h]===r[_])l[_]=so(s[h],n[_]),io(e,l[_+1],s[h]),h++,_--;else if(a[p]===r[u])l[u]=so(s[p],n[u]),io(e,s[h],s[p]),p--,u++;else if(void 0===c&&(c=Hs(r,u,_),d=Hs(a,h,p)),c.has(a[h]))if(c.has(a[p])){const t=d.get(r[u]),o=void 0!==t?s[t]:null;if(null===o){const t=io(e,s[h]);so(t,n[u]),l[u]=t}else l[u]=so(o,n[u]),io(e,s[h],o),s[t]=null;u++}else ao(s[p]),p--;else ao(s[h]),h++;for(;u<=_;){const t=io(e,l[_+1]);so(t,n[u]),l[u++]=t}for(;h<=p;){const e=s[h++];null!==e&&ao(e)}return this.ut=r,ro(e,l),q}});let qs=class extends de{constructor(){super(...arguments),this.coverIds=[],this._openHistory=()=>{const e=es(this.hass,this.coverIds??[]),t=[...new Set(e.map(e=>e.source_id))];0!==t.length&&(history.pushState(null,"",`/history?entity_id=${t.join(",")}`),window.dispatchEvent(new CustomEvent("location-changed",{detail:{replace:!1}})),this.dispatchEvent(new CustomEvent("acp-dialog-close",{bubbles:!0,composed:!0})))}}render(){if(!this.hass)return V;const e=es(this.hass,this.coverIds??[]),t=os(e);if(!t)return V;const o=1===e.length?null===t.level?st("dialog.battery_unknown",this.hass):st("dialog.battery",this.hass,{level:t.level}):e.map(e=>st("dialog.battery_named",this.hass,{name:this._coverName(e.cover_id),level:null===e.level?"—":e.level})).join(" · "),i=`${o} · ${st("dialog.battery_history",this.hass)}`;return H`<button
+      class="battery${ts(t)?" low":""}"
+      type="button"
+      aria-label=${i}
+      ${$o(i)}
+      @click=${this._openHistory}
+    >
+      <ha-icon icon=${is(t.level,t.charging)}></ha-icon>
+    </button>`}_coverName(e){return this.hass?.states[e]?.attributes?.friendly_name??e}};qs.styles=a`
+    :host {
+      display: contents;
     }
-    .pos-band {
-      border-radius: 6px;
+    /* Shares the dialogs' .icon-btn metrics so it lines up with the buttons
+       beside it in either header. */
+    .battery {
+      border: 0;
+      background: transparent;
+      cursor: pointer;
+      color: var(--secondary-text-color);
+      padding: 4px 6px;
+      display: inline-flex;
+      align-items: center;
+      --mdc-icon-size: 18px;
     }
-    /* The ease above smooths server-driven updates; mid-drag it reads as lag. */
-    .pos-slider.dragging .pos-fill {
-      transition: none;
+    .battery:hover {
+      color: var(--primary-text-color);
     }
-    .tilt-line {
-      grid-area: tilt;
-      min-width: 0;
-      cursor: default;
+    .battery.low {
+      color: var(--error-color, #db4437);
     }
-    acp-group-controls-row {
-      grid-area: group;
-      margin-top: 4px;
+    .battery.low:hover {
+      color: var(--error-color, #db4437);
+      filter: brightness(1.2);
     }
-  `,e([ge({attribute:!1})],As.prototype,"hass",void 0),e([ge({attribute:!1})],As.prototype,"discovered",void 0),e([ge({type:Boolean})],As.prototype,"showControls",void 0),e([ge({type:Boolean})],As.prototype,"showPositionBar",void 0),e([ge({type:Boolean})],As.prototype,"showTilt",void 0),e([ge({type:Boolean})],As.prototype,"showSceneSelect",void 0),e([ge({type:Boolean})],As.prototype,"showLock",void 0),e([ge({type:Boolean})],As.prototype,"showAutomation",void 0),e([ge({type:Boolean})],As.prototype,"showClearOverrides",void 0),e([ge({type:Boolean})],As.prototype,"showMemberBadges",void 0),e([ge({type:Boolean})],As.prototype,"stateColor",void 0),e([ge({type:Boolean})],As.prototype,"iconInteractive",void 0),e([ge({attribute:!1})],As.prototype,"name",void 0),e([ge({attribute:!1})],As.prototype,"icon",void 0),e([me()],As.prototype,"_posDrag",void 0),As=ks=e([pe("acp-group-tile")],As);const Ss=(e,t,o)=>{const i=new Map;for(let s=t;s<=o;s++)i.set(e[s],s);return i},Cs=ao(class extends lo{constructor(e){if(super(e),2!==e.type)throw Error("repeat() can only be used in text expressions")}dt(e,t,o){let i;void 0===o?o=t:void 0!==t&&(i=t);const s=[],n=[];let r=0;for(const t of e)s[r]=i?i(t,r):r,n[r]=o(t,r),r++;return{values:n,keys:s}}render(e,t,o){return this.dt(e,t,o).values}update(e,[t,o,i]){const s=(e=>e._$AH)(e),{values:n,keys:r}=this.dt(t,o,i);if(!Array.isArray(s))return this.ut=r,n;const a=this.ut??=[],l=[];let c,d,h=0,p=s.length-1,u=0,_=n.length-1;for(;h<=p&&u<=_;)if(null===s[h])h++;else if(null===s[p])p--;else if(a[h]===r[u])l[u]=io(s[h],n[u]),h++,u++;else if(a[p]===r[_])l[_]=io(s[p],n[_]),p--,_--;else if(a[h]===r[_])l[_]=io(s[h],n[_]),oo(e,l[_+1],s[h]),h++,_--;else if(a[p]===r[u])l[u]=io(s[p],n[u]),oo(e,s[h],s[p]),p--,u++;else if(void 0===c&&(c=Ss(r,u,_),d=Ss(a,h,p)),c.has(a[h]))if(c.has(a[p])){const t=d.get(r[u]),o=void 0!==t?s[t]:null;if(null===o){const t=oo(e,s[h]);io(t,n[u]),l[u]=t}else l[u]=io(o,n[u]),oo(e,s[h],o),s[t]=null;u++}else ro(s[p]),p--;else ro(s[h]),h++;for(;u<=_;){const t=oo(e,l[_+1]);io(t,n[u]),l[u++]=t}for(;h<=p;){const e=s[h++];null!==e&&ro(e)}return this.ut=r,no(e,l),q}}),Es=new Map;function zs(e,t,o){return function(e,t){const o=[],i=new Map;for(const s of e){const e=t(s);if(!e){o.push({entryId:null,covers:[s]});continue}const n=i.get(e);if(n){n.covers.push(s);continue}const r={entryId:e,covers:[s]};i.set(e,r),o.push(r)}return o}(t,t=>{const i=Bo(e,t,o);return i?(Es.set(t,i),i):Es.get(t)??null})}function Ms(){let e=null,t=null,o=[];return(i,s,n)=>{const r=s.join("|");return e===r&&t===n&&o.length>0||(e=r,t=n,o=zs(i,s,n)),o}}function Ts(e){return e.entryId??`generic:${e.covers[0]}`}function Is(e){return e.entryId??e.covers[0]}const Ps=["acp-dialog-close","acp-tile-tap","acp-open-more-info","acp-resume","acp-extend","acp-extend-confirm","acp-extend-close","acp-tilt-set"];let Os=0;const Ns=new WeakMap;let Ds=class extends de{constructor(){super(...arguments),this.position=null,this.winner=null,this.acpManaged=!1,this.showTilt=!0,this.openBlocksSun=!0,this.compact=!1,this._entryId=null,this._tile=null,this._tileKey=null,this._resolveKey=null,this._onMove=e=>{var t,o;"stop"===e.detail?(t=this.hass,o=this.entityId,this.acpManaged?t.callService(Te,"stop",{},{entity_id:o}):t.callService("cover","stop_cover",{},{entity_id:o})):this._set("position","open"===e.detail?100:0)}}willUpdate(e){if(!this.hass||!this.entityId)return;e.has("entityId")&&(this._entryId=null,this._tile=null,this._tileKey=null,this._resolveKey=null);const t=Io();if(!t)return;const o=`${this.entityId}|${function(e){let t=Ns.get(e);return void 0===t&&(t=++Os,Ns.set(e,t)),t}(t)}`;if(this._resolveKey===o)return;this._resolveKey=o;const i=Bo(this.hass,this.entityId);i&&(this._entryId=i)}updated(){this._tile&&this.hass&&(this._tile.hass=this.hass)}_tileCard(e){const t=this.coverIds?.length?this.coverIds:[this.entityId],o=`${e}|${t.join(",")}|${this.displayName??""}|${this.showTilt}`;if(this._tile&&this._tileKey===o)return this._tile.hass=this.hass,this._tile;if(!customElements.get($e))return null;const i=document.createElement($e);i.setConfig({type:`custom:${$e}`,entry_id:e,covers:t,...this.displayName?{name:this.displayName}:{},show_tilt:this.showTilt});for(const e of Ps)i.addEventListener(e,e=>e.stopPropagation());return i.hass=this.hass,this._tile=i,this._tileKey=o,i}render(){if(!this.hass||!this.entityId)return V;if(this._entryId){const e=this._tileCard(this._entryId);if(e)return H`<div class="tile-host">${e}</div>`}return this._fallbackRow()}_fallbackRow(){const e=this.hass.states[this.entityId],t=this.displayName||e?.attributes?.friendly_name||this.entityId,o=at(e?.state),i=this.showTilt&&Bi(this.hass,this.entityId),s=i?e?.attributes?.current_tilt_position??null:null;return H`
+  `,e([ge({attribute:!1})],qs.prototype,"hass",void 0),e([ge({attribute:!1})],qs.prototype,"coverIds",void 0),qs=e([pe("acp-battery-indicator")],qs);const Vs=["acp-dialog-close","acp-tile-tap","acp-open-more-info","acp-resume","acp-extend","acp-extend-confirm","acp-extend-close","acp-tilt-set"];let Ys=0;const Zs=new WeakMap;let Qs=class extends de{constructor(){super(...arguments),this.position=null,this.winner=null,this.acpManaged=!1,this.showTilt=!0,this.openBlocksSun=!0,this.compact=!1,this._entryId=null,this._tile=null,this._tileKey=null,this._resolveKey=null,this._onMove=e=>{var t,o;"stop"===e.detail?(t=this.hass,o=this.entityId,this.acpManaged?t.callService(Te,"stop",{},{entity_id:o}):t.callService("cover","stop_cover",{},{entity_id:o})):this._set("position","open"===e.detail?100:0)}}willUpdate(e){if(!this.hass||!this.entityId)return;e.has("entityId")&&(this._entryId=null,this._tile=null,this._tileKey=null,this._resolveKey=null);const t=Po();if(!t)return;const o=`${this.entityId}|${function(e){let t=Zs.get(e);return void 0===t&&(t=++Ys,Zs.set(e,t)),t}(t)}`;if(this._resolveKey===o)return;this._resolveKey=o;const i=Bo(this.hass,this.entityId);i&&(this._entryId=i)}updated(){this._tile&&this.hass&&(this._tile.hass=this.hass)}_tileCard(e){const t=this.coverIds?.length?this.coverIds:[this.entityId],o=`${e}|${t.join(",")}|${this.displayName??""}|${this.showTilt}`;if(this._tile&&this._tileKey===o)return this._tile.hass=this.hass,this._tile;if(!customElements.get($e))return null;const i=document.createElement($e);i.setConfig({type:`custom:${$e}`,entry_id:e,covers:t,...this.displayName?{name:this.displayName}:{},show_tilt:this.showTilt});for(const e of Vs)i.addEventListener(e,e=>e.stopPropagation());return i.hass=this.hass,this._tile=i,this._tileKey=o,i}render(){if(!this.hass||!this.entityId)return V;if(this._entryId){const e=this._tileCard(this._entryId);if(e)return H`<div class="tile-host">${e}</div>`}return this._fallbackRow()}_fallbackRow(){const e=this.hass.states[this.entityId],t=this.displayName||e?.attributes?.friendly_name||this.entityId,o=at(e?.state),i=this.showTilt&&Hi(this.hass,this.entityId),s=i?e?.attributes?.current_tilt_position??null:null;return H`
       <div class="member ${o?"unavailable":""}">
         <div class="head">
-          <div class="name" ${xo(this.entityId)}>${t}</div>
+          <div class="name" ${$o(this.entityId)}>${t}</div>
           ${this.winner?H`<acp-tile-badge .hass=${this.hass} .winner=${this.winner}></acp-tile-badge>`:V}
         </div>
         <div class="body">
@@ -2155,7 +2262,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
           </div>
         </div>
       </div>
-    `}_set(e,t){!function(e,t,o,i,s){s?Li(e,t,{[o]:i}):"tilt"!==o?e.callService("cover","set_cover_position",{position:i},{entity_id:t}):e.callService("cover","set_cover_tilt_position",{tilt_position:i},{entity_id:t})}(this.hass,this.entityId,e,t,this.acpManaged)}};Ds.styles=a`
+    `}_set(e,t){!function(e,t,o,i,s){s?Yi(e,t,{[o]:i}):"tilt"!==o?e.callService("cover","set_cover_position",{position:i},{entity_id:t}):e.callService("cover","set_cover_tilt_position",{tilt_position:i},{entity_id:t})}(this.hass,this.entityId,e,t,this.acpManaged)}};Qs.styles=a`
     :host {
       display: block;
     }
@@ -2245,31 +2352,35 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
       opacity: 0.4;
       cursor: default;
     }
-  `,e([ge({attribute:!1})],Ds.prototype,"hass",void 0),e([ge({attribute:!1})],Ds.prototype,"entityId",void 0),e([ge({attribute:!1})],Ds.prototype,"coverIds",void 0),e([ge({attribute:!1})],Ds.prototype,"displayName",void 0),e([ge({attribute:!1})],Ds.prototype,"position",void 0),e([ge({attribute:!1})],Ds.prototype,"winner",void 0),e([ge({type:Boolean})],Ds.prototype,"acpManaged",void 0),e([ge({type:Boolean})],Ds.prototype,"showTilt",void 0),e([ge({type:Boolean})],Ds.prototype,"openBlocksSun",void 0),e([ge({type:Boolean,reflect:!0})],Ds.prototype,"compact",void 0),e([me()],Ds.prototype,"_entryId",void 0),Ds=e([pe("acp-group-member-row")],Ds);let Bs=class extends de{constructor(){super(...arguments),this.open=!1,this.showTilt=!0,this.showSceneSelect=!0,this.showLock=!0,this.showAutomation=!0,this.showClearOverrides=!0,this.showMemberBadges=!0,this.stateColor=!0,this._roster=Ms(),this._onBackdrop=e=>{e.target===e.currentTarget&&this._emitClose()},this._emitClose=()=>{this.dispatchEvent(new CustomEvent("acp-dialog-close",{bubbles:!0,composed:!0}))},this._stop=e=>{e.stopPropagation()}}render(){if(!this.open||!this.hass||!this.discovered)return V;const e=_s(this.hass,this.discovered),t=this.stateColor?vt(e.aggregate):"",o=Object.entries(e.memberPositions),i=!!e.target,s=this.showMemberBadges?is(e.memberWinners):[],n=st("dialog.close",this.hass);return H`
+  `,e([ge({attribute:!1})],Qs.prototype,"hass",void 0),e([ge({attribute:!1})],Qs.prototype,"entityId",void 0),e([ge({attribute:!1})],Qs.prototype,"coverIds",void 0),e([ge({attribute:!1})],Qs.prototype,"displayName",void 0),e([ge({attribute:!1})],Qs.prototype,"position",void 0),e([ge({attribute:!1})],Qs.prototype,"winner",void 0),e([ge({type:Boolean})],Qs.prototype,"acpManaged",void 0),e([ge({type:Boolean})],Qs.prototype,"showTilt",void 0),e([ge({type:Boolean})],Qs.prototype,"openBlocksSun",void 0),e([ge({type:Boolean,reflect:!0})],Qs.prototype,"compact",void 0),e([me()],Qs.prototype,"_entryId",void 0),Qs=e([pe("acp-group-member-row")],Qs);let Xs=class extends de{constructor(){super(...arguments),this.open=!1,this.showTilt=!0,this.showSceneSelect=!0,this.showLock=!0,this.showAutomation=!0,this.showClearOverrides=!0,this.showMemberBadges=!0,this.stateColor=!0,this._roster=Os(),this._onBackdrop=e=>{e.target===e.currentTarget&&this._emitClose()},this._emitClose=()=>{this.dispatchEvent(new CustomEvent("acp-dialog-close",{bubbles:!0,composed:!0}))},this._stop=e=>{e.stopPropagation()}}render(){if(!this.open||!this.hass||!this.discovered)return V;const e=$s(this.hass,this.discovered),t=Object.keys(e.memberPositions),o=this._roster(this.hass,t,Po()??void 0),i=As(this.hass,e,Fs(t,this.members)),s=this.stateColor?vt(i.aggregate):"",n=!!i.target,r=this.showMemberBadges?hs(i.memberWinners):[],a=st("dialog.close",this.hass);return H`
       <div class="backdrop" data-open @click=${this._onBackdrop}>
         <div class="dialog" @click=${this._stop} role="dialog" aria-modal="true">
           <div class="header">
             <ha-icon
               class="cover-icon"
-              icon=${this.icon??gs(e,e.position)}
-              style=${t?`color: ${t}`:""}
+              icon=${this.icon??Ss(i,i.position)}
+              style=${s?`color: ${s}`:""}
             ></ha-icon>
             <div class="title">${this.name??this.discovered.entry_title}</div>
-            ${Number.isNaN(e.whoWonCount)?V:H`<acp-tile-badge
+            ${Number.isNaN(i.whoWonCount)?V:H`<acp-tile-badge
                   .hass=${this.hass}
                   kind-override="group"
-                  .groupCount=${e.whoWonCount}
-                  .groupTotal=${e.rosterTotal}
+                  .groupCount=${i.whoWonCount}
+                  .groupTotal=${i.rosterTotal}
                 ></acp-tile-badge>`}
-            ${s.map(e=>H`<acp-tile-badge .hass=${this.hass} .winner=${e}></acp-tile-badge>`)}
-            <button class="close" type="button" aria-label=${n} @click=${this._emitClose}>
+            ${r.map(e=>H`<acp-tile-badge .hass=${this.hass} .winner=${e}></acp-tile-badge>`)}
+            <acp-battery-indicator
+              .hass=${this.hass}
+              .coverIds=${Object.keys(i.memberPositions)}
+            ></acp-battery-indicator>
+            <button class="close" type="button" aria-label=${a} @click=${this._emitClose}>
               ✕
             </button>
           </div>
 
           <div class="summary">
-            <span class="agg-state">${st(`group.state_${e.aggregate}`,this.hass)}</span>
-            <span class="agg-position">${nt(e.position)}</span>
+            <span class="agg-state">${st(`group.state_${i.aggregate}`,this.hass)}</span>
+            <span class="agg-position">${nt(i.position)}</span>
           </div>
 
           <acp-axis-bar
@@ -2278,60 +2389,61 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
             .label=${st("group.position",this.hass)}
             .hintKey=${"covers.click_to_set"}
             .targetHintKey=${"covers.target_tooltip"}
-            .actual=${e.position}
+            .actual=${i.position}
             .openBlocksSun=${At(this.discovered).openBlocksSun}
-            .disabled=${!i}
-            @acp-tilt-set=${t=>fs(this.hass,e,t.detail)}
+            .disabled=${!n}
+            @acp-tilt-set=${e=>zs(this.hass,i,e.detail)}
           ></acp-axis-bar>
-          ${this.showTilt&&e.tilt?H`<acp-axis-bar
+          ${this.showTilt&&i.tilt?H`<acp-axis-bar
                 layout="cover"
                 .hass=${this.hass}
                 .label=${st("covers.tilt_title",this.hass)}
-                .actual=${e.tilt.value}
+                .actual=${i.tilt.value}
                 .openBlocksSun=${!1}
-                @acp-tilt-set=${t=>ys(this.hass,e,t.detail)}
+                @acp-tilt-set=${e=>Ts(this.hass,i,e.detail)}
               ></acp-axis-bar>`:V}
 
           <div class="controls">
             <acp-cover-move-buttons
               labels="group"
               .hass=${this.hass}
-              .position=${e.position}
-              .deviceClass=${e.deviceClass}
-              .enabled=${i}
-              @acp-move=${t=>this._move(t,e)}
+              .position=${i.position}
+              .deviceClass=${i.deviceClass}
+              .enabled=${n}
+              @acp-move=${e=>this._move(e,i)}
             ></acp-cover-move-buttons>
           </div>
 
           <acp-group-controls-row
             .hass=${this.hass}
             .discovered=${this.discovered}
-            .snapshot=${e}
+            .snapshot=${i}
             .showSceneSelect=${this.showSceneSelect}
             .showLock=${this.showLock}
             .showAutomation=${this.showAutomation}
             .showClearOverrides=${this.showClearOverrides}
           ></acp-group-controls-row>
 
-          <div class="members">
-            <div class="members-head">${st("group.members",this.hass)}</div>
-            ${0===o.length?H`<div class="member-placeholder">
-                  ${st("group.member_placeholder",this.hass)}
-                </div>`:Cs(this._roster(this.hass,o.map(([e])=>e),Io()??void 0),Ts,t=>H`<acp-group-member-row
-                      .hass=${this.hass}
-                      .entityId=${t.covers[0]}
-                      .coverIds=${t.covers}
-                      .position=${e.memberPositions[t.covers[0]]??null}
-                      .winner=${e.memberWinners?.[t.covers[0]]}
-                      .openBlocksSun=${At(this.discovered).openBlocksSun}
-                      .acpManaged=${!!e.memberWinners&&t.covers[0]in e.memberWinners}
-                      .displayName=${this.memberNames?.[Is(t)]}
-                      .showTilt=${this.showTilt}
-                    ></acp-group-member-row>`)}
-          </div>
+          ${this._membersTpl(i,t,o)}
         </div>
       </div>
-    `}_move(e,t){"stop"===e.detail?bs(this.hass,this.discovered,t):fs(this.hass,t,"open"===e.detail?100:0)}};function Fs(e){if("number"==typeof e.lu)return 1e3*e.lu;if("number"==typeof e.lc)return 1e3*e.lc;const t=e.last_updated??e.last_changed;if("string"==typeof t){const e=Date.parse(t);if(!Number.isNaN(e))return e}return null}Bs.styles=a`
+    `}_membersTpl(e,t,o){if(0===t.length)return H`<div class="members">
+        <div class="members-head">${st("group.members",this.hass)}</div>
+        <div class="member-placeholder">${st("group.member_placeholder",this.hass)}</div>
+      </div>`;const i=Rs(o,this.members);return 0===i.length?V:H`<div class="members">
+      <div class="members-head">${st("group.members",this.hass)}</div>
+      ${Us(i,Ns,t=>H`<acp-group-member-row
+            .hass=${this.hass}
+            .entityId=${t.covers[0]}
+            .coverIds=${t.covers}
+            .position=${e.memberPositions[t.covers[0]]??null}
+            .winner=${e.memberWinners?.[t.covers[0]]}
+            .openBlocksSun=${At(this.discovered).openBlocksSun}
+            .acpManaged=${!!e.memberWinners&&t.covers[0]in e.memberWinners}
+            .displayName=${this.memberNames?.[Ds(t)]}
+            .showTilt=${this.showTilt}
+          ></acp-group-member-row>`)}
+    </div>`}_move(e,t){"stop"===e.detail?Ms(this.hass,this.discovered,t):zs(this.hass,t,"open"===e.detail?100:0)}};function Js(e){if("number"==typeof e.lu)return 1e3*e.lu;if("number"==typeof e.lc)return 1e3*e.lc;const t=e.last_updated??e.last_changed;if("string"==typeof t){const e=Date.parse(t);if(!Number.isNaN(e))return e}return null}Xs.styles=a`
     :host {
       display: contents;
     }
@@ -2424,7 +2536,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
       text-align: center;
       padding: 12px;
     }
-  `,e([ge({attribute:!1})],Bs.prototype,"hass",void 0),e([ge({attribute:!1})],Bs.prototype,"discovered",void 0),e([ge({type:Boolean,reflect:!0})],Bs.prototype,"open",void 0),e([ge({type:Boolean})],Bs.prototype,"showTilt",void 0),e([ge({type:Boolean})],Bs.prototype,"showSceneSelect",void 0),e([ge({type:Boolean})],Bs.prototype,"showLock",void 0),e([ge({type:Boolean})],Bs.prototype,"showAutomation",void 0),e([ge({type:Boolean})],Bs.prototype,"showClearOverrides",void 0),e([ge({type:Boolean})],Bs.prototype,"showMemberBadges",void 0),e([ge({type:Boolean})],Bs.prototype,"stateColor",void 0),e([ge({attribute:!1})],Bs.prototype,"name",void 0),e([ge({attribute:!1})],Bs.prototype,"icon",void 0),e([ge({attribute:!1})],Bs.prototype,"memberNames",void 0),Bs=e([pe("acp-group-dialog")],Bs);const Rs="current_position";function js(e,t=Rs){const o=e.a??e.attributes,i=o?.[t];return"number"!=typeof i||Number.isNaN(i)?null:i}function Ls(e,t=Rs){const o=[];let i=null;for(const s of e){const e=Fs(s),n=js(s,t);null!==n&&(i=n),null!==e&&null!==i&&o.push({t:e,position:i})}return o}function Ks(e){const t=Object.keys(e).filter(t=>e[t].length>0);if(0===t.length)return[];const o={},i=new Set;for(const s of t){const t=[...e[s]].sort((e,t)=>e.t-t.t);o[s]=t;for(const e of t)i.add(e.t)}const s=[...i].sort((e,t)=>e-t),n={},r={};for(const e of t)n[e]=0,r[e]=null;const a=[];for(const e of s){for(const i of t){const t=o[i];for(;n[i]<t.length&&t[n[i]].t<=e;)r[i]=t[n[i]].position,n[i]++}const i=Ft(r);null!==i&&a.push({t:new Date(e).toISOString(),position:i})}return a}async function Gs(e,t,o,i,s={}){const n={position:{},tilt:{}},r=t.filter(e=>"string"==typeof e&&e.length>0);if(0===r.length)return n;let a;try{a=await e.callWS({type:"history/history_during_period",start_time:new Date(o).toISOString(),end_time:new Date(i).toISOString(),entity_ids:r,minimal_response:!1,no_attributes:!1,significant_changes_only:!1})}catch{return n}if(!a||"object"!=typeof a)return n;const l={position:{},tilt:{}};for(const e of r){const t=a[e];if(!Array.isArray(t))continue;const o=Ws(t,Rs,!!s.inverted,i);if(o&&(l.position[e]=o),s.wantTilt){const o=Ws(t,"current_tilt_position",!!s.tiltInverted,i);o&&(l.tilt[e]=o)}}return l}function Ws(e,t,o,i){const s=Ls(e,t);if(0===s.length)return null;const n=s.sort((e,t)=>e.t-t.t).map(e=>({t:new Date(e.t).toISOString(),position:o?100-e.position:e.position})),r=n[n.length-1];return Date.parse(r.t)<i&&n.push({t:new Date(i).toISOString(),position:r.position}),n}let Hs=class extends de{constructor(){super(...arguments),this.compact=!1,this.resetEnabled=!0,this._tick=null}disconnectedCallback(){super.disconnectedCallback(),this._syncTimer(!1)}shouldUpdate(e){if(e.size>1||!e.has("hass"))return!0;const t=e.get("hass"),o=this.discovered?.entities;return ve(t,this.hass,[o?.manual_override_binary,o?.manual_override_end_sensor,o?.motion_status_sensor,o?.reset_override_button])}updated(){if(!this.hass||!this.discovered)return void this._syncTimer(!1);const e=!this.compact&&(null!==this._manualEndIso()||null!=this._motionStatus()?.endIso);this._syncTimer(e)}_syncTimer(e){e&&null===this._tick?this._tick=setInterval(()=>this.requestUpdate(),1e3):e||null===this._tick||(clearInterval(this._tick),this._tick=null)}_manualActive(){const e=this.discovered.entities.manual_override_binary;return!!e&&"on"===this.hass.states[e]?.state}_manualEndIso(){const e=this.discovered.entities.manual_override_end_sensor;if(!e)return null;const t=this.hass.states[e];return t&&"unknown"!==t.state&&"unavailable"!==t.state?t.state:null}_motionStatus(){const e=this.discovered.entities.motion_status_sensor;if(!e)return null;const t=this.hass.states[e];if(!t)return null;const o=t.attributes.motion_timeout_end_time;return{state:t.state,endIso:o??null}}_resetManual(){const e=this.discovered.entities.reset_override_button;e&&this.hass.callService("button","press",{entity_id:e})}_motionStateLabel(e,t){if(e){const t=this.hass.states[e],o=this.hass.formatEntityState;if(t&&"function"==typeof o){const e=o(t);if(e)return e}}return t.replace(/_/g," ")}render(){if(!this.hass||!this.discovered)return V;const e=this._manualActive(),t=this._manualEndIso(),o=this._motionStatus(),i=this.discovered.entities.motion_status_sensor,s=this.discovered.entities.reset_override_button,n=st("overrides.reset_manual",this.hass);return H`
+  `,e([ge({attribute:!1})],Xs.prototype,"hass",void 0),e([ge({attribute:!1})],Xs.prototype,"discovered",void 0),e([ge({type:Boolean,reflect:!0})],Xs.prototype,"open",void 0),e([ge({type:Boolean})],Xs.prototype,"showTilt",void 0),e([ge({type:Boolean})],Xs.prototype,"showSceneSelect",void 0),e([ge({type:Boolean})],Xs.prototype,"showLock",void 0),e([ge({type:Boolean})],Xs.prototype,"showAutomation",void 0),e([ge({type:Boolean})],Xs.prototype,"showClearOverrides",void 0),e([ge({type:Boolean})],Xs.prototype,"showMemberBadges",void 0),e([ge({type:Boolean})],Xs.prototype,"stateColor",void 0),e([ge({attribute:!1})],Xs.prototype,"name",void 0),e([ge({attribute:!1})],Xs.prototype,"icon",void 0),e([ge({attribute:!1})],Xs.prototype,"memberNames",void 0),e([ge({attribute:!1})],Xs.prototype,"members",void 0),Xs=e([pe("acp-group-dialog")],Xs);const en="current_position";function tn(e,t=en){const o=e.a??e.attributes,i=o?.[t];return"number"!=typeof i||Number.isNaN(i)?null:i}function on(e,t=en){const o=[];let i=null;for(const s of e){const e=Js(s),n=tn(s,t);null!==n&&(i=n),null!==e&&null!==i&&o.push({t:e,position:i})}return o}function sn(e){const t=Object.keys(e).filter(t=>e[t].length>0);if(0===t.length)return[];const o={},i=new Set;for(const s of t){const t=[...e[s]].sort((e,t)=>e.t-t.t);o[s]=t;for(const e of t)i.add(e.t)}const s=[...i].sort((e,t)=>e-t),n={},r={};for(const e of t)n[e]=0,r[e]=null;const a=[];for(const e of s){for(const i of t){const t=o[i];for(;n[i]<t.length&&t[n[i]].t<=e;)r[i]=t[n[i]].position,n[i]++}const i=Bt(r);null!==i&&a.push({t:new Date(e).toISOString(),position:i})}return a}async function nn(e,t,o,i,s={}){const n={position:{},tilt:{}},r=t.filter(e=>"string"==typeof e&&e.length>0);if(0===r.length)return n;let a;try{a=await e.callWS({type:"history/history_during_period",start_time:new Date(o).toISOString(),end_time:new Date(i).toISOString(),entity_ids:r,minimal_response:!1,no_attributes:!1,significant_changes_only:!1})}catch{return n}if(!a||"object"!=typeof a)return n;const l={position:{},tilt:{}};for(const e of r){const t=a[e];if(!Array.isArray(t))continue;const o=rn(t,en,!!s.inverted,i);if(o&&(l.position[e]=o),s.wantTilt){const o=rn(t,"current_tilt_position",!!s.tiltInverted,i);o&&(l.tilt[e]=o)}}return l}function rn(e,t,o,i){const s=on(e,t);if(0===s.length)return null;const n=s.sort((e,t)=>e.t-t.t).map(e=>({t:new Date(e.t).toISOString(),position:o?100-e.position:e.position})),r=n[n.length-1];return Date.parse(r.t)<i&&n.push({t:new Date(i).toISOString(),position:r.position}),n}let an=class extends de{constructor(){super(...arguments),this.compact=!1,this.resetEnabled=!0,this._tick=null}disconnectedCallback(){super.disconnectedCallback(),this._syncTimer(!1)}shouldUpdate(e){if(e.size>1||!e.has("hass"))return!0;const t=e.get("hass"),o=this.discovered?.entities;return ve(t,this.hass,[o?.manual_override_binary,o?.manual_override_end_sensor,o?.motion_status_sensor,o?.reset_override_button])}updated(){if(!this.hass||!this.discovered)return void this._syncTimer(!1);const e=!this.compact&&(null!==this._manualEndIso()||null!=this._motionStatus()?.endIso);this._syncTimer(e)}_syncTimer(e){e&&null===this._tick?this._tick=setInterval(()=>this.requestUpdate(),1e3):e||null===this._tick||(clearInterval(this._tick),this._tick=null)}_manualActive(){const e=this.discovered.entities.manual_override_binary;return!!e&&"on"===this.hass.states[e]?.state}_manualEndIso(){const e=this.discovered.entities.manual_override_end_sensor;if(!e)return null;const t=this.hass.states[e];return t&&"unknown"!==t.state&&"unavailable"!==t.state?t.state:null}_motionStatus(){const e=this.discovered.entities.motion_status_sensor;if(!e)return null;const t=this.hass.states[e];if(!t)return null;const o=t.attributes.motion_timeout_end_time;return{state:t.state,endIso:o??null}}_resetManual(){const e=this.discovered.entities.reset_override_button;e&&this.hass.callService("button","press",{entity_id:e})}_motionStateLabel(e,t){if(e){const t=this.hass.states[e],o=this.hass.formatEntityState;if(t&&"function"==typeof o){const e=o(t);if(e)return e}}return t.replace(/_/g," ")}render(){if(!this.hass||!this.discovered)return V;const e=this._manualActive(),t=this._manualEndIso(),o=this._motionStatus(),i=this.discovered.entities.motion_status_sensor,s=this.discovered.entities.reset_override_button,n=st("overrides.reset_manual",this.hass);return H`
       <div class="wrap">
         <div class="label dim">${st("overrides.title",this.hass)}</div>
         <div class="grid">
@@ -2454,7 +2566,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
                 </button>`:V}
         </div>
       </div>
-    `}};Hs.styles=a`
+    `}};an.styles=a`
     :host {
       display: block;
     }
@@ -2538,7 +2650,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
     ha-icon {
       --mdc-icon-size: 18px;
     }
-  `,e([ge({attribute:!1})],Hs.prototype,"hass",void 0),e([ge({attribute:!1})],Hs.prototype,"discovered",void 0),e([ge({type:Boolean,reflect:!0})],Hs.prototype,"compact",void 0),e([ge({type:Boolean,attribute:"reset-enabled"})],Hs.prototype,"resetEnabled",void 0),Hs=e([pe("acp-overrides-panel")],Hs);const Us=new Set(["mode_off","active"]),qs={summer_mode:"mdi:weather-sunny",winter_mode:"mdi:snowflake",intermediate:"mdi:weather-partly-cloudy"};let Vs=class extends de{constructor(){super(...arguments),this.compact=!1}shouldUpdate(e){if(e.size>1||!e.has("hass"))return!0;const t=e.get("hass"),o=this.discovered?.entities;return ve(t,this.hass,[o?.climate_status_sensor,o?.climate_mode_switch])}render(){if(!this.hass||!this.discovered)return V;const e=this.discovered.entities.climate_status_sensor;if(!e)return V;const t=this.hass.states[e];if(!t||"unavailable"===t.state)return V;if("unknown"===t.state||""===t.state){const e=this.discovered.entities.climate_mode_switch,o=!!e&&"off"===this.hass.states[e]?.state,i=st(o?"climate.mode_off":"climate.standby",this.hass),s=o?"mdi:power-off":"mdi:thermostat",n=t.attributes?.inactive_reason;return this._renderStandby(s,i,n)}const o=t.state,i=t.attributes??{},s=qs[o]??"mdi:thermostat",n=this.hass.formatEntityState,r="function"==typeof n?n(t)??o:o,a=i.temperature_unit??"°",l=!0===i.temp_switch,c=(e,t)=>null==t||Number.isNaN(t)?null:`${st(e,this.hass)} ${t.toFixed(1)}${a}`,d=l?null:[c("climate.threshold_low",i.temp_low),c("climate.threshold_high",i.temp_high)].filter(e=>null!==e).join(" ")||null,h=[...l?[c("climate.threshold_low",i.temp_low),c("climate.threshold_high",i.temp_high)]:[],c("climate.threshold_summer_outside",i.temp_summer_outside)].filter(e=>null!==e).join(" ")||null,p=[void 0!==i.indoor_temperature?{label:st("climate.indoor",this.hass),value:i.indoor_temperature,unit:a,threshold:d}:null,void 0!==i.outdoor_temperature?{label:st("climate.outdoor",this.hass),value:i.outdoor_temperature,unit:a,threshold:h}:null].filter(e=>null!==e);if(null!=(u=i.inactive_reason)&&"active"!==u)return this._renderStandby(s,r,i.inactive_reason,p);var u;const _=void 0!==i.active_temperature?`${i.active_temperature.toFixed(1)}${a}`:"—",g=[{label:st("climate.presence",this.hass),value:i.is_presence,icon:"mdi:account-check"},{label:st("climate.sunny",this.hass),value:i.is_sunny,icon:"mdi:white-balance-sunny"},{label:st("climate.lux",this.hass),value:i.lux_active,icon:"mdi:brightness-7"},{label:st("climate.irradiance",this.hass),value:i.irradiance_active,icon:"mdi:solar-power"}].filter(e=>void 0!==e.value);return H`
+  `,e([ge({attribute:!1})],an.prototype,"hass",void 0),e([ge({attribute:!1})],an.prototype,"discovered",void 0),e([ge({type:Boolean,reflect:!0})],an.prototype,"compact",void 0),e([ge({type:Boolean,attribute:"reset-enabled"})],an.prototype,"resetEnabled",void 0),an=e([pe("acp-overrides-panel")],an);const ln=new Set(["mode_off","active"]),cn={summer_mode:"mdi:weather-sunny",winter_mode:"mdi:snowflake",intermediate:"mdi:weather-partly-cloudy"};let dn=class extends de{constructor(){super(...arguments),this.compact=!1}shouldUpdate(e){if(e.size>1||!e.has("hass"))return!0;const t=e.get("hass"),o=this.discovered?.entities;return ve(t,this.hass,[o?.climate_status_sensor,o?.climate_mode_switch])}render(){if(!this.hass||!this.discovered)return V;const e=this.discovered.entities.climate_status_sensor;if(!e)return V;const t=this.hass.states[e];if(!t||"unavailable"===t.state)return V;if("unknown"===t.state||""===t.state){const e=this.discovered.entities.climate_mode_switch,o=!!e&&"off"===this.hass.states[e]?.state,i=st(o?"climate.mode_off":"climate.standby",this.hass),s=o?"mdi:power-off":"mdi:thermostat",n=t.attributes?.inactive_reason;return this._renderStandby(s,i,n)}const o=t.state,i=t.attributes??{},s=cn[o]??"mdi:thermostat",n=this.hass.formatEntityState,r="function"==typeof n?n(t)??o:o,a=i.temperature_unit??"°",l=!0===i.temp_switch,c=(e,t)=>null==t||Number.isNaN(t)?null:`${st(e,this.hass)} ${t.toFixed(1)}${a}`,d=l?null:[c("climate.threshold_low",i.temp_low),c("climate.threshold_high",i.temp_high)].filter(e=>null!==e).join(" ")||null,h=[...l?[c("climate.threshold_low",i.temp_low),c("climate.threshold_high",i.temp_high)]:[],c("climate.threshold_summer_outside",i.temp_summer_outside)].filter(e=>null!==e).join(" ")||null,p=[void 0!==i.indoor_temperature?{label:st("climate.indoor",this.hass),value:i.indoor_temperature,unit:a,threshold:d}:null,void 0!==i.outdoor_temperature?{label:st("climate.outdoor",this.hass),value:i.outdoor_temperature,unit:a,threshold:h}:null].filter(e=>null!==e);if(null!=(u=i.inactive_reason)&&"active"!==u)return this._renderStandby(s,r,i.inactive_reason,p);var u;const _=void 0!==i.active_temperature?`${i.active_temperature.toFixed(1)}${a}`:"—",g=[{label:st("climate.presence",this.hass),value:i.is_presence,icon:"mdi:account-check"},{label:st("climate.sunny",this.hass),value:i.is_sunny,icon:"mdi:white-balance-sunny"},{label:st("climate.lux",this.hass),value:i.lux_active,icon:"mdi:brightness-7"},{label:st("climate.irradiance",this.hass),value:i.irradiance_active,icon:"mdi:solar-power"}].filter(e=>void 0!==e.value);return H`
       <div class="wrap">
         <div class="head">
           <span class="label">${st("climate.title",this.hass)}</span>
@@ -2552,7 +2664,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
         ${g.length?H`
               <div class="conditions">
                 ${g.map(e=>H`
-                    <div class="chip ${e.value?"on":"off"}" ${xo(e.label)}>
+                    <div class="chip ${e.value?"on":"off"}" ${$o(e.label)}>
                       <ha-icon icon=${e.icon}></ha-icon>
                       <span>${e.label}</span>
                     </div>
@@ -2560,7 +2672,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
               </div>
             `:V}
       </div>
-    `}_renderStandby(e,t,o,i=[]){const s=o&&!Us.has(o)?st(`climate.reason.${o}`,this.hass):void 0;return H`
+    `}_renderStandby(e,t,o,i=[]){const s=o&&!ln.has(o)?st(`climate.reason.${o}`,this.hass):void 0;return H`
       <div class="wrap">
         <div class="head">
           <span class="label">${st("climate.title",this.hass)}</span>
@@ -2582,7 +2694,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
             </div>
           `)}
       </div>
-    `:V}};Vs.styles=a`
+    `:V}};dn.styles=a`
     :host {
       display: block;
     }
@@ -2689,14 +2801,14 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
     .dim {
       color: var(--secondary-text-color);
     }
-  `,e([ge({attribute:!1})],Vs.prototype,"hass",void 0),e([ge({attribute:!1})],Vs.prototype,"discovered",void 0),e([ge({type:Boolean,reflect:!0})],Vs.prototype,"compact",void 0),Vs=e([pe("acp-climate-panel")],Vs);let Ys=class extends de{constructor(){super(...arguments),this.compact=!1,this.coverColor=null,this._dragPreview=null,this._openMoreInfo=()=>{this.dispatchEvent(new CustomEvent("acp-open-more-info",{bubbles:!0,composed:!0}))},this._onNameKeydown=e=>{"Enter"!==e.key&&" "!==e.key||(e.preventDefault(),this._openMoreInfo())},this._onTrackPointerDown=(e,t,o)=>{const i=e.currentTarget;i.setPointerCapture?.(e.pointerId),this._dragPreview={entityId:t,pct:ft(this._pctFromEvent(e,i),o)}},this._onTrackPointerMove=(e,t,o)=>{if(this._dragPreview?.entityId!==t)return;const i=e.currentTarget;this._dragPreview={entityId:t,pct:ft(this._pctFromEvent(e,i),o)}},this._onTrackPointerEnd=e=>{this._dragPreview?.entityId===e&&(this._dragPreview=null)}}shouldUpdate(e){if(e.size>1||!e.has("hass"))return!0;const t=e.get("hass"),o=this.discovered?.entities,i=this.discovered?kt(this.discovered).map(e=>e.targetRole?o?.[e.targetRole]:void 0).filter(e=>!!e):[];return ve(t,this.hass,[...i,o?.position_mismatch_binary,o?.manual_override_binary,...this.discovered?.managed_covers??[]])}_target(){const e=this.discovered.entities.target_position_sensor;return e&&this.hass.states[e]?{target:Xt(this.hass,this.discovered),covers:qt(this.hass,this.discovered)}:{target:null,covers:{}}}_transit(){const e=this.discovered.entities.target_position_sensor;if(!e)return{};const t=this.hass.states[e];if(!t)return{};const o=t.attributes;return o?.transit_states??{}}_mismatched(){const e=this.discovered.entities.position_mismatch_binary;if(!e)return new Set;const t=this.hass.states[e];if("on"!==t?.state)return new Set;const o=t.attributes.entities;return o?new Set(Object.entries(o).filter(([,e])=>e.mismatch).map(([e])=>e)):new Set}_setAxis(e,t,o){Li(this.hass,e,{[t]:o})}_gotoTarget(e,t){Li(this.hass,e,{position:t},{force:!0})}_axisTarget(e){const t=e.targetRole;if(!t)return null;const o=this.discovered.entities[t];if(!o)return null;const i=parseFloat(this.hass.states[o]?.state??"");return Number.isNaN(i)?null:i}_axisActual(e,t){return Yt(this.hass,e,t)}_motorDivergence(){return function(e,t){const o=Wt(e,t),i=Gt(e,t);return null===o||null===i||o===i||St(t)&&i===100-o?null:i}(this.hass,this.discovered)}_axisLabel(e){const t=qe[e.id];return t?st(t,this.hass):e.label}_axisTargetLabel(e,t){return"tilt"===e.id?st("covers.tilt_target",this.hass,{pct:nt(t)}):`${this._axisLabel(e)}: ${nt(t)}`}render(){if(!this.hass||!this.discovered)return V;const{target:e,covers:t}=this._target(),o=this._mismatched(),i=(l=this.hass,c=this.discovered,null!==jt(Qt(l,c),Ut(l,c),Ht(l,c))),s=this._motorDivergence(),n=this._transit(),r=this.coverOrder?.length?this.coverOrder.filter(e=>e in t).map(e=>[e,t[e]]):[],a=r.length>0?r:Object.entries(t);var l,c;if(0===a.length)return H`<div class="placeholder">${st("covers.placeholder",this.hass)}</div>`;const d=kt(this.discovered).filter(e=>"position"!==e.id),h=At(this.discovered),p=new Map(d.map(e=>[e.id,this._axisTarget(e)]));return H`
+  `,e([ge({attribute:!1})],dn.prototype,"hass",void 0),e([ge({attribute:!1})],dn.prototype,"discovered",void 0),e([ge({type:Boolean,reflect:!0})],dn.prototype,"compact",void 0),dn=e([pe("acp-climate-panel")],dn);let hn=class extends de{constructor(){super(...arguments),this.compact=!1,this.coverColor=null,this._dragPreview=null,this._pending=new Li(this),this._lastLive=new Map,this._openMoreInfo=()=>{this.dispatchEvent(new CustomEvent("acp-open-more-info",{bubbles:!0,composed:!0}))},this._onNameKeydown=e=>{"Enter"!==e.key&&" "!==e.key||(e.preventDefault(),this._openMoreInfo())},this._onTrackPointerDown=(e,t,o)=>{const i=e.currentTarget;i.setPointerCapture?.(e.pointerId),this._dragPreview={entityId:t,pct:ft(this._pctFromEvent(e,i),o)}},this._onTrackPointerMove=(e,t,o)=>{if(this._dragPreview?.entityId!==t)return;const i=e.currentTarget;this._dragPreview={entityId:t,pct:ft(this._pctFromEvent(e,i),o)}},this._onTrackPointerEnd=e=>{this._dragPreview?.entityId===e&&(this._dragPreview=null)}}updated(){this._pending.settle(e=>this._lastLive.get(e)??null)}shouldUpdate(e){if(e.size>1||!e.has("hass"))return!0;const t=e.get("hass"),o=this.discovered?.entities,i=this.discovered?kt(this.discovered).map(e=>e.targetRole?o?.[e.targetRole]:void 0).filter(e=>!!e):[];return ve(t,this.hass,[...i,o?.position_mismatch_binary,o?.manual_override_binary,...this.discovered?.managed_covers??[]])}_target(){const e=this.discovered.entities.target_position_sensor;return e&&this.hass.states[e]?{target:Jt(this.hass,this.discovered),covers:Vt(this.hass,this.discovered)}:{target:null,covers:{}}}_transit(){const e=this.discovered.entities.target_position_sensor;if(!e)return{};const t=this.hass.states[e];if(!t)return{};const o=t.attributes;return o?.transit_states??{}}_mismatched(){const e=this.discovered.entities.position_mismatch_binary;if(!e)return new Set;const t=this.hass.states[e];if("on"!==t?.state)return new Set;const o=t.attributes.entities;return o?new Set(Object.entries(o).filter(([,e])=>e.mismatch).map(([e])=>e)):new Set}_setAxis(e,t,o){"position"===t&&this._pending.start(e,o),Yi(this.hass,e,{[t]:o})}_gotoTarget(e,t){this._pending.start(e,t),Yi(this.hass,e,{position:t},{force:!0})}_axisTarget(e){const t=e.targetRole;if(!t)return null;const o=this.discovered.entities[t];if(!o)return null;const i=parseFloat(this.hass.states[o]?.state??"");return Number.isNaN(i)?null:i}_axisActual(e,t){return Zt(this.hass,e,t)}_motorDivergence(){return function(e,t){const o=Ht(e,t),i=Wt(e,t);return null===o||null===i||o===i||St(t)&&i===100-o?null:i}(this.hass,this.discovered)}_axisLabel(e){const t=qe[e.id];return t?st(t,this.hass):e.label}_axisTargetLabel(e,t){return"tilt"===e.id?st("covers.tilt_target",this.hass,{pct:nt(t)}):`${this._axisLabel(e)}: ${nt(t)}`}render(){if(!this.hass||!this.discovered)return V;const{target:e,covers:t}=this._target(),o=this._mismatched(),i=(l=this.hass,c=this.discovered,null!==jt(Xt(l,c),qt(l,c),Ut(l,c))),s=this._motorDivergence(),n=this._transit(),r=this.coverOrder?.length?this.coverOrder.filter(e=>e in t).map(e=>[e,t[e]]):[],a=r.length>0?r:Object.entries(t);var l,c;if(0===a.length)return H`<div class="placeholder">${st("covers.placeholder",this.hass)}</div>`;const d=kt(this.discovered).filter(e=>"position"!==e.id),h=At(this.discovered),p=new Map(d.map(e=>[e.id,this._axisTarget(e)]));return H`
       <div class="wrap" style=${this.coverColor?`--acp-cover-color:${this.coverColor}`:V}>
         <div class="head">
           <span class="label">${st("covers.title",this.hass)}</span>
           <span class="targets">
             <span
               class="target"
-              ${null!==s?xo(st("covers.target_tooltip_motor",this.hass,{pct:s})):V}
+              ${null!==s?$o(st("covers.target_tooltip_motor",this.hass,{pct:s})):V}
               >${st(i?"covers.target_solar":"covers.target",this.hass,{pct:nt(e)})}</span
             >
             ${d.map(e=>H`<span class="target"
@@ -2723,7 +2835,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
             </div>
           `)}
       </div>
-    `}_bar(e,t,o,i,s,n,r){const a=this.hass.states[e]?.attributes?.friendly_name??e,l=o??0,c=this._dragPreview?.entityId===e?this._dragPreview.pct:null,d=nt(null!==c?c:t),h=c??t,p=null===h?0:ft(h,r),u=ft(l,r),_=lt(this.hass,e,n??void 0);return H`
+    `}_bar(e,t,o,i,s,n,r){const a=this.hass.states[e]?.attributes?.friendly_name??e,l=o??0,c=this._dragPreview?.entityId===e?this._dragPreview.pct:null,d=nt(null!==c?c:t),h=c??t,p=null===h?0:ft(h,r),u=ft(l,r),_=lt(this.hass,e,n??void 0);this._lastLive.set(e,t);const g=Ki(this.hass.states[e]?.state)&&null!==o?l:null,m=null!==c?null:this._pending.get(e)??g,v=Ri(t,m)?m:null,f=null===v?null:ft(v,r);return H`
       <div class="cover ${i?"mismatch":""}">
         <div
           class="name"
@@ -2731,7 +2843,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
           tabindex="0"
           @click=${this._openMoreInfo}
           @keydown=${this._onNameKeydown}
-          ${xo(e)}
+          ${$o(e)}
         >
           ${a}
         </div>
@@ -2739,7 +2851,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
           ${n&&!_?H`<ha-icon
                 class="transit transit-${n}"
                 icon=${"opening"===n?"mdi:arrow-up-thin":"mdi:arrow-down-thin"}
-                ${xo(st("covers."+n,this.hass))}
+                ${$o(st("covers."+n,this.hass))}
               ></ha-icon>`:V}${_?H`<span class="num-state">${_}</span><span class="num-sep"> · </span>`:V}<span class="num-pct">${d}</span>
         </div>
         <div
@@ -2757,67 +2869,68 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
           @pointerup=${()=>this._onTrackPointerEnd(e)}
           @pointercancel=${()=>this._onTrackPointerEnd(e)}
           @keydown=${t=>this._onTrackKeydown(t,e,p,r)}
-          ${xo(st("covers.click_to_set",this.hass))}
+          ${$o(st("covers.click_to_set",this.hass))}
         >
           <div class="fill" style="width:${p}%"></div>
           <div class="fill-closed" style="width:${100-p}%"></div>
+          ${null!==v&&null!==f?Gi({hass:this.hass,liveFrac:p,pendingFrac:f,pending:v}):V}
           ${null!==o?H`<div
                 class="marker"
                 style="left:clamp(1px, ${u}%, calc(100% - 1px))"
-                ${xo(st(s?"covers.target_tooltip_override":"covers.target_tooltip",this.hass,{pct:l}))}
+                ${$o(st(s?"covers.target_tooltip_override":"covers.target_tooltip",this.hass,{pct:l}))}
               ></div>`:V}
         </div>
-        ${null!==o&&ji(this.hass)?H`<button
+        ${null!==o&&Vi(this.hass)?H`<button
               class="goto-target"
               type="button"
               aria-label=${st("covers.goto_target",this.hass,{pct:l})}
-              ${xo(st("covers.goto_target",this.hass,{pct:l}))}
+              ${$o(st("covers.goto_target",this.hass,{pct:l}))}
               @click=${()=>this._gotoTarget(e,o)}
             >
               <ha-icon icon="mdi:target"></ha-icon>
             </button>`:H`<span class="goto-target-spacer"></span>`}
         ${i&&!s?H`<ha-icon class="warn" icon="mdi:alert-circle-outline"></ha-icon>`:V}
       </div>
-    `}_pctFromEvent(e,t){const o=t.getBoundingClientRect(),i=Math.round((e.clientX-o.left)/o.width*100);return Math.max(0,Math.min(100,i))}_handleTrackClick(e,t,o){const i=e.currentTarget,s=this._pctFromEvent(e,i);this._setAxis(t,"position",ft(s,o))}_onTrackKeydown(e,t,o,i){let s;switch(e.key){case"ArrowRight":case"ArrowUp":s=o+1;break;case"ArrowLeft":case"ArrowDown":s=o-1;break;case"PageUp":s=o+10;break;case"PageDown":s=o-10;break;case"Home":s=0;break;case"End":s=100;break;default:return}e.preventDefault();const n=Math.max(0,Math.min(100,s));this._setAxis(t,"position",ft(n,i))}};function Zs(e){if("number"==typeof e.lu)return 1e3*e.lu;if("number"==typeof e.lc)return 1e3*e.lc;const t=e.last_updated??e.last_changed;if("string"==typeof t){const e=Date.parse(t);if(!Number.isNaN(e))return e}return null}function Qs(e){if(!Array.isArray(e))return[];const t=[];for(const o of e){if(!o||"object"!=typeof o)continue;const e=Zs(o),i=o.s??o.state;null!==e&&"string"==typeof i&&t.push({t:e,state:i,attributes:o.a??o.attributes??{}})}return t.sort((e,t)=>e.t-t.t),t}function Xs(e,t,o){if(0===e.length||o<=t)return[];let i=null;const s=[];for(const n of e){if(n.t>=o)break;n.t<=t?i=n:s.push(n)}const n=i?[{...i,t:t},...s]:[...s];if(0===n.length)return[];const r=[];for(const e of n){const t=r[r.length-1];t&&t.state===e.state||(t&&(t.end=e.t),r.push({start:e.t,end:o,state:e.state,attributes:e.attributes}))}return r.filter(e=>e.end>e.start)}function Js(e,t={}){const o=[];for(const i of e){const e=t.preferAttribute?i.attributes[t.preferAttribute]:void 0;if("number"==typeof e&&Number.isFinite(e)){o.push({t:i.t,value:e});continue}const s=parseFloat(i.state);Number.isNaN(s)||o.push({t:i.t,value:t.inverted?100-s:s})}return o}function en(e){return e.map(e=>({t:Date.parse(e.t),value:e.position})).filter(e=>!Number.isNaN(e.t))}function tn(e,t){if(0===e.length)return[];const o=[e[0]];for(let t=1;t<e.length;t++){const i=e[t-1],s=e[t];s.value!==i.value&&o.push({t:s.t,value:i.value}),o.push(s)}const i=o[o.length-1];return i.t<t&&o.push({t:t,value:i.value}),o}function on(e,t){let o=null,i=Number.NEGATIVE_INFINITY;for(const s of e)Number.isNaN(s.t)||s.t<=t&&s.t>=i&&(i=s.t,o=s.value);return o}async function sn(e,t,o,i){const s=t.filter(e=>"string"==typeof e&&e.length>0);if(0===s.length)return{};let n;try{n=await e.callWS({type:"history/history_during_period",start_time:new Date(o).toISOString(),end_time:new Date(i).toISOString(),entity_ids:s,minimal_response:!1,no_attributes:!1,significant_changes_only:!1})}catch{return{}}if(!n||"object"!=typeof n)return{};const r={};for(const e of s){const t=Qs(n[e]);t.length>0&&(r[e]=t)}return r}var nn;Ys.styles=a`
-    :host {
-      display: block;
-    }
-    .wrap {
-      display: flex;
-      flex-direction: column;
-      gap: 6px;
-    }
-    .head {
-      display: flex;
-      justify-content: space-between;
-      font-size: 0.78rem;
-      color: var(--secondary-text-color);
-    }
-    .label {
-      letter-spacing: 0.05em;
-      text-transform: uppercase;
-    }
-    .targets {
-      display: flex;
-      gap: 12px;
-    }
-    .target {
-      font-variant-numeric: tabular-nums;
-    }
-    /* Position + (optional) tilt row stack for one cover. */
-    .cover-group {
-      display: flex;
-      flex-direction: column;
-      gap: 4px;
-    }
-    .cover-group acp-tilt-bar {
-      /* Indent the tilt row under the position track so the two read as one
+    `}_pctFromEvent(e,t){const o=t.getBoundingClientRect(),i=Math.round((e.clientX-o.left)/o.width*100);return Math.max(0,Math.min(100,i))}_handleTrackClick(e,t,o){const i=e.currentTarget,s=this._pctFromEvent(e,i);this._setAxis(t,"position",ft(s,o))}_onTrackKeydown(e,t,o,i){let s;switch(e.key){case"ArrowRight":case"ArrowUp":s=o+1;break;case"ArrowLeft":case"ArrowDown":s=o-1;break;case"PageUp":s=o+10;break;case"PageDown":s=o-10;break;case"Home":s=0;break;case"End":s=100;break;default:return}e.preventDefault();const n=Math.max(0,Math.min(100,s));this._setAxis(t,"position",ft(n,i))}};function pn(e){if("number"==typeof e.lu)return 1e3*e.lu;if("number"==typeof e.lc)return 1e3*e.lc;const t=e.last_updated??e.last_changed;if("string"==typeof t){const e=Date.parse(t);if(!Number.isNaN(e))return e}return null}function un(e){if(!Array.isArray(e))return[];const t=[];for(const o of e){if(!o||"object"!=typeof o)continue;const e=pn(o),i=o.s??o.state;null!==e&&"string"==typeof i&&t.push({t:e,state:i,attributes:o.a??o.attributes??{}})}return t.sort((e,t)=>e.t-t.t),t}function _n(e,t,o){if(0===e.length||o<=t)return[];let i=null;const s=[];for(const n of e){if(n.t>=o)break;n.t<=t?i=n:s.push(n)}const n=i?[{...i,t:t},...s]:[...s];if(0===n.length)return[];const r=[];for(const e of n){const t=r[r.length-1];t&&t.state===e.state||(t&&(t.end=e.t),r.push({start:e.t,end:o,state:e.state,attributes:e.attributes}))}return r.filter(e=>e.end>e.start)}function gn(e,t={}){const o=[];for(const i of e){const e=t.preferAttribute?i.attributes[t.preferAttribute]:void 0;if("number"==typeof e&&Number.isFinite(e)){o.push({t:i.t,value:e});continue}const s=parseFloat(i.state);Number.isNaN(s)||o.push({t:i.t,value:t.inverted?100-s:s})}return o}function mn(e){return e.map(e=>({t:Date.parse(e.t),value:e.position})).filter(e=>!Number.isNaN(e.t))}function vn(e,t){if(0===e.length)return[];const o=[e[0]];for(let t=1;t<e.length;t++){const i=e[t-1],s=e[t];s.value!==i.value&&o.push({t:s.t,value:i.value}),o.push(s)}const i=o[o.length-1];return i.t<t&&o.push({t:t,value:i.value}),o}function fn(e,t){let o=null,i=Number.NEGATIVE_INFINITY;for(const s of e)Number.isNaN(s.t)||s.t<=t&&s.t>=i&&(i=s.t,o=s.value);return o}async function bn(e,t,o,i){const s=t.filter(e=>"string"==typeof e&&e.length>0);if(0===s.length)return{};let n;try{n=await e.callWS({type:"history/history_during_period",start_time:new Date(o).toISOString(),end_time:new Date(i).toISOString(),entity_ids:s,minimal_response:!1,no_attributes:!1,significant_changes_only:!1})}catch{return{}}if(!n||"object"!=typeof n)return{};const r={};for(const e of s){const t=un(n[e]);t.length>0&&(r[e]=t)}return r}var yn;hn.styles=[Wi,a`
+      :host {
+        display: block;
+      }
+      .wrap {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+      }
+      .head {
+        display: flex;
+        justify-content: space-between;
+        font-size: 0.78rem;
+        color: var(--secondary-text-color);
+      }
+      .label {
+        letter-spacing: 0.05em;
+        text-transform: uppercase;
+      }
+      .targets {
+        display: flex;
+        gap: 12px;
+      }
+      .target {
+        font-variant-numeric: tabular-nums;
+      }
+      /* Position + (optional) tilt row stack for one cover. */
+      .cover-group {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+      }
+      .cover-group acp-tilt-bar {
+        /* Indent the tilt row under the position track so the two read as one
          cover's two axes. Aligns roughly with the position bar's track column. */
-      padding-left: 0;
-    }
-    .cover {
-      display: grid;
-      /* Final column is fixed at the warn-icon size (16px) rather than auto so
+        padding-left: 0;
+      }
+      .cover {
+        display: grid;
+        /* Final column is fixed at the warn-icon size (16px) rather than auto so
          the track (3fr) keeps the same width whether or not the badge renders —
          a toggling badge no longer reflows the bar graph (#158).
 
@@ -2833,41 +2946,41 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
          would hand those pixels to the track and reflow the bar graph. A spacer
          holds the cell instead. Keep in lock-step with acp-tilt-bar's .row.cover
          grid — they are separate grids stacked in one .cover-group. */
-      grid-template-columns: minmax(80px, 1fr) 11ch 3fr 22px 16px;
-      gap: 8px;
-      align-items: center;
-      font-size: 0.82rem;
-    }
-    /* Snap this cover to the marker's value. Sized and coloured like the row's
+        grid-template-columns: minmax(80px, 1fr) 11ch 3fr 22px 16px;
+        gap: 8px;
+        align-items: center;
+        font-size: 0.82rem;
+      }
+      /* Snap this cover to the marker's value. Sized and coloured like the row's
        other glyphs rather than like a control, so a row of covers does not read
        as a row of buttons — it lights up on hover/focus. */
-    .goto-target {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      width: 22px;
-      height: 22px;
-      padding: 0;
-      border: none;
-      border-radius: 50%;
-      background: none;
-      cursor: pointer;
-      color: var(--secondary-text-color);
-      --mdc-icon-size: 16px;
-      transition:
-        color 0.15s ease,
-        background 0.15s ease;
-    }
-    .goto-target:hover {
-      color: var(--accent-color, var(--primary-color));
-      background: color-mix(in srgb, currentColor 14%, transparent);
-    }
-    .goto-target:focus-visible {
-      outline: 2px solid var(--primary-color);
-      outline-offset: 1px;
-      color: var(--accent-color, var(--primary-color));
-    }
-    /* Floating-tooltip cursor lifecycle for this shadow root's INERT tooltip
+      .goto-target {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 22px;
+        height: 22px;
+        padding: 0;
+        border: none;
+        border-radius: 50%;
+        background: none;
+        cursor: pointer;
+        color: var(--secondary-text-color);
+        --mdc-icon-size: 16px;
+        transition:
+          color 0.15s ease,
+          background 0.15s ease;
+      }
+      .goto-target:hover {
+        color: var(--accent-color, var(--primary-color));
+        background: color-mix(in srgb, currentColor 14%, transparent);
+      }
+      .goto-target:focus-visible {
+        outline: 2px solid var(--primary-color);
+        outline-offset: 1px;
+        color: var(--accent-color, var(--primary-color));
+      }
+      /* Floating-tooltip cursor lifecycle for this shadow root's INERT tooltip
        carriers: the transit arrow and the header target chip. Restated here
        because a shadow root cannot borrow its host's copy of this pair.
 
@@ -2876,59 +2989,59 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
        role="button" that opens more-info, and .track / the tilt track are
        drag-to-set sliders — so a blanket rule would replace three correct
        pointers with a help cursor that promises information instead of action. */
-    .transit[data-tooltip]:hover,
-    .target[data-tooltip]:hover {
-      cursor: help;
-    }
-    .transit[data-tooltip][acp-tt-shown],
-    .target[data-tooltip][acp-tt-shown] {
-      cursor: default;
-    }
-    /* The cover name is a tap target that opens the entry's more-info dialog,
+      .transit[data-tooltip]:hover,
+      .target[data-tooltip]:hover {
+        cursor: help;
+      }
+      .transit[data-tooltip][acp-tt-shown],
+      .target[data-tooltip][acp-tt-shown] {
+        cursor: default;
+      }
+      /* The cover name is a tap target that opens the entry's more-info dialog,
        so it carries a pointer cursor and a keyboard focus ring. It still hovers
        an entity-id tooltip, but click/Enter/Space open the dialog. */
-    .name {
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      cursor: pointer;
-      border-radius: 4px;
-    }
-    .name:focus-visible {
-      outline: 2px solid var(--primary-color);
-      outline-offset: 2px;
-    }
-    .track {
-      position: relative;
-      display: flex;
-      height: 10px;
-      background: var(--secondary-background-color, rgba(0, 0, 0, 0.08));
-      border-radius: 6px;
-      cursor: pointer;
-      overflow: hidden;
-      /* A touch-drag must move the fill, not the page — own the gesture. */
-      touch-action: none;
-    }
-    .track:focus-visible {
-      outline: 2px solid var(--primary-color);
-      outline-offset: 2px;
-    }
-    :host([compact]) .track {
-      height: 6px;
-    }
-    :host([compact]) .cover {
-      font-size: 0.75rem;
-      gap: 6px;
-    }
-    :host([compact]) .goto-target {
-      width: 18px;
-      height: 18px;
-      --mdc-icon-size: 14px;
-    }
-    :host([compact]) .head {
-      display: none;
-    }
-    /* Both segments derive from the cover colour (override, else --primary-color),
+      .name {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        cursor: pointer;
+        border-radius: 4px;
+      }
+      .name:focus-visible {
+        outline: 2px solid var(--primary-color);
+        outline-offset: 2px;
+      }
+      .track {
+        position: relative;
+        display: flex;
+        height: 10px;
+        background: var(--secondary-background-color, rgba(0, 0, 0, 0.08));
+        border-radius: 6px;
+        cursor: pointer;
+        overflow: hidden;
+        /* A touch-drag must move the fill, not the page — own the gesture. */
+        touch-action: none;
+      }
+      .track:focus-visible {
+        outline: 2px solid var(--primary-color);
+        outline-offset: 2px;
+      }
+      :host([compact]) .track {
+        height: 6px;
+      }
+      :host([compact]) .cover {
+        font-size: 0.75rem;
+        gap: 6px;
+      }
+      :host([compact]) .goto-target {
+        width: 18px;
+        height: 18px;
+        --mdc-icon-size: 14px;
+      }
+      :host([compact]) .head {
+        display: none;
+      }
+      /* Both segments derive from the cover colour (override, else --primary-color),
        distinguished by opacity: blocking is solid, clear is pale — "lighter =
        more open" — matching the compass FOV (light) vs cover wedge (solid) of
        the same hue. No gold, so nothing competes with the gold sun on the compass.
@@ -2937,90 +3050,98 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
        the track fills from the left as the cover closes — the same polarity as
        the tile rails and the compass wedge. Class names are kept (a rename buys
        nothing the comment does not) but the colours swapped with the meaning. */
-    .fill {
-      height: 100%;
-      flex-shrink: 0;
-      background: color-mix(in srgb, var(--acp-cover-color, var(--primary-color)) 50%, transparent);
-      transition: width 0.3s ease;
-    }
-    .fill-closed {
-      height: 100%;
-      flex-shrink: 0;
-      background: color-mix(in srgb, var(--acp-cover-color, var(--primary-color)) 18%, transparent);
-      transition: width 0.3s ease;
-    }
-    /* The marker is centred on its left value via translateX(-50%) and its
+      .fill {
+        height: 100%;
+        flex-shrink: 0;
+        background: color-mix(
+          in srgb,
+          var(--acp-cover-color, var(--primary-color)) 50%,
+          transparent
+        );
+        transition: width 0.3s ease;
+      }
+      .fill-closed {
+        height: 100%;
+        flex-shrink: 0;
+        background: color-mix(
+          in srgb,
+          var(--acp-cover-color, var(--primary-color)) 18%,
+          transparent
+        );
+        transition: width 0.3s ease;
+      }
+      /* The marker is centred on its left value via translateX(-50%) and its
        left is clamped 1px inside the rail (inline), so the 2px box never gets
        clipped by .track { overflow:hidden } at the 0%/100% extremes (#158). */
-    .marker {
-      position: absolute;
-      top: -2px;
-      width: 2px;
-      height: 14px;
-      background: var(--accent-color, red);
-      transform: translateX(-50%);
-      transition: left 0.3s ease;
-    }
-    .num {
-      font-variant-numeric: tabular-nums;
-      text-align: right;
-      display: inline-flex;
-      align-items: center;
-      justify-content: flex-end;
-      gap: 2px;
-      white-space: nowrap;
-      min-width: 0;
-      overflow: hidden;
-    }
-    /* The state word yields first; the percentage is the part that must never
+      .marker {
+        position: absolute;
+        top: -2px;
+        width: 2px;
+        height: 14px;
+        background: var(--accent-color, red);
+        transform: translateX(-50%);
+        transition: left 0.3s ease;
+      }
+      .num {
+        font-variant-numeric: tabular-nums;
+        text-align: right;
+        display: inline-flex;
+        align-items: center;
+        justify-content: flex-end;
+        gap: 2px;
+        white-space: nowrap;
+        min-width: 0;
+        overflow: hidden;
+      }
+      /* The state word yields first; the percentage is the part that must never
        be cut, so it holds its intrinsic width. */
-    .num-state {
-      min-width: 0;
-      overflow: hidden;
-      text-overflow: ellipsis;
-    }
-    .num-sep,
-    .num-pct {
-      flex: 0 0 auto;
-    }
-    /* In-transit motion indicator for no-feedback covers: a small direction
+      .num-state {
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+      .num-sep,
+      .num-pct {
+        flex: 0 0 auto;
+      }
+      /* In-transit motion indicator for no-feedback covers: a small direction
        arrow beside the percent, sized to the .num text. */
-    .transit {
-      --mdc-icon-size: 1em;
-      color: var(--primary-color);
-      flex-shrink: 0;
-    }
-    @media (prefers-reduced-motion: no-preference) {
       .transit {
-        animation: acp-transit-pulse 1.1s ease-in-out infinite;
+        --mdc-icon-size: 1em;
+        color: var(--primary-color);
+        flex-shrink: 0;
       }
-    }
-    @keyframes acp-transit-pulse {
-      0%,
-      100% {
-        opacity: 1;
+      @media (prefers-reduced-motion: no-preference) {
+        .transit {
+          animation: acp-transit-pulse 1.1s ease-in-out infinite;
+        }
       }
-      50% {
-        opacity: 0.35;
+      @keyframes acp-transit-pulse {
+        0%,
+        100% {
+          opacity: 1;
+        }
+        50% {
+          opacity: 0.35;
+        }
       }
-    }
-    .warn {
-      color: var(--warning-color, orange);
-      --mdc-icon-size: 16px;
-    }
-    /* On a position mismatch, recolour the leading (sun-blocking) segment with
+      .warn {
+        color: var(--warning-color, orange);
+        --mdc-icon-size: 16px;
+      }
+      /* On a position mismatch, recolour the leading (sun-blocking) segment with
        the error colour and lean on the warn icon at the end of the row. It is
        the segment that carries the cover hue, so tinting it is what reads as a
        divergence rather than as a second cover colour. */
-    .mismatch .fill {
-      background: color-mix(in srgb, var(--error-color, crimson) 35%, transparent);
-    }
-    .placeholder {
-      color: var(--secondary-text-color);
-      text-align: center;
-      padding: 16px;
-    }
-  `,e([ge({attribute:!1})],Ys.prototype,"hass",void 0),e([ge({attribute:!1})],Ys.prototype,"discovered",void 0),e([ge({type:Boolean,reflect:!0})],Ys.prototype,"compact",void 0),e([ge({attribute:!1})],Ys.prototype,"coverColor",void 0),e([ge({attribute:!1})],Ys.prototype,"coverOrder",void 0),e([me()],Ys.prototype,"_dragPreview",void 0),Ys=e([pe("acp-cover-bar")],Ys);const rn=864e5;let an=nn=class extends de{constructor(){super(...arguments),this.samples=[],this.events=[],this.history=[],this.now=Date.now(),this._hoverIdx=null,this._onPointerMove=e=>{const t=e.currentTarget.getBoundingClientRect();if(t.width<=0)return;const o=(e.clientX-t.left)/t.width,i=Math.max(0,Math.min(1,o))*nn.VIEW_W;this._hoverIdx=this._nearestSampleIdx(i)},this._onPointerLeave=()=>{this._hoverIdx=null}}render(){const e=this.samples&&this.samples.length>0,t=this.history&&this.history.length>0;if(!e&&!t)return V;const{VIEW_W:o,VIEW_H:i,TOP_PAD:s,EVENT_HIT_W:n}=nn,r=i-s,a=ei(new Date(this.now)).getTime(),l=a+rn,c=function(e,t,o){if(void 0===t)return[pn,...un(e)].map((e,t)=>hn(e,o,t));if(0===t.length)return[hn(pn,o,0)];const i=new Set,s=t.filter(e=>!i.has(e.id)&&(i.add(e.id),!0));return s.filter((t,o)=>{return 0===o||(i=t.id,e.some(e=>"number"==typeof e[i]));var i}).map((e,t)=>hn(e,o,t))}(this.samples,this.axes,this.hass),d=c[0],h=e=>Ot(e,a,o),p=c.find(e=>"position"===e.key)??d,u=this.samples.map(e=>{const t=Date.parse(e.t),o=h(t),i=e[d.key];return{t:t,x:o,y:Nt(_n("number"==typeof i?i:e.position,d),s,r),sample:e,inDay:!Number.isNaN(t)&&t>=a&&t<=l}}),_=function(e,t,o){if(0===e.length||!(o>t))return[];const i=[...e].sort((e,t)=>e.t-t.t);let s=null;const n=[];for(const e of i){if(e.t>o)break;e.t<=t?s=e:n.push(e)}return s?[{t:t,value:s.value},...n]:n}(en(this.history??[]),a,this.now),g=tn(_,this.now).map(e=>{return`${h(e.t).toFixed(1)},${(t=e.value,Nt(_n(t,p),s,r)).toFixed(1)}`;var t}).join(" ");for(const e of c){let t=[];for(const o of u){if(!o.inDay)continue;const i=o.sample[e.key];"number"==typeof i?t.push(`${o.x.toFixed(1)},${Nt(_n(i,e),s,r).toFixed(1)}`):t.length>0&&(e.runs.push(t.join(" ")),t=[])}t.length>0&&e.runs.push(t.join(" "))}const m=c.filter(e=>e.runs.some(e=>e.includes(" "))),v=m.flatMap(e=>e.runs.map(t=>U`<polyline class="track ${e.cls}" points=${t} fill="none"></polyline>`)),f=(this.events??[]).map(e=>{const t=Date.parse(e.t);if(Number.isNaN(t)||t<a||t>l)return null;const o=h(t),r=`evt-${e.kind}`,c=function(e,t){const o=`forecast.event.${e.kind}`,i=st(o,t),s=i===o?e.label??e.kind:i,n=dt(e.t);return"—"===n?s:`${s} — ${n}`}(e,this.hass);return U`<g class="event-group" ${xo(c)}>
+      .mismatch .fill {
+        background: color-mix(in srgb, var(--error-color, crimson) 35%, transparent);
+      }
+      .placeholder {
+        color: var(--secondary-text-color);
+        text-align: center;
+        padding: 16px;
+      }
+    `],e([ge({attribute:!1})],hn.prototype,"hass",void 0),e([ge({attribute:!1})],hn.prototype,"discovered",void 0),e([ge({type:Boolean,reflect:!0})],hn.prototype,"compact",void 0),e([ge({attribute:!1})],hn.prototype,"coverColor",void 0),e([ge({attribute:!1})],hn.prototype,"coverOrder",void 0),e([me()],hn.prototype,"_dragPreview",void 0),hn=e([pe("acp-cover-bar")],hn);const wn=864e5;let xn=yn=class extends de{constructor(){super(...arguments),this.samples=[],this.events=[],this.history=[],this.now=Date.now(),this._hoverIdx=null,this._onPointerMove=e=>{const t=e.currentTarget.getBoundingClientRect();if(t.width<=0)return;const o=(e.clientX-t.left)/t.width,i=Math.max(0,Math.min(1,o))*yn.VIEW_W;this._hoverIdx=this._nearestSampleIdx(i)},this._onPointerLeave=()=>{this._hoverIdx=null}}render(){const e=this.samples&&this.samples.length>0,t=this.history&&this.history.length>0;if(!e&&!t)return V;const{VIEW_W:o,VIEW_H:i,TOP_PAD:s,EVENT_HIT_W:n}=yn,r=i-s,a=ti(new Date(this.now)).getTime(),l=a+wn,c=function(e,t,o){if(void 0===t)return[Cn,...En(e)].map((e,t)=>Sn(e,o,t));if(0===t.length)return[Sn(Cn,o,0)];const i=new Set,s=t.filter(e=>!i.has(e.id)&&(i.add(e.id),!0));return s.filter((t,o)=>{return 0===o||(i=t.id,e.some(e=>"number"==typeof e[i]));var i}).map((e,t)=>Sn(e,o,t))}(this.samples,this.axes,this.hass),d=c[0],h=e=>Ot(e,a,o),p=c.find(e=>"position"===e.key)??d,u=this.samples.map(e=>{const t=Date.parse(e.t),o=h(t),i=e[d.key];return{t:t,x:o,y:Nt(zn("number"==typeof i?i:e.position,d),s,r),sample:e,inDay:!Number.isNaN(t)&&t>=a&&t<=l}}),_=function(e,t,o){if(0===e.length||!(o>t))return[];const i=[...e].sort((e,t)=>e.t-t.t);let s=null;const n=[];for(const e of i){if(e.t>o)break;e.t<=t?s=e:n.push(e)}return s?[{t:t,value:s.value},...n]:n}(mn(this.history??[]),a,this.now),g=vn(_,this.now).map(e=>{return`${h(e.t).toFixed(1)},${(t=e.value,Nt(zn(t,p),s,r)).toFixed(1)}`;var t}).join(" ");for(const e of c){let t=[];for(const o of u){if(!o.inDay)continue;const i=o.sample[e.key];"number"==typeof i?t.push(`${o.x.toFixed(1)},${Nt(zn(i,e),s,r).toFixed(1)}`):t.length>0&&(e.runs.push(t.join(" ")),t=[])}t.length>0&&e.runs.push(t.join(" "))}const m=c.filter(e=>e.runs.some(e=>e.includes(" "))),v=m.flatMap(e=>e.runs.map(t=>U`<polyline class="track ${e.cls}" points=${t} fill="none"></polyline>`)),f=(this.events??[]).map(e=>{const t=Date.parse(e.t);if(Number.isNaN(t)||t<a||t>l)return null;const o=h(t),r=`evt-${e.kind}`,c=function(e,t){const o=`forecast.event.${e.kind}`,i=st(o,t),s=i===o?e.label??e.kind:i,n=dt(e.t);return"—"===n?s:`${s} — ${n}`}(e,this.hass);return U`<g class="event-group" ${$o(c)}>
           <line
             class="event-hit"
             x1=${o.toFixed(1)}
@@ -3041,12 +3162,12 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
             x1=${b.x.toFixed(1)} x2=${b.x.toFixed(1)}
             y1=${s} y2=${i}></line>
           <circle class="hover-dot" cx=${b.x.toFixed(1)} cy=${b.y.toFixed(1)} r="3"></circle>
-        </g>`:V,w=!b||b.t>this.now?null:on(_,b.t),x=b?H`<div class="hover-label" style=${`left: ${(b.x/o*100).toFixed(2)}%`}>
-          ${function(e,t){const o=dt(e.t),i=t.find(e=>e.primary)??t[0],s=e[i.key],n=gn("number"==typeof s?s:e.position,i);return`${e.handler?`${o} · ${n} · ${e.handler}`:`${o} · ${n}`}${t.filter(e=>e!==i).map(t=>{const o=e[t.key];return"number"==typeof o?` · ${t.label}: ${gn(o,t)}`:""}).join("")}`}(b.sample,c)}${null!==w?` · ${st("forecast.legend_actual",this.hass)} ${gn(w,p)}`:""}
+        </g>`:V,w=!b||b.t>this.now?null:fn(_,b.t),x=b?H`<div class="hover-label" style=${`left: ${(b.x/o*100).toFixed(2)}%`}>
+          ${function(e,t){const o=dt(e.t),i=t.find(e=>e.primary)??t[0],s=e[i.key],n=Mn("number"==typeof s?s:e.position,i);return`${e.handler?`${o} · ${n} · ${e.handler}`:`${o} · ${n}`}${t.filter(e=>e!==i).map(t=>{const o=e[t.key];return"number"==typeof o?` · ${t.label}: ${Mn(o,t)}`:""}).join("")}`}(b.sample,c)}${null!==w?` · ${st("forecast.legend_actual",this.hass)} ${Mn(w,p)}`:""}
         </div>`:V,$=[0,6,12,18,24].map(e=>{const t=h(a+36e5*e);return U`
         <line class="grid faint" x1=${t} y1=${s} x2=${t} y2=${i-.5} />
         <text class="axis-label tick-time" x=${t} y=${i-3} text-anchor="middle">${e.toString().padStart(2,"0")}:00</text>
-      `}),k=this.now,A=h(k),S=k>=a&&k<=l?U`<g class="now-group" ${xo(dt(new Date(k).toISOString()))}>
+      `}),k=this.now,A=h(k),S=k>=a&&k<=l?U`<g class="now-group" ${$o(dt(new Date(k).toISOString()))}>
           <line class="now-hit" x1=${A.toFixed(1)} y1=${s} x2=${A.toFixed(1)} y2=${i-.5}></line>
           <line class="now" x1=${A.toFixed(1)} y1=${s} x2=${A.toFixed(1)} y2=${i-.5}></line>
         </g>`:V;return H`
@@ -3060,7 +3181,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
         >
           <line class="baseline" x1="0" y1=${i-.5} x2=${o} y2=${i-.5}></line>
           <text class="axis-label" x="4" y=${s+8} text-anchor="start">
-            ${gn(d.max,d)}
+            ${Mn(d.max,d)}
           </text>
           ${$}
           <!-- Actual UNDER the forecast, deliberately. SVG paints in document
@@ -3082,7 +3203,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
       ${t?H`<span class="legend-item"
             ><span class="swatch actual-curve"></span>${st("forecast.legend_actual",this.hass)}</span
           >`:V}
-    </div>`}_nearestSampleIdx(e){const t=ei(new Date(this.now)).getTime(),o=t+rn;let i=-1,s=Number.POSITIVE_INFINITY;for(let n=0;n<this.samples.length;n++){const r=Date.parse(this.samples[n].t);if(Number.isNaN(r)||r<t||r>o)continue;const a=Ot(r,t,nn.VIEW_W),l=Math.abs(a-e);l<s&&(s=l,i=n)}return i>=0?i:null}};an.VIEW_W=600,an.VIEW_H=80,an.TOP_PAD=10,an.EVENT_HIT_W=12,an.styles=a`
+    </div>`}_nearestSampleIdx(e){const t=ti(new Date(this.now)).getTime(),o=t+wn;let i=-1,s=Number.POSITIVE_INFINITY;for(let n=0;n<this.samples.length;n++){const r=Date.parse(this.samples[n].t);if(Number.isNaN(r)||r<t||r>o)continue;const a=Ot(r,t,yn.VIEW_W),l=Math.abs(a-e);l<s&&(s=l,i=n)}return i>=0?i:null}};xn.VIEW_W=600,xn.VIEW_H=80,xn.TOP_PAD=10,xn.EVENT_HIT_W=12,xn.styles=a`
     :host {
       display: block;
     }
@@ -3243,7 +3364,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
       stroke: transparent;
       stroke-width: 10;
     }
-  `,e([ge({attribute:!1})],an.prototype,"hass",void 0),e([ge({attribute:!1})],an.prototype,"samples",void 0),e([ge({attribute:!1})],an.prototype,"events",void 0),e([ge({attribute:!1})],an.prototype,"history",void 0),e([ge({attribute:!1})],an.prototype,"now",void 0),e([ge({attribute:!1})],an.prototype,"axes",void 0),e([me()],an.prototype,"_hoverIdx",void 0),an=nn=e([pe("acp-forecast-strip")],an);const ln=new Set(["t","position","handler"]),cn=3;function dn(e,t){const o=qe[e.id];return o?st(o,t):e.label?e.label:e.id.charAt(0).toUpperCase()+e.id.slice(1)}function hn(e,t,o){return{key:e.id,primary:0===o,label:dn(e,t),min:e.min,max:e.max,unit:e.unit,cls:0===o?"curve":`axis-c${(o-1)%cn} secondary`,runs:[]}}const pn={id:"position",label:"",min:0,max:100,unit:"%"};function un(e){for(const t of e)for(const e of Object.keys(t))if(!ln.has(e)&&"number"==typeof t[e])return[{id:e,label:"",min:0,max:100,unit:"%"}];return[]}function _n(e,t){const o=t.max-t.min;return 0===o?0:function(e){return Number.isNaN(e)||e<0?0:e>100?100:e}((e-t.min)/o*100)}function gn(e,t){const o=Math.round(function(e,t){return Number.isNaN(e)?t.min:Math.max(t.min,Math.min(t.max,e))}(e,t));return`${o}${""===t.unit||"%"===t.unit||"°"===t.unit?"":" "}${t.unit}`}const mn=["sol_elev_deg","gamma_deg"],vn=["position_pct"],fn=new Set([...mn,...vn,"status","cover_type","tilt"]),bn={cover_blind:["effective_distance_m","adjusted_height_m","safety_margin"],cover_awning:["awn_angle_deg","vertical_position_m","length_m"],cover_tilt:["slat_angle_raw_deg","tilt_mode","max_degrees"]},yn=new Set([...mn,...vn,...Object.values(bn).flat()]);function wn(e,t){return null==t?"—":"boolean"==typeof t?t?"✓":"✗":Array.isArray(t)?t.length?t.join(", "):"—":"number"==typeof t?Number.isNaN(t)?"—":"position_pct"===e||e.endsWith("_pct")?`${Math.round(t)}%`:e.endsWith("_deg")?`${t.toFixed(1)}°`:e.endsWith("_m")?`${t.toFixed(3)} m`:e.endsWith("_rad")?`${t.toFixed(3)} rad`:t.toFixed(3):String(t)}function xn(e,t,o){const i=[];for(const o of t)o in e&&i.push({key:o,value:wn(o,e[o]),curated:yn.has(o)});return i}function $n(e,t,o){const i=xn(e,mn),s=xn(e,vn);let n;if(o){const o=bn[t]??[],i=Object.keys(e).filter(e=>!fn.has(e)&&!o.includes(e));n=[...o.filter(t=>t in e),...i]}else n=(bn[t]??[]).filter(t=>t in e);const r=xn(e,n),a=e.position_pct;return{status:"string"==typeof e.status?e.status:void 0,hasTarget:"number"==typeof a&&!Number.isNaN(a),inputs:i,intermediates:r,output:s}}function kn(e,t){const o="string"==typeof e.cover_type?e.cover_type:"",i=$n(e,o,t);let s;if("cover_venetian"===o){const o=e.tilt;o&&"object"==typeof o&&(s=$n(o,"cover_tilt",t))}return{coverType:o,position:i,tilt:s}}let An=class extends de{constructor(){super(...arguments),this.compact=!1,this._showAll=!1,this._toggleShowAll=()=>{this._showAll=!this._showAll}}shouldUpdate(e){return e.size>1||!e.has("hass")||ve(e.get("hass"),this.hass,[this.discovered?.entities.solar_calculation_sensor])}render(){if(!this.hass||!this.discovered)return V;const e=this.discovered.entities.solar_calculation_sensor;if(!e)return V;const t=this.hass.states[e];if(!t||"unavailable"===t.state)return V;const o=t.attributes,i=kn(o,this._showAll),s=function(e){const t=kn(e,!0),o=kn(e,!1),i=e=>e.position.intermediates.length+(e.tilt?.intermediates.length??0);return Math.max(0,i(t)-i(o))}(o);return H`
+  `,e([ge({attribute:!1})],xn.prototype,"hass",void 0),e([ge({attribute:!1})],xn.prototype,"samples",void 0),e([ge({attribute:!1})],xn.prototype,"events",void 0),e([ge({attribute:!1})],xn.prototype,"history",void 0),e([ge({attribute:!1})],xn.prototype,"now",void 0),e([ge({attribute:!1})],xn.prototype,"axes",void 0),e([me()],xn.prototype,"_hoverIdx",void 0),xn=yn=e([pe("acp-forecast-strip")],xn);const $n=new Set(["t","position","handler"]),kn=3;function An(e,t){const o=qe[e.id];return o?st(o,t):e.label?e.label:e.id.charAt(0).toUpperCase()+e.id.slice(1)}function Sn(e,t,o){return{key:e.id,primary:0===o,label:An(e,t),min:e.min,max:e.max,unit:e.unit,cls:0===o?"curve":`axis-c${(o-1)%kn} secondary`,runs:[]}}const Cn={id:"position",label:"",min:0,max:100,unit:"%"};function En(e){for(const t of e)for(const e of Object.keys(t))if(!$n.has(e)&&"number"==typeof t[e])return[{id:e,label:"",min:0,max:100,unit:"%"}];return[]}function zn(e,t){const o=t.max-t.min;return 0===o?0:function(e){return Number.isNaN(e)||e<0?0:e>100?100:e}((e-t.min)/o*100)}function Mn(e,t){const o=Math.round(function(e,t){return Number.isNaN(e)?t.min:Math.max(t.min,Math.min(t.max,e))}(e,t));return`${o}${""===t.unit||"%"===t.unit||"°"===t.unit?"":" "}${t.unit}`}const Tn=["sol_elev_deg","gamma_deg"],In=["position_pct"],Pn=new Set([...Tn,...In,"status","cover_type","tilt"]),On={cover_blind:["effective_distance_m","adjusted_height_m","safety_margin"],cover_awning:["awn_angle_deg","vertical_position_m","length_m"],cover_tilt:["slat_angle_raw_deg","tilt_mode","max_degrees"]},Nn=new Set([...Tn,...In,...Object.values(On).flat()]);function Dn(e,t){return null==t?"—":"boolean"==typeof t?t?"✓":"✗":Array.isArray(t)?t.length?t.join(", "):"—":"number"==typeof t?Number.isNaN(t)?"—":"position_pct"===e||e.endsWith("_pct")?`${Math.round(t)}%`:e.endsWith("_deg")?`${t.toFixed(1)}°`:e.endsWith("_m")?`${t.toFixed(3)} m`:e.endsWith("_rad")?`${t.toFixed(3)} rad`:t.toFixed(3):String(t)}function Fn(e,t,o){const i=[];for(const o of t)o in e&&i.push({key:o,value:Dn(o,e[o]),curated:Nn.has(o)});return i}function Bn(e,t,o){const i=Fn(e,Tn),s=Fn(e,In);let n;if(o){const o=On[t]??[],i=Object.keys(e).filter(e=>!Pn.has(e)&&!o.includes(e));n=[...o.filter(t=>t in e),...i]}else n=(On[t]??[]).filter(t=>t in e);const r=Fn(e,n),a=e.position_pct;return{status:"string"==typeof e.status?e.status:void 0,hasTarget:"number"==typeof a&&!Number.isNaN(a),inputs:i,intermediates:r,output:s}}function Rn(e,t){const o="string"==typeof e.cover_type?e.cover_type:"",i=Bn(e,o,t);let s;if("cover_venetian"===o){const o=e.tilt;o&&"object"==typeof o&&(s=Bn(o,"cover_tilt",t))}return{coverType:o,position:i,tilt:s}}let jn=class extends de{constructor(){super(...arguments),this.compact=!1,this._showAll=!1,this._toggleShowAll=()=>{this._showAll=!this._showAll}}shouldUpdate(e){return e.size>1||!e.has("hass")||ve(e.get("hass"),this.hass,[this.discovered?.entities.solar_calculation_sensor])}render(){if(!this.hass||!this.discovered)return V;const e=this.discovered.entities.solar_calculation_sensor;if(!e)return V;const t=this.hass.states[e];if(!t||"unavailable"===t.state)return V;const o=t.attributes,i=Rn(o,this._showAll),s=function(e){const t=Rn(e,!0),o=Rn(e,!1),i=e=>e.position.intermediates.length+(e.tilt?.intermediates.length??0);return Math.max(0,i(t)-i(o))}(o);return H`
       <div class="wrap">
         <div class="head">
           <span class="label">${st("solar.title",this.hass)}</span>
@@ -3276,7 +3397,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
               </div>`)}
         </div>
       </div>
-    `}};function Sn(e){const t=new Map;let o=0;for(const i of e){const e=Math.max(0,i.end-i.start);0!==e&&(t.set(i.state,(t.get(i.state)??0)+e),o+=e)}return 0===o?[]:[...t.entries()].map(([e,t])=>({handler:e,ms:t,fraction:t/o})).sort((e,t)=>t.ms-e.ms)}function Cn(e,t){let o=0;for(const i of e)t(i.state)&&(o+=Math.max(0,i.end-i.start));return o}function En(e){const t=Math.round(e/6e4);if(t<1)return"<1m";const o=Math.floor(t/60),i=t%60;return 0===o?`${i}m`:0===i?`${o}h`:`${o}h ${i}m`}function zn(e){const t=e.services;return!!t?.[Te]?.get_diagnostics}function Mn(e){if(!e||"object"!=typeof e||Array.isArray(e))return null;const t=e,o="string"==typeof t.ts?t.ts:null,i="string"==typeof t.event?t.event:null;if(null===o||null===i)return null;const s=Date.parse(o);if(Number.isNaN(s))return null;const n={};for(const[e,o]of Object.entries(t))"ts"!==e&&"event"!==e&&(n[e]=o);return{ts:o,t:s,event:i,fields:n}}async function Tn(e,t){const o={events:[],window:null,bufferSize:null,available:!1,raw:null};if(!zn(e))return o;const i=e.callService;let s;try{s=await i(Te,"get_diagnostics",{config_entry_id:[t]},void 0,!1,!0)}catch{return o}return function(e,t){const o={events:[],window:null,bufferSize:null,available:!1,raw:null};if(!e||"object"!=typeof e)return o;const i=e.entries;if(!i||"object"!=typeof i)return o;const s=i[t];if(!s||"object"!=typeof s)return o;const n=s.diagnostics;if(!n||"object"!=typeof n)return o;if("error"in n)return o;const r=Array.isArray(n.event_timeline)?n.event_timeline:[],a=[];for(const e of r){const t=Mn(e);t&&a.push(t)}a.sort((e,t)=>e.t-t.t);const l=n.data_window,c=l&&"object"==typeof l?{start:"string"==typeof l.start?l.start:null,end:"string"==typeof l.end?l.end:null,capturedAt:"string"==typeof l.captured_at?l.captured_at:null}:null,d=n.debug_config?.debug_event_buffer_size;return{events:a,window:c,bufferSize:"number"==typeof d?d:null,available:!0,raw:e}}(s&&"object"==typeof s&&"response"in s?s.response:s,t)}function In(e){return"string"==typeof e&&e.length>0?e:null}function Pn(e){if(!e||"object"!=typeof e||Array.isArray(e))return null;const t=e,o=t.when;return"number"==typeof o&&Number.isFinite(o)?{t:1e3*o,entityId:In(t.entity_id),name:In(t.name)??In(t.entity_id)??"",state:In(t.state),message:In(t.message),icon:In(t.icon),contextUserId:In(t.context_user_id),contextName:In(t.context_name),contextDomain:In(t.context_domain),contextService:In(t.context_service)}:null}async function On(e,t,o,i){const s=t.filter(e=>"string"==typeof e&&e.length>0);if(0===s.length)return[];try{return function(e){if(!Array.isArray(e))return[];const t=[];for(const o of e){const e=Pn(o);e&&t.push(e)}return t.sort((e,t)=>t.t-e.t),t}(await e.callWS({type:"logbook/get_events",start_time:new Date(o).toISOString(),end_time:new Date(i).toISOString(),entity_ids:s}))}catch{return[]}}function Nn(e,t){if(e.contextName)return e.contextName;const o=e.contextUserId;return o?t.get(o)??null:null}An.styles=a`
+    `}};function Kn(e){const t=new Map;let o=0;for(const i of e){const e=Math.max(0,i.end-i.start);0!==e&&(t.set(i.state,(t.get(i.state)??0)+e),o+=e)}return 0===o?[]:[...t.entries()].map(([e,t])=>({handler:e,ms:t,fraction:t/o})).sort((e,t)=>t.ms-e.ms)}function Ln(e,t){let o=0;for(const i of e)t(i.state)&&(o+=Math.max(0,i.end-i.start));return o}function Gn(e){const t=Math.round(e/6e4);if(t<1)return"<1m";const o=Math.floor(t/60),i=t%60;return 0===o?`${i}m`:0===i?`${o}h`:`${o}h ${i}m`}function Wn(e){const t=e.services;return!!t?.[Te]?.get_diagnostics}function Hn(e){if(!e||"object"!=typeof e||Array.isArray(e))return null;const t=e,o="string"==typeof t.ts?t.ts:null,i="string"==typeof t.event?t.event:null;if(null===o||null===i)return null;const s=Date.parse(o);if(Number.isNaN(s))return null;const n={};for(const[e,o]of Object.entries(t))"ts"!==e&&"event"!==e&&(n[e]=o);return{ts:o,t:s,event:i,fields:n}}async function Un(e,t){const o={events:[],window:null,bufferSize:null,available:!1,raw:null};if(!Wn(e))return o;const i=e.callService;let s;try{s=await i(Te,"get_diagnostics",{config_entry_id:[t]},void 0,!1,!0)}catch{return o}return function(e,t){const o={events:[],window:null,bufferSize:null,available:!1,raw:null};if(!e||"object"!=typeof e)return o;const i=e.entries;if(!i||"object"!=typeof i)return o;const s=i[t];if(!s||"object"!=typeof s)return o;const n=s.diagnostics;if(!n||"object"!=typeof n)return o;if("error"in n)return o;const r=Array.isArray(n.event_timeline)?n.event_timeline:[],a=[];for(const e of r){const t=Hn(e);t&&a.push(t)}a.sort((e,t)=>e.t-t.t);const l=n.data_window,c=l&&"object"==typeof l?{start:"string"==typeof l.start?l.start:null,end:"string"==typeof l.end?l.end:null,capturedAt:"string"==typeof l.captured_at?l.captured_at:null}:null,d=n.debug_config?.debug_event_buffer_size;return{events:a,window:c,bufferSize:"number"==typeof d?d:null,available:!0,raw:e}}(s&&"object"==typeof s&&"response"in s?s.response:s,t)}function qn(e){return"string"==typeof e&&e.length>0?e:null}function Vn(e){if(!e||"object"!=typeof e||Array.isArray(e))return null;const t=e,o=t.when;return"number"==typeof o&&Number.isFinite(o)?{t:1e3*o,entityId:qn(t.entity_id),name:qn(t.name)??qn(t.entity_id)??"",state:qn(t.state),message:qn(t.message),icon:qn(t.icon),contextUserId:qn(t.context_user_id),contextName:qn(t.context_name),contextDomain:qn(t.context_domain),contextService:qn(t.context_service)}:null}async function Yn(e,t,o,i){const s=t.filter(e=>"string"==typeof e&&e.length>0);if(0===s.length)return[];try{return function(e){if(!Array.isArray(e))return[];const t=[];for(const o of e){const e=Vn(o);e&&t.push(e)}return t.sort((e,t)=>t.t-e.t),t}(await e.callWS({type:"logbook/get_events",start_time:new Date(o).toISOString(),end_time:new Date(i).toISOString(),entity_ids:s}))}catch{return[]}}function Zn(e,t){if(e.contextName)return e.contextName;const o=e.contextUserId;return o?t.get(o)??null:null}jn.styles=a`
     :host {
       display: block;
     }
@@ -3379,16 +3500,16 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
     [data-tooltip][acp-tt-shown] {
       cursor: default;
     }
-  `,e([ge({attribute:!1})],An.prototype,"hass",void 0),e([ge({attribute:!1})],An.prototype,"discovered",void 0),e([ge({type:Boolean,reflect:!0})],An.prototype,"compact",void 0),e([me()],An.prototype,"_showAll",void 0),An=e([pe("acp-solar-calc")],An);const Dn={cover_command_sent:{skipped:!1},end_time_default_sent:{skipped:!1},reconcile_gave_up:{skipped:!0},reconcile_skipped_in_transit:{skipped:!0}},Bn=["position","target_position","to"];function Fn(e,t){return t?100-e:e}function Rn(e,t=!1){const o=[],i=new Set(["entity_id","service","entity_ids"]);for(const s of Bn){const n=e[s];if("number"==typeof n&&Number.isFinite(n)){o.push(`${s} ${Math.round(Fn(n,t))}%`),i.add(s);break}}for(const[t,s]of Object.entries(e))i.has(t)||null!=s&&""!==s&&"object"!=typeof s&&o.push(`${t} ${String(s)}`);return o.length>0?o.join(" · "):null}var jn;const Ln=36e5,Kn=864e5;let Gn=jn=class extends de{constructor(){super(...arguments),this.hours=24,this.advancedOpen=!1,this.hideAdvanced=!1,this.showWindowPicker=!0,this.active=!0,this._target=[],this._actual=[],this._perCover={},this._tiltTarget=[],this._tiltActual={},this._copied=!1,this._whoWon=[],this._controlStatus=[],this._stateBands={},this._activity=[],this._loading=!1,this._loaded=!1,this._timeline=null,this._eventFilter="",this._advanced=!1,this._maximized=null,this._hoverT=null,this._now=Date.now(),this._cancelMinuteTimer=null,this._minutesSinceFetch=0,this._fetchKey=null,this._onPointerMove=e=>{const t=this.renderRoot.querySelector(".track-plot");if(!t)return;const o=t.getBoundingClientRect();if(o.width<=0)return;const i=Math.max(0,Math.min(1,(e.clientX-o.left)/o.width));this._hoverT=this._start+i*(this._now-this._start)},this._onPointerLeave=()=>{this._hoverT=null}}get _posH(){return"tracks"===this._maximized?jn.POS_H_MAX:jn.POS_H}connectedCallback(){super.connectedCallback(),this._advanced=this.advancedOpen}disconnectedCallback(){super.disconnectedCallback(),this._stopMinuteTimer()}updated(e){e.has("advancedOpen")&&(this._advanced=this.advancedOpen),e.has("_maximized")&&this.toggleAttribute("maximized",null!==this._maximized),e.has("active")&&!this.active&&(this._fetchKey=null,this._minutesSinceFetch=0,null!==this._maximized&&(this._maximized=null,this.dispatchEvent(new CustomEvent("acp-history-expand",{detail:{expanded:!1,section:null},bubbles:!0,composed:!0})))),this._syncMinuteTimer(),this._maybeFetch()}shouldUpdate(e){return e.size>1||!e.has("hass")}get _entryId(){return this.discovered?.entry_id??null}_syncMinuteTimer(){this.active&&null===this._cancelMinuteTimer?this._cancelMinuteTimer=vi(()=>{this._minutesSinceFetch+=1,this._minutesSinceFetch>=5?(this._fetchKey=null,this._maybeFetch()):this.requestUpdate()}):this.active||this._stopMinuteTimer()}_stopMinuteTimer(){null!==this._cancelMinuteTimer&&(this._cancelMinuteTimer(),this._cancelMinuteTimer=null)}_maybeFetch(){if(!this.active||!this.hass||!this.discovered)return;const e=this._entryId;if(!e)return;const t=`${e}|${this.hours}|${St(this.discovered)}`;t!==this._fetchKey&&(this._fetchKey=t,this._minutesSinceFetch=0,this._fetch(t))}async _fetch(e){const t=this.hass,o=this.discovered,i=Date.now(),s=i-this.hours*Ln;this._loading=!0,this._now=i;const n=o.entities,r=o.managed_covers??[],a=St(o),l=kt(o).find(e=>"tilt"===e.id),c=l?.inverted??!1,d=!!l,h=[];n.target_position_sensor&&h.push(n.target_position_sensor),d&&n.target_tilt_sensor&&h.push(n.target_tilt_sensor),n.control_status_sensor&&h.push(n.control_status_sensor),n.decision_trace_sensor&&h.push(n.decision_trace_sensor);for(const e of Qe){const t=n[e.role];t&&h.push(t)}const p=[...r];for(const e of Qe){const t=n[e.role];t&&p.push(t)}n.control_status_sensor&&p.push(n.control_status_sensor),n.decision_trace_sensor&&p.push(n.decision_trace_sensor),n.last_action_sensor&&p.push(n.last_action_sensor);const u=this._show("actions"),_=this._show("position")&&r.length>0,[g,m,v,f]=await Promise.all([_?Gs(t,r,s,i,{inverted:a,tiltInverted:c,wantTilt:d}):Promise.resolve({position:{},tilt:{}}),sn(t,h,s,i),u?On(t,p,s,i):Promise.resolve([]),u||this._advanced?Tn(t,this._entryId??""):Promise.resolve(null)]);if(this._fetchKey!==e)return;this._actual=function(e){const t={};for(const[o,i]of Object.entries(e)){const e=i.map(e=>({t:Date.parse(e.t),position:e.position})).filter(e=>!Number.isNaN(e.t));e.length>0&&(t[o]=e)}return Ks(t)}(g.position),this._perCover=r.length>1?g.position:{},this._tiltActual=g.tilt,this._tiltTarget=d&&n.target_tilt_sensor?Js(m[n.target_tilt_sensor]??[]):[],this._target=n.target_position_sensor?Js(m[n.target_position_sensor]??[],{preferAttribute:"linear_position",inverted:a}):[],this._whoWon=n.decision_trace_sensor?Xs(m[n.decision_trace_sensor]??[],s,i):[],this._controlStatus=n.control_status_sensor?Xs(m[n.control_status_sensor]??[],s,i):[];const b={};for(const e of Qe){const t=n[e.role];t&&(b[e.role]=Xs(m[t]??[],s,i))}this._stateBands=b,f&&(this._timeline=f),this._activity=u?function(e,t,o,i){const s=o.filter(e=>e.t>=i.startMs&&e.t<=i.endMs).map(e=>function(e,t=!1){const o=Dn[e.event];if(!o)return null;const i="string"==typeof e.fields.service?e.fields.service:null,s="string"==typeof e.fields.entity_id?e.fields.entity_id:null;return{t:e.t,source:"command",title:i??e.event,name:null,entityId:s&&s.length>0?s:null,detail:Rn(e.fields,t),service:i,triggeredBy:null,skipped:o.skipped}}(e,i.inverted)).filter(e=>null!==e),n=[...t].sort((e,t)=>e.t-t.t),r=new Set;for(const e of s)if(e.entityId)for(const t of n)if(!r.has(t)&&t.entityId===e.entityId&&!(t.t<e.t||t.t-e.t>5e3||t.contextUserId||t.contextName)){r.add(t);break}const a=function(e){const t=new Map;for(const o of Object.values(e.states??{})){if(!o.entity_id.startsWith("person."))continue;const e=o.attributes.user_id,i=o.attributes.friendly_name;"string"==typeof e&&"string"==typeof i&&i.length>0&&t.set(e,i)}const o=e.user;return o?.id&&o.name&&!t.has(o.id)&&t.set(o.id,o.name),t}(e),l=[...s,...t.filter(e=>!r.has(e)).map(t=>function(e,t,o){const i=e.entityId?o.states?.[e.entityId]?.attributes?.friendly_name:void 0;return{t:e.t,source:"logbook",title:e.state??e.message??"",name:i||e.name||null,entityId:e.entityId,detail:null,service:null,triggeredBy:Nn(e,t),skipped:!1}}(t,a,e))];return l.sort((e,t)=>t.t-e.t),l}(t,v,f?.events??[],{startMs:s,endMs:i,inverted:a}):[],this._loading=!1,this._loaded=!0}_show(e){return!1!==this.tracks?.[e]}_setHours(e){e!==this.hours&&(this.hours=e,this.dispatchEvent(new CustomEvent("acp-history-hours",{detail:{hours:e},bubbles:!0,composed:!0})))}_refresh(){this._fetchKey=null,this._timeline=null,this._maybeFetch()}_toggleMaximize(e){this._maximized=this._maximized===e?null:e,"events"===this._maximized&&null===this._timeline&&Tn(this.hass,this._entryId??"").then(e=>{this._timeline=e}),this.dispatchEvent(new CustomEvent("acp-history-expand",{detail:{expanded:null!==this._maximized,section:this._maximized},bubbles:!0,composed:!0}))}_maximizeButton(e){const t=this._maximized===e,o=st(t?"history.collapse":"history.expand",this.hass);return H`<button
+  `,e([ge({attribute:!1})],jn.prototype,"hass",void 0),e([ge({attribute:!1})],jn.prototype,"discovered",void 0),e([ge({type:Boolean,reflect:!0})],jn.prototype,"compact",void 0),e([me()],jn.prototype,"_showAll",void 0),jn=e([pe("acp-solar-calc")],jn);const Qn={cover_command_sent:{skipped:!1},end_time_default_sent:{skipped:!1},reconcile_gave_up:{skipped:!0},reconcile_skipped_in_transit:{skipped:!0}},Xn=["position","target_position","to"];function Jn(e,t){return t?100-e:e}function er(e,t=!1){const o=[],i=new Set(["entity_id","service","entity_ids"]);for(const s of Xn){const n=e[s];if("number"==typeof n&&Number.isFinite(n)){o.push(`${s} ${Math.round(Jn(n,t))}%`),i.add(s);break}}for(const[t,s]of Object.entries(e))i.has(t)||null!=s&&""!==s&&"object"!=typeof s&&o.push(`${t} ${String(s)}`);return o.length>0?o.join(" · "):null}var tr;const or=36e5,ir=864e5;let sr=tr=class extends de{constructor(){super(...arguments),this.hours=24,this.advancedOpen=!1,this.hideAdvanced=!1,this.showWindowPicker=!0,this.active=!0,this._target=[],this._actual=[],this._perCover={},this._tiltTarget=[],this._tiltActual={},this._copied=!1,this._whoWon=[],this._controlStatus=[],this._stateBands={},this._activity=[],this._loading=!1,this._loaded=!1,this._timeline=null,this._eventFilter="",this._advanced=!1,this._maximized=null,this._hoverT=null,this._now=Date.now(),this._cancelMinuteTimer=null,this._minutesSinceFetch=0,this._fetchKey=null,this._onPointerMove=e=>{const t=this.renderRoot.querySelector(".track-plot");if(!t)return;const o=t.getBoundingClientRect();if(o.width<=0)return;const i=Math.max(0,Math.min(1,(e.clientX-o.left)/o.width));this._hoverT=this._start+i*(this._now-this._start)},this._onPointerLeave=()=>{this._hoverT=null}}get _posH(){return"tracks"===this._maximized?tr.POS_H_MAX:tr.POS_H}connectedCallback(){super.connectedCallback(),this._advanced=this.advancedOpen}disconnectedCallback(){super.disconnectedCallback(),this._stopMinuteTimer()}updated(e){e.has("advancedOpen")&&(this._advanced=this.advancedOpen),e.has("_maximized")&&this.toggleAttribute("maximized",null!==this._maximized),e.has("active")&&!this.active&&(this._fetchKey=null,this._minutesSinceFetch=0,null!==this._maximized&&(this._maximized=null,this.dispatchEvent(new CustomEvent("acp-history-expand",{detail:{expanded:!1,section:null},bubbles:!0,composed:!0})))),this._syncMinuteTimer(),this._maybeFetch()}shouldUpdate(e){return e.size>1||!e.has("hass")}get _entryId(){return this.discovered?.entry_id??null}_syncMinuteTimer(){this.active&&null===this._cancelMinuteTimer?this._cancelMinuteTimer=fi(()=>{this._minutesSinceFetch+=1,this._minutesSinceFetch>=5?(this._fetchKey=null,this._maybeFetch()):this.requestUpdate()}):this.active||this._stopMinuteTimer()}_stopMinuteTimer(){null!==this._cancelMinuteTimer&&(this._cancelMinuteTimer(),this._cancelMinuteTimer=null)}_maybeFetch(){if(!this.active||!this.hass||!this.discovered)return;const e=this._entryId;if(!e)return;const t=`${e}|${this.hours}|${St(this.discovered)}`;t!==this._fetchKey&&(this._fetchKey=t,this._minutesSinceFetch=0,this._fetch(t))}async _fetch(e){const t=this.hass,o=this.discovered,i=Date.now(),s=i-this.hours*or;this._loading=!0,this._now=i;const n=o.entities,r=o.managed_covers??[],a=St(o),l=kt(o).find(e=>"tilt"===e.id),c=l?.inverted??!1,d=!!l,h=[];n.target_position_sensor&&h.push(n.target_position_sensor),d&&n.target_tilt_sensor&&h.push(n.target_tilt_sensor),n.control_status_sensor&&h.push(n.control_status_sensor),n.decision_trace_sensor&&h.push(n.decision_trace_sensor);for(const e of Qe){const t=n[e.role];t&&h.push(t)}const p=[...r];for(const e of Qe){const t=n[e.role];t&&p.push(t)}n.control_status_sensor&&p.push(n.control_status_sensor),n.decision_trace_sensor&&p.push(n.decision_trace_sensor),n.last_action_sensor&&p.push(n.last_action_sensor);const u=this._show("actions"),_=this._show("position")&&r.length>0,[g,m,v,f]=await Promise.all([_?nn(t,r,s,i,{inverted:a,tiltInverted:c,wantTilt:d}):Promise.resolve({position:{},tilt:{}}),bn(t,h,s,i),u?Yn(t,p,s,i):Promise.resolve([]),u||this._advanced?Un(t,this._entryId??""):Promise.resolve(null)]);if(this._fetchKey!==e)return;this._actual=function(e){const t={};for(const[o,i]of Object.entries(e)){const e=i.map(e=>({t:Date.parse(e.t),position:e.position})).filter(e=>!Number.isNaN(e.t));e.length>0&&(t[o]=e)}return sn(t)}(g.position),this._perCover=r.length>1?g.position:{},this._tiltActual=g.tilt,this._tiltTarget=d&&n.target_tilt_sensor?gn(m[n.target_tilt_sensor]??[]):[],this._target=n.target_position_sensor?gn(m[n.target_position_sensor]??[],{preferAttribute:"linear_position",inverted:a}):[],this._whoWon=n.decision_trace_sensor?_n(m[n.decision_trace_sensor]??[],s,i):[],this._controlStatus=n.control_status_sensor?_n(m[n.control_status_sensor]??[],s,i):[];const b={};for(const e of Qe){const t=n[e.role];t&&(b[e.role]=_n(m[t]??[],s,i))}this._stateBands=b,f&&(this._timeline=f),this._activity=u?function(e,t,o,i){const s=o.filter(e=>e.t>=i.startMs&&e.t<=i.endMs).map(e=>function(e,t=!1){const o=Qn[e.event];if(!o)return null;const i="string"==typeof e.fields.service?e.fields.service:null,s="string"==typeof e.fields.entity_id?e.fields.entity_id:null;return{t:e.t,source:"command",title:i??e.event,name:null,entityId:s&&s.length>0?s:null,detail:er(e.fields,t),service:i,triggeredBy:null,skipped:o.skipped}}(e,i.inverted)).filter(e=>null!==e),n=[...t].sort((e,t)=>e.t-t.t),r=new Set;for(const e of s)if(e.entityId)for(const t of n)if(!r.has(t)&&t.entityId===e.entityId&&!(t.t<e.t||t.t-e.t>5e3||t.contextUserId||t.contextName)){r.add(t);break}const a=function(e){const t=new Map;for(const o of Object.values(e.states??{})){if(!o.entity_id.startsWith("person."))continue;const e=o.attributes.user_id,i=o.attributes.friendly_name;"string"==typeof e&&"string"==typeof i&&i.length>0&&t.set(e,i)}const o=e.user;return o?.id&&o.name&&!t.has(o.id)&&t.set(o.id,o.name),t}(e),l=[...s,...t.filter(e=>!r.has(e)).map(t=>function(e,t,o){const i=e.entityId?o.states?.[e.entityId]?.attributes?.friendly_name:void 0;return{t:e.t,source:"logbook",title:e.state??e.message??"",name:i||e.name||null,entityId:e.entityId,detail:null,service:null,triggeredBy:Zn(e,t),skipped:!1}}(t,a,e))];return l.sort((e,t)=>t.t-e.t),l}(t,v,f?.events??[],{startMs:s,endMs:i,inverted:a}):[],this._loading=!1,this._loaded=!0}_show(e){return!1!==this.tracks?.[e]}_setHours(e){e!==this.hours&&(this.hours=e,this.dispatchEvent(new CustomEvent("acp-history-hours",{detail:{hours:e},bubbles:!0,composed:!0})))}_refresh(){this._fetchKey=null,this._timeline=null,this._maybeFetch()}_toggleMaximize(e){this._maximized=this._maximized===e?null:e,"events"===this._maximized&&null===this._timeline&&Un(this.hass,this._entryId??"").then(e=>{this._timeline=e}),this.dispatchEvent(new CustomEvent("acp-history-expand",{detail:{expanded:null!==this._maximized,section:this._maximized},bubbles:!0,composed:!0}))}_maximizeButton(e){const t=this._maximized===e,o=st(t?"history.collapse":"history.expand",this.hass);return H`<button
       type="button"
       class="icon-btn"
       @click=${()=>this._toggleMaximize(e)}
-      ${xo(o)}
+      ${$o(o)}
       aria-label=${o}
       aria-pressed=${t?"true":"false"}
     >
       <ha-icon icon=${t?"mdi:arrow-collapse":"mdi:arrow-expand"}></ha-icon>
-    </button>`}_toggleAdvanced(){this._advanced=!this._advanced,this._advanced&&null===this._timeline&&Tn(this.hass,this._entryId??"").then(e=>{this._timeline=e})}async _copyDiagnostics(){const e=this._timeline?.raw;if(null!=e)try{await navigator.clipboard.writeText(JSON.stringify(e,null,2)),this._copied=!0,setTimeout(()=>{this._copied=!1},2e3)}catch{}}_showMore(e,t){const o=new URLSearchParams;t.length>0&&o.set("entity_id",t.join(",")),o.set("start_date",new Date(this._start).toISOString()),o.set("end_date",new Date(this._now).toISOString());const i=`/${e}?${o.toString()}`;history.pushState(null,"",i),window.dispatchEvent(new CustomEvent("location-changed",{detail:{replace:!1}})),this.dispatchEvent(new CustomEvent("acp-history-closed",{bubbles:!0,composed:!0}))}get _start(){return this._now-this.hours*Ln}_pct(e){const t=this._now-this._start;return t>0?Math.max(0,Math.min(100,(e-this._start)/t*100)):0}_x(e){return function(e,t,o,i){const s=o-t;if(!(s>0))return 0;const n=(e-t)/s;return Math.max(0,Math.min(i,n*i))}(e,this._start,this._now,jn.VIEW_W)}_stepPoints(e,t){return tn(e,this._now).map(e=>`${this._x(e.t).toFixed(1)},${t(e.value).toFixed(1)}`).join(" ")}render(){return this.hass&&this.discovered?null!==this._maximized?this._renderMaximized():H`
+    </button>`}_toggleAdvanced(){this._advanced=!this._advanced,this._advanced&&null===this._timeline&&Un(this.hass,this._entryId??"").then(e=>{this._timeline=e})}async _copyDiagnostics(){const e=this._timeline?.raw;if(null!=e)try{await navigator.clipboard.writeText(JSON.stringify(e,null,2)),this._copied=!0,setTimeout(()=>{this._copied=!1},2e3)}catch{}}_showMore(e,t){const o=new URLSearchParams;t.length>0&&o.set("entity_id",t.join(",")),o.set("start_date",new Date(this._start).toISOString()),o.set("end_date",new Date(this._now).toISOString());const i=`/${e}?${o.toString()}`;history.pushState(null,"",i),window.dispatchEvent(new CustomEvent("location-changed",{detail:{replace:!1}})),this.dispatchEvent(new CustomEvent("acp-history-closed",{bubbles:!0,composed:!0}))}get _start(){return this._now-this.hours*or}_pct(e){const t=this._now-this._start;return t>0?Math.max(0,Math.min(100,(e-this._start)/t*100)):0}_x(e){return function(e,t,o,i){const s=o-t;if(!(s>0))return 0;const n=(e-t)/s;return Math.max(0,Math.min(i,n*i))}(e,this._start,this._now,tr.VIEW_W)}_stepPoints(e,t){return vn(e,this._now).map(e=>`${this._x(e.t).toFixed(1)},${t(e.value).toFixed(1)}`).join(" ")}render(){return this.hass&&this.discovered?null!==this._maximized?this._renderMaximized():H`
       <div class="history">
         ${this._renderToolbar()} ${this._renderStats()} ${this._renderReadout()}
         <div
@@ -3431,7 +3552,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
             type="button"
             class="icon-btn"
             @click=${this._refresh}
-            ${xo(st("history.refresh",this.hass))}
+            ${$o(st("history.refresh",this.hass))}
             aria-label=${st("history.refresh",this.hass)}
           >
             <ha-icon icon="mdi:refresh" class=${this._loading?"spin":""}></ha-icon>
@@ -3439,7 +3560,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
           ${null===this._maximized?this._maximizeButton("tracks"):V}
         </div>
       </div>
-    `:V}_allEntityIds(){const e=this.discovered.entities,t=[...this.discovered.managed_covers??[]];e.target_position_sensor&&t.push(e.target_position_sensor),e.control_status_sensor&&t.push(e.control_status_sensor),e.decision_trace_sensor&&t.push(e.decision_trace_sensor);for(const o of Qe){const i=e[o.role];i&&t.push(i)}return t}_renderReadout(){const e=this._hoverT;if(null===e)return H`<div class="readout dim">${this._renderRangeLabel()}</div>`;const t=[qn(e)],o=on(this._target,e);null!==o&&t.push(`${st("history.legend_target",this.hass)} ${Math.round(o)}%`);const i=on(en(this._actual),e);null!==i&&t.push(`${st("history.legend_actual",this.hass)} ${Math.round(i)}%`);const s=Un(this._whoWon,e);s&&t.push(this._handlerLabel(s.state));const n=Un(this._controlStatus,e);n&&!Ze.has(n.state)&&t.push(this._controlStatusLabel(n.state));for(const o of Qe){const i=Un(this._stateBands[o.role]??[],e);i&&Hn(i.state)&&t.push(st(o.key,this.hass))}return H`<div class="readout">${t.join(" · ")}</div>`}_renderRangeLabel(){const e=this._now-this._start>Kn,t=t=>e?`${Vn(t)} ${qn(t)}`:qn(t);return`${t(this._start)} → ${t(this._now)}`}_renderPositionTrack(){const{VIEW_W:e,POS_TOP_PAD:t}=jn,o=this._posH,i=o-t,s=e=>Nt(e,t,i),n=this._stepPoints(this._target,s),r=this._stepPoints(en(this._actual),s),a=Object.entries(this._perCover).map(([e,t])=>({id:e,points:this._stepPoints(en(t),s)})),l=!n&&!r;return H`
+    `:V}_allEntityIds(){const e=this.discovered.entities,t=[...this.discovered.managed_covers??[]];e.target_position_sensor&&t.push(e.target_position_sensor),e.control_status_sensor&&t.push(e.control_status_sensor),e.decision_trace_sensor&&t.push(e.decision_trace_sensor);for(const o of Qe){const i=e[o.role];i&&t.push(i)}return t}_renderReadout(){const e=this._hoverT;if(null===e)return H`<div class="readout dim">${this._renderRangeLabel()}</div>`;const t=[lr(e)],o=fn(this._target,e);null!==o&&t.push(`${st("history.legend_target",this.hass)} ${Math.round(o)}%`);const i=fn(mn(this._actual),e);null!==i&&t.push(`${st("history.legend_actual",this.hass)} ${Math.round(i)}%`);const s=ar(this._whoWon,e);s&&t.push(this._handlerLabel(s.state));const n=ar(this._controlStatus,e);n&&!Ze.has(n.state)&&t.push(this._controlStatusLabel(n.state));for(const o of Qe){const i=ar(this._stateBands[o.role]??[],e);i&&rr(i.state)&&t.push(st(o.key,this.hass))}return H`<div class="readout">${t.join(" · ")}</div>`}_renderRangeLabel(){const e=this._now-this._start>ir,t=t=>e?`${cr(t)} ${lr(t)}`:lr(t);return`${t(this._start)} → ${t(this._now)}`}_renderPositionTrack(){const{VIEW_W:e,POS_TOP_PAD:t}=tr,o=this._posH,i=o-t,s=e=>Nt(e,t,i),n=this._stepPoints(this._target,s),r=this._stepPoints(mn(this._actual),s),a=Object.entries(this._perCover).map(([e,t])=>({id:e,points:this._stepPoints(mn(t),s)})),l=!n&&!r;return H`
       <div class="track">
         <div class="track-label">${st("history.track_position",this.hass)}</div>
         <div class="track-plot">
@@ -3461,7 +3582,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
         </div>
       </div>
       ${l?V:this._renderPositionLegend(a.length>0)}
-    `}_renderTiltTrack(){const{VIEW_W:e,POS_TOP_PAD:t}=jn,o=this._posH,i=Object.values(this._tiltActual);if(0===this._tiltTarget.length&&0===i.length)return V;const s=o-t,n=e=>Nt(e,t,s),r=this._stepPoints(this._tiltTarget,n),a=i.map(e=>this._stepPoints(en(e),n));return H`
+    `}_renderTiltTrack(){const{VIEW_W:e,POS_TOP_PAD:t}=tr,o=this._posH,i=Object.values(this._tiltActual);if(0===this._tiltTarget.length&&0===i.length)return V;const s=o-t,n=e=>Nt(e,t,s),r=this._stepPoints(this._tiltTarget,n),a=i.map(e=>this._stepPoints(mn(e),n));return H`
       <div class="track">
         <div class="track-label">${st("covers.tilt_title",this.hass)}</div>
         <div class="track-plot">
@@ -3480,7 +3601,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
           <span class="y-max">100%</span>
         </div>
       </div>
-    `}_sunShading(e,t){const o=[],i=t-e;for(const t of this._nightSegments()){const s=this._x(t.start),n=this._x(t.end)-s;n<=0||o.push(U`<rect class="night" x=${s.toFixed(1)} y=${e} width=${n.toFixed(1)} height=${i}></rect>`)}for(const t of this._stateBands.sun_infront_binary??[]){if(!Hn(t.state))continue;const s=this._x(t.start),n=this._x(t.end)-s;n<=0||o.push(U`<rect class="saa" x=${s.toFixed(1)} y=${e} width=${n.toFixed(1)} height=${i}></rect>`)}return o}_nightSegments(){const e=this.hass?.config?.latitude,t=this.hass?.config?.longitude;if("number"!=typeof e||"number"!=typeof t)return[];const o=[];let i=ei(new Date(this._start)).getTime();for(let s=0;s<8&&i<this._now;s++){const s=Jo(e,t,new Date(i));if(0===s.length)continue;const n=si(s);let r=s[0].t.getTime();for(const e of n){const t=s[e.startIdx].t.getTime();t>r&&o.push({start:r,end:t}),r=s[e.endIdx].t.getTime()}const a=s[s.length-1].t.getTime();r<a&&o.push({start:r,end:a});const l=ei(new Date(i+Kn+432e5)).getTime();i=l>i?l:i+Kn}return o.map(e=>({start:Math.max(e.start,this._start),end:Math.min(e.end,this._now)})).filter(e=>e.end>e.start)}_renderEmptyNote(e){const t=!!e&&!!this.hass.states?.[e];return H`<span class="empty-note"
+    `}_sunShading(e,t){const o=[],i=t-e;for(const t of this._nightSegments()){const s=this._x(t.start),n=this._x(t.end)-s;n<=0||o.push(U`<rect class="night" x=${s.toFixed(1)} y=${e} width=${n.toFixed(1)} height=${i}></rect>`)}for(const t of this._stateBands.sun_infront_binary??[]){if(!rr(t.state))continue;const s=this._x(t.start),n=this._x(t.end)-s;n<=0||o.push(U`<rect class="saa" x=${s.toFixed(1)} y=${e} width=${n.toFixed(1)} height=${i}></rect>`)}return o}_nightSegments(){const e=this.hass?.config?.latitude,t=this.hass?.config?.longitude;if("number"!=typeof e||"number"!=typeof t)return[];const o=[];let i=ti(new Date(this._start)).getTime();for(let s=0;s<8&&i<this._now;s++){const s=ei(e,t,new Date(i));if(0===s.length)continue;const n=ni(s);let r=s[0].t.getTime();for(const e of n){const t=s[e.startIdx].t.getTime();t>r&&o.push({start:r,end:t}),r=s[e.endIdx].t.getTime()}const a=s[s.length-1].t.getTime();r<a&&o.push({start:r,end:a});const l=ti(new Date(i+ir+432e5)).getTime();i=l>i?l:i+ir}return o.map(e=>({start:Math.max(e.start,this._start),end:Math.min(e.end,this._now)})).filter(e=>e.end>e.start)}_renderEmptyNote(e){const t=!!e&&!!this.hass.states?.[e];return H`<span class="empty-note"
       >${st(t?"history.no_recorder_data":"history.no_data",this.hass)}</span
     >`}_renderPositionLegend(e){return H`
       <div class="track">
@@ -3503,7 +3624,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
           >
         </div>
       </div>
-    `}_renderStats(){if(!this._loaded)return V;const e=function(e){const{moves:t,travel:o}=function(e){let t=0,o=0,i=null;for(const s of e)Number.isFinite(s.position)&&(null!==i&&s.position!==i&&(t+=1,o+=Math.abs(s.position-i)),i=s.position);return{moves:t,travel:Math.round(o)}}(e.actual);return{moves:t,travel:o,handlers:Sn(e.whoWon),activeMs:Cn(e.overrideBands,e.isActive)}}({actual:this._actual,whoWon:this._whoWon,overrideBands:this._stateBands.manual_override_binary??[],isActive:Hn});return 0===e.moves&&0===e.handlers.length?V:H`
+    `}_renderStats(){if(!this._loaded)return V;const e=function(e){const{moves:t,travel:o}=function(e){let t=0,o=0,i=null;for(const s of e)Number.isFinite(s.position)&&(null!==i&&s.position!==i&&(t+=1,o+=Math.abs(s.position-i)),i=s.position);return{moves:t,travel:Math.round(o)}}(e.actual);return{moves:t,travel:o,handlers:Kn(e.whoWon),activeMs:Ln(e.overrideBands,e.isActive)}}({actual:this._actual,whoWon:this._whoWon,overrideBands:this._stateBands.manual_override_binary??[],isActive:rr});return 0===e.moves&&0===e.handlers.length?V:H`
       <div class="stats">
         <span class="stat"
           ><strong>${e.moves}</strong> ${st("history.stat_moves",this.hass)}</span
@@ -3512,17 +3633,17 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
           ><strong>${e.travel}</strong> ${st("history.stat_travel",this.hass)}</span
         >
         ${e.activeMs>0?H`<span class="stat"
-              ><strong>${En(e.activeMs)}</strong> ${st("history.stat_override",this.hass)}</span
+              ><strong>${Gn(e.activeMs)}</strong> ${st("history.stat_override",this.hass)}</span
             >`:V}
-        ${e.handlers.slice(0,3).map(e=>{const t=Ke[this._badgeKind(e.handler)];return H`<span class="stat handler-stat">
+        ${e.handlers.slice(0,3).map(e=>{const t=Le[this._badgeKind(e.handler)];return H`<span class="stat handler-stat">
             <span class="swatch" style="background:${t.bg};border-color:${t.fg}"></span>
-            ${this._handlerLabel(e.handler)} ${En(e.ms)}
+            ${this._handlerLabel(e.handler)} ${Gn(e.ms)}
           </span>`})}
       </div>
-    `}_renderWhoWonTrack(){const e=this._whoWon.map(e=>{const t=this._pct(e.start),o=Math.max(.2,this._pct(e.end)-t),i=Ke[this._badgeKind(e.state)],s=this._handlerLabel(e.state);return H`<div
+    `}_renderWhoWonTrack(){const e=this._whoWon.map(e=>{const t=this._pct(e.start),o=Math.max(.2,this._pct(e.end)-t),i=Le[this._badgeKind(e.state)],s=this._handlerLabel(e.state);return H`<div
         class="band"
         style=${`left:${t.toFixed(2)}%;width:${o.toFixed(2)}%;background:${i.bg};color:${i.fg};box-shadow:inset 0 0 0 1px ${i.fg}`}
-        ${xo(`${s} — ${qn(e.start)} → ${qn(e.end)}`)}
+        ${$o(`${s} — ${lr(e.start)} → ${lr(e.end)}`)}
       >
         ${o>=6?s:""}
       </div>`});return H`
@@ -3540,7 +3661,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
       <div class="track">
         <div class="track-label"></div>
         <div class="legend">
-          ${[...e.entries()].map(([e,t])=>{const o=Ke[e];return H`<span class="legend-item">
+          ${[...e.entries()].map(([e,t])=>{const o=Le[e];return H`<span class="legend-item">
               <span class="swatch" style="background:${o.bg};border-color:${o.fg}"></span>
               <ha-icon icon=${We[e]} style="color:${o.fg}"></ha-icon>
               ${this._handlerLabel(t)}
@@ -3549,13 +3670,13 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
       </div>
     `}_renderControlStatusTrack(){if(0===this._controlStatus.length)return V;const e=st("history.track_control_status",this.hass);return H`
       <div class="track">
-        <div class="track-label" ${xo(e)}>${e}</div>
+        <div class="track-label" ${$o(e)}>${e}</div>
         <div class="track-plot">
           <div class="bar">
             ${this._controlStatus.map(e=>{const t=this._pct(e.start),o=Math.max(.2,this._pct(e.end)-t),i=this._controlStatusLabel(e.state),s=Ze.has(e.state);return H`<div
                 class=${"band status "+(s?"active":"idle")}
                 style=${`left:${t.toFixed(2)}%;width:${o.toFixed(2)}%`}
-                ${xo(`${i} — ${qn(e.start)} → ${qn(e.end)}`)}
+                ${$o(`${i} — ${lr(e.start)} → ${lr(e.end)}`)}
               >
                 ${o>=6?i:""}
               </div>`})}${this._hoverMarker()}
@@ -3564,13 +3685,13 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
       </div>
     `}_renderStateTracks(){return Qe.filter(e=>this.discovered.entities[e.role]).map(e=>{const t=this._stateBands[e.role]??[],o=st(e.key,this.hass);return H`
         <div class="track">
-          <div class="track-label" ${xo(o)}>${o}</div>
+          <div class="track-label" ${$o(o)}>${o}</div>
           <div class="track-plot">
             <div class="bar">
-              ${t.map(t=>{const i=this._pct(t.start),s=Math.max(.2,this._pct(t.end)-i),n=Hn(t.state),r=this._stateLabel(t.state);return H`<div
+              ${t.map(t=>{const i=this._pct(t.start),s=Math.max(.2,this._pct(t.end)-i),n=rr(t.state),r=this._stateLabel(t.state);return H`<div
                   class=${`band state ${n?"on":"off"} ${e.cls}`}
                   style=${`left:${i.toFixed(2)}%;width:${s.toFixed(2)}%`}
-                  ${xo(`${o}: ${r} — ${qn(t.start)} → ${qn(t.end)}`)}
+                  ${$o(`${o}: ${r} — ${lr(t.start)} → ${lr(t.end)}`)}
                 >
                   ${s>=6?r:""}
                 </div>`})}${this._hoverMarker()}
@@ -3586,12 +3707,12 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
             ${e.map((e,t)=>{return H`<span
                   class=${"axis-tick"+(0===t?" first":"")}
                   style="left:${this._pct(e).toFixed(2)}%"
-                  >${0===t||(o=e,0===new Date(o).getHours())?Vn(e):qn(e)}</span
+                  >${0===t||(o=e,0===new Date(o).getHours())?cr(e):lr(e)}</span
                 >`;var o})}
           </div>
         </div>
       </div>
-    `}_axisTicks(){const e=(this._now-this._start)/4,t=[];for(let o=0;o<=4;o++)t.push(Math.round((this._start+o*e)/Ln)*Ln);return t}_gridLines(e,t){return this._axisTicks().map(o=>{const i=this._x(o).toFixed(1);return U`<line class="grid" x1=${i} y1=${e} x2=${i} y2=${t}></line>`})}_hoverLine(e,t){if(null===this._hoverT)return V;const o=this._x(this._hoverT).toFixed(1);return U`<line class="hover-line" x1=${o} y1=${e} x2=${o} y2=${t}></line>`}_hoverMarker(){return null===this._hoverT?V:H`<div
+    `}_axisTicks(){const e=(this._now-this._start)/4,t=[];for(let o=0;o<=4;o++)t.push(Math.round((this._start+o*e)/or)*or);return t}_gridLines(e,t){return this._axisTicks().map(o=>{const i=this._x(o).toFixed(1);return U`<line class="grid" x1=${i} y1=${e} x2=${i} y2=${t}></line>`})}_hoverLine(e,t){if(null===this._hoverT)return V;const o=this._x(this._hoverT).toFixed(1);return U`<line class="hover-line" x1=${o} y1=${e} x2=${o} y2=${t}></line>`}_hoverMarker(){return null===this._hoverT?V:H`<div
       class="hover-marker"
       style="left:${this._pct(this._hoverT).toFixed(2)}%"
     ></div>`}_renderActivity(){const e=function(e){const t=new Map;for(const o of e){const e=new Date(o.t);e.setHours(0,0,0,0);const i=e.getTime(),s=t.get(i);s?s.push(o):t.set(i,[o])}return[...t.entries()].sort((e,t)=>t[0]-e[0]).map(([e,t])=>({dayMs:e,entries:[...t].sort((e,t)=>t.t-e.t)}))}(this._activity);return H`
@@ -3611,7 +3732,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
             </div>`}
         ${0===this._activity.length?H`<p class="dim">${st("history.activity_empty",this.hass)}</p>`:H`<div class="activity">
               ${e.map(e=>H`
-                  <div class="day-head">${function(e,t,o){const i=new Date(t);i.setHours(0,0,0,0);const s=Math.round((i.getTime()-e)/Kn),n=new Date(e).toLocaleDateString([],{year:"numeric",month:"long",day:"numeric"});return 0===s?`${st("history.today",o)} · ${n}`:1===s?`${st("history.yesterday",o)} · ${n}`:n}(e.dayMs,this._now,this.hass)}</div>
+                  <div class="day-head">${function(e,t,o){const i=new Date(t);i.setHours(0,0,0,0);const s=Math.round((i.getTime()-e)/ir),n=new Date(e).toLocaleDateString([],{year:"numeric",month:"long",day:"numeric"});return 0===s?`${st("history.today",o)} · ${n}`:1===s?`${st("history.yesterday",o)} · ${n}`:n}(e.dayMs,this._now,this.hass)}</div>
                   <ul class="log">
                     ${e.entries.map(e=>this._renderActivityRow(e))}
                   </ul>
@@ -3625,8 +3746,8 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
         ${e.detail?H`<span class="evt-detail">${e.detail}</span>`:V}
         ${e.name&&"logbook"===e.source?H`<span class="evt-entity">${e.name}</span>`:V}
       </span>
-      ${t?H`<span class="who" ${xo(t)}>${function(e){const t=e.trim().split(/\s+/).filter(Boolean);return 0===t.length?"?":1===t.length?t[0].slice(0,2).toUpperCase():(t[0][0]+t[t.length-1][0]).toUpperCase()}(t)}</span>`:V}
-      <span class="evt-time">${qn(e.t)}</span>
+      ${t?H`<span class="who" ${$o(t)}>${function(e){const t=e.trim().split(/\s+/).filter(Boolean);return 0===t.length?"?":1===t.length?t[0].slice(0,2).toUpperCase():(t[0][0]+t[t.length-1][0]).toUpperCase()}(t)}</span>`:V}
+      <span class="evt-time">${lr(e.t)}</span>
     </li>`}_renderMaximized(){const e=this._maximized,t={tracks:st("history.section_tracks",this.hass),activity:st("history.activity_title",this.hass),events:st("history.advanced",this.hass)},o="tracks"===e?"history":"activity"===e?"logbook":null;return H`
       <div class=${`history full full-${e}`}>
         <div class="full-head">
@@ -3663,7 +3784,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
         ${"activity"===e?this._renderActivity():V}
         ${"events"===e?this._renderEventBuffer():V}
       </div>
-    `}_renderAdvanced(){return this.hideAdvanced?V:zn(this.hass)?H`
+    `}_renderAdvanced(){return this.hideAdvanced?V:Wn(this.hass)?H`
       <div class="section advanced">
         <div class="section-head">
           <button
@@ -3679,7 +3800,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
         </div>
         <div class="advanced-body">${this._advanced?this._renderEventBuffer():V}</div>
       </div>
-    `:V}_renderEventBuffer(){const e=this._timeline;if(null===e)return H`<p class="dim">${st("history.loading",this.hass)}</p>`;if(!e.available)return H`<p class="dim">${st("history.events_unavailable",this.hass)}</p>`;const t=this._eventFilter.trim().toLowerCase(),o=t?e.events.filter(e=>function(e){return`${e.event} ${Yn(e.fields)}`.toLowerCase()}(e).includes(t)):e.events;return H`
+    `:V}_renderEventBuffer(){const e=this._timeline;if(null===e)return H`<p class="dim">${st("history.loading",this.hass)}</p>`;if(!e.available)return H`<p class="dim">${st("history.events_unavailable",this.hass)}</p>`;const t=this._eventFilter.trim().toLowerCase(),o=t?e.events.filter(e=>function(e){return`${e.event} ${dr(e.fields)}`.toLowerCase()}(e).includes(t)):e.events;return H`
       <div class="events">
         <div class="events-meta">
           <span
@@ -3707,11 +3828,11 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
               ${[...o].reverse().map(e=>H`<li class="evt sev-${Je[e.event]??"info"}">
                     <span class="evt-time">${dt(e.ts)}</span>
                     <span class="evt-name">${e.event}</span>
-                    <span class="evt-fields">${Yn(e.fields)}</span>
+                    <span class="evt-fields">${dr(e.fields)}</span>
                   </li>`)}
             </ul>`}
       </div>
-    `}_badgeKind(e){return je[e]??"auto"}_handlerLabel(e){const t=Oe[e];if(t)return st(t,this.hass);const o=Ge[e];return o?st(o,this.hass):Wn(e)}_controlStatusLabel(e){const t=Ye[e];return t?st(t,this.hass):Wn(e)}_stateLabel(e){return"on"===e?st("dialog.on",this.hass):"off"===e?st("dialog.off",this.hass):e}};function Wn(e){if(!e)return e;const t=e.replace(/_/g," ");return t.charAt(0).toUpperCase()+t.slice(1)}function Hn(e){return"off"!==e&&"unavailable"!==e&&"unknown"!==e}function Un(e,t){for(const o of e)if(t>=o.start&&t<o.end)return o;return null}function qn(e){const t=new Date(e);return Number.isNaN(t.getTime())?"—":t.toLocaleTimeString([],{hour:"2-digit",minute:"2-digit"})}function Vn(e){return new Date(e).toLocaleDateString([],{month:"short",day:"numeric"})}function Yn(e){const t=[];for(const[o,i]of Object.entries(e))null!=i&&""!==i&&t.push(`${o}=${"object"==typeof i?JSON.stringify(i):String(i)}`);return t.join("  ")}Gn.VIEW_W=600,Gn.POS_H=96,Gn.POS_H_MAX=220,Gn.POS_TOP_PAD=8,Gn.styles=a`
+    `}_badgeKind(e){return je[e]??"auto"}_handlerLabel(e){const t=Oe[e];if(t)return st(t,this.hass);const o=Ge[e];return o?st(o,this.hass):nr(e)}_controlStatusLabel(e){const t=Ye[e];return t?st(t,this.hass):nr(e)}_stateLabel(e){return"on"===e?st("dialog.on",this.hass):"off"===e?st("dialog.off",this.hass):e}};function nr(e){if(!e)return e;const t=e.replace(/_/g," ");return t.charAt(0).toUpperCase()+t.slice(1)}function rr(e){return"off"!==e&&"unavailable"!==e&&"unknown"!==e}function ar(e,t){for(const o of e)if(t>=o.start&&t<o.end)return o;return null}function lr(e){const t=new Date(e);return Number.isNaN(t.getTime())?"—":t.toLocaleTimeString([],{hour:"2-digit",minute:"2-digit"})}function cr(e){return new Date(e).toLocaleDateString([],{month:"short",day:"numeric"})}function dr(e){const t=[];for(const[o,i]of Object.entries(e))null!=i&&""!==i&&t.push(`${o}=${"object"==typeof i?JSON.stringify(i):String(i)}`);return t.join("  ")}sr.VIEW_W=600,sr.POS_H=96,sr.POS_H_MAX=220,sr.POS_TOP_PAD=8,sr.styles=a`
     :host {
       display: block;
     }
@@ -4288,7 +4409,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
     [data-tooltip][acp-tt-shown] {
       cursor: default;
     }
-  `,e([ge({attribute:!1})],Gn.prototype,"hass",void 0),e([ge({attribute:!1})],Gn.prototype,"discovered",void 0),e([ge({type:Number})],Gn.prototype,"hours",void 0),e([ge({attribute:!1})],Gn.prototype,"tracks",void 0),e([ge({type:Boolean})],Gn.prototype,"advancedOpen",void 0),e([ge({type:Boolean})],Gn.prototype,"hideAdvanced",void 0),e([ge({type:Boolean})],Gn.prototype,"showWindowPicker",void 0),e([ge({type:Boolean})],Gn.prototype,"active",void 0),e([me()],Gn.prototype,"_target",void 0),e([me()],Gn.prototype,"_actual",void 0),e([me()],Gn.prototype,"_perCover",void 0),e([me()],Gn.prototype,"_tiltTarget",void 0),e([me()],Gn.prototype,"_tiltActual",void 0),e([me()],Gn.prototype,"_copied",void 0),e([me()],Gn.prototype,"_whoWon",void 0),e([me()],Gn.prototype,"_controlStatus",void 0),e([me()],Gn.prototype,"_stateBands",void 0),e([me()],Gn.prototype,"_activity",void 0),e([me()],Gn.prototype,"_loading",void 0),e([me()],Gn.prototype,"_loaded",void 0),e([me()],Gn.prototype,"_timeline",void 0),e([me()],Gn.prototype,"_eventFilter",void 0),e([me()],Gn.prototype,"_advanced",void 0),e([me()],Gn.prototype,"_maximized",void 0),e([me()],Gn.prototype,"_hoverT",void 0),e([me()],Gn.prototype,"_now",void 0),Gn=jn=e([pe("acp-history-view")],Gn);let Zn=class extends de{constructor(){super(...arguments),this.open=!1,this.hours=24,this._expanded=null,this._onKeyDown=e=>{this.open&&"Escape"===e.key&&this._close()},this._close=()=>{this.open=!1,this._expanded=null,this.dispatchEvent(new CustomEvent("acp-history-closed",{bubbles:!0,composed:!0}))},this._onBackdrop=e=>{e.target===e.currentTarget&&this._close()}}connectedCallback(){super.connectedCallback(),window.addEventListener("keydown",this._onKeyDown)}disconnectedCallback(){super.disconnectedCallback(),window.removeEventListener("keydown",this._onKeyDown)}render(){if(!this.hass||!this.discovered)return V;const e=this.discovered.entry_title||st("history.title",this.hass);return H`
+  `,e([ge({attribute:!1})],sr.prototype,"hass",void 0),e([ge({attribute:!1})],sr.prototype,"discovered",void 0),e([ge({type:Number})],sr.prototype,"hours",void 0),e([ge({attribute:!1})],sr.prototype,"tracks",void 0),e([ge({type:Boolean})],sr.prototype,"advancedOpen",void 0),e([ge({type:Boolean})],sr.prototype,"hideAdvanced",void 0),e([ge({type:Boolean})],sr.prototype,"showWindowPicker",void 0),e([ge({type:Boolean})],sr.prototype,"active",void 0),e([me()],sr.prototype,"_target",void 0),e([me()],sr.prototype,"_actual",void 0),e([me()],sr.prototype,"_perCover",void 0),e([me()],sr.prototype,"_tiltTarget",void 0),e([me()],sr.prototype,"_tiltActual",void 0),e([me()],sr.prototype,"_copied",void 0),e([me()],sr.prototype,"_whoWon",void 0),e([me()],sr.prototype,"_controlStatus",void 0),e([me()],sr.prototype,"_stateBands",void 0),e([me()],sr.prototype,"_activity",void 0),e([me()],sr.prototype,"_loading",void 0),e([me()],sr.prototype,"_loaded",void 0),e([me()],sr.prototype,"_timeline",void 0),e([me()],sr.prototype,"_eventFilter",void 0),e([me()],sr.prototype,"_advanced",void 0),e([me()],sr.prototype,"_maximized",void 0),e([me()],sr.prototype,"_hoverT",void 0),e([me()],sr.prototype,"_now",void 0),sr=tr=e([pe("acp-history-view")],sr);let hr=class extends de{constructor(){super(...arguments),this.open=!1,this.hours=24,this._expanded=null,this._onKeyDown=e=>{this.open&&"Escape"===e.key&&this._close()},this._close=()=>{this.open=!1,this._expanded=null,this.dispatchEvent(new CustomEvent("acp-history-closed",{bubbles:!0,composed:!0}))},this._onBackdrop=e=>{e.target===e.currentTarget&&this._close()}}connectedCallback(){super.connectedCallback(),window.addEventListener("keydown",this._onKeyDown)}disconnectedCallback(){super.disconnectedCallback(),window.removeEventListener("keydown",this._onKeyDown)}render(){if(!this.hass||!this.discovered)return V;const e=this.discovered.entry_title||st("history.title",this.hass);return H`
       <div
         class="backdrop"
         role="dialog"
@@ -4326,7 +4447,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
           </div>
         </div>
       </div>
-    `}};Zn.styles=a`
+    `}};hr.styles=a`
     :host {
       display: none;
     }
@@ -4414,14 +4535,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
       padding: 12px 14px 14px;
       overflow-y: auto;
     }
-  `,e([ge({attribute:!1})],Zn.prototype,"hass",void 0),e([ge({attribute:!1})],Zn.prototype,"discovered",void 0),e([ge({type:Boolean,reflect:!0})],Zn.prototype,"open",void 0),e([ge({type:Number})],Zn.prototype,"hours",void 0),e([ge({attribute:!1})],Zn.prototype,"tracks",void 0),e([me()],Zn.prototype,"_expanded",void 0),Zn=e([pe("acp-history-dialog")],Zn);let Qn=class extends de{constructor(){super(...arguments),this.open=!1,this.advancedOpen=!1,this.showCompass=!0,this.showElevationChart=!0,this.showSolarCalc=!0,this.stateColor=!0,this._cancelMinuteTimer=null,this._positionHistory=[],this._historyKey=null,this._historyOpen=!1,this._listSource=null,this._list=[],this._openHistory=e=>{e.stopPropagation(),this._historyOpen=!0},this._onResume=()=>{const e=this.discovered.entities.reset_override_button;e&&this.hass.callService("button","press",{entity_id:e})},this._toggleAdvanced=()=>{this.advancedOpen=!this.advancedOpen},this._openDevicePage=()=>{const e=this.discovered.device_id;e&&this._navigate(`/config/devices/device/${e}`)},this._openIntegrationPage=()=>{const e=this.discovered.entry_id;this._navigate(`/config/integrations/integration/${Te}`+(e?`#config_entry=${e}`:""))},this._onBackdrop=e=>{e.target===e.currentTarget&&this._emitClose()},this._emitClose=()=>{this.dispatchEvent(new CustomEvent("acp-dialog-close",{bubbles:!0,composed:!0}))},this._stop=e=>{e.stopPropagation()}}updated(){this._syncMinuteTimer(this.open),this._maybeFetchHistory()}_maybeFetchHistory(){if(!this.open||!this.hass||!this.discovered)return;const e=this.discovered.managed_covers??[];if(0===e.length)return this._historyKey=null,void(this._positionHistory.length>0&&(this._positionHistory=[]));const t=Date.now(),o=ei(new Date(t)).getTime(),i=St(this.discovered),s=`${e.join(",")}|${o}|${i}`;s!==this._historyKey&&(this._historyKey=s,async function(e,t,o,i,s=!1){if(0===t.length)return[];let n;try{n=await e.callWS({type:"history/history_during_period",start_time:new Date(o).toISOString(),end_time:new Date(i).toISOString(),entity_ids:t,minimal_response:!1,no_attributes:!1,significant_changes_only:!1})}catch{return[]}if(!n||"object"!=typeof n)return[];const r={};for(const e of t){const t=n[e];if(!Array.isArray(t))continue;const o=Ls(t);o.length>0&&(r[e]=o)}const a=Ks(r);if(a.length>0){const e=a[a.length-1];Date.parse(e.t)<i&&a.push({t:new Date(i).toISOString(),position:e.position})}return s?a.map(e=>({t:e.t,position:100-e.position})):a}(this.hass,e,o,t,i).then(e=>{this._historyKey===s&&(this._positionHistory=e)}))}disconnectedCallback(){super.disconnectedCallback(),this._syncMinuteTimer(!1)}_syncMinuteTimer(e){e&&null===this._cancelMinuteTimer?this._cancelMinuteTimer=vi(()=>this.requestUpdate()):e||null===this._cancelMinuteTimer||(this._cancelMinuteTimer(),this._cancelMinuteTimer=null)}get _discoveredList(){return this.discovered!==this._listSource&&(this._listSource=this.discovered,this._list=this.discovered?[this.discovered]:[]),this._list}_buildHandlerLabels(){const e={};for(const[t,o]of Object.entries(Oe))e[t]=st(o,this.hass);return e}_headerIcon(){const e=this.discovered.managed_covers?.[0],t=e?this.hass.states[e]:void 0;return ut({explicitIcon:t?.attributes?.icon,deviceClass:t?.attributes?.device_class,coverType:this.discovered.cover_type,position:Vt(this.hass,this.discovered,e)})}_headerColor(){if(!this.stateColor)return null;const e=this.discovered.managed_covers?.[0],t=e?this.hass.states[e]:void 0;return vt(t?.state)}_batteryTpl(){const e=this.coverOrder??this.discovered?.managed_covers??[],t=Ui(this.hass,e),o=Vi(t);if(!o)return V;const i=1===t.length?null===o.level?st("dialog.battery_unknown",this.hass):st("dialog.battery",this.hass,{level:o.level}):t.map(e=>st("dialog.battery_named",this.hass,{name:this._coverName(e.cover_id),level:null===e.level?"—":e.level})).join(" · ");return H`<div
-      class="icon-btn battery${qi(o)?" low":""}"
-      role="img"
-      aria-label=${i}
-      ${xo(i)}
-    >
-      <ha-icon icon=${Yi(o.level,o.charging)}></ha-icon>
-    </div>`}_coverName(e){return this.hass?.states[e]?.attributes?.friendly_name??e}render(){if(!this.open||!this.hass||!this.discovered)return V;const e=this._winner(),t=this._traceAttrs(),o=this._matchedHandlers(t,e),i=$i(t),s=t?Ai(t.trace??[],t,0,this._buildHandlerLabels(),st("badge.safety",this.hass)):"",n=this._target(),r=this._shouldShowResume(),a=this._switchOn("integration_enabled_switch"),l=this._switchOn("automatic_control_switch"),c=st("dialog.configure_integration",this.hass),d=st("dialog.open_device_page",this.hass),h=st("dialog.close",this.hass),p=st("history.open",this.hass),u=this._headerColor();return H`
+  `,e([ge({attribute:!1})],hr.prototype,"hass",void 0),e([ge({attribute:!1})],hr.prototype,"discovered",void 0),e([ge({type:Boolean,reflect:!0})],hr.prototype,"open",void 0),e([ge({type:Number})],hr.prototype,"hours",void 0),e([ge({attribute:!1})],hr.prototype,"tracks",void 0),e([me()],hr.prototype,"_expanded",void 0),hr=e([pe("acp-history-dialog")],hr);let pr=class extends de{constructor(){super(...arguments),this.open=!1,this.advancedOpen=!1,this.showCompass=!0,this.showElevationChart=!0,this.showSolarCalc=!0,this.stateColor=!0,this._cancelMinuteTimer=null,this._positionHistory=[],this._historyKey=null,this._historyOpen=!1,this._listSource=null,this._list=[],this._openHistory=e=>{e.stopPropagation(),this._historyOpen=!0},this._onResume=()=>{const e=this.discovered.entities.reset_override_button;e&&this.hass.callService("button","press",{entity_id:e})},this._toggleAdvanced=()=>{this.advancedOpen=!this.advancedOpen},this._openDevicePage=()=>{const e=this.discovered.device_id;e&&this._navigate(`/config/devices/device/${e}`)},this._openIntegrationPage=()=>{const e=this.discovered.entry_id;this._navigate(`/config/integrations/integration/${Te}`+(e?`#config_entry=${e}`:""))},this._onBackdrop=e=>{e.target===e.currentTarget&&this._emitClose()},this._emitClose=()=>{this.dispatchEvent(new CustomEvent("acp-dialog-close",{bubbles:!0,composed:!0}))},this._stop=e=>{e.stopPropagation()}}updated(){this._syncMinuteTimer(this.open),this._maybeFetchHistory()}_maybeFetchHistory(){if(!this.open||!this.hass||!this.discovered)return;const e=this.discovered.managed_covers??[];if(0===e.length)return this._historyKey=null,void(this._positionHistory.length>0&&(this._positionHistory=[]));const t=Date.now(),o=ti(new Date(t)).getTime(),i=St(this.discovered),s=`${e.join(",")}|${o}|${i}`;s!==this._historyKey&&(this._historyKey=s,async function(e,t,o,i,s=!1){if(0===t.length)return[];let n;try{n=await e.callWS({type:"history/history_during_period",start_time:new Date(o).toISOString(),end_time:new Date(i).toISOString(),entity_ids:t,minimal_response:!1,no_attributes:!1,significant_changes_only:!1})}catch{return[]}if(!n||"object"!=typeof n)return[];const r={};for(const e of t){const t=n[e];if(!Array.isArray(t))continue;const o=on(t);o.length>0&&(r[e]=o)}const a=sn(r);if(a.length>0){const e=a[a.length-1];Date.parse(e.t)<i&&a.push({t:new Date(i).toISOString(),position:e.position})}return s?a.map(e=>({t:e.t,position:100-e.position})):a}(this.hass,e,o,t,i).then(e=>{this._historyKey===s&&(this._positionHistory=e)}))}disconnectedCallback(){super.disconnectedCallback(),this._syncMinuteTimer(!1)}_syncMinuteTimer(e){e&&null===this._cancelMinuteTimer?this._cancelMinuteTimer=fi(()=>this.requestUpdate()):e||null===this._cancelMinuteTimer||(this._cancelMinuteTimer(),this._cancelMinuteTimer=null)}get _discoveredList(){return this.discovered!==this._listSource&&(this._listSource=this.discovered,this._list=this.discovered?[this.discovered]:[]),this._list}_buildHandlerLabels(){const e={};for(const[t,o]of Object.entries(Oe))e[t]=st(o,this.hass);return e}_headerIcon(){const e=this.discovered.managed_covers?.[0],t=e?this.hass.states[e]:void 0;return ut({explicitIcon:t?.attributes?.icon,deviceClass:t?.attributes?.device_class,coverType:this.discovered.cover_type,position:Yt(this.hass,this.discovered,e)})}_headerColor(){if(!this.stateColor)return null;const e=this.discovered.managed_covers?.[0],t=e?this.hass.states[e]:void 0;return vt(t?.state)}render(){if(!this.open||!this.hass||!this.discovered)return V;const e=this._winner(),t=this._traceAttrs(),o=this._matchedHandlers(t,e),i=ki(t),s=t?Si(t.trace??[],t,0,this._buildHandlerLabels(),st("badge.safety",this.hass)):"",n=this._target(),r=this._shouldShowResume(),a=this._switchOn("integration_enabled_switch"),l=this._switchOn("automatic_control_switch"),c=st("dialog.configure_integration",this.hass),d=st("dialog.open_device_page",this.hass),h=st("dialog.close",this.hass),p=st("history.open",this.hass),u=this._headerColor();return H`
       <div class="backdrop" data-open @click=${this._onBackdrop}>
         <div class="dialog" @click=${this._stop} role="dialog" aria-modal="true">
           <div class="header">
@@ -4437,7 +4551,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
                           .winner=${e}
                           .slotNumber=${"custom_position"===e?t?.custom_position_active_slot:void 0}
                           .slotName=${"custom_position"===e?t?.custom_position_active_slot_name:void 0}
-                          .pct=${"custom_position"===e?xi(t,n)??void 0:void 0}
+                          .pct=${"custom_position"===e?$i(t,n)??void 0:void 0}
                           .minimumMode=${"custom_position"===e?t?.custom_position_minimum_mode:void 0}
                           .safetyActive=${"custom_position"===e&&i}
                         ></acp-tile-badge>`):V:H`<acp-tile-badge
@@ -4445,12 +4559,15 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
                     .integrationEnabled=${!1}
                   ></acp-tile-badge>`}
             </div>
-            ${this._batteryTpl()}
+            <acp-battery-indicator
+              .hass=${this.hass}
+              .coverIds=${this.coverOrder??this.discovered.managed_covers??[]}
+            ></acp-battery-indicator>
             <button
               class="icon-btn history-link"
               type="button"
               aria-label=${p}
-              ${xo(p)}
+              ${$o(p)}
               @click=${this._openHistory}
             >
               <ha-icon icon=${Ve}></ha-icon>
@@ -4459,7 +4576,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
               class="icon-btn options-link"
               type="button"
               aria-label=${c}
-              ${xo(c)}
+              ${$o(c)}
               @click=${this._openIntegrationPage}
             >
               <ha-icon icon="mdi:cog"></ha-icon>
@@ -4468,7 +4585,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
                   class="icon-btn device-link"
                   type="button"
                   aria-label=${d}
-                  ${xo(d)}
+                  ${$o(d)}
                   @click=${this._openDevicePage}
                 >
                   <ha-icon icon="mdi:tune-variant"></ha-icon>
@@ -4543,12 +4660,12 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
         .open=${this._historyOpen}
         @acp-history-closed=${()=>{this._historyOpen=!1}}
       ></acp-history-dialog>
-    `}_winner(){const e=this.discovered.entities.decision_trace_sensor;return e?this.hass.states[e]?.state??"default":"default"}_traceAttrs(){const e=this.discovered.entities.decision_trace_sensor;if(e)return this.hass.states[e]?.attributes}_matchedHandlers(e,t){if(!e?.trace)return[];const o=Xi(e.trace),i=Ie.filter(e=>o.has(e)).map(e=>je[e]).filter(e=>void 0!==e),s=ts(e.trace,t);return Zi(i,this.badges,s)}_target(){return Ht(this.hass,this.discovered)}_mismatchActive(){const e=this.discovered.entities.position_mismatch_binary;return!!e&&"on"===this.hass.states[e]?.state}_manualOverrideOn(){const e=this.discovered.entities.manual_override_binary;return!!e&&"on"===this.hass.states[e]?.state}_switchOn(e){const t=this.discovered.entities[e];return!t||"off"!==this.hass.states[t]?.state}_shouldShowResume(){return!!this.discovered.entities.reset_override_button&&this._manualOverrideOn()}_renderSlots(e){if(!e)return V;const t=e.filter(e=>null!==e.sensor);return 0===t.length?V:H`<div class="slots-section">
+    `}_winner(){const e=this.discovered.entities.decision_trace_sensor;return e?this.hass.states[e]?.state??"default":"default"}_traceAttrs(){const e=this.discovered.entities.decision_trace_sensor;if(e)return this.hass.states[e]?.attributes}_matchedHandlers(e,t){if(!e?.trace)return[];const o=rs(e.trace),i=Ie.filter(e=>o.has(e)).map(e=>je[e]).filter(e=>void 0!==e),s=cs(e.trace,t);return ss(i,this.badges,s)}_target(){return Ut(this.hass,this.discovered)}_mismatchActive(){const e=this.discovered.entities.position_mismatch_binary;return!!e&&"on"===this.hass.states[e]?.state}_manualOverrideOn(){const e=this.discovered.entities.manual_override_binary;return!!e&&"on"===this.hass.states[e]?.state}_switchOn(e){const t=this.discovered.entities[e];return!t||"off"!==this.hass.states[t]?.state}_shouldShowResume(){return!!this.discovered.entities.reset_override_button&&this._manualOverrideOn()}_renderSlots(e){if(!e)return V;const t=e.filter(e=>null!==e.sensor);return 0===t.length?V:H`<div class="slots-section">
       <div class="slots-label">${st("dialog.custom_positions",this.hass)}</div>
       ${t.map(e=>this._renderSlotRow(e))}
     </div>`}_renderSlotRow(e){const t=e.sensor_name??`#${e.slot}`,o=e.sensors?.length??0,i=!0===e.template?H`<span
             class="slot-template"
-            ${xo("Template"+(o>0?` · ${o} sensors${e.template_mode?` (${e.template_mode})`:""}`:""))}
+            ${$o("Template"+(o>0?` · ${o} sensors${e.template_mode?` (${e.template_mode})`:""}`:""))}
           >
             <ha-icon icon="mdi:code-braces"></ha-icon>
           </span>`:V;return H`<div class="slot-row" data-slot=${e.slot}>
@@ -4557,7 +4674,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
       <span class="slot-position">${nt(e.position)}</span>
       ${!0===e.min_mode?H`<span
             class="slot-min-mode${null!=e.priority&&e.priority>80?"":" is-bypassable"}"
-            ${xo(st("dialog.floor_tooltip",this.hass))}
+            ${$o(st("dialog.floor_tooltip",this.hass))}
           >
             ${st("dialog.floor",this.hass)}
           </span>`:V}
@@ -4592,7 +4709,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
         .axes=${kt(this.discovered)}
       ></acp-forecast-strip>
       <div class="forecast-note">${st("forecast.solar_only_note",this.hass)}</div>
-    </div>`}_toggleSlot(e){const t=this.discovered.managed_covers[0];t&&this.hass.callService(Te,"set_custom_position",{entity_id:t,slot:e.slot,enabled:!e.enabled})}_navigate(e){history.pushState(null,"",e),window.dispatchEvent(new CustomEvent("location-changed",{detail:{replace:!1}})),this._emitClose()}};function Xn(e){return H`
+    </div>`}_toggleSlot(e){const t=this.discovered.managed_covers[0];t&&this.hass.callService(Te,"set_custom_position",{entity_id:t,slot:e.slot,enabled:!e.enabled})}_navigate(e){history.pushState(null,"",e),window.dispatchEvent(new CustomEvent("location-changed",{detail:{replace:!1}})),this._emitClose()}};function ur(e){return H`
     <div
       class="editor-footer"
       style="display:flex;align-items:center;justify-content:space-between;gap:8px;"
@@ -4604,7 +4721,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
         ${st("root.footer_version",e,{version:fe})}
       </span>
     </div>
-  `}Qn.styles=a`
+  `}pr.styles=a`
     :host {
       display: contents;
     }
@@ -4673,14 +4790,6 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
       display: inline-flex;
       align-items: center;
       --mdc-icon-size: 18px;
-    }
-    /* The battery shares .icon-btn's metrics so it lines up with the buttons
-       beside it, but it is a readout, not a control — no pointer affordance. */
-    .icon-btn.battery {
-      cursor: default;
-    }
-    .icon-btn.battery.low {
-      color: var(--error-color, #db4437);
     }
     .icon-btn:hover {
       color: var(--primary-text-color);
@@ -4895,7 +5004,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
     .ctrl-toggle:hover {
       background: rgba(var(--rgb-primary-color, 33, 150, 243), 0.08);
     }
-  `,e([ge({attribute:!1})],Qn.prototype,"hass",void 0),e([ge({attribute:!1})],Qn.prototype,"discovered",void 0),e([ge({type:Boolean,reflect:!0})],Qn.prototype,"open",void 0),e([ge({type:Boolean})],Qn.prototype,"advancedOpen",void 0),e([ge({type:Boolean})],Qn.prototype,"showCompass",void 0),e([ge({type:Boolean})],Qn.prototype,"showElevationChart",void 0),e([ge({type:Boolean})],Qn.prototype,"showSolarCalc",void 0),e([ge({type:Boolean})],Qn.prototype,"stateColor",void 0),e([ge({attribute:!1})],Qn.prototype,"badges",void 0),e([ge({attribute:!1})],Qn.prototype,"coverOrder",void 0),e([me()],Qn.prototype,"_positionHistory",void 0),e([me()],Qn.prototype,"_historyOpen",void 0),Qn=e([pe("acp-more-info-dialog")],Qn);const Jn=["auto","solar","force","weather","manual","custom_position","motion","climate","glare_zone","cloud"],er={show_position:!0,show_state:!0,show_decision_summary:!1,show_controls:!0,show_badge:!0,show_position_bar:!0,show_tilt:!0,show_compass:!0,show_elevation_chart:!0,show_solar_calc:!0,show_motion_icon:!0,state_color:!0,layout:"detailed",badge_auto:!0,badge_solar:!0,badge_force:!0,badge_weather:!0,badge_manual:!0,badge_custom_position:!0,badge_motion:!0,badge_climate:!0,badge_glare_zone:!0,badge_cloud:!0,show_scene_select:!0,show_lock:!0,show_automation:!0,show_clear_overrides:!0,show_member_badges:!0},tr={entry_id:"editor.common.entry_id",name:"editor.tile.name",icon:"editor.tile.icon",cover:"editor.tile.cover",layout:"editor.tile.layout",show_position:"editor.tile.show_position",show_state:"editor.tile.show_state",show_decision_summary:"editor.tile.show_decision_summary",show_controls:"editor.tile.show_controls",controls_cover:"editor.tile.controls_cover",controls_axis:"editor.tile.controls_axis",show_badge:"editor.tile.show_badge",show_position_bar:"editor.tile.show_position_bar",show_tilt:"editor.tile.show_tilt",badge_section:"editor.tile.badge_section",badge_auto:"editor.tile.badge_auto",badge_solar:"editor.tile.badge_solar",badge_force:"editor.tile.badge_force",badge_weather:"editor.tile.badge_weather",badge_manual:"editor.tile.badge_manual",badge_custom_position:"editor.tile.badge_custom_position",badge_motion:"editor.tile.badge_motion",badge_climate:"editor.tile.badge_climate",badge_glare_zone:"editor.tile.badge_glare_zone",badge_cloud:"editor.tile.badge_cloud",show_compass:"editor.tile.show_compass",show_elevation_chart:"editor.tile.show_elevation_chart",show_solar_calc:"editor.tile.show_solar_calc",show_motion_icon:"editor.tile.show_motion_icon",state_color:"editor.tile.state_color",tap_action:"editor.tile.tap_action",icon_tap_action:"editor.tile.icon_tap_action",hold_action:"editor.tile.hold_action",double_tap_action:"editor.tile.double_tap_action",interactions_section:"editor.tile.interactions_section",content_section:"editor.tile.content_section",controls_section:"editor.tile.controls_section",dialog_section:"editor.tile.dialog_section",group_row_section:"editor.tile.group_row_section",show_scene_select:"editor.tile.show_scene_select",show_lock:"editor.tile.show_lock",show_automation:"editor.tile.show_automation",show_clear_overrides:"editor.tile.show_clear_overrides",show_member_badges:"editor.tile.show_member_badges"};let or=class extends de{constructor(){super(...arguments),this._entries=null,this._entriesError=null,this._registry=null,this._managedCovers=[],this._entriesFetchInFlight=!1,this._registryFetchInFlight=!1,this._unsubRegistry=null,this._isGroupEntry=!1,this._groupDiscovered=null,this._memberDrafts=null,this._memberDraftsFor=null,this._computeLabel=e=>{const t=tr[e.name];return t?st(t,this.hass):e.name},this._valueChanged=e=>{e.stopPropagation();const t={...e.detail.value};this._nameIsComposed()&&!t.name&&delete t.name;for(const[e,o]of Object.entries(er))e.startsWith("badge_")?t[e]===o&&delete t[e]:this._config&&Object.prototype.hasOwnProperty.call(this._config,e)||t[e]!==o||delete t[e];const o={};for(const e of Jn){const i=`badge_${e}`;!1===t[i]&&(o[e]=!1),delete t[i]}const i={...this._config??{type:"",entry_id:""},...t};this._config?.entry_id&&i.entry_id!==this._config.entry_id&&(delete i.cover,delete i.covers,delete i.controls_cover,delete i.controls_axis),Object.keys(o).length>0?i.badges=o:delete i.badges,this._emit(i)},this._dragFrom=null,this._memberLabels=new Map}setConfig(e){this._config={...e}}disconnectedCallback(){super.disconnectedCallback(),this._unsubRegistry&&(this._unsubRegistry(),this._unsubRegistry=null)}updated(e){e.has("hass")&&this.hass&&(this._ensureEntries(),this._ensureRegistry()),(e.has("_registry")||e.has("_config"))&&null!==this._registry&&this._refreshManagedCovers()}_ensureEntries(){this._entries||this._entriesFetchInFlight||(this._entriesFetchInFlight=!0,Ro(this.hass).then(e=>{this._entries=e,this._entriesError=null,this._config?.entry_id||1!==e.length||this._emit({...this._config??{type:"",entry_id:""},entry_id:e[0].entry_id}),this._refreshManagedCovers()}).catch(e=>{this._entriesError=e?.message??"failed to load config entries"}).finally(()=>{this._entriesFetchInFlight=!1}))}_ensureRegistry(){if(null===this._registry){const e=Io();e&&(this._registry=e,this._refreshManagedCovers())}null!==this._registry||this._registryFetchInFlight||(this._registryFetchInFlight=!0,Eo(this.hass).then(e=>{this._registry=e,this._refreshManagedCovers()}).catch(()=>{this._registry=[]}).finally(()=>{this._registryFetchInFlight=!1})),this._unsubRegistry||(this._unsubRegistry=zo(this.hass,()=>{this._registryFetchInFlight=!0,Eo(this.hass).then(e=>{this._registry=e}).catch(()=>{}).finally(()=>{this._registryFetchInFlight=!1})}))}_emit(e){this._config=e,this.dispatchEvent(new CustomEvent("config-changed",{detail:{config:e},bubbles:!0,composed:!0}))}_refreshManagedCovers(){if(!this._config?.entry_id||!this._registry||!this.hass)return;const e=Co(this.hass,{type:this._config.type,entry_id:this._config.entry_id},this._registry);this._managedCovers=e?.managed_covers??[],this._isGroupEntry=!!e?.is_group,this._groupDiscovered=e?.is_group?e:null,this._memberLabels.clear();const t=this._config?.entry_id??"";null!==this._memberDrafts&&this._memberDraftsFor===t||(this._memberDrafts={...this._config?.member_names??{}},this._memberDraftsFor=t)}_nameIsComposed(){return Array.isArray(this._config?.name)}render(){if(!this._config)return V;if(this._entriesError&&!this._entries)return H`
+  `,e([ge({attribute:!1})],pr.prototype,"hass",void 0),e([ge({attribute:!1})],pr.prototype,"discovered",void 0),e([ge({type:Boolean,reflect:!0})],pr.prototype,"open",void 0),e([ge({type:Boolean})],pr.prototype,"advancedOpen",void 0),e([ge({type:Boolean})],pr.prototype,"showCompass",void 0),e([ge({type:Boolean})],pr.prototype,"showElevationChart",void 0),e([ge({type:Boolean})],pr.prototype,"showSolarCalc",void 0),e([ge({type:Boolean})],pr.prototype,"stateColor",void 0),e([ge({attribute:!1})],pr.prototype,"badges",void 0),e([ge({attribute:!1})],pr.prototype,"coverOrder",void 0),e([me()],pr.prototype,"_positionHistory",void 0),e([me()],pr.prototype,"_historyOpen",void 0),pr=e([pe("acp-more-info-dialog")],pr);const _r=["auto","solar","force","weather","manual","custom_position","motion","climate","glare_zone","cloud"],gr={show_position:!0,show_state:!0,show_decision_summary:!1,show_controls:!0,show_badge:!0,show_position_bar:!0,show_tilt:!0,show_compass:!0,show_elevation_chart:!0,show_solar_calc:!0,show_motion_icon:!0,state_color:!0,layout:"detailed",badge_auto:!0,badge_solar:!0,badge_force:!0,badge_weather:!0,badge_manual:!0,badge_custom_position:!0,badge_motion:!0,badge_climate:!0,badge_glare_zone:!0,badge_cloud:!0,show_scene_select:!0,show_lock:!0,show_automation:!0,show_clear_overrides:!0,show_member_badges:!0},mr={entry_id:"editor.common.entry_id",name:"editor.tile.name",icon:"editor.tile.icon",cover:"editor.tile.cover",layout:"editor.tile.layout",show_position:"editor.tile.show_position",show_state:"editor.tile.show_state",show_decision_summary:"editor.tile.show_decision_summary",show_controls:"editor.tile.show_controls",controls_cover:"editor.tile.controls_cover",controls_axis:"editor.tile.controls_axis",show_badge:"editor.tile.show_badge",show_position_bar:"editor.tile.show_position_bar",show_tilt:"editor.tile.show_tilt",badge_section:"editor.tile.badge_section",badge_auto:"editor.tile.badge_auto",badge_solar:"editor.tile.badge_solar",badge_force:"editor.tile.badge_force",badge_weather:"editor.tile.badge_weather",badge_manual:"editor.tile.badge_manual",badge_custom_position:"editor.tile.badge_custom_position",badge_motion:"editor.tile.badge_motion",badge_climate:"editor.tile.badge_climate",badge_glare_zone:"editor.tile.badge_glare_zone",badge_cloud:"editor.tile.badge_cloud",show_compass:"editor.tile.show_compass",show_elevation_chart:"editor.tile.show_elevation_chart",show_solar_calc:"editor.tile.show_solar_calc",show_motion_icon:"editor.tile.show_motion_icon",state_color:"editor.tile.state_color",tap_action:"editor.tile.tap_action",icon_tap_action:"editor.tile.icon_tap_action",hold_action:"editor.tile.hold_action",double_tap_action:"editor.tile.double_tap_action",interactions_section:"editor.tile.interactions_section",content_section:"editor.tile.content_section",controls_section:"editor.tile.controls_section",dialog_section:"editor.tile.dialog_section",group_row_section:"editor.tile.group_row_section",show_scene_select:"editor.tile.show_scene_select",show_lock:"editor.tile.show_lock",show_automation:"editor.tile.show_automation",show_clear_overrides:"editor.tile.show_clear_overrides",show_member_badges:"editor.tile.show_member_badges"};let vr=class extends de{constructor(){super(...arguments),this._entries=null,this._entriesError=null,this._registry=null,this._managedCovers=[],this._entriesFetchInFlight=!1,this._registryFetchInFlight=!1,this._unsubRegistry=null,this._isGroupEntry=!1,this._groupDiscovered=null,this._memberDrafts=null,this._memberDraftsFor=null,this._computeLabel=e=>{const t=mr[e.name];return t?st(t,this.hass):e.name},this._valueChanged=e=>{e.stopPropagation();const t={...e.detail.value};this._nameIsComposed()&&!t.name&&delete t.name;for(const[e,o]of Object.entries(gr))e.startsWith("badge_")?t[e]===o&&delete t[e]:this._config&&Object.prototype.hasOwnProperty.call(this._config,e)||t[e]!==o||delete t[e];const o={};for(const e of _r){const i=`badge_${e}`;!1===t[i]&&(o[e]=!1),delete t[i]}const i={...this._config??{type:"",entry_id:""},...t};this._config?.entry_id&&i.entry_id!==this._config.entry_id&&(delete i.cover,delete i.covers,delete i.controls_cover,delete i.controls_axis),Object.keys(o).length>0?i.badges=o:delete i.badges,this._emit(i)},this._dragFrom=null,this._memberDragFrom=null,this._memberLabels=new Map}setConfig(e){this._config={...e}}disconnectedCallback(){super.disconnectedCallback(),this._unsubRegistry&&(this._unsubRegistry(),this._unsubRegistry=null)}updated(e){e.has("hass")&&this.hass&&(this._ensureEntries(),this._ensureRegistry()),(e.has("_registry")||e.has("_config"))&&null!==this._registry&&this._refreshManagedCovers()}_ensureEntries(){this._entries||this._entriesFetchInFlight||(this._entriesFetchInFlight=!0,jo(this.hass).then(e=>{this._entries=e,this._entriesError=null,this._config?.entry_id||1!==e.length||this._emit({...this._config??{type:"",entry_id:""},entry_id:e[0].entry_id}),this._refreshManagedCovers()}).catch(e=>{this._entriesError=e?.message??"failed to load config entries"}).finally(()=>{this._entriesFetchInFlight=!1}))}_ensureRegistry(){if(null===this._registry){const e=Po();e&&(this._registry=e,this._refreshManagedCovers())}null!==this._registry||this._registryFetchInFlight||(this._registryFetchInFlight=!0,zo(this.hass).then(e=>{this._registry=e,this._refreshManagedCovers()}).catch(()=>{this._registry=[]}).finally(()=>{this._registryFetchInFlight=!1})),this._unsubRegistry||(this._unsubRegistry=Mo(this.hass,()=>{this._registryFetchInFlight=!0,zo(this.hass).then(e=>{this._registry=e}).catch(()=>{}).finally(()=>{this._registryFetchInFlight=!1})}))}_emit(e){this._config=e,this.dispatchEvent(new CustomEvent("config-changed",{detail:{config:e},bubbles:!0,composed:!0}))}_refreshManagedCovers(){if(!this._config?.entry_id||!this._registry||!this.hass)return;const e=Eo(this.hass,{type:this._config.type,entry_id:this._config.entry_id},this._registry);this._managedCovers=e?.managed_covers??[],this._isGroupEntry=!!e?.is_group,this._groupDiscovered=e?.is_group?e:null,this._memberLabels.clear();const t=this._config?.entry_id??"";null!==this._memberDrafts&&this._memberDraftsFor===t||(this._memberDrafts={...this._config?.member_names??{}},this._memberDraftsFor=t)}_nameIsComposed(){return Array.isArray(this._config?.name)}render(){if(!this._config)return V;if(this._entriesError&&!this._entries)return H`
         <div class="form">
           <div class="error">
             ${st("editor.common.load_failed",this.hass,{error:this._entriesError})}
@@ -4911,9 +5020,9 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
             placeholder=${st("editor.common.entry_id_manual_placeholder",this.hass)}
             @change=${e=>{const t={...this._config??{type:"",entry_id:""},entry_id:e.target.value};this._config?.entry_id&&t.entry_id!==this._config.entry_id&&(delete t.cover,delete t.covers,delete t.controls_cover,delete t.controls_axis),this._emit(t)}}
           />
-          ${Xn(this.hass)}
+          ${ur(this.hass)}
         </div>
-      `;const e=this._schema(),{badges:t,...o}=this._config,i={};for(const e of Jn)t&&!1===t[e]&&(i[`badge_${e}`]=!1);const s=this._nameIsComposed(),n={...er,...o,...s?{name:""}:{},...i};return H`
+      `;const e=this._schema(),{badges:t,...o}=this._config,i={};for(const e of _r)t&&!1===t[e]&&(i[`badge_${e}`]=!1);const s=this._nameIsComposed(),n={...gr,...o,...s?{name:""}:{},...i};return H`
       <div class="form">
         <ha-form
           .hass=${this.hass}
@@ -4924,21 +5033,63 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
         ></ha-form>
         ${s?H`<div class="hint">${st("editor.tile.name_composed_hint",this.hass)}</div>`:V}
         ${this._managedCovers.length>1&&!this._config?.cover?H`<div class="hint">${st("editor.tile.cover_blank_hint",this.hass)}</div>`:V}
-        ${this._renderRailOrder()} ${this._renderMemberNames()} ${Xn(this.hass)}
+        ${this._renderRailOrder()} ${this._renderMemberNames()} ${ur(this.hass)}
       </div>
-    `}_railRows(){const e=this._managedCovers,t=(this._config?.covers??[]).filter(t=>e.includes(t)),o=e.filter(e=>!t.includes(e)),i=t.length>0?[...t.map(e=>({id:e,shown:!0})),...o.map(e=>({id:e,shown:!1}))]:e.map(e=>({id:e,shown:this._defaultShows(e)}));return[...i.filter(e=>e.shown),...i.filter(e=>!e.shown)]}_defaultShows(e){return!this._config?.cover||e===this._config.cover}_coverName(e){return this.hass?.states[e]?.attributes?.friendly_name??e}_emitRails(e){if(!this._config)return;const t=e.filter(e=>e.shown).map(e=>e.id),o=this._managedCovers.filter(e=>this._defaultShows(e)),i=t.length===o.length&&t.every((e,t)=>e===o[t]),{covers:s,...n}=this._config;this._emit(i?n:{...n,covers:t})}_moveRail(e,t){const o=this._railRows(),i=o.filter(e=>e.shown).length;if(t<0||t>=i||e>=i||e===t)return;const s=[...o],[n]=s.splice(e,1);s.splice(t,0,n),this._emitRails(s)}_toggleRail(e){const t=this._railRows();if(t[e].shown&&1===t.filter(e=>e.shown).length)return;const o=t[e];if(o.shown)return void this._emitRails(t.map((t,o)=>o===e?{...t,shown:!1}:t));const i=t.filter(e=>e.shown),s=this._managedCovers.indexOf(o.id),n=i.filter(e=>this._managedCovers.indexOf(e.id)<s).length,r=[...i];r.splice(n,0,{...o,shown:!0}),this._emitRails(r)}_renderMemberNames(){const e=this._groupDiscovered;if(!e||!this.hass)return V;const t=_s(this.hass,e),o=zs(this.hass,Object.keys(t.memberPositions),this._registry??void 0);if(0===o.length)return V;const i=this._memberDrafts??{};return H`
+    `}_railRows(){const e=this._managedCovers,t=(this._config?.covers??[]).filter(t=>e.includes(t)),o=e.filter(e=>!t.includes(e)),i=t.length>0?[...t.map(e=>({id:e,shown:!0})),...o.map(e=>({id:e,shown:!1}))]:e.map(e=>({id:e,shown:this._defaultShows(e)}));return[...i.filter(e=>e.shown),...i.filter(e=>!e.shown)]}_defaultShows(e){return!this._config?.cover||e===this._config.cover}_coverName(e){return this.hass?.states[e]?.attributes?.friendly_name??e}_emitRails(e){if(!this._config)return;const t=e.filter(e=>e.shown).map(e=>e.id),o=this._managedCovers.filter(e=>this._defaultShows(e)),i=t.length===o.length&&t.every((e,t)=>e===o[t]),{covers:s,...n}=this._config;this._emit(i?n:{...n,covers:t})}_moveRail(e,t){const o=this._railRows(),i=o.filter(e=>e.shown).length;if(t<0||t>=i||e>=i||e===t)return;const s=[...o],[n]=s.splice(e,1);s.splice(t,0,n),this._emitRails(s)}_toggleRail(e){const t=this._railRows();if(t[e].shown&&1===t.filter(e=>e.shown).length)return;const o=t[e];if(o.shown)return void this._emitRails(t.map((t,o)=>o===e?{...t,shown:!1}:t));const i=t.filter(e=>e.shown),s=this._managedCovers.indexOf(o.id),n=i.filter(e=>this._managedCovers.indexOf(e.id)<s).length,r=[...i];r.splice(n,0,{...o,shown:!0}),this._emitRails(r)}_renderMemberNames(){const e=this._memberRows();if(0===e.length)return V;const t=this._memberDrafts??{},o=e.filter(e=>e.shown).length;return H`
       <div class="rail-order">
         <div class="rail-order-title">${st("editor.tile.member_names",this.hass)}</div>
         <div class="hint">${st("editor.tile.member_names_hint",this.hass)}</div>
-        <ha-form
-          .hass=${this.hass}
-          .data=${i}
-          .schema=${o.map(e=>({name:Is(e),selector:{text:{}}}))}
-          .computeLabel=${e=>this._memberFieldLabel(e.name,o)}
-          @value-changed=${e=>this._memberNamesChanged(e.detail.value)}
-        ></ha-form>
+        <ul>
+          ${e.map((e,i)=>{const s=Ds(e.row),n=this._memberRowLabel(e.row);return H`
+              <li
+                class=${`rail member-row${e.shown?"":" hidden-rail"}${this._memberDragFrom===i?" dragging":""}`}
+                draggable=${e.shown?"true":"false"}
+                @dragstart=${()=>this._memberDragFrom=i}
+                @dragend=${()=>this._memberDragFrom=null}
+                @dragover=${t=>{e.shown&&t.preventDefault()}}
+                @drop=${t=>{t.preventDefault(),null!==this._memberDragFrom&&e.shown&&this._moveMember(this._memberDragFrom,i),this._memberDragFrom=null}}
+              >
+                <ha-icon class="grip" icon="mdi:drag-horizontal-variant"></ha-icon>
+                <input
+                  class="member-name"
+                  type="text"
+                  .value=${t[s]??""}
+                  placeholder=${n}
+                  aria-label=${n}
+                  @change=${e=>this._memberNameChanged(s,e.target.value)}
+                />
+                <button
+                  type="button"
+                  class="rail-btn"
+                  aria-label=${st("editor.tile.covers_move_up",this.hass)}
+                  ?disabled=${!e.shown||0===i}
+                  @click=${()=>this._moveMember(i,i-1)}
+                >
+                  <ha-icon icon="mdi:arrow-up"></ha-icon>
+                </button>
+                <button
+                  type="button"
+                  class="rail-btn"
+                  aria-label=${st("editor.tile.covers_move_down",this.hass)}
+                  ?disabled=${!e.shown||i>=o-1}
+                  @click=${()=>this._moveMember(i,i+1)}
+                >
+                  <ha-icon icon="mdi:arrow-down"></ha-icon>
+                </button>
+                <button
+                  type="button"
+                  class="rail-btn"
+                  aria-label=${st(e.shown?"editor.tile.members_hide":"editor.tile.members_show",this.hass)}
+                  aria-pressed=${e.shown?"true":"false"}
+                  @click=${()=>this._toggleMember(i)}
+                >
+                  <ha-icon icon=${e.shown?"mdi:eye":"mdi:eye-off"}></ha-icon>
+                </button>
+              </li>
+            `})}
+        </ul>
       </div>
-    `}_memberRowLabel(e){const t=this._memberLabels.get(e.entryId??e.covers[0]);if(void 0!==t)return t;let o;if(e.entryId&&this._registry){const t=Co(this.hass,{type:this._config.type,entry_id:e.entryId},this._registry);o=t?.entry_title}if(!o){const t=this.hass.states[e.covers[0]];o=t?.attributes?.friendly_name??e.covers[0]}return this._memberLabels.set(e.entryId??e.covers[0],o),o}_memberFieldLabel(e,t){const o=t.find(t=>Is(t)===e);return o?this._memberRowLabel(o):e}_memberNamesChanged(e){const t={};for(const[o,i]of Object.entries(e??{})){const e="string"==typeof i?i.trim():"";e&&(t[o]=e)}this._memberDrafts={...e},this._memberDraftsFor=this._config?.entry_id??"";const o={...this._config};Object.keys(t).length>0?o.member_names=t:delete o.member_names,this._emit(o)}_renderRailOrder(){if(this._isGroupEntry||this._managedCovers.length<2)return V;const e=this._railRows(),t=e.filter(e=>e.shown).length;return H`
+    `}_memberRows(){const e=this._naturalRoster(),t=this._config?.members;if(!t?.length)return e.map(e=>({row:e,shown:!0}));const o=new Set(t),i=new Map(e.map(e=>[Ns(e),e]));return[...Rs(e,t).map(e=>({row:i.get(Ns(e))??e,shown:!0})),...e.filter(e=>!e.covers.some(e=>o.has(e))).map(e=>({row:e,shown:!1}))]}_naturalRoster(){const e=this._groupDiscovered;return e&&this.hass?Ps(this.hass,Object.keys($s(this.hass,e).memberPositions),this._registry??void 0):[]}_emitMembers(e){if(!this._config)return;const t=e.filter(e=>e.shown).flatMap(e=>e.row.covers),o=this._naturalRoster().flatMap(e=>e.covers),i=t.length===o.length&&t.every((e,t)=>e===o[t]),{members:s,...n}=this._config;this._emit(i?n:{...n,members:t})}_moveMember(e,t){const o=this._memberRows(),i=o.filter(e=>e.shown).length;if(t<0||t>=i||e>=i||e===t)return;const s=[...o],[n]=s.splice(e,1);s.splice(t,0,n),this._emitMembers(s)}_toggleMember(e){const t=this._memberRows(),o=t[e];if(!o)return;if(o.shown)return void this._emitMembers(t.map((t,o)=>o===e?{...t,shown:!1}:t));const i=this._naturalRoster().map(Ns),s=i.indexOf(Ns(o.row)),n=t.filter(e=>e.shown),r=n.filter(e=>i.indexOf(Ns(e.row))<s).length,a=[...n];a.splice(r,0,{...o,shown:!0}),this._emitMembers(a)}_memberNameChanged(e,t){this._memberNamesChanged({...this._memberDrafts??{},[e]:t})}_memberRowLabel(e){const t=this._memberLabels.get(e.entryId??e.covers[0]);if(void 0!==t)return t;let o;if(e.entryId&&this._registry){const t=Eo(this.hass,{type:this._config.type,entry_id:e.entryId},this._registry);o=t?.entry_title}if(!o){const t=this.hass.states[e.covers[0]];o=t?.attributes?.friendly_name??e.covers[0]}return this._memberLabels.set(e.entryId??e.covers[0],o),o}_memberNamesChanged(e){const t={};for(const[o,i]of Object.entries(e??{})){const e="string"==typeof i?i.trim():"";e&&(t[o]=e)}this._memberDrafts={...e},this._memberDraftsFor=this._config?.entry_id??"";const o={...this._config};Object.keys(t).length>0?o.member_names=t:delete o.member_names,this._emit(o)}_renderRailOrder(){if(this._isGroupEntry||this._managedCovers.length<2)return V;const e=this._railRows(),t=e.filter(e=>e.shown).length;return H`
       <div class="rail-order">
         <div class="rail-order-title">${st("editor.tile.covers",this.hass)}</div>
         <div class="hint">${st("editor.tile.covers_hint",this.hass)}</div>
@@ -4986,7 +5137,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
             `)}
         </ul>
       </div>
-    `}_schema(){const e=this._entries?.map(e=>({value:e.entry_id,label:e.title}))??[],t=[{value:"one-line",label:st("editor.tile.layout_option_one_line",this.hass)},{value:"detailed",label:st("editor.tile.layout_option_detailed",this.hass)}];let o={entity:{domain:"cover"}},i=!1,s=0,n=[];if(this._registry&&this._config?.entry_id){const e=Co(this.hass,{type:this._config.type,entry_id:this._config.entry_id},this._registry);i=!!e?.is_group,s=e?.managed_covers.length??0,e&&!i&&e.managed_covers.length>0&&(o={entity:{domain:"cover",include_entities:e.managed_covers}}),e&&!i&&(n=kt(e).map(e=>({value:e.id,label:qe[e.id]?st(qe[e.id],this.hass):e.label})))}return i?[{name:"entry_id",required:!0,selector:{select:{options:e,mode:"dropdown"}}},this._section("content_section","mdi:format-text",!0,[{name:"name",selector:{text:{}}},{name:"icon",selector:{icon:{}}},this._grid([{name:"state_color",selector:{boolean:{}}}])]),this._section("controls_section","mdi:arrow-up-down",!1,[this._grid([{name:"show_controls",selector:{boolean:{}}},{name:"show_position_bar",selector:{boolean:{}}},{name:"show_tilt",selector:{boolean:{}}}])]),this._section("group_row_section","mdi:window-shutter-cog",!1,[this._grid([{name:"show_scene_select",selector:{boolean:{}}},{name:"show_lock",selector:{boolean:{}}},{name:"show_automation",selector:{boolean:{}}},{name:"show_clear_overrides",selector:{boolean:{}}},{name:"show_member_badges",selector:{boolean:{}}}])]),this._interactionsSection()]:[{name:"entry_id",required:!0,selector:{select:{options:e,mode:"dropdown"}}},...s>1||this._config?.cover?[{name:"cover",selector:o}]:[],this._section("content_section","mdi:format-text",!0,[{name:"name",selector:{text:{}}},{name:"icon",selector:{icon:{}}},{name:"layout",selector:{select:{mode:"list",options:t}}},this._grid([{name:"show_position",selector:{boolean:{}}},{name:"show_state",selector:{boolean:{}}},{name:"show_decision_summary",selector:{boolean:{}}},{name:"state_color",selector:{boolean:{}}},{name:"show_motion_icon",selector:{boolean:{}}}])]),this._section("controls_section","mdi:arrow-up-down",!1,[this._grid([{name:"show_controls",selector:{boolean:{}}},{name:"show_position_bar",selector:{boolean:{}}},{name:"show_tilt",selector:{boolean:{}}}]),...s>1||this._config?.controls_cover?[{name:"controls_cover",selector:o}]:[],...n.length>1||this._config?.controls_axis?[{name:"controls_axis",selector:{select:{options:n,mode:"dropdown"}}}]:[]]),this._section("badge_section","mdi:label-multiple-outline",!1,[{name:"show_badge",selector:{boolean:{}}},this._grid(Jn.map(e=>({name:`badge_${e}`,selector:{boolean:{}}})))]),this._section("dialog_section","mdi:card-text-outline",!1,[this._grid([{name:"show_compass",selector:{boolean:{}}},{name:"show_elevation_chart",selector:{boolean:{}}},{name:"show_solar_calc",selector:{boolean:{}}}])]),this._interactionsSection()]}_section(e,t,o,i){return{type:"expandable",name:"",title:st(`editor.tile.${e}`,this.hass),icon:t,expanded:o,schema:i}}_grid(e){return{type:"grid",name:"",schema:e}}_interactionsSection(){return this._section("interactions_section","mdi:gesture-tap",!1,[{name:"tap_action",selector:{ui_action:{}}},{name:"icon_tap_action",selector:{ui_action:{default_action:"none"}}},{name:"hold_action",selector:{ui_action:{}}},{name:"double_tap_action",selector:{ui_action:{}}}])}};or.styles=a`
+    `}_schema(){const e=this._entries?.map(e=>({value:e.entry_id,label:e.title}))??[],t=[{value:"one-line",label:st("editor.tile.layout_option_one_line",this.hass)},{value:"detailed",label:st("editor.tile.layout_option_detailed",this.hass)}];let o={entity:{domain:"cover"}},i=!1,s=0,n=[];if(this._registry&&this._config?.entry_id){const e=Eo(this.hass,{type:this._config.type,entry_id:this._config.entry_id},this._registry);i=!!e?.is_group,s=e?.managed_covers.length??0,e&&!i&&e.managed_covers.length>0&&(o={entity:{domain:"cover",include_entities:e.managed_covers}}),e&&!i&&(n=kt(e).map(e=>({value:e.id,label:qe[e.id]?st(qe[e.id],this.hass):e.label})))}return i?[{name:"entry_id",required:!0,selector:{select:{options:e,mode:"dropdown"}}},this._section("content_section","mdi:format-text",!0,[{name:"name",selector:{text:{}}},{name:"icon",selector:{icon:{}}},this._grid([{name:"state_color",selector:{boolean:{}}}])]),this._section("controls_section","mdi:arrow-up-down",!1,[this._grid([{name:"show_controls",selector:{boolean:{}}},{name:"show_position_bar",selector:{boolean:{}}},{name:"show_tilt",selector:{boolean:{}}}])]),this._section("group_row_section","mdi:window-shutter-cog",!1,[this._grid([{name:"show_scene_select",selector:{boolean:{}}},{name:"show_lock",selector:{boolean:{}}},{name:"show_automation",selector:{boolean:{}}},{name:"show_clear_overrides",selector:{boolean:{}}},{name:"show_member_badges",selector:{boolean:{}}}])]),this._interactionsSection()]:[{name:"entry_id",required:!0,selector:{select:{options:e,mode:"dropdown"}}},...s>1||this._config?.cover?[{name:"cover",selector:o}]:[],this._section("content_section","mdi:format-text",!0,[{name:"name",selector:{text:{}}},{name:"icon",selector:{icon:{}}},{name:"layout",selector:{select:{mode:"list",options:t}}},this._grid([{name:"show_position",selector:{boolean:{}}},{name:"show_state",selector:{boolean:{}}},{name:"show_decision_summary",selector:{boolean:{}}},{name:"state_color",selector:{boolean:{}}},{name:"show_motion_icon",selector:{boolean:{}}}])]),this._section("controls_section","mdi:arrow-up-down",!1,[this._grid([{name:"show_controls",selector:{boolean:{}}},{name:"show_position_bar",selector:{boolean:{}}},{name:"show_tilt",selector:{boolean:{}}}]),...s>1||this._config?.controls_cover?[{name:"controls_cover",selector:o}]:[],...n.length>1||this._config?.controls_axis?[{name:"controls_axis",selector:{select:{options:n,mode:"dropdown"}}}]:[]]),this._section("badge_section","mdi:label-multiple-outline",!1,[{name:"show_badge",selector:{boolean:{}}},this._grid(_r.map(e=>({name:`badge_${e}`,selector:{boolean:{}}})))]),this._section("dialog_section","mdi:card-text-outline",!1,[this._grid([{name:"show_compass",selector:{boolean:{}}},{name:"show_elevation_chart",selector:{boolean:{}}},{name:"show_solar_calc",selector:{boolean:{}}}])]),this._interactionsSection()]}_section(e,t,o,i){return{type:"expandable",name:"",title:st(`editor.tile.${e}`,this.hass),icon:t,expanded:o,schema:i}}_grid(e){return{type:"grid",name:"",schema:e}}_interactionsSection(){return this._section("interactions_section","mdi:gesture-tap",!1,[{name:"tap_action",selector:{ui_action:{}}},{name:"icon_tap_action",selector:{ui_action:{default_action:"none"}}},{name:"hold_action",selector:{ui_action:{}}},{name:"double_tap_action",selector:{ui_action:{}}}])}};vr.styles=a`
     :host {
       display: block;
     }
@@ -5061,6 +5212,40 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
       text-overflow: ellipsis;
       white-space: nowrap;
     }
+    /* The member row's name field stands in for .rail-name, so it takes the
+       same flex slot. Borderless until hovered/focused so the list reads as a
+       list rather than as a stack of form fields. */
+    .rail-order .member-name {
+      flex: 1 1 auto;
+      min-width: 0;
+      font: inherit;
+      font-size: 0.88rem;
+      color: var(--primary-text-color);
+      background: transparent;
+      border: 1px solid transparent;
+      border-radius: 4px;
+      padding: 3px 6px;
+    }
+    .rail-order .member-name::placeholder {
+      color: var(--secondary-text-color);
+      opacity: 1;
+    }
+    .rail-order .member-name:hover {
+      border-color: var(--divider-color);
+    }
+    .rail-order .member-name:focus {
+      outline: none;
+      border-color: var(--primary-color);
+    }
+    .rail-order li.rail.hidden-rail .member-name {
+      opacity: 0.45;
+      text-decoration: line-through;
+    }
+    /* A text field inside a draggable row swallows click-to-place-caret on some
+       browsers unless the row's grab cursor yields to it. */
+    .rail-order li.member-row .member-name {
+      cursor: text;
+    }
     .rail-order .rail-btn {
       flex: 0 0 auto;
       display: inline-flex;
@@ -5097,7 +5282,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
     .dim {
       color: var(--secondary-text-color);
     }
-  `,e([ge({attribute:!1})],or.prototype,"hass",void 0),e([me()],or.prototype,"_config",void 0),e([me()],or.prototype,"_entries",void 0),e([me()],or.prototype,"_entriesError",void 0),e([me()],or.prototype,"_registry",void 0),e([me()],or.prototype,"_managedCovers",void 0),e([me()],or.prototype,"_isGroupEntry",void 0),e([me()],or.prototype,"_groupDiscovered",void 0),e([me()],or.prototype,"_memberDrafts",void 0),e([me()],or.prototype,"_dragFrom",void 0),or=e([pe(ke)],or);let ir=class extends de{constructor(){super(...arguments),this._registry=null,this._registryError=null,this._dialogOpen=!1,this._posDrag=null,this._extendOpen=!1,this._unsubRegistry=null,this._fetchInFlight=!1,this._memo=$o(),this._discovered=null,this._fetchGen=0,this._closeDialog=()=>{this._dialogOpen=!1},this._onPosPointerDown=(e,t,o)=>{e.stopPropagation();const i=e.currentTarget;i.setPointerCapture?.(e.pointerId),this._posDrag={id:t,pct:ft(this._posPctFromEvent(e,i),o)}},this._onPosPointerMove=(e,t,o)=>{this._posDrag?.id===t&&(e.stopPropagation(),this._posDrag={id:t,pct:ft(this._posPctFromEvent(e,e.currentTarget),o)})},this._onPosPointerEnd=e=>{e.stopPropagation(),this._posDrag=null},this._holdTimer=null,this._pendingTapTimer=null,this._holdFired=!1,this._onPointerDown=()=>{this._holdFired=!1,null!=this._holdTimer&&clearTimeout(this._holdTimer),Pi(this._config?.hold_action)&&(this._holdTimer=setTimeout(()=>{this._holdFired=!0,this._holdTimer=null,this._fireAction("hold")},500))},this._onPointerUp=()=>{null!=this._holdTimer&&(clearTimeout(this._holdTimer),this._holdTimer=null)},this._onPointerCancel=()=>{null!=this._holdTimer&&(clearTimeout(this._holdTimer),this._holdTimer=null)},this._onClick=()=>{if(!this._holdFired)return Pi(this._config?.double_tap_action)?null!=this._pendingTapTimer?(clearTimeout(this._pendingTapTimer),this._pendingTapTimer=null,void this._fireAction("double_tap")):void(this._pendingTapTimer=setTimeout(()=>{this._pendingTapTimer=null,this._fireAction("tap")},250)):void this._fireAction("tap");this._holdFired=!1},this._onIconClick=e=>{this._hasIconAction()&&(e.stopPropagation(),this._config&&this.hass&&Ii(this,this.hass,{entity:this._actionEntity(),tap_action:this._config.icon_tap_action},"tap"))},this._onIconKeydown=e=>{this._hasIconAction()&&("Enter"!==e.key&&" "!==e.key||(e.preventDefault(),this._onIconClick(e)))}}setConfig(e){if(!e||"string"!=typeof e.entry_id||0===e.entry_id.length)throw new Error(`${$e}: \`entry_id\` is required and must be a non-empty string`);if(null!=(t=e.name)&&"string"!=typeof t&&!(Array.isArray(t)?t.every(Ni):"object"!=typeof t))throw new Error(`${$e}: \`name\` must be a string or an array of {type: 'entry'|'area'} or {type: 'text', text: string} parts`);var t;let o={...e};if("string"==typeof o.tap_action&&(o={...o,tap_action:"none"===o.tap_action?{action:"none"}:void 0}),this._config=o,o.tooltips&&bo(o.tooltips),null===this._registry){const e=Lo.get(o.entry_id);e&&(this._registry=e.entries)}}getCardSize(){return 1}getGridOptions(){return{columns:"full",rows:"auto",min_columns:3,min_rows:"one-line"!==this._config?.layout?2:1}}static async getStubConfig(e){let t="";try{const o=await Ro(e);t=o[0]?.entry_id??""}catch{}return{type:`custom:${$e}`,entry_id:t}}static async getConfigElement(){return document.createElement(ke)}connectedCallback(){if(super.connectedCallback(),null===this._registry){const e=Io();e&&(this._registry=e)}this.hass&&this._ensureRegistry()}disconnectedCallback(){super.disconnectedCallback(),this._unsubRegistry&&(this._unsubRegistry(),this._unsubRegistry=null)}updated(e){e.has("hass")&&this.hass&&this._ensureRegistry()}shouldUpdate(e){return e.size>1||!e.has("hass")||(!this._discovered||(!!this._discovered.is_group||ve(e.get("hass"),this.hass,Object.values(this._discovered.entities))))}willUpdate(e){this._config&&this.hass&&null!==this._registry&&(e.has("hass")||e.has("_registry")||e.has("_config"))&&(this._discovered=this._memo(this.hass,{type:this._config.type,entry_id:this._config.entry_id},this._registry))}_ensureRegistry(){this._fetchRegistry(),this._unsubRegistry||(this._unsubRegistry=zo(this.hass,()=>{this._fetchRegistry(!0)}))}_fetchRegistry(e=!1){if(this._fetchInFlight)return;this._fetchInFlight=!0;const t=++this._fetchGen;Po(this.hass,e).then(e=>{t===this._fetchGen&&e!==this._registry&&(this._registry=e,this._registryError=null,this._config&&Lo.set(this._config.entry_id,Go(e,this._config.entry_id)))}).catch(e=>{t===this._fetchGen&&(this._registryError=e?.message??"entity registry fetch failed")}).finally(()=>{t===this._fetchGen&&(this._fetchInFlight=!1)})}render(){if(!this._config||!this.hass)return V;if(null===this._registry)return H`<ha-card>
+  `,e([ge({attribute:!1})],vr.prototype,"hass",void 0),e([me()],vr.prototype,"_config",void 0),e([me()],vr.prototype,"_entries",void 0),e([me()],vr.prototype,"_entriesError",void 0),e([me()],vr.prototype,"_registry",void 0),e([me()],vr.prototype,"_managedCovers",void 0),e([me()],vr.prototype,"_isGroupEntry",void 0),e([me()],vr.prototype,"_groupDiscovered",void 0),e([me()],vr.prototype,"_memberDrafts",void 0),e([me()],vr.prototype,"_dragFrom",void 0),e([me()],vr.prototype,"_memberDragFrom",void 0),vr=e([pe(ke)],vr);let fr=class extends de{constructor(){super(...arguments),this._registry=null,this._registryError=null,this._dialogOpen=!1,this._posDrag=null,this._extendOpen=!1,this._unsubRegistry=null,this._fetchInFlight=!1,this._memo=ko(),this._discovered=null,this._posPending=new Li(this),this._lastRailLive=new Map,this._fetchGen=0,this._closeDialog=()=>{this._dialogOpen=!1},this._onPosPointerDown=(e,t,o)=>{e.stopPropagation();const i=e.currentTarget;i.setPointerCapture?.(e.pointerId),this._posDrag={id:t,pct:ft(this._posPctFromEvent(e,i),o)}},this._onPosPointerMove=(e,t,o)=>{this._posDrag?.id===t&&(e.stopPropagation(),this._posDrag={id:t,pct:ft(this._posPctFromEvent(e,e.currentTarget),o)})},this._onPosPointerEnd=e=>{e.stopPropagation(),this._posDrag=null},this._holdTimer=null,this._pendingTapTimer=null,this._holdFired=!1,this._onPointerDown=()=>{this._holdFired=!1,null!=this._holdTimer&&clearTimeout(this._holdTimer),Oi(this._config?.hold_action)&&(this._holdTimer=setTimeout(()=>{this._holdFired=!0,this._holdTimer=null,this._fireAction("hold")},500))},this._onPointerUp=()=>{null!=this._holdTimer&&(clearTimeout(this._holdTimer),this._holdTimer=null)},this._onPointerCancel=()=>{null!=this._holdTimer&&(clearTimeout(this._holdTimer),this._holdTimer=null)},this._onClick=()=>{if(!this._holdFired)return Oi(this._config?.double_tap_action)?null!=this._pendingTapTimer?(clearTimeout(this._pendingTapTimer),this._pendingTapTimer=null,void this._fireAction("double_tap")):void(this._pendingTapTimer=setTimeout(()=>{this._pendingTapTimer=null,this._fireAction("tap")},250)):void this._fireAction("tap");this._holdFired=!1},this._onIconClick=e=>{this._hasIconAction()&&(e.stopPropagation(),this._config&&this.hass&&Pi(this,this.hass,{entity:this._actionEntity(),tap_action:this._config.icon_tap_action},"tap"))},this._onIconKeydown=e=>{this._hasIconAction()&&("Enter"!==e.key&&" "!==e.key||(e.preventDefault(),this._onIconClick(e)))}}setConfig(e){if(!e||"string"!=typeof e.entry_id||0===e.entry_id.length)throw new Error(`${$e}: \`entry_id\` is required and must be a non-empty string`);if(null!=(t=e.name)&&"string"!=typeof t&&!(Array.isArray(t)?t.every(Di):"object"!=typeof t))throw new Error(`${$e}: \`name\` must be a string or an array of {type: 'entry'|'area'} or {type: 'text', text: string} parts`);var t;let o={...e};if("string"==typeof o.tap_action&&(o={...o,tap_action:"none"===o.tap_action?{action:"none"}:void 0}),this._config=o,o.tooltips&&yo(o.tooltips),null===this._registry){const e=Lo.get(o.entry_id);e&&(this._registry=e.entries)}}getCardSize(){return 1}getGridOptions(){return{columns:"full",rows:"auto",min_columns:3,min_rows:"one-line"!==this._config?.layout?2:1}}static async getStubConfig(e){let t="";try{const o=await jo(e);t=o[0]?.entry_id??""}catch{}return{type:`custom:${$e}`,entry_id:t}}static async getConfigElement(){return document.createElement(ke)}connectedCallback(){if(super.connectedCallback(),null===this._registry){const e=Po();e&&(this._registry=e)}this.hass&&this._ensureRegistry()}disconnectedCallback(){super.disconnectedCallback(),this._unsubRegistry&&(this._unsubRegistry(),this._unsubRegistry=null)}updated(e){e.has("hass")&&this.hass&&this._ensureRegistry(),this._posPending.settle(e=>this._lastRailLive.get(e)??null)}shouldUpdate(e){return e.size>1||!e.has("hass")||(!this._discovered||(!!this._discovered.is_group||ve(e.get("hass"),this.hass,Object.values(this._discovered.entities))))}willUpdate(e){this._config&&this.hass&&null!==this._registry&&(e.has("hass")||e.has("_registry")||e.has("_config"))&&(this._discovered=this._memo(this.hass,{type:this._config.type,entry_id:this._config.entry_id},this._registry))}_ensureRegistry(){this._fetchRegistry(),this._unsubRegistry||(this._unsubRegistry=Mo(this.hass,()=>{this._fetchRegistry(!0)}))}_fetchRegistry(e=!1){if(this._fetchInFlight)return;this._fetchInFlight=!0;const t=++this._fetchGen;Oo(this.hass,e).then(e=>{t===this._fetchGen&&e!==this._registry&&(this._registry=e,this._registryError=null,this._config&&Lo.set(this._config.entry_id,Wo(e,this._config.entry_id)))}).catch(e=>{t===this._fetchGen&&(this._registryError=e?.message??"entity registry fetch failed")}).finally(()=>{t===this._fetchGen&&(this._fetchInFlight=!1)})}render(){if(!this._config||!this.hass)return V;if(null===this._registry)return H`<ha-card>
         <div class="empty">
           <p class="dim">
             ${this._registryError?st("tile.registry_failed",this.hass,{error:this._registryError}):st("tile.loading",this.hass)}
@@ -5109,7 +5294,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
             ${st("tile.entry_not_found",this.hass,{entry:this._config.entry_id})}
           </p>
         </div>
-      </ha-card>`;if(e.is_group){const t=Oi(this._config.name,e);return H`
+      </ha-card>`;if(e.is_group){const t=Ni(this._config.name,e);return H`
         <ha-card>
           <acp-group-tile
             @pointerdown=${this._onPointerDown}
@@ -5119,6 +5304,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
             .hass=${this.hass}
             .discovered=${e}
             .name=${t}
+            .members=${this._config.members}
             .icon=${this._config.icon}
             .stateColor=${!1!==this._config.state_color}
             .showControls=${!1!==this._config.show_controls}
@@ -5140,6 +5326,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
           .open=${this._dialogOpen}
           .name=${t}
           .memberNames=${this._config.member_names}
+          .members=${this._config.members}
           .icon=${this._config.icon}
           .stateColor=${!1!==this._config.state_color}
           .showTilt=${!1!==this._config.show_tilt}
@@ -5172,50 +5359,50 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
         @acp-extend-confirm=${t=>this._onExtendConfirm(t,e)}
         @acp-extend-close=${()=>this._extendOpen=!1}
       ></acp-extend-override-dialog>
-    `}_extendPresets(e){const t=e.entities.position_forecast_sensor,o=t?this.hass.states[t]?.attributes:void 0;return function(e){const{events:t,nowMs:o,latitude:i,longitude:s,max:n=Ki}=e,r=t.filter(e=>{const t=Date.parse(e.t);return!Number.isNaN(t)&&t>o}).map(e=>({kind:e.kind,t:e.t,label:e.label}));if(r.length<2&&null!=i&&null!=s)for(const e of function(e,t,o){const i=[];for(let s=0;s<=1;s++){const n=new Date(o+24*s*60*60*1e3),r=Qo.getTimes(n,e,t);for(const[e,t]of[["sunrise",r.sunrise],["sunset",r.sunset]])t&&!Number.isNaN(t.getTime())&&(t.getTime()<=o||i.some(t=>t.kind===e)||i.push({kind:e,t:t.toISOString()}))}return i.sort((e,t)=>Date.parse(e.t)-Date.parse(t.t))}(i,s,o)){const t=r.some(t=>{return t.kind===e.kind&&(o=t.t,i=e.t,Math.floor(Date.parse(o)/6e4)===Math.floor(Date.parse(i)/6e4));var o,i});t||r.push({kind:e.kind,t:e.t,label:e.kind})}return r.sort((e,t)=>Date.parse(e.t)-Date.parse(t.t)).slice(0,n)}({events:o?.events??[],nowMs:Date.now(),latitude:this.hass.config?.latitude,longitude:this.hass.config?.longitude})}_manualEndMs(e){const t=e.entities.manual_override_end_sensor,o=t?this.hass.states[t]?.state:void 0;if(!o)return;const i=Date.parse(o);return Number.isNaN(i)?void 0:i}_onExtendConfirm(e,t){!function(e,t,o){const i={};if(o.endTime)i.end_time=o.endTime.toISOString();else{if(null==o.duration)return;i.duration={seconds:o.duration}}e.callService(Te,"engage_manual_override",i,{entity_id:t})}(this.hass,t.managed_covers,{endTime:new Date(e.detail.endMs)}),this._extendOpen=!1}_buildHandlerLabels(){const e={};for(const[t,o]of Object.entries(Oe))e[t]=st(o,this.hass);return e}_renderTile(e){const t=this._config,o=this._resolvedCover(e),i=Oi(t.name,e),s=o?this.hass.states[o]:void 0,n=s?.attributes?.device_class,r=at(s?.state),a=rt(s?.state),l=this._currentPosition(e),c=a?null:this._liveCoverPosition(e,o),d=r?null:c??l,h=t.icon??(r?"mdi:help-rhombus-outline":ut({explicitIcon:s?.attributes?.icon,deviceClass:n,coverType:e.cover_type,position:d})),p=!1!==t.state_color?vt(s?.state):null,u=this._hasIconAction(),_=!1!==t.show_position,g=!1!==t.show_state,m=!1!==t.show_controls,v=!1!==t.show_badge,f=!1!==t.show_motion_icon?this._motionActiveState(e):null,b=st("timeout_pending"===f?"tile.motion_pending":"tile.motion_detected",this.hass),y="one-line"!==t.layout,w=kt(e),x=w.find(e=>"position"!==e.id),$=At(e),k=!1!==t.show_tilt&&!!x,A=!a&&x?this._liveAxis(o,x):null,S=!r&&x?this._axisTarget(e,x):null,C=w.find(e=>e.id===t.controls_axis)??At(e),E=t.controls_cover&&(0===e.managed_covers.length||e.managed_covers.includes(t.controls_cover))?t.controls_cover:o,z=E?this.hass.states[E]:void 0,M=at(z?.state),T=rt(z?.state)||!C?null:"position"===C.id?Vt(this.hass,e,E):Yt(this.hass,C,E),I=null!==T&&T>=(C?.max??100),P=null!==T&&T<=(C?.min??0),O=this._winner(e),N=this._traceAttrs(e),D=this._manualEndIso(e),B=this._isFullyInert(t),F=$i(N),R=!0===t.show_decision_summary&&N?Ai(N.trace??[],N,0,this._buildHandlerLabels(),st("badge.safety",this.hass)):"",j=!!R&&y,L=this._switchOn(e,"integration_enabled_switch"),K=this._switchOn(e,"automatic_control_switch"),G=this._manualOverrideOn(e),W=function(e){const t=function(e){const t=es(e);return"motion"!==t?"auto"!==t?t:function(e,t){const o=Xi(e);for(const e of Ie){if("motion"===e)continue;if(!o.has(e))continue;const i=je[e];if(void 0!==i){if("off"===i||"group"===i)return i;if(!1!==t?.[i])return i}}return null}(e.trace,e.badges)??"auto":!1===e.badges?.motion||e.showMotionIcon?!1===e.badges?.auto?null:"auto":t}(e);return!1===e.inTimeWindow&&!1!==e.badges?.off_schedule&&"off"!==t&&"manual"!==t&&"force"!==t?"off_schedule":t}({winner:O,integrationEnabled:L,manualActive:G,badges:t.badges,showMotionIcon:!1!==t.show_motion_icon,inTimeWindow:N?.in_time_window,trace:N?.trace}),U=ts(N?.trace,O),q=null!==W&&Zi([W],t.badges,U).length>0,Y=v&&q&&!(!1===K&&!0===L),Z=function(e){if(!e.integrationEnabled)return!1;if(!e.automaticControl)return!1;if(e.manualActive)return!1;const t=ki(e.winner);return"force"!==t&&("custom_position"!==t||!e.bypassAutoControl&&!0!==e.safetyActive)}({winner:O,integrationEnabled:L,automaticControl:K,manualActive:G,bypassAutoControl:!0===N?.bypass_auto_control,safetyActive:F}),Q=y&&v&&!1!==t.badges?.auto&&Z,X=!(Q&&"auto"===W),J=this._transitState(e),ee=r?st("tile.unavailable",this.hass):g?lt(this.hass,o,J??void 0):null,te=[ee,_&&null!==d?nt(d):null,k&&!y&&null!==A?`⟂${nt(A)}`:null].filter(e=>!!e),oe=!!ee,ie=function(e,t,o){if(!Array.isArray(e?.custom_position_slots))return null;const i=e.custom_position_slots.filter(e=>!0===e.min_mode&&!0===e.enabled&&null!==e.sensor&&null!==e.position&&"on"===t[e.sensor]?.state);if(0===i.length)return null;const s=i.reduce((e,t)=>(t.position??0)>(e.position??0)?t:e),n=s.position,r=s.priority??null;return{slot:s.slot,position:n,label:s.sensor_name??`#${s.slot}`,clamping:null!==o&&n>o,sensorOn:!0,priority:r,resistsManual:null!=r&&r>80}}(N,this.hass.states,l),se=ki(O),ne=v&&!!ie&&!("custom_position"===se&&!0===N?.custom_position_minimum_mode)&&L,re=G&&!!e.entities.reset_override_button,ae=G&&function(e){const t=e.services;return!!t?.[Te]?.engage_manual_override}(this.hass),le=te.length>0?H`<div class="position">${te.join(" · ")}</div>`:V,ce=ne?H`<span
-          class=${`acp-floor-chip${ie.clamping?"":" is-armed"}${ie.resistsManual?" resists-manual":" is-bypassable"}`}
-          ${xo(st("dialog.floor_tooltip",this.hass))}
-          >${st("dialog.floor",this.hass)} ${nt(ie.position)}</span
-        >`:V,de=Y?H`<acp-tile-badge
+    `}_extendPresets(e){const t=e.entities.position_forecast_sensor,o=t?this.hass.states[t]?.attributes:void 0;return function(e){const{events:t,nowMs:o,latitude:i,longitude:s,max:n=Zi}=e,r=t.filter(e=>{const t=Date.parse(e.t);return!Number.isNaN(t)&&t>o}).map(e=>({kind:e.kind,t:e.t,label:e.label}));if(r.length<2&&null!=i&&null!=s)for(const e of function(e,t,o){const i=[];for(let s=0;s<=1;s++){const n=new Date(o+24*s*60*60*1e3),r=Xo.getTimes(n,e,t);for(const[e,t]of[["sunrise",r.sunrise],["sunset",r.sunset]])t&&!Number.isNaN(t.getTime())&&(t.getTime()<=o||i.some(t=>t.kind===e)||i.push({kind:e,t:t.toISOString()}))}return i.sort((e,t)=>Date.parse(e.t)-Date.parse(t.t))}(i,s,o)){const t=r.some(t=>{return t.kind===e.kind&&(o=t.t,i=e.t,Math.floor(Date.parse(o)/6e4)===Math.floor(Date.parse(i)/6e4));var o,i});t||r.push({kind:e.kind,t:e.t,label:e.kind})}return r.sort((e,t)=>Date.parse(e.t)-Date.parse(t.t)).slice(0,n)}({events:o?.events??[],nowMs:Date.now(),latitude:this.hass.config?.latitude,longitude:this.hass.config?.longitude})}_manualEndMs(e){const t=e.entities.manual_override_end_sensor,o=t?this.hass.states[t]?.state:void 0;if(!o)return;const i=Date.parse(o);return Number.isNaN(i)?void 0:i}_onExtendConfirm(e,t){!function(e,t,o){const i={};if(o.endTime)i.end_time=o.endTime.toISOString();else{if(null==o.duration)return;i.duration={seconds:o.duration}}e.callService(Te,"engage_manual_override",i,{entity_id:t})}(this.hass,t.managed_covers,{endTime:new Date(e.detail.endMs)}),this._extendOpen=!1}_buildHandlerLabels(){const e={};for(const[t,o]of Object.entries(Oe))e[t]=st(o,this.hass);return e}_renderTile(e){const t=this._config,o=this._resolvedCover(e),i=Ni(t.name,e),s=o?this.hass.states[o]:void 0,n=s?.attributes?.device_class,r=at(s?.state),a=rt(s?.state),l=this._currentPosition(e),c=a?null:this._liveCoverPosition(e,o),d=r?null:c??l,h=t.icon??(r?"mdi:help-rhombus-outline":ut({explicitIcon:s?.attributes?.icon,deviceClass:n,coverType:e.cover_type,position:d})),p=!1!==t.state_color?vt(s?.state):null,u=this._hasIconAction(),_=!1!==t.show_position,g=!1!==t.show_state,m=!1!==t.show_controls,v=!1!==t.show_badge,f=!1!==t.show_motion_icon?this._motionActiveState(e):null,b=st("timeout_pending"===f?"tile.motion_pending":"tile.motion_detected",this.hass),y="one-line"!==t.layout,w=kt(e),x=w.find(e=>"position"!==e.id),$=At(e),k=!1!==t.show_tilt&&!!x,A=!a&&x?this._liveAxis(o,x):null,S=!r&&x?this._axisTarget(e,x):null,C=w.find(e=>e.id===t.controls_axis)??At(e),E=t.controls_cover&&(0===e.managed_covers.length||e.managed_covers.includes(t.controls_cover))?t.controls_cover:o,z=E?this.hass.states[E]:void 0,M=at(z?.state),T=rt(z?.state)||!C?null:"position"===C.id?Yt(this.hass,e,E):Zt(this.hass,C,E),I=null!==T&&T>=(C?.max??100),P=null!==T&&T<=(C?.min??0),O=this._winner(e),N=this._traceAttrs(e),D=this._manualEndIso(e),F=this._isFullyInert(t),B=ki(N),R=!0===t.show_decision_summary&&N?Si(N.trace??[],N,0,this._buildHandlerLabels(),st("badge.safety",this.hass)):"",j=!!R&&y,K=this._switchOn(e,"integration_enabled_switch"),L=this._switchOn(e,"automatic_control_switch"),G=this._manualOverrideOn(e),W=function(e){const t=function(e){const t=ls(e);return"motion"!==t?"auto"!==t?t:function(e,t){const o=rs(e);for(const e of Ie){if("motion"===e)continue;if(!o.has(e))continue;const i=je[e];if(void 0!==i){if("off"===i||"group"===i)return i;if(!1!==t?.[i])return i}}return null}(e.trace,e.badges)??"auto":!1===e.badges?.motion||e.showMotionIcon?!1===e.badges?.auto?null:"auto":t}(e);return!1===e.inTimeWindow&&!1!==e.badges?.off_schedule&&"off"!==t&&"manual"!==t&&"force"!==t?"off_schedule":t}({winner:O,integrationEnabled:K,manualActive:G,badges:t.badges,showMotionIcon:!1!==t.show_motion_icon,inTimeWindow:N?.in_time_window,trace:N?.trace}),U=cs(N?.trace,O),q=null!==W&&ss([W],t.badges,U).length>0,Y=v&&q&&!(!1===L&&!0===K),Z=function(e){if(!e.integrationEnabled)return!1;if(!e.automaticControl)return!1;if(e.manualActive)return!1;const t=Ai(e.winner);return"force"!==t&&("custom_position"!==t||!e.bypassAutoControl&&!0!==e.safetyActive)}({winner:O,integrationEnabled:K,automaticControl:L,manualActive:G,bypassAutoControl:!0===N?.bypass_auto_control,safetyActive:B}),Q=y&&v&&!1!==t.badges?.auto&&Z,X=!(Q&&"auto"===W),J=t.cover?[t.cover]:e.managed_covers.length>0?e.managed_covers:o?[o]:[],ee=t.covers?.length?e.managed_covers.length>0?t.covers.filter(t=>e.managed_covers.includes(t)):t.covers:[],te=ee.length>0?ee:J,oe=function(e,t){return!(t<2)&&!e.is_group&&Fi.has(e.cover_type)}(e,te.length),ie=Vt(this.hass,e),se=t=>{if(t===o)return d;const i=this.hass.states[t];return at(i?.state)?null:(rt(i?.state)?null:Yt(this.hass,e,t))??ie[t]??null},ne=this._transitState(e),re=r?st("tile.unavailable",this.hass):g?lt(this.hass,o,ne??void 0):null,ae=_&&null!==d?nt(d):null,le=k&&!y&&null!==A?`⟂${nt(A)}`:null,ce=(()=>{if(!y||r||!oe||2!==te.length)return null;const e=te.map(e=>{const t=at(this.hass.states[e]?.state)?st("tile.unavailable",this.hass):lt(this.hass,e,e===o?ne??void 0:void 0),i=se(e);return{state:t,pos:i,text:[g?t:null,_&&null!==i?nt(i):null].filter(e=>!!e).join(" ")}});return e.some(e=>!e.text)||e[0].state===e[1].state&&e[0].pos===e[1].pos?null:e.map(e=>e.text)})(),de=ce??[re,ae,le].filter(e=>!!e),he=!!ce||!!re,pe=function(e,t,o){if(!Array.isArray(e?.custom_position_slots))return null;const i=e.custom_position_slots.filter(e=>!0===e.min_mode&&!0===e.enabled&&null!==e.sensor&&null!==e.position&&"on"===t[e.sensor]?.state);if(0===i.length)return null;const s=i.reduce((e,t)=>(t.position??0)>(e.position??0)?t:e),n=s.position,r=s.priority??null;return{slot:s.slot,position:n,label:s.sensor_name??`#${s.slot}`,clamping:null!==o&&n>o,sensorOn:!0,priority:r,resistsManual:null!=r&&r>80}}(N,this.hass.states,l),ue=Ai(O),_e=v&&!!pe&&!("custom_position"===ue&&!0===N?.custom_position_minimum_mode)&&K,ge=G&&!!e.entities.reset_override_button,me=G&&function(e){const t=e.services;return!!t?.[Te]?.engage_manual_override}(this.hass),ve=de.length>0?H`<div class="position">${de.join(" · ")}</div>`:V,fe=_e?H`<span
+          class=${`acp-floor-chip${pe.clamping?"":" is-armed"}${pe.resistsManual?" resists-manual":" is-bypassable"}`}
+          ${$o(st("dialog.floor_tooltip",this.hass))}
+          >${st("dialog.floor",this.hass)} ${nt(pe.position)}</span
+        >`:V,be=Y?H`<acp-tile-badge
           .hass=${this.hass}
           .winner=${O}
           .kindOverride=${W??void 0}
-          .integrationEnabled=${L}
+          .integrationEnabled=${K}
           .slotNumber=${N?.custom_position_active_slot}
           .slotName=${N?.custom_position_active_slot_name}
-          .pct=${xi(N,l)??void 0}
+          .pct=${$i(N,l)??void 0}
           .minimumMode=${N?.custom_position_minimum_mode}
-          .safetyActive=${F}
+          .safetyActive=${B}
           .manualEndIso=${D}
           .manualActive=${G}
-          .resumable=${re}
-          .extendable=${ae}
+          .resumable=${ge}
+          .extendable=${me}
           @acp-resume=${()=>this._resume(e)}
           @acp-extend=${()=>this._extendOpen=!0}
-        ></acp-tile-badge>`:V,he=Q?H`<acp-tile-badge
+        ></acp-tile-badge>`:V,ye=Q?H`<acp-tile-badge
           .hass=${this.hass}
           .winner=${O}
           .kindOverride=${"auto"}
-          .integrationEnabled=${L}
-        ></acp-tile-badge>`:V,pe=te.length>0?H`<div class="state">${te.join(" · ")}</div>`:V,ue=t.cover?[t.cover]:e.managed_covers.length>0?e.managed_covers:o?[o]:[],_e=t.covers?.length?e.managed_covers.length>0?t.covers.filter(t=>e.managed_covers.includes(t)):t.covers:[],ge=_e.length>0?_e:ue,me=function(e,t){return!(t<2)&&!e.is_group&&Di.has(e.cover_type)}(e,ge.length),ve=(()=>{const e=Vi(Ui(this.hass,ge));return qi(e)?e:null})(),fe=qt(this.hass,e),be=t=>{if(t===o)return d;const i=this.hass.states[t];return at(i?.state)?null:(rt(i?.state)?null:Vt(this.hass,e,t))??fe[t]??null},ye=function(e,t){const o=t.entities.position_verification_sensor;if(!o)return{};const i=e.states[o]?.attributes?.per_entity;if(!i||"object"!=typeof i)return{};const s=St(t),n={};for(const[e,t]of Object.entries(i)){const o=t?.target;"number"==typeof o&&Number.isFinite(o)&&(n[e]=s?100-o:o)}return n}(this.hass,e),we=e=>e===o?l:ye[e]??null,xe=y&&!1!==t.show_position_bar&&ge.some(e=>null!==be(e)),$e=xe?1===ge.length?this._posBar(ge[0],be(ge[0]),we(ge[0]),$):H`<div
-            class=${"pos-stack"+(me?" layered":"")}
+          .integrationEnabled=${K}
+        ></acp-tile-badge>`:V,we=de.length>0?H`<div class="state">${de.join(" · ")}</div>`:V,xe=(()=>{const e=os(es(this.hass,te));return ts(e)?e:null})(),$e=function(e,t){const o=t.entities.position_verification_sensor;if(!o)return{};const i=e.states[o]?.attributes?.per_entity;if(!i||"object"!=typeof i)return{};const s=St(t),n={};for(const[e,t]of Object.entries(i)){const o=t?.target;"number"==typeof o&&Number.isFinite(o)&&(n[e]=s?100-o:o)}return n}(this.hass,e),ke=e=>e===o?l:$e[e]??null,Ae=y&&!1!==t.show_position_bar&&te.some(e=>null!==se(e)),Se=Ae?1===te.length?this._posBar(te[0],se(te[0]),ke(te[0]),$):H`<div
+            class=${"pos-stack"+(oe?" layered":"")}
             role="group"
-            aria-label=${st(me?"tile.rails_layered":"tile.rails_separate",this.hass,{count:ge.length})}
-            ${me?xo(st("tile.rails_layered_hint",this.hass)):V}
+            aria-label=${st(oe?"tile.rails_layered":"tile.rails_separate",this.hass,{count:te.length})}
+            ${oe?$o(st("tile.rails_layered_hint",this.hass)):V}
           >
-            ${ge.map(t=>{const o=be(t),i=this._coverShortName(t,e);return H`<div class="pos-row">
+            ${te.map(t=>{const o=se(t),i=this._coverShortName(t,e);return H`<div class="pos-row">
                 <ha-icon
                   class="pos-glyph"
                   icon=${this._railIcon(t,e,o)}
-                  ${xo(i)}
+                  ${$o(i)}
                 ></ha-icon>
-                ${this._posBar(t,o,we(t),$,i)}
+                ${this._posBar(t,o,ke(t),$,i)}
               </div>`})}
-          </div>`:V,ke=Y&&X,Ae=y&&(Q||ke||ne),Se=Ae?H`${he}${ke?de:V}${ce}`:V,Ce=y&&(Ae||xe);return H`
+          </div>`:V,Ce=Y&&X,Ee=y&&(Q||Ce||_e),ze=Ee?H`${ye}${Ce?be:V}${fe}`:V,Me=y&&(Ee||Ae);return H`
       <div
-        class=${`tile-body${y?" detailed":""}${oe?" has-state-label":""}${ne&&!y?" has-floor-chip":""}${k&&y?" has-tilt":""}${Ce?" has-chrome-row":""}${Ce&&!Ae?" bar-only":""}${m?" has-controls":""}${r?" unavailable":""}`}
-        role=${B?"group":"button"}
-        tabindex=${B?-1:0}
+        class=${`tile-body${y?" detailed":""}${he?" has-state-label":""}${_e&&!y?" has-floor-chip":""}${k&&y?" has-tilt":""}${Me?" has-chrome-row":""}${Me&&!Ee?" bar-only":""}${m?" has-controls":""}${r?" unavailable":""}`}
+        role=${F?"group":"button"}
+        tabindex=${F?-1:0}
         @pointerdown=${this._onPointerDown}
         @pointerup=${this._onPointerUp}
         @pointercancel=${this._onPointerCancel}
@@ -5239,22 +5426,22 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
           ${f?H`<ha-icon
                 class="motion-overlay ${f}"
                 icon="mdi:motion-sensor"
-                ${xo(b)}
+                ${$o(b)}
               ></ha-icon>`:V}
-          ${ve?H`<ha-icon
+          ${xe?H`<ha-icon
                 class="battery-overlay"
-                icon=${Yi(ve.level,ve.charging)}
-                ${xo(null===ve.level?st("tile.battery_unknown",this.hass):st("tile.battery_low",this.hass,{level:ve.level}))}
+                icon=${is(xe.level,xe.charging)}
+                ${$o(null===xe.level?st("tile.battery_unknown",this.hass):st("tile.battery_low",this.hass,{level:xe.level}))}
               ></ha-icon>`:V}
         </div>
         <div class="label">
           <div class="title">${i}</div>
-          ${y?pe:V}
+          ${y?we:V}
           ${R&&!y?H`<div class="summary">${R}</div>`:V}
-          ${j?H`<div class="summary" ${xo(R)}>${R}</div>`:V}
+          ${j?H`<div class="summary" ${$o(R)}>${R}</div>`:V}
         </div>
-        ${y?V:H`${le}${ce}`}
-        ${Ce?H`<div class="chrome-line">${Se}${$e}</div>`:V}
+        ${y?V:H`${ve}${fe}`}
+        ${Me?H`<div class="chrome-line">${ze}${Se}</div>`:V}
         ${k&&y?H`<div
               class="tilt-line"
               @click=${this._stop}
@@ -5304,9 +5491,9 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
                 <ha-icon icon=${gt(n)}></ha-icon>
               </button>
             </div>`:V}
-        ${y?V:de}
+        ${y?V:be}
       </div>
-    `}_resolvedCover(e){return this._config?.cover?this._config.cover:e.managed_covers[0]}_currentPosition(e){return Ht(this.hass,e)}_transitState(e){const t=e.entities.target_position_sensor;if(!t)return null;const o=this._resolvedCover(e);if(!o)return null;const i=this.hass.states[t]?.attributes?.transit_states;return i?.[o]??null}_liveCoverPosition(e,t){return Vt(this.hass,e,t)}_winner(e){const t=e.entities.decision_trace_sensor;return t?this.hass.states[t]?.state??"default":"default"}_traceAttrs(e){const t=e.entities.decision_trace_sensor;if(t)return this.hass.states[t]?.attributes}_motionActiveState(e){const t=e.entities.motion_status_sensor;if(!t)return null;const o=this.hass.states[t]?.state;return"motion_detected"===o||"timeout_pending"===o?o:null}_manualOverrideOn(e){const t=e.entities.manual_override_binary;return!!t&&"on"===this.hass.states[t]?.state}_switchOn(e,t){const o=e.entities[t];return!o||"off"!==this.hass.states[o]?.state}_manualEndIso(e){if(!this._manualOverrideOn(e))return;const t=e.entities.manual_override_end_sensor;return t?this.hass.states[t]?.state:void 0}_setCoverPosition(e,t){e&&this._setAxis(e,"position",t)}_posBar(e,t,o,i,s){const n=this._posDrag?.id===e,r=n?this._posDrag.pct:t,a=null===r?0:ft(r,i),l=null===o?null:ft(o,i),c=null!==o?`${nt(r)} · ${st("dialog.target",this.hass)} ${nt(o)}`:nt(r);return H`<div
+    `}_resolvedCover(e){return this._config?.cover?this._config.cover:e.managed_covers[0]}_currentPosition(e){return Ut(this.hass,e)}_transitState(e){const t=e.entities.target_position_sensor;if(!t)return null;const o=this._resolvedCover(e);if(!o)return null;const i=this.hass.states[t]?.attributes?.transit_states;return i?.[o]??null}_liveCoverPosition(e,t){return Yt(this.hass,e,t)}_winner(e){const t=e.entities.decision_trace_sensor;return t?this.hass.states[t]?.state??"default":"default"}_traceAttrs(e){const t=e.entities.decision_trace_sensor;if(t)return this.hass.states[t]?.attributes}_motionActiveState(e){const t=e.entities.motion_status_sensor;if(!t)return null;const o=this.hass.states[t]?.state;return"motion_detected"===o||"timeout_pending"===o?o:null}_manualOverrideOn(e){const t=e.entities.manual_override_binary;return!!t&&"on"===this.hass.states[t]?.state}_switchOn(e,t){const o=e.entities[t];return!o||"off"!==this.hass.states[o]?.state}_manualEndIso(e){if(!this._manualOverrideOn(e))return;const t=e.entities.manual_override_end_sensor;return t?this.hass.states[t]?.state:void 0}_setCoverPosition(e,t){e&&this._setAxis(e,"position",t)}_posBar(e,t,o,i,s){const n=this._posDrag?.id===e,r=n?this._posDrag.pct:t,a=null===r?0:ft(r,i),l=null===o?null:ft(o,i);this._lastRailLive.set(e,t);const c=Ki(this.hass.states[e]?.state)?o:null,d=n?null:this._posPending.get(e)??c,h=Ri(t,d)?d:null,p=null===h?null:ft(h,i),u=null!==o?`${nt(r)} · ${st("dialog.target",this.hass)} ${nt(o)}`:nt(r);return H`<div
       class="pos-slider${n?" dragging":""}"
       role="slider"
       tabindex="0"
@@ -5322,8 +5509,9 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
       @pointercancel=${this._onPosPointerEnd}
       @keydown=${t=>this._onPosKeydown(t,e,a,i)}
     >
-      <div class="pos-bar" ${xo(c)}>
+      <div class="pos-bar" ${$o(u)}>
         <div class="pos-fill" style=${`width:${a}%`}></div>
+        ${null!==h&&null!==p?Gi({hass:this.hass,liveFrac:a,pendingFrac:p,pending:h,prefix:"pos-"}):V}
         ${null!==l?H`<div
               class="pos-marker"
               style=${`left:clamp(1px, ${l}%, calc(100% - 1px))`}
@@ -5335,99 +5523,99 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
           >
             ${nt(r)}
           </div>`:V}
-    </div>`}_railIcon(e,t,o){const i=this.hass.states[e];return ut({explicitIcon:i?.attributes?.icon,deviceClass:i?.attributes?.device_class,coverType:t.cover_type,position:o})}_coverShortName(e,t){const o=this.hass.states[e]?.attributes?.friendly_name??e,i=t.entry_title;if(i&&o.toLowerCase().startsWith(i.toLowerCase())){const e=o.slice(i.length).replace(/^[\s\-–—:]+/,"");if(e)return e}return o}_posPctFromEvent(e,t){const o=t.getBoundingClientRect(),i=Math.round((e.clientX-o.left)/o.width*100);return Math.max(0,Math.min(100,i))}_onPosClick(e,t,o){e.stopPropagation(),this._setCoverPosition(t,ft(this._posPctFromEvent(e,e.currentTarget),o))}_onPosKeydown(e,t,o,i){let s;switch(e.key){case"ArrowRight":case"ArrowUp":s=o+1;break;case"ArrowLeft":case"ArrowDown":s=o-1;break;case"PageUp":s=o+10;break;case"PageDown":s=o-10;break;case"Home":s=0;break;case"End":s=100;break;default:return}e.preventDefault(),e.stopPropagation(),this._setCoverPosition(t,ft(Math.max(0,Math.min(100,s)),i))}_stopCover(e){e&&this.hass.callService(Te,"stop",{},{entity_id:e})}_setAxis(e,t,o){e&&Li(this.hass,e,{[t]:o})}_axisTarget(e,t){const o=t.targetRole;if(!o)return null;const i=e.entities[o];if(!i)return null;const s=parseFloat(this.hass.states[i]?.state??"");return Number.isNaN(s)?null:s}_liveAxis(e,t){return Yt(this.hass,t,e)}_axisLabel(e){const t=qe[e.id];return t?st(t,this.hass):e.label}_resume(e){const t=e.entities.reset_override_button;t&&this.hass.callService("button","press",{entity_id:t})}_tapActionConfig(){const e=this._config?.tap_action;if("string"!=typeof e)return e}_isFullyInert(e){return!!(e=>!!e&&"none"===e.action)(this._tapActionConfig())&&!Pi(e.hold_action)&&!Pi(e.double_tap_action)}_fireAction(e){if(!this._config||!this.hass)return;const t=this._tapActionConfig();if("tap"===e&&void 0===t)return this._dialogOpen=!0,void this.dispatchEvent(new CustomEvent("acp-tile-tap",{bubbles:!0,composed:!0}));Ii(this,this.hass,{entity:this._actionEntity(),tap_action:t,hold_action:this._config.hold_action,double_tap_action:this._config.double_tap_action},e)}_hasIconAction(){return Pi(this._config?.icon_tap_action)}_actionEntity(){const e=this._discovered;return e?.is_group?e.entities.group_cover??e.entities.group_position_sensor:this._resolvedCoverFromState()}_resolvedCoverFromState(){if(this._config?.cover)return this._config.cover;if(null===this._registry)return;const e=this._discovered??this._memo(this.hass,{type:this._config.type,entry_id:this._config.entry_id},this._registry);return e?.managed_covers[0]}_stop(e){e.stopPropagation()}};ir.styles=a`
-    :host {
-      display: block;
-      height: 100%;
-    }
-    ha-card {
-      padding: 6px 10px;
-      overflow: hidden;
-      height: 100%;
-      box-sizing: border-box;
-      /* Center the tile body vertically so a taller-than-default grid cell
+    </div>`}_railIcon(e,t,o){const i=this.hass.states[e];return ut({explicitIcon:i?.attributes?.icon,deviceClass:i?.attributes?.device_class,coverType:t.cover_type,position:o})}_coverShortName(e,t){const o=this.hass.states[e]?.attributes?.friendly_name??e,i=t.entry_title;if(i&&o.toLowerCase().startsWith(i.toLowerCase())){const e=o.slice(i.length).replace(/^[\s\-–—:]+/,"");if(e)return e}return o}_posPctFromEvent(e,t){const o=t.getBoundingClientRect(),i=Math.round((e.clientX-o.left)/o.width*100);return Math.max(0,Math.min(100,i))}_onPosClick(e,t,o){e.stopPropagation(),this._setCoverPosition(t,ft(this._posPctFromEvent(e,e.currentTarget),o))}_onPosKeydown(e,t,o,i){let s;switch(e.key){case"ArrowRight":case"ArrowUp":s=o+1;break;case"ArrowLeft":case"ArrowDown":s=o-1;break;case"PageUp":s=o+10;break;case"PageDown":s=o-10;break;case"Home":s=0;break;case"End":s=100;break;default:return}e.preventDefault(),e.stopPropagation(),this._setCoverPosition(t,ft(Math.max(0,Math.min(100,s)),i))}_stopCover(e){e&&(this._posPending.clear(e),this.hass.callService(Te,"stop",{},{entity_id:e}))}_setAxis(e,t,o){e&&("position"===t&&this._posPending.start(e,o),Yi(this.hass,e,{[t]:o}))}_axisTarget(e,t){const o=t.targetRole;if(!o)return null;const i=e.entities[o];if(!i)return null;const s=parseFloat(this.hass.states[i]?.state??"");return Number.isNaN(s)?null:s}_liveAxis(e,t){return Zt(this.hass,t,e)}_axisLabel(e){const t=qe[e.id];return t?st(t,this.hass):e.label}_resume(e){const t=e.entities.reset_override_button;t&&this.hass.callService("button","press",{entity_id:t})}_tapActionConfig(){const e=this._config?.tap_action;if("string"!=typeof e)return e}_isFullyInert(e){return!!(e=>!!e&&"none"===e.action)(this._tapActionConfig())&&!Oi(e.hold_action)&&!Oi(e.double_tap_action)}_fireAction(e){if(!this._config||!this.hass)return;const t=this._tapActionConfig();if("tap"===e&&void 0===t)return this._dialogOpen=!0,void this.dispatchEvent(new CustomEvent("acp-tile-tap",{bubbles:!0,composed:!0}));Pi(this,this.hass,{entity:this._actionEntity(),tap_action:t,hold_action:this._config.hold_action,double_tap_action:this._config.double_tap_action},e)}_hasIconAction(){return Oi(this._config?.icon_tap_action)}_actionEntity(){const e=this._discovered;return e?.is_group?e.entities.group_cover??e.entities.group_position_sensor:this._resolvedCoverFromState()}_resolvedCoverFromState(){if(this._config?.cover)return this._config.cover;if(null===this._registry)return;const e=this._discovered??this._memo(this.hass,{type:this._config.type,entry_id:this._config.entry_id},this._registry);return e?.managed_covers[0]}_stop(e){e.stopPropagation()}};fr.styles=[Wi,a`
+      :host {
+        display: block;
+        height: 100%;
+      }
+      ha-card {
+        padding: 6px 10px;
+        overflow: hidden;
+        height: 100%;
+        box-sizing: border-box;
+        /* Center the tile body vertically so a taller-than-default grid cell
          (Sections drag-resize) keeps the content centered rather than top-aligned. */
-      display: flex;
-      flex-direction: column;
-      justify-content: center;
-      /* In HA's "Sections" view the tile width is driven by the dashboard
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        /* In HA's "Sections" view the tile width is driven by the dashboard
          column, not the viewport, so @media can't see the squeeze. Make the
          card a query container (issue #136) so the detailed layout can reflow
          its controls onto their own row once the column gets narrow. */
-      container-type: inline-size;
-    }
-    .tile-body {
-      display: grid;
-      /* Position column is fixed-width so the controls land at the same x
+        container-type: inline-size;
+      }
+      .tile-body {
+        display: grid;
+        /* Position column is fixed-width so the controls land at the same x
          across stacked tiles regardless of the digit count (87% vs 100%). */
-      grid-template-columns: 24px minmax(0, 1fr) 3rem auto auto;
-      grid-template-areas: 'icon label position controls badge';
-      align-items: center;
-      column-gap: 8px;
-      row-gap: 2px;
-      cursor: pointer;
-      user-select: none;
-      min-width: 0;
-    }
-    /* When the state label is rendered ("Open · 12%") the position cell needs
+        grid-template-columns: 24px minmax(0, 1fr) 3rem auto auto;
+        grid-template-areas: 'icon label position controls badge';
+        align-items: center;
+        column-gap: 8px;
+        row-gap: 2px;
+        cursor: pointer;
+        user-select: none;
+        min-width: 0;
+      }
+      /* When the state label is rendered ("Open · 12%") the position cell needs
        to grow to fit variable-width text. Strict tile-to-tile alignment of the
        ▲ ■ ▼ controls is impossible once the label is variable, so we let
        the cell auto-size. */
-    .tile-body.has-state-label {
-      grid-template-columns: 24px minmax(0, 1fr) auto auto auto;
-    }
-    /* Detailed layout matches HA's native tile card: a tinted icon shape, a
+      .tile-body.has-state-label {
+        grid-template-columns: 24px minmax(0, 1fr) auto auto auto;
+      }
+      /* Detailed layout matches HA's native tile card: a tinted icon shape, a
        name-over-state label column, and inline control buttons on the right —
        all on one row. ACP's own chrome (Auto / winner / floor badges) and the
        position bar share a second row (.chrome-line): badges left, bar right.
        The icon spans both rows so it stays vertically centered (issue #208). */
-    .tile-body.detailed {
-      grid-template-columns: 36px minmax(0, 1fr) auto;
-      grid-template-rows: auto;
-      grid-template-areas: 'icon label controls';
-      align-items: center;
-      /* HA's ha-tile-container .content uses a 10px gap and a 56px row floor. */
-      column-gap: 10px;
-      min-height: var(--row-height, 56px);
-      /* Tight row gap pulls the chrome row (badges + position bar) up snug under
+      .tile-body.detailed {
+        grid-template-columns: 36px minmax(0, 1fr) auto;
+        grid-template-rows: auto;
+        grid-template-areas: 'icon label controls';
+        align-items: center;
+        /* HA's ha-tile-container .content uses a 10px gap and a 56px row floor. */
+        column-gap: 10px;
+        min-height: var(--row-height, 56px);
+        /* Tight row gap pulls the chrome row (badges + position bar) up snug under
          the name/state so the tile stays as short as possible when badges are
          present (issue #208). */
-      row-gap: 2px;
-    }
-    /* HA's inline features block is a hard 50% of the card, not a content-sized
+        row-gap: 2px;
+      }
+      /* HA's inline features block is a hard 50% of the card, not a content-sized
        or equal-share column — see the .controls rule below. The 12px subtrahend
        is its --ha-space-3 inline-end padding. Gated on .has-controls: with
        show_controls false the track is empty, and a 50% track would reserve half
        the tile for nothing where the auto above collapses to zero. */
-    .tile-body.detailed.has-controls {
-      grid-template-columns: 36px minmax(0, 1fr) calc(50% - 12px);
-    }
-    /* Row 2 = the chrome row: Auto/winner/floor badges on the left, position bar
+      .tile-body.detailed.has-controls {
+        grid-template-columns: 36px minmax(0, 1fr) calc(50% - 12px);
+      }
+      /* Row 2 = the chrome row: Auto/winner/floor badges on the left, position bar
        right-aligned. The icon spans both rows (grid-area repeated) so it stays
        vertically centered in the tile rather than pinned to the name row
        (issue #208). */
-    .tile-body.detailed.has-chrome-row {
-      grid-template-rows: auto auto;
-      grid-template-areas:
-        'icon label  controls'
-        'icon chrome chrome';
-    }
-    /* Row 2 (or 3) = the venetian tilt slider, indented under label; icon still
+      .tile-body.detailed.has-chrome-row {
+        grid-template-rows: auto auto;
+        grid-template-areas:
+          'icon label  controls'
+          'icon chrome chrome';
+      }
+      /* Row 2 (or 3) = the venetian tilt slider, indented under label; icon still
        spans every row so it stays centered. */
-    .tile-body.detailed.has-tilt {
-      grid-template-rows: auto auto;
-      grid-template-areas:
-        'icon label controls'
-        'icon tilt  tilt';
-    }
-    .tile-body.detailed.has-chrome-row.has-tilt {
-      grid-template-rows: auto auto auto;
-      grid-template-areas:
-        'icon label  controls'
-        'icon chrome chrome'
-        'icon tilt   tilt';
-    }
-    /* Bar-only (position bar, no badges) gets NO grid special-case: it uses the
+      .tile-body.detailed.has-tilt {
+        grid-template-rows: auto auto;
+        grid-template-areas:
+          'icon label controls'
+          'icon tilt  tilt';
+      }
+      .tile-body.detailed.has-chrome-row.has-tilt {
+        grid-template-rows: auto auto auto;
+        grid-template-areas:
+          'icon label  controls'
+          'icon chrome chrome'
+          'icon tilt   tilt';
+      }
+      /* Bar-only (position bar, no badges) gets NO grid special-case: it uses the
        same .has-chrome-row grid as a badged tile, so the bar spans label+controls
        at full tile width and the name/state sit in row 1. The old special-case
        confined the bar to the label column and spanned .label across both rows to
@@ -5435,98 +5623,98 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
        bar then shared one cell and overlapped (issue #260), and the confined bar
        read as a different component from the badged tile's full-width one. A
        bar-only tile is now a badged tile minus the badges. */
-    /* Name over state, vertically centered against the icon (HA ha-tile-info).
+      /* Name over state, vertically centered against the icon (HA ha-tile-info).
        No gap: HA's .info stacks the two lines with no gap and lets the primary
        line-height (normal, 1.6) do the spacing. */
-    .tile-body.detailed .label {
-      display: flex;
-      flex-direction: column;
-      justify-content: center;
-    }
-    /* Match HA's ha-tile-info text through the same theme tokens the native
+      .tile-body.detailed .label {
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+      }
+      /* Match HA's ha-tile-info text through the same theme tokens the native
        tile card uses, so ACP inherits any theme font-scaling/recoloring
        instead of drifting with hardcoded values. Fallbacks are HA's own
        defaults: name 14px/500 at line-height normal with 0.1px tracking, state
        12px/400 at condensed with 0.4px. Note the primary and secondary lines
        use DIFFERENT line-heights upstream — normal for the name, condensed for
        the state. */
-    .tile-body.detailed .title {
-      font-size: var(--ha-font-size-m, 0.875rem);
-      font-weight: var(--ha-font-weight-medium, 500);
-      line-height: var(--ha-line-height-normal, 1.6);
-      letter-spacing: 0.1px;
-      color: var(--primary-text-color);
-    }
-    .tile-body.detailed .state {
-      font-size: var(--ha-font-size-s, 0.75rem);
-      font-weight: var(--ha-font-weight-normal, 400);
-      line-height: var(--ha-line-height-condensed, 1.2);
-      letter-spacing: 0.4px;
-      color: var(--secondary-text-color);
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      min-width: 0;
-    }
-    /* Chrome row: Auto/winner/floor badges (left) and the position bar (right)
+      .tile-body.detailed .title {
+        font-size: var(--ha-font-size-m, 0.875rem);
+        font-weight: var(--ha-font-weight-medium, 500);
+        line-height: var(--ha-line-height-normal, 1.6);
+        letter-spacing: 0.1px;
+        color: var(--primary-text-color);
+      }
+      .tile-body.detailed .state {
+        font-size: var(--ha-font-size-s, 0.75rem);
+        font-weight: var(--ha-font-weight-normal, 400);
+        line-height: var(--ha-line-height-condensed, 1.2);
+        letter-spacing: 0.4px;
+        color: var(--secondary-text-color);
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        min-width: 0;
+      }
+      /* Chrome row: Auto/winner/floor badges (left) and the position bar (right)
        share one row under the name/state. Kept on a single line (nowrap): the
        badges hold their size and the position bar shrinks to absorb the squeeze,
        so badges never spill onto a second row before the bar has given up its
        width (issue #208). */
-    .chrome-line {
-      grid-area: chrome;
-      display: flex;
-      flex-wrap: nowrap;
-      align-items: center;
-      gap: 6px;
-      min-width: 0;
-      /* Rail geometry, shared by the lone rail and the multi-cover stack so the
+      .chrome-line {
+        grid-area: chrome;
+        display: flex;
+        flex-wrap: nowrap;
+        align-items: center;
+        gap: 6px;
+        min-width: 0;
+        /* Rail geometry, shared by the lone rail and the multi-cover stack so the
          two stay the same length — see the .pos-stack note (issue #260). The
          glyph lane is the per-rail glyph plus the .pos-row gap that separates it
          from the rail. */
-      --acp-rail-basis: 170px;
-      --acp-rail-max: 55%;
-      --acp-rail-glyph-size: 15px;
-      --acp-rail-glyph-gap: 6px;
-      --acp-rail-glyph-lane: calc(var(--acp-rail-glyph-size) + var(--acp-rail-glyph-gap));
-      /* Reserve the badge pill's height even when no badge is present, so a
+        --acp-rail-basis: 170px;
+        --acp-rail-max: 55%;
+        --acp-rail-glyph-size: 15px;
+        --acp-rail-glyph-gap: 6px;
+        --acp-rail-glyph-lane: calc(var(--acp-rail-glyph-size) + var(--acp-rail-glyph-gap));
+        /* Reserve the badge pill's height even when no badge is present, so a
          bar-only tile is the same height as one with badges — the position bar
          just centers in the reserved space (issue #208). Matches the tile-badge
          height (0.75rem × 1.4 line + 2px×2 padding ≈ 22px). */
-      min-height: 22px;
-    }
-    /* Badges hold their intrinsic width so the bar (not the badges) absorbs any
+        min-height: 22px;
+      }
+      /* Badges hold their intrinsic width so the bar (not the badges) absorbs any
        shortage of room on the single chrome line. */
-    .chrome-line acp-tile-badge {
-      overflow: visible;
-      flex: 0 0 auto;
-    }
-    .chrome-line .acp-floor-chip {
-      flex: 0 0 auto;
-    }
-    /* Target-vs-actual mini bar: right-aligned (margin-left:auto) so it fills the
+      .chrome-line acp-tile-badge {
+        overflow: visible;
+        flex: 0 0 auto;
+      }
+      .chrome-line .acp-floor-chip {
+        flex: 0 0 auto;
+      }
+      /* Target-vs-actual mini bar: right-aligned (margin-left:auto) so it fills the
        otherwise-empty space beneath the ↑■↓ buttons. Fill = live openness in the
        state color; the tick marks the auto/solar target. */
-    /* Interactive wrapper: carries the flex sizing the rail used to own, so the
+      /* Interactive wrapper: carries the flex sizing the rail used to own, so the
        visible 6px rail below is unchanged while the gesture target is bigger. */
-    .chrome-line .pos-slider {
-      margin-left: auto;
-      align-self: center;
-      position: relative;
-      flex: 0 1 var(--acp-rail-basis);
-      max-width: var(--acp-rail-max);
-      cursor: pointer;
-      /* A touch-drag must move the fill, not scroll the dashboard. */
-      touch-action: none;
-    }
-    /* The rail is 6px tall — too thin to grab on a phone. Widen the hit area
+      .chrome-line .pos-slider {
+        margin-left: auto;
+        align-self: center;
+        position: relative;
+        flex: 0 1 var(--acp-rail-basis);
+        max-width: var(--acp-rail-max);
+        cursor: pointer;
+        /* A touch-drag must move the fill, not scroll the dashboard. */
+        touch-action: none;
+      }
+      /* The rail is 6px tall — too thin to grab on a phone. Widen the hit area
        vertically with an invisible absolute box, which adds no layout height. */
-    .chrome-line .pos-slider::before {
-      content: '';
-      position: absolute;
-      inset: -8px 0;
-    }
-    /* Multi-cover entry: the rails stack in the slot the single rail occupies,
+      .chrome-line .pos-slider::before {
+        content: '';
+        position: absolute;
+        inset: -8px 0;
+      }
+      /* Multi-cover entry: the rails stack in the slot the single rail occupies,
        each labelled with its cover's glyph. The stack owns the flex sizing so
        each rail below it can size itself to the full stack width.
 
@@ -5536,23 +5724,23 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
        the left — a stacked rail and a lone rail are the same length and start at
        the same x (issue #260). Derive, never hardcode: the lane is the glyph's
        own width plus the .pos-row gap. */
-    .chrome-line .pos-stack {
-      margin-left: auto;
-      align-self: center;
-      flex: 0 1 calc(var(--acp-rail-basis) + var(--acp-rail-glyph-lane));
-      max-width: calc(var(--acp-rail-max) + var(--acp-rail-glyph-lane));
-      min-width: 0;
-      display: flex;
-      flex-direction: column;
-      gap: 5px;
-    }
-    .chrome-line .pos-stack .pos-row {
-      display: flex;
-      align-items: center;
-      gap: var(--acp-rail-glyph-gap);
-      min-width: 0;
-    }
-    /* Layers of ONE cover vs. separate covers. A day/night shade's two rails and
+      .chrome-line .pos-stack {
+        margin-left: auto;
+        align-self: center;
+        flex: 0 1 calc(var(--acp-rail-basis) + var(--acp-rail-glyph-lane));
+        max-width: calc(var(--acp-rail-max) + var(--acp-rail-glyph-lane));
+        min-width: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 5px;
+      }
+      .chrome-line .pos-stack .pos-row {
+        display: flex;
+        align-items: center;
+        gap: var(--acp-rail-glyph-gap);
+        min-width: 0;
+      }
+      /* Layers of ONE cover vs. separate covers. A day/night shade's two rails and
        a blind entry with three windows attached both render as a rail stack, and
        until now looked identical — same glyph, same spacing, same everything.
 
@@ -5565,134 +5753,134 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
        stack widens its gap. That widens the derived glyph lane, which moves the
        stack's LEFT edge out; the rails keep their length and their right edge,
        which is the invariant issue #260 established. */
-    .chrome-line .pos-stack.layered {
-      --acp-rail-glyph-gap: 10px;
-      /* Re-declare the lane HERE, not just the gap. A custom property is
+      .chrome-line .pos-stack.layered {
+        --acp-rail-glyph-gap: 10px;
+        /* Re-declare the lane HERE, not just the gap. A custom property is
          substituted at computed-value time on the element that DECLARES it, so
          the lane inherited from .chrome-line is already frozen at the 6px gap —
          overriding the gap alone would leave the flex basis 4px short and the
          rails 4px stubbier than a lone rail. Redeclaring recomputes it against
          the local gap, which is the whole point of deriving it. */
-      --acp-rail-glyph-lane: calc(var(--acp-rail-glyph-size) + var(--acp-rail-glyph-gap));
-      position: relative;
-      gap: 2px;
-    }
-    .chrome-line .pos-stack.layered::before {
-      content: '';
-      position: absolute;
-      /* Centered in the gap between the glyph column and the rails. */
-      left: calc(var(--acp-rail-glyph-size) + (var(--acp-rail-glyph-gap) / 2) - 1px);
-      width: 2px;
-      /* Span rail-center to rail-center rather than the full box, so the brace
+        --acp-rail-glyph-lane: calc(var(--acp-rail-glyph-size) + var(--acp-rail-glyph-gap));
+        position: relative;
+        gap: 2px;
+      }
+      .chrome-line .pos-stack.layered::before {
+        content: '';
+        position: absolute;
+        /* Centered in the gap between the glyph column and the rails. */
+        left: calc(var(--acp-rail-glyph-size) + (var(--acp-rail-glyph-gap) / 2) - 1px);
+        width: 2px;
+        /* Span rail-center to rail-center rather than the full box, so the brace
          reads as joining the rails instead of boxing the stack. A row is the
          glyph's height, so half of one is the inset at each end. */
-      top: calc(var(--acp-rail-glyph-size) / 2);
-      bottom: calc(var(--acp-rail-glyph-size) / 2);
-      border-radius: 1px;
-      background: var(--secondary-text-color);
-      opacity: 0.45;
-    }
-    /* Per-rail glyph in place of a name: two rails of one shade have long,
+        top: calc(var(--acp-rail-glyph-size) / 2);
+        bottom: calc(var(--acp-rail-glyph-size) / 2);
+        border-radius: 1px;
+        background: var(--secondary-text-color);
+        opacity: 0.45;
+      }
+      /* Per-rail glyph in place of a name: two rails of one shade have long,
        near-identical names that ate the rail's width.
 
        ha-icon defaults to inline-flex and inherits the tile's line-height, so
        its glyph sits low inside its own box even though the row centers that
        box. Making it a zero-line-height flex box centers the glyph on the rail
        rather than on a text baseline the rail knows nothing about. */
-    .chrome-line .pos-stack .pos-glyph {
-      flex: 0 0 auto;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      align-self: center;
-      line-height: 0;
-      --mdc-icon-size: var(--acp-rail-glyph-size);
-      width: var(--acp-rail-glyph-size);
-      height: var(--acp-rail-glyph-size);
-      color: var(--secondary-text-color);
-    }
-    .chrome-line .pos-stack .pos-slider {
-      margin-left: 0;
-      flex: 1 1 auto;
-      max-width: none;
-    }
-    /* Rails sit tight in the stack, so the ±8px grab boxes would overlap and
+      .chrome-line .pos-stack .pos-glyph {
+        flex: 0 0 auto;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        align-self: center;
+        line-height: 0;
+        --mdc-icon-size: var(--acp-rail-glyph-size);
+        width: var(--acp-rail-glyph-size);
+        height: var(--acp-rail-glyph-size);
+        color: var(--secondary-text-color);
+      }
+      .chrome-line .pos-stack .pos-slider {
+        margin-left: 0;
+        flex: 1 1 auto;
+        max-width: none;
+      }
+      /* Rails sit tight in the stack, so the ±8px grab boxes would overlap and
        the upper rail would swallow the lower rail's top half. */
-    .chrome-line .pos-stack .pos-slider::before {
-      inset: -2px 0;
-    }
-    .chrome-line .pos-slider:focus-visible {
-      outline: 2px solid var(--primary-color);
-      outline-offset: 3px;
-      border-radius: 6px;
-    }
-    /* The 0.3s ease below smooths server-driven updates; mid-drag it would read
+      .chrome-line .pos-stack .pos-slider::before {
+        inset: -2px 0;
+      }
+      .chrome-line .pos-slider:focus-visible {
+        outline: 2px solid var(--primary-color);
+        outline-offset: 3px;
+        border-radius: 6px;
+      }
+      /* The 0.3s ease below smooths server-driven updates; mid-drag it would read
        as the fill lagging behind the finger. */
-    .chrome-line .pos-slider.dragging .pos-fill {
-      transition: none;
-    }
-    /* Live percentage while a drag is in flight. The hover tooltip carries the
+      .chrome-line .pos-slider.dragging .pos-fill {
+        transition: none;
+      }
+      /* Live percentage while a drag is in flight. The hover tooltip carries the
        same number, but a tooltip is mouse-only — on a phone, the finger setting
        the position is also the thing covering the rail, so without this the user
        is dragging blind. Sits in .pos-slider, NOT .pos-bar: the bar is
        overflow:hidden to clip the fill, which would clip this too. Pointer-events
        off so it never eats the drag it is reporting on. */
-    .chrome-line .pos-readout {
-      position: absolute;
-      bottom: calc(100% + 6px);
-      transform: translateX(-50%);
-      padding: 1px 5px;
-      border-radius: 4px;
-      background: var(--secondary-background-color, rgba(127, 127, 127, 0.9));
-      color: var(--primary-text-color);
-      font-size: var(--ha-font-size-s, 0.75rem);
-      line-height: var(--ha-line-height-condensed, 1.2);
-      white-space: nowrap;
-      pointer-events: none;
-      z-index: 2;
-    }
-    .chrome-line .pos-bar {
-      position: relative;
-      width: 100%;
-      height: 6px;
-      border-radius: 6px;
-      background: var(--secondary-background-color, rgba(127, 127, 127, 0.15));
-      overflow: hidden;
-    }
-    .chrome-line .pos-fill {
-      position: absolute;
-      inset: 0 auto 0 0;
-      /* One constant color for every rail, never the cover's state color: a rail
+      .chrome-line .pos-readout {
+        position: absolute;
+        bottom: calc(100% + 6px);
+        transform: translateX(-50%);
+        padding: 1px 5px;
+        border-radius: 4px;
+        background: var(--secondary-background-color, rgba(127, 127, 127, 0.9));
+        color: var(--primary-text-color);
+        font-size: var(--ha-font-size-s, 0.75rem);
+        line-height: var(--ha-line-height-condensed, 1.2);
+        white-space: nowrap;
+        pointer-events: none;
+        z-index: 2;
+      }
+      .chrome-line .pos-bar {
+        position: relative;
+        width: 100%;
+        height: 6px;
+        border-radius: 6px;
+        background: var(--secondary-background-color, rgba(127, 127, 127, 0.15));
+        overflow: hidden;
+      }
+      .chrome-line .pos-fill {
+        position: absolute;
+        inset: 0 auto 0 0;
+        /* One constant color for every rail, never the cover's state color: a rail
          that changed hue as it crossed open/closed read as a status light rather
          than a measurement, and on a multi-rail tile the rails disagreed with
          each other. The icon still carries state color (the state_color option),
          which is where that signal belongs. Overridable per-theme via
          --acp-pos-fill-color. */
-      background: var(--acp-pos-fill-color, ${r(mt)});
-      opacity: 0.55;
-      border-radius: 6px;
-      transition: width 0.3s ease;
-    }
-    .chrome-line .pos-marker {
-      position: absolute;
-      top: 0;
-      width: 2px;
-      height: 100%;
-      background: var(--accent-color, #ff9800);
-      transform: translateX(-50%);
-      transition: left 0.3s ease;
-    }
-    .tilt-line {
-      grid-area: tilt;
-      min-width: 0;
-      margin-top: 2px;
-      cursor: default;
-    }
-    /* Optional decision summary stacks as a dim third line under the state. */
-    .tile-body.detailed .label .summary {
-      font-size: 0.72rem;
-    }
-    /* Mirror HA's tile card in features_position: inline mode, whose spec
+        background: var(--acp-pos-fill-color, ${r(mt)});
+        opacity: 0.55;
+        border-radius: 6px;
+        transition: width 0.3s ease;
+      }
+      .chrome-line .pos-marker {
+        position: absolute;
+        top: 0;
+        width: 2px;
+        height: 100%;
+        background: var(--accent-color, #ff9800);
+        transform: translateX(-50%);
+        transition: left 0.3s ease;
+      }
+      .tilt-line {
+        grid-area: tilt;
+        min-width: 0;
+        margin-top: 2px;
+        cursor: default;
+      }
+      /* Optional decision summary stacks as a dim third line under the state. */
+      .tile-body.detailed .label .summary {
+        font-size: 0.72rem;
+      }
+      /* Mirror HA's tile card in features_position: inline mode, whose spec
        differs from the bottom feature row. ha-tile-container's
        .container.horizontal rule for the features slot sets
        --feature-height: var(--ha-space-9) — 36px, not the 42px of a bottom row —
@@ -5703,202 +5891,202 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
        ha-control-button contributes a 20px glyph and a --disabled-color fill at
        20% opacity. Buttons are flex: 1 inside that block, so they widen with the
        tile exactly as HA's do. */
-    .tile-body.detailed .controls {
-      align-self: center;
-      /* --feature-button-spacing */
-      gap: 12px;
-      width: 100%;
-    }
-    .tile-body.detailed .controls button {
-      flex: 1 1 0;
-      width: auto;
-      height: var(--control-button-group-thickness, 36px);
-      border-radius: var(--control-button-border-radius, 12px);
-      border: none;
-      background: color-mix(
-        in srgb,
-        var(--control-button-background-color, var(--disabled-color, #7f7f7f)) 20%,
-        transparent
-      );
-    }
-    .tile-body.detailed .controls button ha-icon {
-      --mdc-icon-size: 20px;
-      color: var(--primary-text-color);
-    }
-    .tile-body.detailed .controls button:hover {
-      background: color-mix(
-        in srgb,
-        var(--control-button-background-color, var(--disabled-color, #7f7f7f)) 32%,
-        transparent
-      );
-    }
-    /* Bare 36px glyph by default — the state color carries the cover's status
+      .tile-body.detailed .controls {
+        align-self: center;
+        /* --feature-button-spacing */
+        gap: 12px;
+        width: 100%;
+      }
+      .tile-body.detailed .controls button {
+        flex: 1 1 0;
+        width: auto;
+        height: var(--control-button-group-thickness, 36px);
+        border-radius: var(--control-button-border-radius, 12px);
+        border: none;
+        background: color-mix(
+          in srgb,
+          var(--control-button-background-color, var(--disabled-color, #7f7f7f)) 20%,
+          transparent
+        );
+      }
+      .tile-body.detailed .controls button ha-icon {
+        --mdc-icon-size: 20px;
+        color: var(--primary-text-color);
+      }
+      .tile-body.detailed .controls button:hover {
+        background: color-mix(
+          in srgb,
+          var(--control-button-background-color, var(--disabled-color, #7f7f7f)) 32%,
+          transparent
+        );
+      }
+      /* Bare 36px glyph by default — the state color carries the cover's status
        with nothing behind it. HA does the same for covers, though by a
        different route: its shape is drawn only when the icon is interactive,
        and getEntityDefaultTileIconAction returns none for the cover domain.
        Setting icon_tap_action opts into the shape via .background below. */
-    .tile-body.detailed .cover-icon-wrap {
-      place-self: center;
-      width: 36px;
-      height: 36px;
-    }
-    /* HA's ha-tile-icon shape: a pill at --ha-border-radius-pill filled with the
+      .tile-body.detailed .cover-icon-wrap {
+        place-self: center;
+        width: 36px;
+        height: 36px;
+      }
+      /* HA's ha-tile-icon shape: a pill at --ha-border-radius-pill filled with the
        icon's own color at 0.2 opacity (0.35 on hover), painted as a ::before so
        the tint never dims the glyph on top of it. --acp-tile-icon-color is set
        inline from coverStateColor, so shape and glyph always agree. */
-    /* Scoped to .detailed: the one-line layout's glyph box is 24px around a 22px
+      /* Scoped to .detailed: the one-line layout's glyph box is 24px around a 22px
        icon, so a pill there would be a hairline of tint around the glyph. The
        tap action still works in one-line — only the shape is detailed-only. */
-    .tile-body.detailed .cover-icon-wrap.background {
-      position: relative;
-      border-radius: var(--ha-border-radius-pill, 9999px);
-      overflow: hidden;
-      cursor: pointer;
-    }
-    .tile-body.detailed .cover-icon-wrap.background::before {
-      content: '';
-      position: absolute;
-      inset: 0;
-      background-color: var(--acp-tile-icon-color, var(--disabled-color, #7f7f7f));
-      opacity: 0.2;
-      transition: opacity 180ms ease-in-out;
-    }
-    .tile-body.detailed .cover-icon-wrap.background:hover::before {
-      opacity: 0.35;
-    }
-    .cover-icon-wrap.background:focus-visible {
-      outline: none;
-      box-shadow: 0 0 0 2px var(--acp-tile-icon-color, var(--primary-text-color));
-      border-radius: var(--ha-border-radius-pill, 9999px);
-    }
-    /* The glyph must sit above the ::before wash. */
-    .tile-body.detailed .cover-icon-wrap.background .cover-icon {
-      position: relative;
-    }
-    .tile-body.detailed .cover-icon {
-      --mdc-icon-size: 24px;
-    }
-    .tile-body[role='group'] {
-      cursor: default;
-    }
-    /* Offline/unresponsive cover (issue #212): dim the whole tile so it reads
+      .tile-body.detailed .cover-icon-wrap.background {
+        position: relative;
+        border-radius: var(--ha-border-radius-pill, 9999px);
+        overflow: hidden;
+        cursor: pointer;
+      }
+      .tile-body.detailed .cover-icon-wrap.background::before {
+        content: '';
+        position: absolute;
+        inset: 0;
+        background-color: var(--acp-tile-icon-color, var(--disabled-color, #7f7f7f));
+        opacity: 0.2;
+        transition: opacity 180ms ease-in-out;
+      }
+      .tile-body.detailed .cover-icon-wrap.background:hover::before {
+        opacity: 0.35;
+      }
+      .cover-icon-wrap.background:focus-visible {
+        outline: none;
+        box-shadow: 0 0 0 2px var(--acp-tile-icon-color, var(--primary-text-color));
+        border-radius: var(--ha-border-radius-pill, 9999px);
+      }
+      /* The glyph must sit above the ::before wash. */
+      .tile-body.detailed .cover-icon-wrap.background .cover-icon {
+        position: relative;
+      }
+      .tile-body.detailed .cover-icon {
+        --mdc-icon-size: 24px;
+      }
+      .tile-body[role='group'] {
+        cursor: default;
+      }
+      /* Offline/unresponsive cover (issue #212): dim the whole tile so it reads
        as unavailable at a glance, matching HA's own unavailable-entity dimming. */
-    .tile-body.unavailable {
-      opacity: 0.5;
-    }
-    .cover-icon-wrap {
-      grid-area: icon;
-      position: relative;
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      width: 24px;
-      height: 24px;
-    }
-    .cover-icon {
-      --mdc-icon-size: 22px;
-      color: var(--primary-text-color);
-    }
-    .motion-overlay {
-      position: absolute;
-      top: -4px;
-      right: -6px;
-      --mdc-icon-size: 12px;
-      color: var(--warning-color, #f1c232);
-      background: var(--card-background-color, white);
-      border-radius: 50%;
-      padding: 1px;
-      line-height: 0;
-    }
-    /* Sibling of .motion-overlay, pinned to the opposite corner so a cover that
+      .tile-body.unavailable {
+        opacity: 0.5;
+      }
+      .cover-icon-wrap {
+        grid-area: icon;
+        position: relative;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 24px;
+        height: 24px;
+      }
+      .cover-icon {
+        --mdc-icon-size: 22px;
+        color: var(--primary-text-color);
+      }
+      .motion-overlay {
+        position: absolute;
+        top: -4px;
+        right: -6px;
+        --mdc-icon-size: 12px;
+        color: var(--warning-color, #f1c232);
+        background: var(--card-background-color, white);
+        border-radius: 50%;
+        padding: 1px;
+        line-height: 0;
+      }
+      /* Sibling of .motion-overlay, pinned to the opposite corner so a cover that
        is both occupied and low on battery shows both without them colliding —
        motion top-right, battery bottom-left. */
-    .battery-overlay {
-      position: absolute;
-      bottom: -4px;
-      left: -6px;
-      --mdc-icon-size: 12px;
-      color: var(--error-color, #db4437);
-      background: var(--card-background-color, white);
-      border-radius: 50%;
-      padding: 1px;
-      line-height: 0;
-    }
-    .label {
-      grid-area: label;
-      min-width: 0;
-    }
-    .title {
-      font-size: 0.95rem;
-      font-weight: 500;
-      color: var(--primary-text-color);
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-    }
-    .summary {
-      font-size: 0.78rem;
-      color: var(--secondary-text-color);
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      min-width: 0;
-    }
-    .position {
-      grid-area: position;
-      font-size: 0.85rem;
-      font-variant-numeric: tabular-nums;
-      color: var(--primary-text-color);
-      padding: 0 4px;
-      /* Right-align the digits so the % sign sits flush against the controls
+      .battery-overlay {
+        position: absolute;
+        bottom: -4px;
+        left: -6px;
+        --mdc-icon-size: 12px;
+        color: var(--error-color, #db4437);
+        background: var(--card-background-color, white);
+        border-radius: 50%;
+        padding: 1px;
+        line-height: 0;
+      }
+      .label {
+        grid-area: label;
+        min-width: 0;
+      }
+      .title {
+        font-size: 0.95rem;
+        font-weight: 500;
+        color: var(--primary-text-color);
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+      .summary {
+        font-size: 0.78rem;
+        color: var(--secondary-text-color);
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        min-width: 0;
+      }
+      .position {
+        grid-area: position;
+        font-size: 0.85rem;
+        font-variant-numeric: tabular-nums;
+        color: var(--primary-text-color);
+        padding: 0 4px;
+        /* Right-align the digits so the % sign sits flush against the controls
          column edge — combined with the fixed-width position grid column, this
          keeps the ▲ ■ ▼ row aligned across stacked tiles. */
-      text-align: right;
-    }
-    .controls {
-      grid-area: controls;
-      display: inline-flex;
-      gap: 2px;
-    }
-    .controls button {
-      width: 26px;
-      height: 26px;
-      border: 1px solid var(--divider-color, rgba(0, 0, 0, 0.12));
-      border-radius: 4px;
-      background: var(--card-background-color, white);
-      color: var(--primary-text-color);
-      cursor: pointer;
-      font-size: 0.8rem;
-      line-height: 1;
-      padding: 0;
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-    }
-    .controls button ha-icon {
-      --mdc-icon-size: 16px;
-      color: var(--primary-text-color);
-      line-height: 0;
-    }
-    .controls button:hover {
-      background: var(--secondary-background-color);
-    }
-    .controls button:disabled {
-      opacity: 0.4;
-      cursor: not-allowed;
-    }
-    acp-tile-badge {
-      grid-area: badge;
-      min-width: 0;
-      overflow: hidden;
-    }
-    .acp-floor-chip {
-      grid-area: floor-chip;
-      font-size: 0.7rem;
-      padding: 1px 6px;
-      border-radius: 999px;
-      background: color-mix(in srgb, var(--acp-floor-accent) ${22}%, transparent);
-      /* The custom-position purple resolved AGAINST THE THEME'S OWN TEXT COLOR
+        text-align: right;
+      }
+      .controls {
+        grid-area: controls;
+        display: inline-flex;
+        gap: 2px;
+      }
+      .controls button {
+        width: 26px;
+        height: 26px;
+        border: 1px solid var(--divider-color, rgba(0, 0, 0, 0.12));
+        border-radius: 4px;
+        background: var(--card-background-color, white);
+        color: var(--primary-text-color);
+        cursor: pointer;
+        font-size: 0.8rem;
+        line-height: 1;
+        padding: 0;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+      }
+      .controls button ha-icon {
+        --mdc-icon-size: 16px;
+        color: var(--primary-text-color);
+        line-height: 0;
+      }
+      .controls button:hover {
+        background: var(--secondary-background-color);
+      }
+      .controls button:disabled {
+        opacity: 0.4;
+        cursor: not-allowed;
+      }
+      acp-tile-badge {
+        grid-area: badge;
+        min-width: 0;
+        overflow: hidden;
+      }
+      .acp-floor-chip {
+        grid-area: floor-chip;
+        font-size: 0.7rem;
+        padding: 1px 6px;
+        border-radius: 999px;
+        background: color-mix(in srgb, var(--acp-floor-accent) ${22}%, transparent);
+        /* The custom-position purple resolved AGAINST THE THEME'S OWN TEXT COLOR
          rather than pinned to a literal. The literal it replaces (#6a1b9a) is a
          dark purple chosen for a light background; on HA's dark theme it landed
          at 1.6:1 filled and 1.3:1 hollow — the chip was legible only if you knew
@@ -5912,65 +6100,65 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
          and is not — it lands at 4.35:1 on HA dark, under the 4.5:1 floor the
          badges beside it clear at 40%. Importing the constants is what stops the
          chip and the badges from drifting apart again. */
-      --acp-floor-accent: #9c27b0;
-      color: color-mix(
-        in srgb,
-        var(--acp-floor-accent) ${40}%,
-        var(--primary-text-color, #212121)
-      );
-      /* Reserve the border so the outline (is-armed) state doesn't shift layout. */
-      border: 1px solid transparent;
-      white-space: nowrap;
-      align-self: center;
-    }
-    /* Floating-tooltip cursor lifecycle for the tooltip carriers inside the
+        --acp-floor-accent: #9c27b0;
+        color: color-mix(
+          in srgb,
+          var(--acp-floor-accent) ${40}%,
+          var(--primary-text-color, #212121)
+        );
+        /* Reserve the border so the outline (is-armed) state doesn't shift layout. */
+        border: 1px solid transparent;
+        white-space: nowrap;
+        align-self: center;
+      }
+      /* Floating-tooltip cursor lifecycle for the tooltip carriers inside the
        tile (floor chip, title, inline summary, motion overlay). Help hint on
        hover, default once OUR bubble appears. */
-    [data-tooltip]:hover {
-      cursor: help;
-    }
-    [data-tooltip][acp-tt-shown] {
-      cursor: default;
-    }
-    /* Clamping axis: not-clamping → hollow/outline (transparent fill + purple border). */
-    .acp-floor-chip.is-armed {
-      background: transparent;
-      border-color: color-mix(in srgb, var(--acp-floor-accent) 60%, transparent);
-    }
-    /* Priority axis: bypassable (priority ≤ 80) → subdued.
+      [data-tooltip]:hover {
+        cursor: help;
+      }
+      [data-tooltip][acp-tt-shown] {
+        cursor: default;
+      }
+      /* Clamping axis: not-clamping → hollow/outline (transparent fill + purple border). */
+      .acp-floor-chip.is-armed {
+        background: transparent;
+        border-color: color-mix(in srgb, var(--acp-floor-accent) 60%, transparent);
+      }
+      /* Priority axis: bypassable (priority ≤ 80) → subdued.
        NOT opacity any more. Opacity multiplies into the TEXT as much as the
        chrome, and stacked on the hollow variant it was what took this chip to
        1.3:1 — a legibility cost paid to signal a secondary attribute. The
        priority axis already has a non-destructive carrier in font-weight (see
        .resists-manual), so bypassable states itself by NOT being emphasized,
        and softens its outline instead. Text contrast is untouched. */
-    .acp-floor-chip.is-bypassable {
-      font-weight: 400;
-    }
-    /* Scoped to the hollow variant on purpose: the filled one has a deliberately
+      .acp-floor-chip.is-bypassable {
+        font-weight: 400;
+      }
+      /* Scoped to the hollow variant on purpose: the filled one has a deliberately
        transparent border, and softening a border that isn't drawn would instead
        make one appear. */
-    .acp-floor-chip.is-armed.is-bypassable {
-      border-color: color-mix(in srgb, var(--acp-floor-accent) 35%, transparent);
-    }
-    /* Priority axis: resists manual ↓ (priority > 80) → emphasized. */
-    .acp-floor-chip.resists-manual {
-      font-weight: 600;
-    }
-    /* One-line layout: add a second row for the floor chip under the position cell */
-    .tile-body.has-floor-chip {
-      grid-template-rows: auto auto;
-      grid-template-areas:
-        'icon label     position  controls badge resume'
-        'icon label     floor-chip .        .     .';
-    }
-    .tile-body.has-state-label.has-floor-chip {
-      grid-template-rows: auto auto;
-      grid-template-areas:
-        'icon label     position  controls badge resume'
-        'icon label     floor-chip .        .     .';
-    }
-    /* Reflow (issues #136, #154): drop the ↑■▼ controls onto their own
+      .acp-floor-chip.is-armed.is-bypassable {
+        border-color: color-mix(in srgb, var(--acp-floor-accent) 35%, transparent);
+      }
+      /* Priority axis: resists manual ↓ (priority > 80) → emphasized. */
+      .acp-floor-chip.resists-manual {
+        font-weight: 600;
+      }
+      /* One-line layout: add a second row for the floor chip under the position cell */
+      .tile-body.has-floor-chip {
+        grid-template-rows: auto auto;
+        grid-template-areas:
+          'icon label     position  controls badge resume'
+          'icon label     floor-chip .        .     .';
+      }
+      .tile-body.has-state-label.has-floor-chip {
+        grid-template-rows: auto auto;
+        grid-template-areas:
+          'icon label     position  controls badge resume'
+          'icon label     floor-chip .        .     .';
+      }
+      /* Reflow (issues #136, #154): drop the ↑■▼ controls onto their own
        full-width row beneath the name so the cover name gets the whole column,
        with the badge and tilt rows stacked between. The same reflow fires from
        two independent triggers, because "the tile is narrow" alone can't tell a
@@ -5990,17 +6178,61 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
        sync. Each detailed grid variant is re-asserted (placed after the wide
        rules so it wins when a query matches — the grid rules rely on source
        order, not just specificity). */
-    @media (max-width: 500px) {
-      @container (max-width: 480px) {
+      @media (max-width: 500px) {
+        @container (max-width: 480px) {
+          .tile-body.detailed {
+            grid-template-columns: 36px minmax(0, 1fr);
+            grid-template-areas:
+              'icon label'
+              'controls controls';
+          }
+          /* The 50% has-controls track is (0,3,0) and a query adds no specificity,
+           so without this it would keep a third column alive here and strand the
+           reflowed full-width controls row beside it. */
+          .tile-body.detailed.has-controls {
+            grid-template-columns: 36px minmax(0, 1fr);
+          }
+          .tile-body.detailed.has-chrome-row {
+            grid-template-areas:
+              'icon label'
+              'icon chrome'
+              'controls controls';
+          }
+          .tile-body.detailed.has-tilt {
+            grid-template-areas:
+              'icon label'
+              'icon tilt'
+              'controls controls';
+          }
+          .tile-body.detailed.has-chrome-row.has-tilt {
+            grid-template-areas:
+              'icon label'
+              'icon chrome'
+              'icon tilt'
+              'controls controls';
+          }
+          /* No bar-only re-assertion needed: the wide layout no longer special-cases
+           bar-only, so the .has-chrome-row reflow above already applies (#260). */
+          .tile-body.detailed .controls {
+            margin-top: 4px;
+            gap: 8px;
+            justify-content: space-between;
+          }
+          .tile-body.detailed .controls button {
+            flex: 1 1 0;
+            width: auto;
+            height: var(--control-button-group-thickness, 36px);
+          }
+        }
+      }
+      @container (max-width: 340px) {
         .tile-body.detailed {
           grid-template-columns: 36px minmax(0, 1fr);
           grid-template-areas:
             'icon label'
             'controls controls';
         }
-        /* The 50% has-controls track is (0,3,0) and a query adds no specificity,
-           so without this it would keep a third column alive here and strand the
-           reflowed full-width controls row beside it. */
+        /* Same re-assertion as the 480px block — see the note there. */
         .tile-body.detailed.has-controls {
           grid-template-columns: 36px minmax(0, 1fr);
         }
@@ -6020,11 +6252,10 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
           grid-template-areas:
             'icon label'
             'icon chrome'
-            'icon tilt'
+            'tilt tilt'
             'controls controls';
         }
-        /* No bar-only re-assertion needed: the wide layout no longer special-cases
-           bar-only, so the .has-chrome-row reflow above already applies (#260). */
+        /* Same as the 480px block: no bar-only re-assertion needed (#260). */
         .tile-body.detailed .controls {
           margin-top: 4px;
           gap: 8px;
@@ -6036,63 +6267,20 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
           height: var(--control-button-group-thickness, 36px);
         }
       }
-    }
-    @container (max-width: 340px) {
-      .tile-body.detailed {
-        grid-template-columns: 36px minmax(0, 1fr);
-        grid-template-areas:
-          'icon label'
-          'controls controls';
+      .empty {
+        padding: 12px;
+        text-align: center;
       }
-      /* Same re-assertion as the 480px block — see the note there. */
-      .tile-body.detailed.has-controls {
-        grid-template-columns: 36px minmax(0, 1fr);
+      .dim {
+        color: var(--secondary-text-color);
+        margin: 0;
       }
-      .tile-body.detailed.has-chrome-row {
-        grid-template-areas:
-          'icon label'
-          'icon chrome'
-          'controls controls';
-      }
-      .tile-body.detailed.has-tilt {
-        grid-template-areas:
-          'icon label'
-          'icon tilt'
-          'controls controls';
-      }
-      .tile-body.detailed.has-chrome-row.has-tilt {
-        grid-template-areas:
-          'icon label'
-          'icon chrome'
-          'tilt tilt'
-          'controls controls';
-      }
-      /* Same as the 480px block: no bar-only re-assertion needed (#260). */
-      .tile-body.detailed .controls {
-        margin-top: 4px;
-        gap: 8px;
-        justify-content: space-between;
-      }
-      .tile-body.detailed .controls button {
-        flex: 1 1 0;
-        width: auto;
-        height: var(--control-button-group-thickness, 36px);
-      }
-    }
-    .empty {
-      padding: 12px;
-      text-align: center;
-    }
-    .dim {
-      color: var(--secondary-text-color);
-      margin: 0;
-    }
-  `,e([ge({attribute:!1})],ir.prototype,"hass",void 0),e([me()],ir.prototype,"_config",void 0),e([me()],ir.prototype,"_registry",void 0),e([me()],ir.prototype,"_registryError",void 0),e([me()],ir.prototype,"_dialogOpen",void 0),e([me()],ir.prototype,"_posDrag",void 0),e([me()],ir.prototype,"_extendOpen",void 0),ir=e([pe($e)],ir),window.customCards=window.customCards||[],window.customCards.some(e=>e.type===$e)||window.customCards.push({type:$e,name:"Adaptive Cover Pro — Tile",description:"Compact chip-style tile for one Adaptive Cover Pro instance: icon, name, position, ↑■↓, contextual badge.",preview:!0,documentationURL:"https://github.com/jrhubott/adaptive-cover-pro/wiki/Lovelace-Card",getEntitySuggestion:Fo(`custom:${$e}`,"entry_id")});let sr=class extends de{constructor(){super(...arguments),this.compact=!1,this._roster=Ms()}render(){if(!this.hass||!this.discovered)return V;const e=_s(this.hass,this.discovered),t=Object.entries(e.memberPositions),o=!!e.target;return H`
+    `],e([ge({attribute:!1})],fr.prototype,"hass",void 0),e([me()],fr.prototype,"_config",void 0),e([me()],fr.prototype,"_registry",void 0),e([me()],fr.prototype,"_registryError",void 0),e([me()],fr.prototype,"_dialogOpen",void 0),e([me()],fr.prototype,"_posDrag",void 0),e([me()],fr.prototype,"_extendOpen",void 0),fr=e([pe($e)],fr),window.customCards=window.customCards||[],window.customCards.some(e=>e.type===$e)||window.customCards.push({type:$e,name:"Adaptive Cover Pro — Tile",description:"Compact chip-style tile for one Adaptive Cover Pro instance: icon, name, position, ↑■↓, contextual badge.",preview:!0,documentationURL:"https://github.com/jrhubott/adaptive-cover-pro/wiki/Lovelace-Card",getEntitySuggestion:Ro(`custom:${$e}`,"entry_id")});let br=class extends de{constructor(){super(...arguments),this.compact=!1,this._roster=Os()}render(){if(!this.hass||!this.discovered)return V;const e=$s(this.hass,this.discovered),t=Object.keys(e.memberPositions),o=this._roster(this.hass,t,Po()??void 0),i=As(this.hass,e,Fs(t,this.members)),s=!!i.target;return H`
       <div class="group-view">
         <div class="summary">
-          <span class="agg-state">${st(`group.state_${e.aggregate}`,this.hass)}</span>
-          <span class="agg-position">${nt(e.position)}</span>
-          ${is(e.memberWinners).map(e=>H`<acp-tile-badge .hass=${this.hass} .winner=${e}></acp-tile-badge>`)}
+          <span class="agg-state">${st(`group.state_${i.aggregate}`,this.hass)}</span>
+          <span class="agg-position">${nt(i.position)}</span>
+          ${hs(i.memberWinners).map(e=>H`<acp-tile-badge .hass=${this.hass} .winner=${e}></acp-tile-badge>`)}
         </div>
 
         <acp-axis-bar
@@ -6101,57 +6289,58 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
           .label=${st("group.position",this.hass)}
           .hintKey=${"covers.click_to_set"}
           .targetHintKey=${"covers.target_tooltip"}
-          .actual=${e.position}
+          .actual=${i.position}
           .openBlocksSun=${At(this.discovered).openBlocksSun}
           .compact=${this.compact}
-          .disabled=${!o}
-          @acp-tilt-set=${t=>fs(this.hass,e,t.detail)}
+          .disabled=${!s}
+          @acp-tilt-set=${e=>zs(this.hass,i,e.detail)}
         ></acp-axis-bar>
-        ${e.tilt?H`<acp-axis-bar
+        ${i.tilt?H`<acp-axis-bar
               layout="cover"
               .hass=${this.hass}
               .label=${st("covers.tilt_title",this.hass)}
-              .actual=${e.tilt.value}
+              .actual=${i.tilt.value}
               .openBlocksSun=${!1}
               .compact=${this.compact}
-              @acp-tilt-set=${t=>ys(this.hass,e,t.detail)}
+              @acp-tilt-set=${e=>Ts(this.hass,i,e.detail)}
             ></acp-axis-bar>`:V}
 
         <div class="controls">
           <acp-cover-move-buttons
             labels="group"
             .hass=${this.hass}
-            .position=${e.position}
-            .deviceClass=${e.deviceClass}
-            .enabled=${o}
-            @acp-move=${t=>this._move(t,e)}
+            .position=${i.position}
+            .deviceClass=${i.deviceClass}
+            .enabled=${s}
+            @acp-move=${e=>this._move(e,i)}
           ></acp-cover-move-buttons>
         </div>
 
         <acp-group-controls-row
           .hass=${this.hass}
           .discovered=${this.discovered}
-          .snapshot=${e}
+          .snapshot=${i}
         ></acp-group-controls-row>
 
-        <div class="members">
-          <div class="members-head">${st("group.members",this.hass)}</div>
-          ${0===t.length?H`<div class="member-placeholder">
-                ${st("group.member_placeholder",this.hass)}
-              </div>`:Cs(this._roster(this.hass,t.map(([e])=>e),Io()??void 0),Ts,t=>H`<acp-group-member-row
-                    .hass=${this.hass}
-                    .entityId=${t.covers[0]}
-                    .coverIds=${t.covers}
-                    .position=${e.memberPositions[t.covers[0]]??null}
-                    .winner=${e.memberWinners?.[t.covers[0]]}
-                    .openBlocksSun=${At(this.discovered).openBlocksSun}
-                    .acpManaged=${!!e.memberWinners&&t.covers[0]in e.memberWinners}
-                    .displayName=${this.memberNames?.[Is(t)]}
-                    .compact=${this.compact}
-                  ></acp-group-member-row>`)}
-        </div>
+        ${this._membersTpl(i,t,o)}
       </div>
-    `}_move(e,t){"stop"===e.detail?bs(this.hass,this.discovered,t):fs(this.hass,t,"open"===e.detail?100:0)}};sr.styles=a`
+    `}_membersTpl(e,t,o){if(0===t.length)return H`<div class="members">
+        <div class="members-head">${st("group.members",this.hass)}</div>
+        <div class="member-placeholder">${st("group.member_placeholder",this.hass)}</div>
+      </div>`;const i=Rs(o,this.members);return 0===i.length?V:H`<div class="members">
+      <div class="members-head">${st("group.members",this.hass)}</div>
+      ${Us(i,Ns,t=>H`<acp-group-member-row
+            .hass=${this.hass}
+            .entityId=${t.covers[0]}
+            .coverIds=${t.covers}
+            .position=${e.memberPositions[t.covers[0]]??null}
+            .winner=${e.memberWinners?.[t.covers[0]]}
+            .openBlocksSun=${At(this.discovered).openBlocksSun}
+            .acpManaged=${!!e.memberWinners&&t.covers[0]in e.memberWinners}
+            .displayName=${this.memberNames?.[Ds(t)]}
+            .compact=${this.compact}
+          ></acp-group-member-row>`)}
+    </div>`}_move(e,t){"stop"===e.detail?Ms(this.hass,this.discovered,t):zs(this.hass,t,"open"===e.detail?100:0)}};br.styles=a`
     :host {
       display: block;
     }
@@ -6195,7 +6384,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
       text-align: center;
       padding: 12px;
     }
-  `,e([ge({attribute:!1})],sr.prototype,"hass",void 0),e([ge({attribute:!1})],sr.prototype,"discovered",void 0),e([ge({type:Boolean,reflect:!0})],sr.prototype,"compact",void 0),e([ge({attribute:!1})],sr.prototype,"memberNames",void 0),sr=e([pe("acp-group-view")],sr);const nr=[{key:"sky",labelKey:"editor.main.section_sky_label",descKey:"editor.main.section_sky_desc"},{key:"elevation",labelKey:"editor.main.section_elevation_label",descKey:"editor.main.section_elevation_desc"},{key:"decision",labelKey:"editor.main.section_decision_label",descKey:"editor.main.section_decision_desc"},{key:"covers",labelKey:"editor.main.section_covers_label",descKey:"editor.main.section_covers_desc"},{key:"overrides",labelKey:"editor.main.section_overrides_label",descKey:"editor.main.section_overrides_desc"},{key:"climate",labelKey:"editor.main.section_climate_label",descKey:"editor.main.section_climate_desc"},{key:"solar",labelKey:"editor.main.section_solar_label",descKey:"editor.main.section_solar_desc",enabledByDefault:!1}],rr=nr.filter(e=>!1!==e.enabledByDefault).map(e=>e.key);let ar=class extends de{constructor(){super(...arguments),this._entries=null,this._entriesError=null,this._fetchInFlight=!1}setConfig(e){this._config=e}updated(e){e.has("hass")&&this.hass&&!this._entries&&!this._fetchInFlight&&(this._fetchInFlight=!0,Ro(this.hass).then(e=>{this._entries=e,this._entriesError=null,this._config?.entry_id||1!==e.length||this._emit({...this._config??{type:"",entry_id:""},entry_id:e[0].entry_id})}).catch(e=>{this._entriesError=e?.message??"failed to load config entries"}).finally(()=>{this._fetchInFlight=!1}))}get _currentSections(){return this._config?.show_sections??rr}_emit(e){this._config=e,this.dispatchEvent(new CustomEvent("config-changed",{detail:{config:e},bubbles:!0,composed:!0}))}_onEntryChange(e){const t=e.target.value;this._emit({...this._config??{type:"",entry_id:""},entry_id:t})}_onSectionToggle(e,t){const o=new Set(this._currentSections);t?o.add(e):o.delete(e);const i=nr.map(e=>e.key).filter(e=>o.has(e));this._emit({...this._config??{type:"",entry_id:""},show_sections:i})}_onCompactToggle(e){this._emit({...this._config??{type:"",entry_id:""},compact:e})}_onCompassStatsToggle(e){this._emit({...this._config??{type:"",entry_id:""},show_compass_stats:e})}_onCompassLegendToggle(e){this._emit({...this._config??{type:"",entry_id:""},show_compass_legend:e})}_onMoonToggle(e){this._emit({...this._config??{type:"",entry_id:""},show_moon:e})}_onHideInactiveToggle(e){this._emit({...this._config??{type:"",entry_id:""},hide_inactive_handlers:e})}_onStateColorToggle(e){this._emit({...this._config??{type:"",entry_id:""},state_color:e})}_onNorthOffsetChange(e){const t=parseFloat(e.target.value),o=Number.isFinite(t)?t:0;this._emit({...this._config??{type:"",entry_id:""},north_offset:o})}_onControlToggle(e,t){const o=this._config??{type:"",entry_id:""};this._emit({...o,controls:{...o.controls,[e]:t}})}_onCoverColorChange(e){const t=this._config??{type:"",entry_id:""};this._emit({...t,cover_colors:[e]})}_onCoverColorReset(){const e={...this._config??{type:"",entry_id:""}};delete e.cover_colors,this._emit(e)}render(){if(!this._config)return V;const e=new Set(this._currentSections);return H`
+  `,e([ge({attribute:!1})],br.prototype,"hass",void 0),e([ge({attribute:!1})],br.prototype,"discovered",void 0),e([ge({type:Boolean,reflect:!0})],br.prototype,"compact",void 0),e([ge({attribute:!1})],br.prototype,"memberNames",void 0),e([ge({attribute:!1})],br.prototype,"members",void 0),br=e([pe("acp-group-view")],br);const yr=[{key:"sky",labelKey:"editor.main.section_sky_label",descKey:"editor.main.section_sky_desc"},{key:"elevation",labelKey:"editor.main.section_elevation_label",descKey:"editor.main.section_elevation_desc"},{key:"decision",labelKey:"editor.main.section_decision_label",descKey:"editor.main.section_decision_desc"},{key:"covers",labelKey:"editor.main.section_covers_label",descKey:"editor.main.section_covers_desc"},{key:"overrides",labelKey:"editor.main.section_overrides_label",descKey:"editor.main.section_overrides_desc"},{key:"climate",labelKey:"editor.main.section_climate_label",descKey:"editor.main.section_climate_desc"},{key:"solar",labelKey:"editor.main.section_solar_label",descKey:"editor.main.section_solar_desc",enabledByDefault:!1}],wr=yr.filter(e=>!1!==e.enabledByDefault).map(e=>e.key);let xr=class extends de{constructor(){super(...arguments),this._entries=null,this._entriesError=null,this._fetchInFlight=!1}setConfig(e){this._config=e}updated(e){e.has("hass")&&this.hass&&!this._entries&&!this._fetchInFlight&&(this._fetchInFlight=!0,jo(this.hass).then(e=>{this._entries=e,this._entriesError=null,this._config?.entry_id||1!==e.length||this._emit({...this._config??{type:"",entry_id:""},entry_id:e[0].entry_id})}).catch(e=>{this._entriesError=e?.message??"failed to load config entries"}).finally(()=>{this._fetchInFlight=!1}))}get _currentSections(){return this._config?.show_sections??wr}_emit(e){this._config=e,this.dispatchEvent(new CustomEvent("config-changed",{detail:{config:e},bubbles:!0,composed:!0}))}_onEntryChange(e){const t=e.target.value;this._emit({...this._config??{type:"",entry_id:""},entry_id:t})}_onSectionToggle(e,t){const o=new Set(this._currentSections);t?o.add(e):o.delete(e);const i=yr.map(e=>e.key).filter(e=>o.has(e));this._emit({...this._config??{type:"",entry_id:""},show_sections:i})}_onCompactToggle(e){this._emit({...this._config??{type:"",entry_id:""},compact:e})}_onCompassStatsToggle(e){this._emit({...this._config??{type:"",entry_id:""},show_compass_stats:e})}_onCompassLegendToggle(e){this._emit({...this._config??{type:"",entry_id:""},show_compass_legend:e})}_onMoonToggle(e){this._emit({...this._config??{type:"",entry_id:""},show_moon:e})}_onHideInactiveToggle(e){this._emit({...this._config??{type:"",entry_id:""},hide_inactive_handlers:e})}_onStateColorToggle(e){this._emit({...this._config??{type:"",entry_id:""},state_color:e})}_onNorthOffsetChange(e){const t=parseFloat(e.target.value),o=Number.isFinite(t)?t:0;this._emit({...this._config??{type:"",entry_id:""},north_offset:o})}_onControlToggle(e,t){const o=this._config??{type:"",entry_id:""};this._emit({...o,controls:{...o.controls,[e]:t}})}_onCoverColorChange(e){const t=this._config??{type:"",entry_id:""};this._emit({...t,cover_colors:[e]})}_onCoverColorReset(){const e={...this._config??{type:"",entry_id:""}};delete e.cover_colors,this._emit(e)}render(){if(!this._config)return V;const e=new Set(this._currentSections);return H`
       <div class="form">
         <div class="section">
           <label class="field-label">${st("editor.common.entry_id",this.hass)}</label>
@@ -6205,7 +6394,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
         <div class="section">
           <label class="field-label">${st("editor.main.sections",this.hass)}</label>
           <div class="hint">${st("editor.main.sections_hint",this.hass)}</div>
-          ${nr.map(t=>H`
+          ${yr.map(t=>H`
               <label class="toggle-row">
                 <input
                   type="checkbox"
@@ -6264,7 +6453,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
               <div class="section">
                 <label class="field-label">${st("editor.compass.cover_colors",this.hass)}</label>
                 <div class="hint">${st("editor.compass.cover_colors_hint",this.hass)}</div>
-                ${(()=>{const e=this._config.cover_colors?.[0]??null,t=e??hi(0);return H`
+                ${(()=>{const e=this._config.cover_colors?.[0]??null,t=e??pi(0);return H`
                     <div class="color-row">
                       <input
                         type="color"
@@ -6379,7 +6568,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
             @change=${this._onNorthOffsetChange}
           />
         </div>
-        ${Xn(this.hass)}
+        ${ur(this.hass)}
       </div>
     `}_renderEntryPicker(){return this._entriesError?H`
         <div class="error">
@@ -6408,7 +6597,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
             </option>
           `)}
       </select>
-    `:H`<div class="hint">${st("editor.common.loading_entries",this.hass)}</div>`}};ar.styles=a`
+    `:H`<div class="hint">${st("editor.common.loading_entries",this.hass)}</div>`}};xr.styles=a`
     :host {
       display: block;
     }
@@ -6523,7 +6712,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
     .dim {
       color: var(--secondary-text-color);
     }
-  `,e([ge({attribute:!1})],ar.prototype,"hass",void 0),e([me()],ar.prototype,"_config",void 0),e([me()],ar.prototype,"_entries",void 0),e([me()],ar.prototype,"_entriesError",void 0),ar=e([pe(ye)],ar);const lr=[{key:"compact",labelKey:"editor.compass.toggle_compact_label",descKey:"editor.compass.toggle_compact_desc",defaultOn:!1},{key:"show_legend",labelKey:"editor.compass.toggle_legend_label",descKey:"editor.compass.toggle_legend_desc",defaultOn:!0},{key:"show_stats",labelKey:"editor.compass.toggle_stats_label",descKey:"editor.compass.toggle_stats_desc",defaultOn:!0},{key:"show_moon",labelKey:"editor.compass.toggle_moon_label",descKey:"editor.compass.toggle_moon_desc",defaultOn:!1},{key:"show_cardinals",labelKey:"editor.compass.toggle_cardinals_label",descKey:"editor.compass.toggle_cardinals_desc",defaultOn:!0},{key:"show_blind_spot",labelKey:"editor.compass.toggle_blind_spot_label",descKey:"editor.compass.toggle_blind_spot_desc",defaultOn:!0},{key:"show_sun_path",labelKey:"editor.compass.toggle_sun_path_label",descKey:"editor.compass.toggle_sun_path_desc",defaultOn:!0},{key:"show_sunrise_sunset",labelKey:"editor.compass.toggle_sunrise_sunset_label",descKey:"editor.compass.toggle_sunrise_sunset_desc",defaultOn:!0},{key:"show_cover_fill",labelKey:"editor.compass.toggle_cover_fill_label",descKey:"editor.compass.toggle_cover_fill_desc",defaultOn:!0},{key:"show_window_arrow",labelKey:"editor.compass.toggle_window_arrow_label",descKey:"editor.compass.toggle_window_arrow_desc",defaultOn:!0},{key:"show_elevation_chart",labelKey:"editor.compass.toggle_elevation_chart_label",descKey:"editor.compass.toggle_elevation_chart_desc",defaultOn:!0}];let cr=class extends de{constructor(){super(...arguments),this._entries=null,this._entriesError=null,this._fetchInFlight=!1}setConfig(e){this._config=e}updated(e){e.has("hass")&&this.hass&&!this._entries&&!this._fetchInFlight&&(this._fetchInFlight=!0,Ro(this.hass).then(e=>{this._entries=e,this._entriesError=null}).catch(e=>{this._entriesError=e?.message??"failed to load config entries"}).finally(()=>{this._fetchInFlight=!1}))}_emit(e){this._config=e,this.dispatchEvent(new CustomEvent("config-changed",{detail:{config:e},bubbles:!0,composed:!0}))}_baseConfig(){return this._config??{type:`custom:${we}`,entry_ids:[]}}_trimColors(e){let t=-1;for(let o=0;o<e.length;o++)e[o]&&(t=o);if(!(t<0))return e.slice(0,t+1)}_emitWithColors(e,t,o){const i=this._trimColors(t),{cover_colors:s,...n}=e,r=i?{...n,...o,cover_colors:i}:{...n,...o};this._emit(r)}_onCoverColorChange(e,t){const o=this._baseConfig(),i=[...o.cover_colors??[]];for(;i.length<=e;)i.push(null);i[e]=t,this._emitWithColors(o,i)}_onCoverColorReset(e){const t=this._baseConfig(),o=[...t.cover_colors??[]];e<o.length&&(o[e]=null),this._emitWithColors(t,o)}_onEntryToggle(e,t){const o=this._baseConfig(),i=new Set(o.entry_ids);t?i.add(e):i.delete(e);const s=(this._entries??[]).map(e=>e.entry_id).filter(e=>i.has(e)),n=o.cover_colors??[],r=s.map(e=>{const t=o.entry_ids.indexOf(e);return t>=0?n[t]??null:null});this._emitWithColors(o,r,{entry_ids:s})}_onToggle(e,t){this._emit({...this._baseConfig(),[e]:t})}_onNorthOffsetChange(e){const t=parseFloat(e.target.value),o=Number.isFinite(t)?t:0;this._emit({...this._baseConfig(),north_offset:o})}_onTitleChange(e){const t=e.target.value,o=this._baseConfig();if(t)this._emit({...o,title:t});else{const{title:e,...t}=o;this._emit(t)}}render(){if(!this._config)return V;const e=new Set(this._config.entry_ids);return H`
+  `,e([ge({attribute:!1})],xr.prototype,"hass",void 0),e([me()],xr.prototype,"_config",void 0),e([me()],xr.prototype,"_entries",void 0),e([me()],xr.prototype,"_entriesError",void 0),xr=e([pe(ye)],xr);const $r=[{key:"compact",labelKey:"editor.compass.toggle_compact_label",descKey:"editor.compass.toggle_compact_desc",defaultOn:!1},{key:"show_legend",labelKey:"editor.compass.toggle_legend_label",descKey:"editor.compass.toggle_legend_desc",defaultOn:!0},{key:"show_stats",labelKey:"editor.compass.toggle_stats_label",descKey:"editor.compass.toggle_stats_desc",defaultOn:!0},{key:"show_moon",labelKey:"editor.compass.toggle_moon_label",descKey:"editor.compass.toggle_moon_desc",defaultOn:!1},{key:"show_cardinals",labelKey:"editor.compass.toggle_cardinals_label",descKey:"editor.compass.toggle_cardinals_desc",defaultOn:!0},{key:"show_blind_spot",labelKey:"editor.compass.toggle_blind_spot_label",descKey:"editor.compass.toggle_blind_spot_desc",defaultOn:!0},{key:"show_sun_path",labelKey:"editor.compass.toggle_sun_path_label",descKey:"editor.compass.toggle_sun_path_desc",defaultOn:!0},{key:"show_sunrise_sunset",labelKey:"editor.compass.toggle_sunrise_sunset_label",descKey:"editor.compass.toggle_sunrise_sunset_desc",defaultOn:!0},{key:"show_cover_fill",labelKey:"editor.compass.toggle_cover_fill_label",descKey:"editor.compass.toggle_cover_fill_desc",defaultOn:!0},{key:"show_window_arrow",labelKey:"editor.compass.toggle_window_arrow_label",descKey:"editor.compass.toggle_window_arrow_desc",defaultOn:!0},{key:"show_elevation_chart",labelKey:"editor.compass.toggle_elevation_chart_label",descKey:"editor.compass.toggle_elevation_chart_desc",defaultOn:!0}];let kr=class extends de{constructor(){super(...arguments),this._entries=null,this._entriesError=null,this._fetchInFlight=!1}setConfig(e){this._config=e}updated(e){e.has("hass")&&this.hass&&!this._entries&&!this._fetchInFlight&&(this._fetchInFlight=!0,jo(this.hass).then(e=>{this._entries=e,this._entriesError=null}).catch(e=>{this._entriesError=e?.message??"failed to load config entries"}).finally(()=>{this._fetchInFlight=!1}))}_emit(e){this._config=e,this.dispatchEvent(new CustomEvent("config-changed",{detail:{config:e},bubbles:!0,composed:!0}))}_baseConfig(){return this._config??{type:`custom:${we}`,entry_ids:[]}}_trimColors(e){let t=-1;for(let o=0;o<e.length;o++)e[o]&&(t=o);if(!(t<0))return e.slice(0,t+1)}_emitWithColors(e,t,o){const i=this._trimColors(t),{cover_colors:s,...n}=e,r=i?{...n,...o,cover_colors:i}:{...n,...o};this._emit(r)}_onCoverColorChange(e,t){const o=this._baseConfig(),i=[...o.cover_colors??[]];for(;i.length<=e;)i.push(null);i[e]=t,this._emitWithColors(o,i)}_onCoverColorReset(e){const t=this._baseConfig(),o=[...t.cover_colors??[]];e<o.length&&(o[e]=null),this._emitWithColors(t,o)}_onEntryToggle(e,t){const o=this._baseConfig(),i=new Set(o.entry_ids);t?i.add(e):i.delete(e);const s=(this._entries??[]).map(e=>e.entry_id).filter(e=>i.has(e)),n=o.cover_colors??[],r=s.map(e=>{const t=o.entry_ids.indexOf(e);return t>=0?n[t]??null:null});this._emitWithColors(o,r,{entry_ids:s})}_onToggle(e,t){this._emit({...this._baseConfig(),[e]:t})}_onNorthOffsetChange(e){const t=parseFloat(e.target.value),o=Number.isFinite(t)?t:0;this._emit({...this._baseConfig(),north_offset:o})}_onTitleChange(e){const t=e.target.value,o=this._baseConfig();if(t)this._emit({...o,title:t});else{const{title:e,...t}=o;this._emit(t)}}render(){if(!this._config)return V;const e=new Set(this._config.entry_ids);return H`
       <div class="form">
         <div class="section">
           <label class="field-label">${st("editor.compass.instances",this.hass)}</label>
@@ -6546,7 +6735,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
               <div class="section">
                 <label class="field-label">${st("editor.compass.cover_colors",this.hass)}</label>
                 <div class="hint">${st("editor.compass.cover_colors_hint",this.hass)}</div>
-                ${this._config.entry_ids.map((e,t)=>{const o=this._config.cover_colors?.[t]??null,i=o??hi(t),s=this._entries?.find(t=>t.entry_id===e);return H`
+                ${this._config.entry_ids.map((e,t)=>{const o=this._config.cover_colors?.[t]??null,i=o??pi(t),s=this._entries?.find(t=>t.entry_id===e);return H`
                     <div class="color-row">
                       <input
                         type="color"
@@ -6574,7 +6763,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
 
         <div class="section">
           <label class="field-label">${st("editor.compass.display",this.hass)}</label>
-          ${lr.map(e=>H`
+          ${$r.map(e=>H`
               <label class="toggle-row">
                 <input
                   type="checkbox"
@@ -6601,7 +6790,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
             @change=${this._onNorthOffsetChange}
           />
         </div>
-        ${Xn(this.hass)}
+        ${ur(this.hass)}
       </div>
     `}_renderEntryPicker(e){return this._entriesError?H`<div class="error">
         ${st("editor.common.load_failed",this.hass,{error:this._entriesError})}
@@ -6626,7 +6815,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
             </label>
           `)}
       </div>
-    `:H`<div class="hint">${st("editor.common.loading_entries",this.hass)}</div>`}};cr.styles=a`
+    `:H`<div class="hint">${st("editor.common.loading_entries",this.hass)}</div>`}};kr.styles=a`
     :host {
       display: block;
     }
@@ -6743,7 +6932,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
     .dim {
       color: var(--secondary-text-color);
     }
-  `,e([ge({attribute:!1})],cr.prototype,"hass",void 0),e([me()],cr.prototype,"_config",void 0),e([me()],cr.prototype,"_entries",void 0),e([me()],cr.prototype,"_entriesError",void 0),cr=e([pe(xe)],cr);let dr=class extends de{constructor(){super(...arguments),this._registry=null,this._registryError=null,this._unsubRegistry=null,this._fetchInFlight=!1,this._listMemo=ko(),this._discoveredResult={list:[],missing:[]}}setConfig(e){if(!e||!Array.isArray(e.entry_ids)||0===e.entry_ids.length)throw new Error("adaptive-cover-pro-sky-compass-card: `entry_ids` must be a non-empty array");if(e.entry_ids.some(e=>"string"!=typeof e||0===e.length))throw new Error("adaptive-cover-pro-sky-compass-card: every `entry_ids` entry must be a non-empty string");if(this._config={...e,entry_ids:[...e.entry_ids]},e.tooltips&&bo(e.tooltips),null===this._registry){const e=this._config.entry_ids.map(e=>Lo.get(e)?.entries);e.every(e=>void 0!==e)&&(this._registry=e.flat())}}getCardSize(){return 4}getGridOptions(){return{columns:12,rows:"auto",min_columns:6,max_columns:12}}static async getConfigElement(){return document.createElement(xe)}static async getStubConfig(e){let t=[];try{const o=await Ro(e);o[0]&&(t=[o[0].entry_id])}catch{}return{type:`custom:${we}`,entry_ids:t}}connectedCallback(){if(super.connectedCallback(),null===this._registry){const e=Io();e&&(this._registry=e)}this.hass&&this._ensureRegistry()}disconnectedCallback(){super.disconnectedCallback(),this._unsubRegistry&&(this._unsubRegistry(),this._unsubRegistry=null)}updated(e){e.has("hass")&&this.hass&&this._ensureRegistry()}shouldUpdate(e){if(e.size>1||!e.has("hass"))return!0;const t=[];for(const e of this._discoveredResult.list)t.push(...Object.values(e.entities));return 0===t.length||ve(e.get("hass"),this.hass,t)}willUpdate(e){this._config&&this.hass&&null!==this._registry&&(e.has("hass")||e.has("_registry")||e.has("_config"))&&(this._discoveredResult=this._listMemo(this.hass,this._config.entry_ids,this._registry,this._config.type))}_ensureRegistry(){this._fetchRegistry(),this._unsubRegistry||(this._unsubRegistry=zo(this.hass,()=>{this._fetchRegistry(!0)}))}_fetchRegistry(e=!1){this._fetchInFlight||(this._fetchInFlight=!0,Po(this.hass,e).then(e=>{if(e!==this._registry&&(this._registry=e,this._registryError=null,this._config))for(const t of this._config.entry_ids)Lo.set(t,Go(e,t))}).catch(e=>{this._registryError=e?.message??"entity registry fetch failed"}).finally(()=>{this._fetchInFlight=!1}))}render(){if(!this._config||!this.hass)return V;if(null===this._registry)return H`<ha-card>
+  `,e([ge({attribute:!1})],kr.prototype,"hass",void 0),e([me()],kr.prototype,"_config",void 0),e([me()],kr.prototype,"_entries",void 0),e([me()],kr.prototype,"_entriesError",void 0),kr=e([pe(xe)],kr);let Ar=class extends de{constructor(){super(...arguments),this._registry=null,this._registryError=null,this._unsubRegistry=null,this._fetchInFlight=!1,this._listMemo=Ao(),this._discoveredResult={list:[],missing:[]}}setConfig(e){if(!e||!Array.isArray(e.entry_ids)||0===e.entry_ids.length)throw new Error("adaptive-cover-pro-sky-compass-card: `entry_ids` must be a non-empty array");if(e.entry_ids.some(e=>"string"!=typeof e||0===e.length))throw new Error("adaptive-cover-pro-sky-compass-card: every `entry_ids` entry must be a non-empty string");if(this._config={...e,entry_ids:[...e.entry_ids]},e.tooltips&&yo(e.tooltips),null===this._registry){const e=this._config.entry_ids.map(e=>Lo.get(e)?.entries);e.every(e=>void 0!==e)&&(this._registry=e.flat())}}getCardSize(){return 4}getGridOptions(){return{columns:12,rows:"auto",min_columns:6,max_columns:12}}static async getConfigElement(){return document.createElement(xe)}static async getStubConfig(e){let t=[];try{const o=await jo(e);o[0]&&(t=[o[0].entry_id])}catch{}return{type:`custom:${we}`,entry_ids:t}}connectedCallback(){if(super.connectedCallback(),null===this._registry){const e=Po();e&&(this._registry=e)}this.hass&&this._ensureRegistry()}disconnectedCallback(){super.disconnectedCallback(),this._unsubRegistry&&(this._unsubRegistry(),this._unsubRegistry=null)}updated(e){e.has("hass")&&this.hass&&this._ensureRegistry()}shouldUpdate(e){if(e.size>1||!e.has("hass"))return!0;const t=[];for(const e of this._discoveredResult.list)t.push(...Object.values(e.entities));return 0===t.length||ve(e.get("hass"),this.hass,t)}willUpdate(e){this._config&&this.hass&&null!==this._registry&&(e.has("hass")||e.has("_registry")||e.has("_config"))&&(this._discoveredResult=this._listMemo(this.hass,this._config.entry_ids,this._registry,this._config.type))}_ensureRegistry(){this._fetchRegistry(),this._unsubRegistry||(this._unsubRegistry=Mo(this.hass,()=>{this._fetchRegistry(!0)}))}_fetchRegistry(e=!1){this._fetchInFlight||(this._fetchInFlight=!0,Oo(this.hass,e).then(e=>{if(e!==this._registry&&(this._registry=e,this._registryError=null,this._config))for(const t of this._config.entry_ids)Lo.set(t,Wo(e,t))}).catch(e=>{this._registryError=e?.message??"entity registry fetch failed"}).finally(()=>{this._fetchInFlight=!1}))}render(){if(!this._config||!this.hass)return V;if(null===this._registry)return H`<ha-card>
         <div class="empty">
           <p class="dim">
             ${this._registryError?st("tile.registry_failed",this.hass,{error:this._registryError}):st("root.loading_registry",this.hass)}
@@ -6785,7 +6974,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
               ${st("root.compass_not_found",this.hass,{entries:t.join(", ")})}
             </div>`:V}
       </ha-card>
-    `}};dr.styles=a`
+    `}};Ar.styles=a`
     :host {
       display: block;
     }
@@ -6812,7 +7001,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
       font-size: 0.78rem;
       text-align: center;
     }
-  `,e([ge({attribute:!1})],dr.prototype,"hass",void 0),e([me()],dr.prototype,"_config",void 0),e([me()],dr.prototype,"_registry",void 0),e([me()],dr.prototype,"_registryError",void 0),dr=e([pe(we)],dr),window.customCards=window.customCards||[],window.customCards.some(e=>e.type===we)||window.customCards.push({type:we,name:"Adaptive Cover Pro — Sky Compass",description:"Polar sun-vs-SAA plot; overlay one or more Adaptive Cover Pro entries on a single compass.",preview:!0,documentationURL:"https://github.com/jrhubott/adaptive-cover-pro/wiki/Lovelace-Card",getEntitySuggestion:Fo(`custom:${we}`,"entry_ids")});const hr={compact:!1,hide_inactive_handlers:!1,show_decision_summary:!0},pr={entry_id:"editor.common.entry_id",title:"editor.decision.title",compact:"editor.decision.compact_label",hide_inactive_handlers:"editor.decision.hide_inactive_handlers_label",show_decision_summary:"editor.decision.show_decision_summary_label"},ur={compact:"editor.decision.compact_desc",hide_inactive_handlers:"editor.decision.hide_inactive_handlers_desc",show_decision_summary:"editor.decision.show_decision_summary_desc"};let _r=class extends de{constructor(){super(...arguments),this._entries=null,this._entriesError=null,this._entriesFetchInFlight=!1,this._computeLabel=e=>{const t=pr[e.name];return t?st(t,this.hass):e.name},this._computeHelper=e=>{const t=ur[e.name];return t?st(t,this.hass):void 0},this._valueChanged=e=>{e.stopPropagation();const t={...e.detail.value};for(const[e,o]of Object.entries(hr))this._config&&Object.prototype.hasOwnProperty.call(this._config,e)||t[e]!==o||delete t[e];const o={...this._config??{type:"",entry_id:""},...t};this._emit(o)}}setConfig(e){this._config={...e}}updated(e){e.has("hass")&&this.hass&&this._ensureEntries()}_ensureEntries(){this._entries||this._entriesFetchInFlight||(this._entriesFetchInFlight=!0,Ro(this.hass).then(e=>{this._entries=e,this._entriesError=null,this._config?.entry_id||1!==e.length||this._emit({...this._config??{type:"",entry_id:""},entry_id:e[0].entry_id})}).catch(e=>{this._entriesError=e?.message??"failed to load config entries"}).finally(()=>{this._entriesFetchInFlight=!1}))}_emit(e){this._config=e,this.dispatchEvent(new CustomEvent("config-changed",{detail:{config:e},bubbles:!0,composed:!0}))}render(){if(!this._config)return V;if(this._entriesError&&!this._entries)return H`
+  `,e([ge({attribute:!1})],Ar.prototype,"hass",void 0),e([me()],Ar.prototype,"_config",void 0),e([me()],Ar.prototype,"_registry",void 0),e([me()],Ar.prototype,"_registryError",void 0),Ar=e([pe(we)],Ar),window.customCards=window.customCards||[],window.customCards.some(e=>e.type===we)||window.customCards.push({type:we,name:"Adaptive Cover Pro — Sky Compass",description:"Polar sun-vs-SAA plot; overlay one or more Adaptive Cover Pro entries on a single compass.",preview:!0,documentationURL:"https://github.com/jrhubott/adaptive-cover-pro/wiki/Lovelace-Card",getEntitySuggestion:Ro(`custom:${we}`,"entry_ids")});const Sr={compact:!1,hide_inactive_handlers:!1,show_decision_summary:!0},Cr={entry_id:"editor.common.entry_id",title:"editor.decision.title",compact:"editor.decision.compact_label",hide_inactive_handlers:"editor.decision.hide_inactive_handlers_label",show_decision_summary:"editor.decision.show_decision_summary_label"},Er={compact:"editor.decision.compact_desc",hide_inactive_handlers:"editor.decision.hide_inactive_handlers_desc",show_decision_summary:"editor.decision.show_decision_summary_desc"};let zr=class extends de{constructor(){super(...arguments),this._entries=null,this._entriesError=null,this._entriesFetchInFlight=!1,this._computeLabel=e=>{const t=Cr[e.name];return t?st(t,this.hass):e.name},this._computeHelper=e=>{const t=Er[e.name];return t?st(t,this.hass):void 0},this._valueChanged=e=>{e.stopPropagation();const t={...e.detail.value};for(const[e,o]of Object.entries(Sr))this._config&&Object.prototype.hasOwnProperty.call(this._config,e)||t[e]!==o||delete t[e];const o={...this._config??{type:"",entry_id:""},...t};this._emit(o)}}setConfig(e){this._config={...e}}updated(e){e.has("hass")&&this.hass&&this._ensureEntries()}_ensureEntries(){this._entries||this._entriesFetchInFlight||(this._entriesFetchInFlight=!0,jo(this.hass).then(e=>{this._entries=e,this._entriesError=null,this._config?.entry_id||1!==e.length||this._emit({...this._config??{type:"",entry_id:""},entry_id:e[0].entry_id})}).catch(e=>{this._entriesError=e?.message??"failed to load config entries"}).finally(()=>{this._entriesFetchInFlight=!1}))}_emit(e){this._config=e,this.dispatchEvent(new CustomEvent("config-changed",{detail:{config:e},bubbles:!0,composed:!0}))}render(){if(!this._config)return V;if(this._entriesError&&!this._entries)return H`
         <div class="form">
           <div class="error">
             ${st("editor.common.load_failed",this.hass,{error:this._entriesError})}
@@ -6828,9 +7017,9 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
             placeholder=${st("editor.common.entry_id_manual_placeholder",this.hass)}
             @change=${e=>this._emit({...this._config??{type:"",entry_id:""},entry_id:e.target.value})}
           />
-          ${Xn(this.hass)}
+          ${ur(this.hass)}
         </div>
-      `;const e=this._schema(),t={...hr,...this._config};return H`
+      `;const e=this._schema(),t={...Sr,...this._config};return H`
       <div class="form">
         <ha-form
           .hass=${this.hass}
@@ -6840,9 +7029,9 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
           .computeHelper=${this._computeHelper}
           @value-changed=${this._valueChanged}
         ></ha-form>
-        ${Xn(this.hass)}
+        ${ur(this.hass)}
       </div>
-    `}_schema(){const e=this._entries?.map(e=>({value:e.entry_id,label:e.title}))??[];return[{name:"entry_id",required:!0,selector:{select:{options:e,mode:"dropdown"}}},{name:"title",selector:{text:{}}},{name:"compact",selector:{boolean:{}}},{name:"hide_inactive_handlers",selector:{boolean:{}}},{name:"show_decision_summary",selector:{boolean:{}}}]}};_r.styles=a`
+    `}_schema(){const e=this._entries?.map(e=>({value:e.entry_id,label:e.title}))??[];return[{name:"entry_id",required:!0,selector:{select:{options:e,mode:"dropdown"}}},{name:"title",selector:{text:{}}},{name:"compact",selector:{boolean:{}}},{name:"hide_inactive_handlers",selector:{boolean:{}}},{name:"show_decision_summary",selector:{boolean:{}}}]}};zr.styles=a`
     :host {
       display: block;
     }
@@ -6878,7 +7067,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
     .dim {
       color: var(--secondary-text-color);
     }
-  `,e([ge({attribute:!1})],_r.prototype,"hass",void 0),e([me()],_r.prototype,"_config",void 0),e([me()],_r.prototype,"_entries",void 0),e([me()],_r.prototype,"_entriesError",void 0),_r=e([pe(Se)],_r);let gr=class extends de{constructor(){super(...arguments),this._registry=null,this._registryError=null,this._historyOpen=!1,this._unsubRegistry=null,this._fetchInFlight=!1,this._fetchGen=0,this._memo=$o(),this._discovered=null}setConfig(e){if(!e||"string"!=typeof e.entry_id||0===e.entry_id.length)throw new Error(`${Ae}: \`entry_id\` is required and must be a non-empty string`);if(this._config={...e},e.tooltips&&bo(e.tooltips),null===this._registry){const t=Lo.get(e.entry_id);t&&(this._registry=t.entries)}}getCardSize(){return 3}getGridOptions(){return{columns:12,rows:"auto",min_columns:4,max_columns:12}}static async getStubConfig(e){let t="";try{const o=await Ro(e);t=o[0]?.entry_id??""}catch{}return{type:`custom:${Ae}`,entry_id:t}}static async getConfigElement(){return document.createElement(Se)}connectedCallback(){if(super.connectedCallback(),null===this._registry){const e=Io();e&&(this._registry=e)}this.hass&&this._ensureRegistry()}disconnectedCallback(){super.disconnectedCallback(),this._unsubRegistry&&(this._unsubRegistry(),this._unsubRegistry=null)}updated(e){e.has("hass")&&this.hass&&this._ensureRegistry()}shouldUpdate(e){return e.size>1||!e.has("hass")||(!this._discovered||ve(e.get("hass"),this.hass,Object.values(this._discovered.entities)))}willUpdate(e){this._config&&this.hass&&null!==this._registry&&(e.has("hass")||e.has("_registry")||e.has("_config"))&&(this._discovered=this._memo(this.hass,{type:this._config.type,entry_id:this._config.entry_id},this._registry))}_ensureRegistry(){this._fetchRegistry(),this._unsubRegistry||(this._unsubRegistry=zo(this.hass,()=>{this._fetchRegistry(!0)}))}_fetchRegistry(e=!1){if(this._fetchInFlight)return;this._fetchInFlight=!0;const t=++this._fetchGen;Po(this.hass,e).then(e=>{t===this._fetchGen&&e!==this._registry&&(this._registry=e,this._registryError=null,this._config&&Lo.set(this._config.entry_id,Go(e,this._config.entry_id)))}).catch(e=>{t===this._fetchGen&&(this._registryError=e?.message??"entity registry fetch failed")}).finally(()=>{t===this._fetchGen&&(this._fetchInFlight=!1)})}render(){if(!this._config||!this.hass)return V;if(null===this._registry)return H`<ha-card>
+  `,e([ge({attribute:!1})],zr.prototype,"hass",void 0),e([me()],zr.prototype,"_config",void 0),e([me()],zr.prototype,"_entries",void 0),e([me()],zr.prototype,"_entriesError",void 0),zr=e([pe(Se)],zr);let Mr=class extends de{constructor(){super(...arguments),this._registry=null,this._registryError=null,this._historyOpen=!1,this._unsubRegistry=null,this._fetchInFlight=!1,this._fetchGen=0,this._memo=ko(),this._discovered=null}setConfig(e){if(!e||"string"!=typeof e.entry_id||0===e.entry_id.length)throw new Error(`${Ae}: \`entry_id\` is required and must be a non-empty string`);if(this._config={...e},e.tooltips&&yo(e.tooltips),null===this._registry){const t=Lo.get(e.entry_id);t&&(this._registry=t.entries)}}getCardSize(){return 3}getGridOptions(){return{columns:12,rows:"auto",min_columns:4,max_columns:12}}static async getStubConfig(e){let t="";try{const o=await jo(e);t=o[0]?.entry_id??""}catch{}return{type:`custom:${Ae}`,entry_id:t}}static async getConfigElement(){return document.createElement(Se)}connectedCallback(){if(super.connectedCallback(),null===this._registry){const e=Po();e&&(this._registry=e)}this.hass&&this._ensureRegistry()}disconnectedCallback(){super.disconnectedCallback(),this._unsubRegistry&&(this._unsubRegistry(),this._unsubRegistry=null)}updated(e){e.has("hass")&&this.hass&&this._ensureRegistry()}shouldUpdate(e){return e.size>1||!e.has("hass")||(!this._discovered||ve(e.get("hass"),this.hass,Object.values(this._discovered.entities)))}willUpdate(e){this._config&&this.hass&&null!==this._registry&&(e.has("hass")||e.has("_registry")||e.has("_config"))&&(this._discovered=this._memo(this.hass,{type:this._config.type,entry_id:this._config.entry_id},this._registry))}_ensureRegistry(){this._fetchRegistry(),this._unsubRegistry||(this._unsubRegistry=Mo(this.hass,()=>{this._fetchRegistry(!0)}))}_fetchRegistry(e=!1){if(this._fetchInFlight)return;this._fetchInFlight=!0;const t=++this._fetchGen;Oo(this.hass,e).then(e=>{t===this._fetchGen&&e!==this._registry&&(this._registry=e,this._registryError=null,this._config&&Lo.set(this._config.entry_id,Wo(e,this._config.entry_id)))}).catch(e=>{t===this._fetchGen&&(this._registryError=e?.message??"entity registry fetch failed")}).finally(()=>{t===this._fetchGen&&(this._fetchInFlight=!1)})}render(){if(!this._config||!this.hass)return V;if(null===this._registry)return H`<ha-card>
         <div class="empty">
           <p class="dim">
             ${this._registryError?st("tile.registry_failed",this.hass,{error:this._registryError}):st("tile.loading",this.hass)}
@@ -6918,7 +7107,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
         .open=${this._historyOpen}
         @acp-history-closed=${()=>{this._historyOpen=!1}}
       ></acp-history-dialog>
-    `}};gr.styles=a`
+    `}};Mr.styles=a`
     :host {
       display: block;
     }
@@ -6966,7 +7155,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
       color: var(--secondary-text-color);
       margin: 0;
     }
-  `,e([ge({attribute:!1})],gr.prototype,"hass",void 0),e([me()],gr.prototype,"_config",void 0),e([me()],gr.prototype,"_registry",void 0),e([me()],gr.prototype,"_registryError",void 0),e([me()],gr.prototype,"_historyOpen",void 0),gr=e([pe(Ae)],gr),window.customCards=window.customCards||[],window.customCards.some(e=>e.type===Ae)||window.customCards.push({type:Ae,name:"Adaptive Cover Pro — Decision Strip",description:"Standalone decision strip: all pipeline handlers for one Adaptive Cover Pro instance with the winning row highlighted.",preview:!0,documentationURL:"https://github.com/jrhubott/adaptive-cover-pro/wiki/Lovelace-Card",getEntitySuggestion:Fo(`custom:${Ae}`,"entry_id")});let mr=class extends de{constructor(){super(...arguments),this._entries=null,this._entriesError=null,this._fetchInFlight=!1}setConfig(e){this._config=e}updated(e){e.has("hass")&&this.hass&&!this._entries&&!this._fetchInFlight&&(this._fetchInFlight=!0,Ro(this.hass).then(e=>{this._entries=e,this._entriesError=null}).catch(e=>{this._entriesError=e?.message??"failed to load config entries"}).finally(()=>{this._fetchInFlight=!1}))}_emit(e){this._config=e,this.dispatchEvent(new CustomEvent("config-changed",{detail:{config:e},bubbles:!0,composed:!0}))}_baseConfig(){return this._config??{type:`custom:${Ce}`,entry_ids:[]}}_trimColors(e){let t=-1;for(let o=0;o<e.length;o++)e[o]&&(t=o);if(!(t<0))return e.slice(0,t+1)}_emitWithColors(e,t,o){const i=this._trimColors(t),{cover_colors:s,...n}=e,r=i?{...n,...o,cover_colors:i}:{...n,...o};this._emit(r)}_onCoverColorChange(e,t){const o=this._baseConfig(),i=[...o.cover_colors??[]];for(;i.length<=e;)i.push(null);i[e]=t,this._emitWithColors(o,i)}_onCoverColorReset(e){const t=this._baseConfig(),o=[...t.cover_colors??[]];e<o.length&&(o[e]=null),this._emitWithColors(t,o)}_onEntryToggle(e,t){const o=this._baseConfig(),i=new Set(o.entry_ids);t?i.add(e):i.delete(e);const s=(this._entries??[]).map(e=>e.entry_id).filter(e=>i.has(e)),n=o.cover_colors??[],r=s.map(e=>{const t=o.entry_ids.indexOf(e);return t>=0?n[t]??null:null});this._emitWithColors(o,r,{entry_ids:s})}_onToggle(e,t){this._emit({...this._baseConfig(),[e]:t})}_onTitleChange(e){const t=e.target.value,o=this._baseConfig();if(t)this._emit({...o,title:t});else{const{title:e,...t}=o;this._emit(t)}}render(){if(!this._config)return V;const e=new Set(this._config.entry_ids);return H`
+  `,e([ge({attribute:!1})],Mr.prototype,"hass",void 0),e([me()],Mr.prototype,"_config",void 0),e([me()],Mr.prototype,"_registry",void 0),e([me()],Mr.prototype,"_registryError",void 0),e([me()],Mr.prototype,"_historyOpen",void 0),Mr=e([pe(Ae)],Mr),window.customCards=window.customCards||[],window.customCards.some(e=>e.type===Ae)||window.customCards.push({type:Ae,name:"Adaptive Cover Pro — Decision Strip",description:"Standalone decision strip: all pipeline handlers for one Adaptive Cover Pro instance with the winning row highlighted.",preview:!0,documentationURL:"https://github.com/jrhubott/adaptive-cover-pro/wiki/Lovelace-Card",getEntitySuggestion:Ro(`custom:${Ae}`,"entry_id")});let Tr=class extends de{constructor(){super(...arguments),this._entries=null,this._entriesError=null,this._fetchInFlight=!1}setConfig(e){this._config=e}updated(e){e.has("hass")&&this.hass&&!this._entries&&!this._fetchInFlight&&(this._fetchInFlight=!0,jo(this.hass).then(e=>{this._entries=e,this._entriesError=null}).catch(e=>{this._entriesError=e?.message??"failed to load config entries"}).finally(()=>{this._fetchInFlight=!1}))}_emit(e){this._config=e,this.dispatchEvent(new CustomEvent("config-changed",{detail:{config:e},bubbles:!0,composed:!0}))}_baseConfig(){return this._config??{type:`custom:${Ce}`,entry_ids:[]}}_trimColors(e){let t=-1;for(let o=0;o<e.length;o++)e[o]&&(t=o);if(!(t<0))return e.slice(0,t+1)}_emitWithColors(e,t,o){const i=this._trimColors(t),{cover_colors:s,...n}=e,r=i?{...n,...o,cover_colors:i}:{...n,...o};this._emit(r)}_onCoverColorChange(e,t){const o=this._baseConfig(),i=[...o.cover_colors??[]];for(;i.length<=e;)i.push(null);i[e]=t,this._emitWithColors(o,i)}_onCoverColorReset(e){const t=this._baseConfig(),o=[...t.cover_colors??[]];e<o.length&&(o[e]=null),this._emitWithColors(t,o)}_onEntryToggle(e,t){const o=this._baseConfig(),i=new Set(o.entry_ids);t?i.add(e):i.delete(e);const s=(this._entries??[]).map(e=>e.entry_id).filter(e=>i.has(e)),n=o.cover_colors??[],r=s.map(e=>{const t=o.entry_ids.indexOf(e);return t>=0?n[t]??null:null});this._emitWithColors(o,r,{entry_ids:s})}_onToggle(e,t){this._emit({...this._baseConfig(),[e]:t})}_onTitleChange(e){const t=e.target.value,o=this._baseConfig();if(t)this._emit({...o,title:t});else{const{title:e,...t}=o;this._emit(t)}}render(){if(!this._config)return V;const e=new Set(this._config.entry_ids);return H`
       <div class="form">
         <div class="section">
           <label class="field-label">${st("editor.solar_chart.instances",this.hass)}</label>
@@ -6991,7 +7180,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
                   >${st("editor.solar_chart.cover_colors",this.hass)}</label
                 >
                 <div class="hint">${st("editor.solar_chart.cover_colors_hint",this.hass)}</div>
-                ${this._config.entry_ids.map((e,t)=>{const o=this._config.cover_colors?.[t]??null,i=o??hi(t),s=this._entries?.find(t=>t.entry_id===e);return H`
+                ${this._config.entry_ids.map((e,t)=>{const o=this._config.cover_colors?.[t]??null,i=o??pi(t),s=this._entries?.find(t=>t.entry_id===e);return H`
                     <div class="color-row">
                       <input
                         type="color"
@@ -7035,7 +7224,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
             </span>
           </label>
         </div>
-        ${Xn(this.hass)}
+        ${ur(this.hass)}
       </div>
     `}_renderEntryPicker(e){return this._entriesError?H`<div class="error">
         ${st("editor.common.load_failed",this.hass,{error:this._entriesError})}
@@ -7060,7 +7249,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
             </label>
           `)}
       </div>
-    `:H`<div class="hint">${st("editor.common.loading_entries",this.hass)}</div>`}};mr.styles=a`
+    `:H`<div class="hint">${st("editor.common.loading_entries",this.hass)}</div>`}};Tr.styles=a`
     :host {
       display: block;
     }
@@ -7177,7 +7366,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
     .dim {
       color: var(--secondary-text-color);
     }
-  `,e([ge({attribute:!1})],mr.prototype,"hass",void 0),e([me()],mr.prototype,"_config",void 0),e([me()],mr.prototype,"_entries",void 0),e([me()],mr.prototype,"_entriesError",void 0),mr=e([pe(Ee)],mr);let vr=class extends de{constructor(){super(...arguments),this._registry=null,this._registryError=null,this._unsubRegistry=null,this._fetchInFlight=!1,this._listMemo=ko(),this._discoveredResult={list:[],missing:[]}}setConfig(e){if(!e||!Array.isArray(e.entry_ids)||0===e.entry_ids.length)throw new Error("adaptive-cover-pro-solar-chart-card: `entry_ids` must be a non-empty array");if(e.entry_ids.some(e=>"string"!=typeof e||0===e.length))throw new Error("adaptive-cover-pro-solar-chart-card: every `entry_ids` entry must be a non-empty string");if(this._config={...e,entry_ids:[...e.entry_ids]},e.tooltips&&bo(e.tooltips),null===this._registry){const e=this._config.entry_ids.map(e=>Lo.get(e)?.entries);e.every(e=>void 0!==e)&&(this._registry=e.flat())}}getCardSize(){return 2}getGridOptions(){return{columns:12,rows:"auto",min_columns:6,max_columns:12}}static async getConfigElement(){return document.createElement(Ee)}static async getStubConfig(e){let t=[];try{const o=await Ro(e);o[0]&&(t=[o[0].entry_id])}catch{}return{type:`custom:${Ce}`,entry_ids:t}}connectedCallback(){if(super.connectedCallback(),null===this._registry){const e=Io();e&&(this._registry=e)}this.hass&&this._ensureRegistry()}disconnectedCallback(){super.disconnectedCallback(),this._unsubRegistry&&(this._unsubRegistry(),this._unsubRegistry=null)}updated(e){e.has("hass")&&this.hass&&this._ensureRegistry()}shouldUpdate(e){if(e.size>1||!e.has("hass"))return!0;const t=[];for(const e of this._discoveredResult.list)t.push(...Object.values(e.entities));return 0===t.length||ve(e.get("hass"),this.hass,t)}willUpdate(e){this._config&&this.hass&&null!==this._registry&&(e.has("hass")||e.has("_registry")||e.has("_config"))&&(this._discoveredResult=this._listMemo(this.hass,this._config.entry_ids,this._registry,this._config.type))}_ensureRegistry(){this._fetchRegistry(),this._unsubRegistry||(this._unsubRegistry=zo(this.hass,()=>{this._fetchRegistry(!0)}))}_fetchRegistry(e=!1){this._fetchInFlight||(this._fetchInFlight=!0,Po(this.hass,e).then(e=>{if(e!==this._registry&&(this._registry=e,this._registryError=null,this._config))for(const t of this._config.entry_ids)Lo.set(t,Go(e,t))}).catch(e=>{this._registryError=e?.message??"entity registry fetch failed"}).finally(()=>{this._fetchInFlight=!1}))}render(){if(!this._config||!this.hass)return V;if(null===this._registry)return H`<ha-card>
+  `,e([ge({attribute:!1})],Tr.prototype,"hass",void 0),e([me()],Tr.prototype,"_config",void 0),e([me()],Tr.prototype,"_entries",void 0),e([me()],Tr.prototype,"_entriesError",void 0),Tr=e([pe(Ee)],Tr);let Ir=class extends de{constructor(){super(...arguments),this._registry=null,this._registryError=null,this._unsubRegistry=null,this._fetchInFlight=!1,this._listMemo=Ao(),this._discoveredResult={list:[],missing:[]}}setConfig(e){if(!e||!Array.isArray(e.entry_ids)||0===e.entry_ids.length)throw new Error("adaptive-cover-pro-solar-chart-card: `entry_ids` must be a non-empty array");if(e.entry_ids.some(e=>"string"!=typeof e||0===e.length))throw new Error("adaptive-cover-pro-solar-chart-card: every `entry_ids` entry must be a non-empty string");if(this._config={...e,entry_ids:[...e.entry_ids]},e.tooltips&&yo(e.tooltips),null===this._registry){const e=this._config.entry_ids.map(e=>Lo.get(e)?.entries);e.every(e=>void 0!==e)&&(this._registry=e.flat())}}getCardSize(){return 2}getGridOptions(){return{columns:12,rows:"auto",min_columns:6,max_columns:12}}static async getConfigElement(){return document.createElement(Ee)}static async getStubConfig(e){let t=[];try{const o=await jo(e);o[0]&&(t=[o[0].entry_id])}catch{}return{type:`custom:${Ce}`,entry_ids:t}}connectedCallback(){if(super.connectedCallback(),null===this._registry){const e=Po();e&&(this._registry=e)}this.hass&&this._ensureRegistry()}disconnectedCallback(){super.disconnectedCallback(),this._unsubRegistry&&(this._unsubRegistry(),this._unsubRegistry=null)}updated(e){e.has("hass")&&this.hass&&this._ensureRegistry()}shouldUpdate(e){if(e.size>1||!e.has("hass"))return!0;const t=[];for(const e of this._discoveredResult.list)t.push(...Object.values(e.entities));return 0===t.length||ve(e.get("hass"),this.hass,t)}willUpdate(e){this._config&&this.hass&&null!==this._registry&&(e.has("hass")||e.has("_registry")||e.has("_config"))&&(this._discoveredResult=this._listMemo(this.hass,this._config.entry_ids,this._registry,this._config.type))}_ensureRegistry(){this._fetchRegistry(),this._unsubRegistry||(this._unsubRegistry=Mo(this.hass,()=>{this._fetchRegistry(!0)}))}_fetchRegistry(e=!1){this._fetchInFlight||(this._fetchInFlight=!0,Oo(this.hass,e).then(e=>{if(e!==this._registry&&(this._registry=e,this._registryError=null,this._config))for(const t of this._config.entry_ids)Lo.set(t,Wo(e,t))}).catch(e=>{this._registryError=e?.message??"entity registry fetch failed"}).finally(()=>{this._fetchInFlight=!1}))}render(){if(!this._config||!this.hass)return V;if(null===this._registry)return H`<ha-card>
         <div class="empty">
           <p class="dim">
             ${this._registryError?st("tile.registry_failed",this.hass,{error:this._registryError}):st("root.loading_registry",this.hass)}
@@ -7203,7 +7392,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
               ${st("root.compass_not_found",this.hass,{entries:t.join(", ")})}
             </div>`:V}
       </ha-card>
-    `}};vr.styles=a`
+    `}};Ir.styles=a`
     :host {
       display: block;
     }
@@ -7230,7 +7419,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
       font-size: 0.78rem;
       text-align: center;
     }
-  `,e([ge({attribute:!1})],vr.prototype,"hass",void 0),e([me()],vr.prototype,"_config",void 0),e([me()],vr.prototype,"_registry",void 0),e([me()],vr.prototype,"_registryError",void 0),vr=e([pe(Ce)],vr),window.customCards=window.customCards||[],window.customCards.some(e=>e.type===Ce)||window.customCards.push({type:Ce,name:"Adaptive Cover Pro — Solar Chart",description:"Standalone solar elevation-vs-time chart; overlay one or more entries’ field-of-view windows.",preview:!0,documentationURL:"https://github.com/jrhubott/adaptive-cover-pro/wiki/Lovelace-Card",getEntitySuggestion:Fo(`custom:${Ce}`,"entry_ids")});const fr={hours:24,advanced_open:!1,hide_advanced:!1,track_position:!0,track_who_won:!0,track_context:!0,track_actions:!0},br={track_position:"position",track_who_won:"who_won",track_context:"context",track_actions:"actions"},yr={entry_id:"editor.common.entry_id",title:"editor.history.title",hours:"editor.history.hours_label",advanced_open:"editor.history.advanced_open_label",hide_advanced:"editor.history.hide_advanced_label",track_position:"editor.history.track_position_label",track_who_won:"editor.history.track_who_won_label",track_context:"editor.history.track_context_label",track_actions:"editor.history.track_actions_label"},wr={hours:"editor.history.hours_desc",advanced_open:"editor.history.advanced_open_desc",hide_advanced:"editor.history.hide_advanced_desc",track_position:"editor.history.track_position_desc",track_who_won:"editor.history.track_who_won_desc",track_context:"editor.history.track_context_desc",track_actions:"editor.history.track_actions_desc"};let xr=class extends de{constructor(){super(...arguments),this._entries=null,this._entriesError=null,this._entriesFetchInFlight=!1,this._computeLabel=e=>{const t=yr[e.name];return t?st(t,this.hass):e.name},this._computeHelper=e=>{const t=wr[e.name];return t?st(t,this.hass):void 0},this._valueChanged=e=>{e.stopPropagation();const t={...e.detail.value},o={};for(const[e,i]of Object.entries(br))!1===t[e]&&(o[i]=!1),delete t[e];for(const[e,o]of Object.entries(fr))e in br||this._config&&Object.prototype.hasOwnProperty.call(this._config,e)||t[e]!==o||delete t[e];const i={...this._config??{type:"",entry_id:""},...t};Object.keys(o).length>0?i.tracks=o:delete i.tracks,this._emit(i)}}setConfig(e){this._config={...e}}updated(e){e.has("hass")&&this.hass&&this._ensureEntries()}_ensureEntries(){this._entries||this._entriesFetchInFlight||(this._entriesFetchInFlight=!0,Ro(this.hass).then(e=>{this._entries=e,this._entriesError=null,this._config?.entry_id||1!==e.length||this._emit({...this._config??{type:"",entry_id:""},entry_id:e[0].entry_id})}).catch(e=>{this._entriesError=e?.message??"failed to load config entries"}).finally(()=>{this._entriesFetchInFlight=!1}))}_emit(e){this._config=e,this.dispatchEvent(new CustomEvent("config-changed",{detail:{config:e},bubbles:!0,composed:!0}))}render(){if(!this._config)return V;if(this._entriesError&&!this._entries)return H`
+  `,e([ge({attribute:!1})],Ir.prototype,"hass",void 0),e([me()],Ir.prototype,"_config",void 0),e([me()],Ir.prototype,"_registry",void 0),e([me()],Ir.prototype,"_registryError",void 0),Ir=e([pe(Ce)],Ir),window.customCards=window.customCards||[],window.customCards.some(e=>e.type===Ce)||window.customCards.push({type:Ce,name:"Adaptive Cover Pro — Solar Chart",description:"Standalone solar elevation-vs-time chart; overlay one or more entries’ field-of-view windows.",preview:!0,documentationURL:"https://github.com/jrhubott/adaptive-cover-pro/wiki/Lovelace-Card",getEntitySuggestion:Ro(`custom:${Ce}`,"entry_ids")});const Pr={hours:24,advanced_open:!1,hide_advanced:!1,track_position:!0,track_who_won:!0,track_context:!0,track_actions:!0},Or={track_position:"position",track_who_won:"who_won",track_context:"context",track_actions:"actions"},Nr={entry_id:"editor.common.entry_id",title:"editor.history.title",hours:"editor.history.hours_label",advanced_open:"editor.history.advanced_open_label",hide_advanced:"editor.history.hide_advanced_label",track_position:"editor.history.track_position_label",track_who_won:"editor.history.track_who_won_label",track_context:"editor.history.track_context_label",track_actions:"editor.history.track_actions_label"},Dr={hours:"editor.history.hours_desc",advanced_open:"editor.history.advanced_open_desc",hide_advanced:"editor.history.hide_advanced_desc",track_position:"editor.history.track_position_desc",track_who_won:"editor.history.track_who_won_desc",track_context:"editor.history.track_context_desc",track_actions:"editor.history.track_actions_desc"};let Fr=class extends de{constructor(){super(...arguments),this._entries=null,this._entriesError=null,this._entriesFetchInFlight=!1,this._computeLabel=e=>{const t=Nr[e.name];return t?st(t,this.hass):e.name},this._computeHelper=e=>{const t=Dr[e.name];return t?st(t,this.hass):void 0},this._valueChanged=e=>{e.stopPropagation();const t={...e.detail.value},o={};for(const[e,i]of Object.entries(Or))!1===t[e]&&(o[i]=!1),delete t[e];for(const[e,o]of Object.entries(Pr))e in Or||this._config&&Object.prototype.hasOwnProperty.call(this._config,e)||t[e]!==o||delete t[e];const i={...this._config??{type:"",entry_id:""},...t};Object.keys(o).length>0?i.tracks=o:delete i.tracks,this._emit(i)}}setConfig(e){this._config={...e}}updated(e){e.has("hass")&&this.hass&&this._ensureEntries()}_ensureEntries(){this._entries||this._entriesFetchInFlight||(this._entriesFetchInFlight=!0,jo(this.hass).then(e=>{this._entries=e,this._entriesError=null,this._config?.entry_id||1!==e.length||this._emit({...this._config??{type:"",entry_id:""},entry_id:e[0].entry_id})}).catch(e=>{this._entriesError=e?.message??"failed to load config entries"}).finally(()=>{this._entriesFetchInFlight=!1}))}_emit(e){this._config=e,this.dispatchEvent(new CustomEvent("config-changed",{detail:{config:e},bubbles:!0,composed:!0}))}render(){if(!this._config)return V;if(this._entriesError&&!this._entries)return H`
         <div class="form">
           <div class="error">
             ${st("editor.common.load_failed",this.hass,{error:this._entriesError})}
@@ -7246,9 +7435,9 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
             placeholder=${st("editor.common.entry_id_manual_placeholder",this.hass)}
             @change=${e=>this._emit({...this._config??{type:"",entry_id:""},entry_id:e.target.value})}
           />
-          ${Xn(this.hass)}
+          ${ur(this.hass)}
         </div>
-      `;const e=this._config,t={...fr,...e,track_position:!1!==e.tracks?.position,track_who_won:!1!==e.tracks?.who_won,track_context:!1!==e.tracks?.context,track_actions:!1!==e.tracks?.actions};return H`
+      `;const e=this._config,t={...Pr,...e,track_position:!1!==e.tracks?.position,track_who_won:!1!==e.tracks?.who_won,track_context:!1!==e.tracks?.context,track_actions:!1!==e.tracks?.actions};return H`
       <div class="form">
         <ha-form
           .hass=${this.hass}
@@ -7258,9 +7447,9 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
           .computeHelper=${this._computeHelper}
           @value-changed=${this._valueChanged}
         ></ha-form>
-        ${Xn(this.hass)}
+        ${ur(this.hass)}
       </div>
-    `}_schema(){const e=this._entries?.map(e=>({value:e.entry_id,label:e.title}))??[],t=Xe.map(e=>({value:e,label:st("history.window_hours",this.hass,{hours:e})}));return[{name:"entry_id",required:!0,selector:{select:{options:e,mode:"dropdown"}}},{name:"title",selector:{text:{}}},{name:"hours",selector:{select:{options:t,mode:"dropdown"}}},{name:"track_position",selector:{boolean:{}}},{name:"track_who_won",selector:{boolean:{}}},{name:"track_context",selector:{boolean:{}}},{name:"track_actions",selector:{boolean:{}}},{name:"advanced_open",selector:{boolean:{}}},{name:"hide_advanced",selector:{boolean:{}}}]}};xr.styles=a`
+    `}_schema(){const e=this._entries?.map(e=>({value:e.entry_id,label:e.title}))??[],t=Xe.map(e=>({value:e,label:st("history.window_hours",this.hass,{hours:e})}));return[{name:"entry_id",required:!0,selector:{select:{options:e,mode:"dropdown"}}},{name:"title",selector:{text:{}}},{name:"hours",selector:{select:{options:t,mode:"dropdown"}}},{name:"track_position",selector:{boolean:{}}},{name:"track_who_won",selector:{boolean:{}}},{name:"track_context",selector:{boolean:{}}},{name:"track_actions",selector:{boolean:{}}},{name:"advanced_open",selector:{boolean:{}}},{name:"hide_advanced",selector:{boolean:{}}}]}};Fr.styles=a`
     :host {
       display: block;
     }
@@ -7296,7 +7485,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
     .dim {
       color: var(--secondary-text-color);
     }
-  `,e([ge({attribute:!1})],xr.prototype,"hass",void 0),e([me()],xr.prototype,"_config",void 0),e([me()],xr.prototype,"_entries",void 0),e([me()],xr.prototype,"_entriesError",void 0),xr=e([pe(Me)],xr);let $r=class extends de{constructor(){super(...arguments),this._registry=null,this._registryError=null,this._unsubRegistry=null,this._fetchInFlight=!1,this._fetchGen=0,this._memo=$o(),this._discovered=null}setConfig(e){if(!e||"string"!=typeof e.entry_id||0===e.entry_id.length)throw new Error(`${ze}: \`entry_id\` is required and must be a non-empty string`);if(void 0!==e.hours&&("number"!=typeof e.hours||e.hours<=0))throw new Error(`${ze}: \`hours\` must be a positive number`);if(this._config={...e},e.tooltips&&bo(e.tooltips),null===this._registry){const t=Lo.get(e.entry_id);t&&(this._registry=t.entries)}}getCardSize(){return 6}getGridOptions(){return{columns:12,rows:"auto",min_columns:6,max_columns:12}}static async getStubConfig(e){let t="";try{const o=await Ro(e);t=o[0]?.entry_id??""}catch{}return{type:`custom:${ze}`,entry_id:t,hours:24}}static async getConfigElement(){return document.createElement(Me)}connectedCallback(){if(super.connectedCallback(),null===this._registry){const e=Io();e&&(this._registry=e)}this.hass&&this._ensureRegistry()}disconnectedCallback(){super.disconnectedCallback(),this._unsubRegistry&&(this._unsubRegistry(),this._unsubRegistry=null)}updated(e){e.has("hass")&&this.hass&&this._ensureRegistry()}willUpdate(e){this._config&&this.hass&&null!==this._registry&&(e.has("hass")||e.has("_registry")||e.has("_config"))&&(this._discovered=this._memo(this.hass,{type:this._config.type,entry_id:this._config.entry_id},this._registry))}_ensureRegistry(){this._fetchRegistry(),this._unsubRegistry||(this._unsubRegistry=zo(this.hass,()=>{this._fetchRegistry(!0)}))}_fetchRegistry(e=!1){if(this._fetchInFlight)return;this._fetchInFlight=!0;const t=++this._fetchGen;Po(this.hass,e).then(e=>{t===this._fetchGen&&e!==this._registry&&(this._registry=e,this._registryError=null,this._config&&Lo.set(this._config.entry_id,Go(e,this._config.entry_id)))}).catch(e=>{t===this._fetchGen&&(this._registryError=e?.message??"entity registry fetch failed")}).finally(()=>{t===this._fetchGen&&(this._fetchInFlight=!1)})}render(){if(!this._config||!this.hass)return V;if(null===this._registry)return H`<ha-card>
+  `,e([ge({attribute:!1})],Fr.prototype,"hass",void 0),e([me()],Fr.prototype,"_config",void 0),e([me()],Fr.prototype,"_entries",void 0),e([me()],Fr.prototype,"_entriesError",void 0),Fr=e([pe(Me)],Fr);let Br=class extends de{constructor(){super(...arguments),this._registry=null,this._registryError=null,this._unsubRegistry=null,this._fetchInFlight=!1,this._fetchGen=0,this._memo=ko(),this._discovered=null}setConfig(e){if(!e||"string"!=typeof e.entry_id||0===e.entry_id.length)throw new Error(`${ze}: \`entry_id\` is required and must be a non-empty string`);if(void 0!==e.hours&&("number"!=typeof e.hours||e.hours<=0))throw new Error(`${ze}: \`hours\` must be a positive number`);if(this._config={...e},e.tooltips&&yo(e.tooltips),null===this._registry){const t=Lo.get(e.entry_id);t&&(this._registry=t.entries)}}getCardSize(){return 6}getGridOptions(){return{columns:12,rows:"auto",min_columns:6,max_columns:12}}static async getStubConfig(e){let t="";try{const o=await jo(e);t=o[0]?.entry_id??""}catch{}return{type:`custom:${ze}`,entry_id:t,hours:24}}static async getConfigElement(){return document.createElement(Me)}connectedCallback(){if(super.connectedCallback(),null===this._registry){const e=Po();e&&(this._registry=e)}this.hass&&this._ensureRegistry()}disconnectedCallback(){super.disconnectedCallback(),this._unsubRegistry&&(this._unsubRegistry(),this._unsubRegistry=null)}updated(e){e.has("hass")&&this.hass&&this._ensureRegistry()}willUpdate(e){this._config&&this.hass&&null!==this._registry&&(e.has("hass")||e.has("_registry")||e.has("_config"))&&(this._discovered=this._memo(this.hass,{type:this._config.type,entry_id:this._config.entry_id},this._registry))}_ensureRegistry(){this._fetchRegistry(),this._unsubRegistry||(this._unsubRegistry=Mo(this.hass,()=>{this._fetchRegistry(!0)}))}_fetchRegistry(e=!1){if(this._fetchInFlight)return;this._fetchInFlight=!0;const t=++this._fetchGen;Oo(this.hass,e).then(e=>{t===this._fetchGen&&e!==this._registry&&(this._registry=e,this._registryError=null,this._config&&Lo.set(this._config.entry_id,Wo(e,this._config.entry_id)))}).catch(e=>{t===this._fetchGen&&(this._registryError=e?.message??"entity registry fetch failed")}).finally(()=>{t===this._fetchGen&&(this._fetchInFlight=!1)})}render(){if(!this._config||!this.hass)return V;if(null===this._registry)return H`<ha-card>
         <div class="empty">
           <p class="dim">
             ${this._registryError?st("tile.registry_failed",this.hass,{error:this._registryError}):st("tile.loading",this.hass)}
@@ -7320,7 +7509,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
           .hideAdvanced=${!!t.hide_advanced}
         ></acp-history-view>
       </ha-card>
-    `}};$r.styles=a`
+    `}};Br.styles=a`
     :host {
       display: block;
     }
@@ -7344,7 +7533,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
       color: var(--secondary-text-color);
       margin: 0;
     }
-  `,e([ge({attribute:!1})],$r.prototype,"hass",void 0),e([me()],$r.prototype,"_config",void 0),e([me()],$r.prototype,"_registry",void 0),e([me()],$r.prototype,"_registryError",void 0),$r=e([pe(ze)],$r),window.customCards=window.customCards||[],window.customCards.some(e=>e.type===ze)||window.customCards.push({type:ze,name:"Adaptive Cover Pro — History",description:"Recorded position, winning handler, sun/glare/override context and cover actions for one Adaptive Cover Pro instance, plus the diagnostic event buffer.",preview:!0,documentationURL:"https://github.com/jrhubott/adaptive-cover-pro/wiki/Lovelace-Card",getEntitySuggestion:Fo(`custom:${ze}`,"entry_id")});const kr=["sky","elevation","decision","covers","overrides","climate"];let Ar=class extends de{constructor(){super(...arguments),this._registry=null,this._registryError=null,this._discovered=null,this._dialogOpen=!1,this._discoveredList=[],this._discoveredListSource=null,this._unsubRegistry=null,this._fetchInFlight=!1,this._memo=$o(),this._debounceTimer=null,this._debounceFirstAt=null,this._DEBOUNCE_DELAY=500,this._DEBOUNCE_MAX=2e3,this._openDialog=()=>{this._dialogOpen=!0},this._closeDialog=()=>{this._dialogOpen=!1},this._onHeaderInfoKeydown=e=>{"Enter"!==e.key&&" "!==e.key||(e.preventDefault(),this._openDialog())}}setConfig(e){if(!e?.entry_id)throw new Error("adaptive-cover-pro-card: `entry_id` is required");if(this._config={...e},e.tooltips&&bo(e.tooltips),null===this._registry){const t=Lo.get(e.entry_id);t&&(this._registry=t.entries)}}getCardSize(){return 6}getGridOptions(){return{columns:12,rows:"auto",min_columns:6,max_columns:12}}static async getConfigElement(){return document.createElement(ye)}static async getStubConfig(e){let t="";try{const o=await Ro(e);t=o[0]?.entry_id??""}catch{}return{type:`custom:${be}`,entry_id:t}}connectedCallback(){if(super.connectedCallback(),null===this._registry){const e=Io();e&&(this._registry=e)}this.hass&&this._ensureRegistry()}disconnectedCallback(){super.disconnectedCallback(),this._unsubRegistry&&(this._unsubRegistry(),this._unsubRegistry=null),null!==this._debounceTimer&&(clearTimeout(this._debounceTimer),this._debounceTimer=null,this._debounceFirstAt=null)}updated(e){e.has("hass")&&this.hass&&this._ensureRegistry()}shouldUpdate(e){return e.size>1||!e.has("hass")||(!this._discovered||(!!this._discovered.is_group||ve(e.get("hass"),this.hass,Object.values(this._discovered.entities))))}willUpdate(e){null!==this._registry&&this._config&&this.hass&&(e.has("hass")||e.has("_registry")||e.has("_config"))&&(this._discovered=this._memo(this.hass,this._config,this._registry)),this._discovered!==this._discoveredListSource&&(this._discoveredListSource=this._discovered,this._discoveredList=this._discovered?[this._discovered]:[])}_ensureRegistry(){this._fetchRegistry(),this._unsubRegistry||(this._unsubRegistry=zo(this.hass,e=>{const t=new Set(Go(this._registry??[],this._config?.entry_id??"").map(e=>e.entity_id));(function(e,t){return"create"===e.action||t.has(e.entity_id)})(e,t)&&this._scheduleRefetch()}))}_fetchRegistry(e=!1){this._fetchInFlight||(this._fetchInFlight=!0,Po(this.hass,e).then(e=>{if(e===this._registry)return;const t=this._config?.entry_id;if(t){const o=Go(e,t);(null===this._registry||function(e,t){if(e.length!==t.length)return!0;const o=new Map(e.map(e=>[e.entity_id,Ko(e)]));for(const e of t)if(o.get(e.entity_id)!==Ko(e))return!0;return!1}(Go(this._registry,t),o))&&(this._registry=e,o.length&&Lo.set(t,o))}else this._registry=e;this._registryError=null}).catch(e=>{this._registryError=e?.message??"entity registry fetch failed"}).finally(()=>{this._fetchInFlight=!1}))}_scheduleRefetch(){const e=Date.now();null===this._debounceFirstAt&&(this._debounceFirstAt=e);const t=e-this._debounceFirstAt,o=this._DEBOUNCE_MAX-t,i=Math.min(this._DEBOUNCE_DELAY,o);if(null!==this._debounceTimer&&clearTimeout(this._debounceTimer),i<=0)return this._debounceFirstAt=null,void this._fetchRegistry(!0);this._debounceTimer=setTimeout(()=>{this._debounceTimer=null,this._debounceFirstAt=null,this._fetchRegistry(!0)},i)}get _sections(){return this._config?.show_sections??kr}_renderHeader(e,t){const o=e.managed_covers?.[0],i=o?this.hass.states[o]:void 0,s=ut({explicitIcon:i?.attributes?.icon,deviceClass:i?.attributes?.device_class,coverType:e.cover_type,position:Vt(this.hass,e,o)}),n=!1!==this._config.state_color?vt(i?.state):null,r=e.entities.integration_enabled_switch,a=e.entities.automatic_control_switch,l=!r||"on"===this.hass.states[r]?.state,c=!a||"on"===this.hass.states[a]?.state;return H`
+  `,e([ge({attribute:!1})],Br.prototype,"hass",void 0),e([me()],Br.prototype,"_config",void 0),e([me()],Br.prototype,"_registry",void 0),e([me()],Br.prototype,"_registryError",void 0),Br=e([pe(ze)],Br),window.customCards=window.customCards||[],window.customCards.some(e=>e.type===ze)||window.customCards.push({type:ze,name:"Adaptive Cover Pro — History",description:"Recorded position, winning handler, sun/glare/override context and cover actions for one Adaptive Cover Pro instance, plus the diagnostic event buffer.",preview:!0,documentationURL:"https://github.com/jrhubott/adaptive-cover-pro/wiki/Lovelace-Card",getEntitySuggestion:Ro(`custom:${ze}`,"entry_id")});const Rr=["sky","elevation","decision","covers","overrides","climate"];let jr=class extends de{constructor(){super(...arguments),this._registry=null,this._registryError=null,this._discovered=null,this._dialogOpen=!1,this._discoveredList=[],this._discoveredListSource=null,this._unsubRegistry=null,this._fetchInFlight=!1,this._memo=ko(),this._debounceTimer=null,this._debounceFirstAt=null,this._DEBOUNCE_DELAY=500,this._DEBOUNCE_MAX=2e3,this._openDialog=()=>{this._dialogOpen=!0},this._closeDialog=()=>{this._dialogOpen=!1},this._onHeaderInfoKeydown=e=>{"Enter"!==e.key&&" "!==e.key||(e.preventDefault(),this._openDialog())}}setConfig(e){if(!e?.entry_id)throw new Error("adaptive-cover-pro-card: `entry_id` is required");if(this._config={...e},e.tooltips&&yo(e.tooltips),null===this._registry){const t=Lo.get(e.entry_id);t&&(this._registry=t.entries)}}getCardSize(){return 6}getGridOptions(){return{columns:12,rows:"auto",min_columns:6,max_columns:12}}static async getConfigElement(){return document.createElement(ye)}static async getStubConfig(e){let t="";try{const o=await jo(e);t=o[0]?.entry_id??""}catch{}return{type:`custom:${be}`,entry_id:t}}connectedCallback(){if(super.connectedCallback(),null===this._registry){const e=Po();e&&(this._registry=e)}this.hass&&this._ensureRegistry()}disconnectedCallback(){super.disconnectedCallback(),this._unsubRegistry&&(this._unsubRegistry(),this._unsubRegistry=null),null!==this._debounceTimer&&(clearTimeout(this._debounceTimer),this._debounceTimer=null,this._debounceFirstAt=null)}updated(e){e.has("hass")&&this.hass&&this._ensureRegistry()}shouldUpdate(e){return e.size>1||!e.has("hass")||(!this._discovered||(!!this._discovered.is_group||ve(e.get("hass"),this.hass,Object.values(this._discovered.entities))))}willUpdate(e){null!==this._registry&&this._config&&this.hass&&(e.has("hass")||e.has("_registry")||e.has("_config"))&&(this._discovered=this._memo(this.hass,this._config,this._registry)),this._discovered!==this._discoveredListSource&&(this._discoveredListSource=this._discovered,this._discoveredList=this._discovered?[this._discovered]:[])}_ensureRegistry(){this._fetchRegistry(),this._unsubRegistry||(this._unsubRegistry=Mo(this.hass,e=>{const t=new Set(Wo(this._registry??[],this._config?.entry_id??"").map(e=>e.entity_id));(function(e,t){return"create"===e.action||t.has(e.entity_id)})(e,t)&&this._scheduleRefetch()}))}_fetchRegistry(e=!1){this._fetchInFlight||(this._fetchInFlight=!0,Oo(this.hass,e).then(e=>{if(e===this._registry)return;const t=this._config?.entry_id;if(t){const o=Wo(e,t);(null===this._registry||function(e,t){if(e.length!==t.length)return!0;const o=new Map(e.map(e=>[e.entity_id,Go(e)]));for(const e of t)if(o.get(e.entity_id)!==Go(e))return!0;return!1}(Wo(this._registry,t),o))&&(this._registry=e,o.length&&Lo.set(t,o))}else this._registry=e;this._registryError=null}).catch(e=>{this._registryError=e?.message??"entity registry fetch failed"}).finally(()=>{this._fetchInFlight=!1}))}_scheduleRefetch(){const e=Date.now();null===this._debounceFirstAt&&(this._debounceFirstAt=e);const t=e-this._debounceFirstAt,o=this._DEBOUNCE_MAX-t,i=Math.min(this._DEBOUNCE_DELAY,o);if(null!==this._debounceTimer&&clearTimeout(this._debounceTimer),i<=0)return this._debounceFirstAt=null,void this._fetchRegistry(!0);this._debounceTimer=setTimeout(()=>{this._debounceTimer=null,this._debounceFirstAt=null,this._fetchRegistry(!0)},i)}get _sections(){return this._config?.show_sections??Rr}_renderHeader(e,t){const o=e.managed_covers?.[0],i=o?this.hass.states[o]:void 0,s=ut({explicitIcon:i?.attributes?.icon,deviceClass:i?.attributes?.device_class,coverType:e.cover_type,position:Yt(this.hass,e,o)}),n=!1!==this._config.state_color?vt(i?.state):null,r=e.entities.integration_enabled_switch,a=e.entities.automatic_control_switch,l=!r||"on"===this.hass.states[r]?.state,c=!a||"on"===this.hass.states[a]?.state;return H`
       <div class="header">
         <div
           class="header-info"
@@ -7404,6 +7593,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
               .hass=${this.hass}
               .discovered=${e}
               .memberNames=${this._config.member_names}
+              .members=${this._config.members}
               ?compact=${!!this._config.compact}
             ></acp-group-view>
           </div>
@@ -7467,7 +7657,7 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
         .stateColor=${!1!==this._config.state_color}
         @acp-dialog-close=${this._closeDialog}
       ></acp-more-info-dialog>
-    `}};Ar.styles=a`
+    `}};jr.styles=a`
     :host {
       display: block;
     }
@@ -7532,4 +7722,4 @@ function e(e,t,o,i){var s,n=arguments.length,r=n<3?t:null===i?i=Object.getOwnPro
     .dim {
       color: var(--secondary-text-color);
     }
-  `,e([ge({attribute:!1})],Ar.prototype,"hass",void 0),e([me()],Ar.prototype,"_config",void 0),e([me()],Ar.prototype,"_registry",void 0),e([me()],Ar.prototype,"_registryError",void 0),e([me()],Ar.prototype,"_discovered",void 0),e([me()],Ar.prototype,"_dialogOpen",void 0),Ar=e([pe(be)],Ar),window.customCards=window.customCards||[],window.customCards.push({type:be,name:"Adaptive Cover Pro",description:"Visualize sun/window geometry, the pipeline decision trace, and live cover positions with inline controls.",preview:!0,documentationURL:"https://github.com/jrhubott/adaptive-cover-pro/wiki/Lovelace-Card",getEntitySuggestion:Fo(`custom:${be}`,"entry_id")}),console.info(`%c adaptive-cover-pro-card %c v${fe} `,"color: white; background: #3f51b5; font-weight: 700;","color: #3f51b5; background: white; font-weight: 700;");export{Ar as AdaptiveCoverProCard};
+  `,e([ge({attribute:!1})],jr.prototype,"hass",void 0),e([me()],jr.prototype,"_config",void 0),e([me()],jr.prototype,"_registry",void 0),e([me()],jr.prototype,"_registryError",void 0),e([me()],jr.prototype,"_discovered",void 0),e([me()],jr.prototype,"_dialogOpen",void 0),jr=e([pe(be)],jr),window.customCards=window.customCards||[],window.customCards.push({type:be,name:"Adaptive Cover Pro",description:"Visualize sun/window geometry, the pipeline decision trace, and live cover positions with inline controls.",preview:!0,documentationURL:"https://github.com/jrhubott/adaptive-cover-pro/wiki/Lovelace-Card",getEntitySuggestion:Ro(`custom:${be}`,"entry_id")}),console.info(`%c adaptive-cover-pro-card %c v${fe} `,"color: white; background: #3f51b5; font-weight: 700;","color: #3f51b5; background: white; font-weight: 700;");export{jr as AdaptiveCoverProCard};

--- a/harness/src/card-stage.ts
+++ b/harness/src/card-stage.ts
@@ -390,6 +390,7 @@ export class AcpHarnessCardStage extends LitElement {
       show_clear_overrides: t.show_clear_overrides,
       show_member_badges: t.show_member_badges,
       ...(t.member_names ? { member_names: t.member_names } : {}),
+      ...(t.members?.length ? { members: t.members } : {}),
       ...(Object.keys(badges).length > 0 ? { badges } : {}),
       show_compass: t.show_compass,
       show_elevation_chart: t.show_elevation_chart,

--- a/harness/src/control-panel.ts
+++ b/harness/src/control-panel.ts
@@ -646,29 +646,51 @@ export class AcpHarnessControlPanel extends LitElement {
     `;
   }
 
+  /** Blind-spot slots. The integration allows three (its #701) and publishes
+   *  them all on `blind_spot_ranges`; only slot 1 also lands on the legacy
+   *  `blind_spot_range`. Editing slot 2 or 3 here is the #269 repro — before
+   *  the fix the compass drew slot 1 alone. */
   private _renderBlindSpot(e: HarnessEntry, idx: number): TemplateResult {
-    const enabled = !!e.blind_spot_range;
+    const slots = e.blind_spot_ranges ?? (e.blind_spot_range ? [e.blind_spot_range] : []);
+    const patchSlots = (next: Array<[number, number]>) =>
+      this._patchEntry(idx, {
+        blind_spot_ranges: next.length ? next : undefined,
+        blind_spot_range: next[0],
+      });
     return html`
       <label class="row">
         <span>Blind spot</span>
         <input
           type="checkbox"
-          .checked=${enabled}
+          .checked=${slots.length > 0}
           @change=${(ev: Event) => {
-            const on = (ev.target as HTMLInputElement).checked;
-            this._patchEntry(idx, { blind_spot_range: on ? [10, 10] : undefined });
+            patchSlots((ev.target as HTMLInputElement).checked ? [[10, 10]] : []);
           }}
         />
       </label>
-      ${enabled
-        ? html`
-            ${this._numberSlider('Blind spot left', e.blind_spot_range![0], 0, 90, 1, (v) =>
-              this._patchEntry(idx, { blind_spot_range: [v, e.blind_spot_range![1]] }),
-            )}
-            ${this._numberSlider('Blind spot right', e.blind_spot_range![1], 0, 90, 1, (v) =>
-              this._patchEntry(idx, { blind_spot_range: [e.blind_spot_range![0], v] }),
-            )}
-          `
+      ${slots.map(
+        (slot, s) => html`
+          ${this._numberSlider(`Slot ${s + 1} lower γ`, slot[0], -90, 90, 1, (v) =>
+            patchSlots(slots.map((r, i) => (i === s ? [v, r[1]] : r))),
+          )}
+          ${this._numberSlider(`Slot ${s + 1} upper γ`, slot[1], -90, 90, 1, (v) =>
+            patchSlots(slots.map((r, i) => (i === s ? [r[0], v] : r))),
+          )}
+        `,
+      )}
+      ${slots.length > 0 && slots.length < 3
+        ? html`<label class="row">
+            <span>Add blind spot slot</span>
+            <button @click=${() => patchSlots([...slots, [30, 45]])}>
+              + slot ${slots.length + 1}
+            </button>
+          </label>`
+        : ''}
+      ${slots.length > 1
+        ? html`<label class="row">
+            <span>Remove last slot</span>
+            <button @click=${() => patchSlots(slots.slice(0, -1))}>− slot ${slots.length}</button>
+          </label>`
         : ''}
     `;
   }

--- a/harness/src/mock/hass.ts
+++ b/harness/src/mock/hass.ts
@@ -214,9 +214,12 @@ const FALLBACK_LOCALIZATIONS: Record<string, string> = {
   'dialog.extend.tomorrow_suffix': ' (tomorrow)',
   'tile.motion_detected': 'Occupancy detected',
   'tile.motion_pending': 'Occupancy timeout',
-  'editor.tile.member_names': 'Member names',
+  'covers.moving_to': 'Moving to {pct}%',
+  'editor.tile.member_names': 'Members',
   'editor.tile.member_names_hint':
-    'Rename a group member as it appears on this card. Leave blank to use the entry\u2019s own name.',
+    'Drag a row, or use the arrows, to set the order members appear in. The eye hides a member from this card without removing it from the group. Type to rename a member here; leave blank to use the entry\u2019s own name.',
+  'editor.tile.members_hide': 'Hide this member',
+  'editor.tile.members_show': 'Show this member',
   // Group tile: the state line leads with how many members the group drives,
   // and the rail is drag-only because a group write flattens every member.
   'group.range': '{min}–{max}%',

--- a/harness/src/mock/state-gen.ts
+++ b/harness/src/mock/state-gen.ts
@@ -263,6 +263,7 @@ function addEntryStates(
     });
   }
 
+  const bsRanges = blindSpotRanges(entry);
   states[id('sun_sensor')] = mkState(id('sun_sensor'), sun.azimuth.toFixed(2), {
     friendly_name: `${entry.title} Sun Position`,
     elevation: sun.elevation,
@@ -277,7 +278,11 @@ function addEntryStates(
     in_fov: decision.azimuthInFov,
     min_elevation: entry.min_elevation,
     max_elevation: entry.max_elevation,
-    blind_spot_range: entry.blind_spot_range,
+    // Emitted exactly the way the integration does it: the whole slot list on
+    // `blind_spot_ranges`, and slot 1 alone on the legacy `blind_spot_range`
+    // that pre-multi-slot cards read (#269).
+    blind_spot_range: bsRanges[0],
+    blind_spot_ranges: bsRanges.length ? bsRanges : undefined,
   });
 
   // Start / end Sun sensors bound today's contiguous in-FOV + above-horizon
@@ -623,6 +628,13 @@ function addCoverStates(states: Record<string, HassState>, entry: HarnessEntry):
       });
     }
   }
+}
+
+/** Every blind-spot slot an entry declares. `blind_spot_ranges` wins when set;
+ *  otherwise the single `blind_spot_range` stands in as slot 1. */
+export function blindSpotRanges(entry: HarnessEntry): Array<[number, number]> {
+  if (entry.blind_spot_ranges?.length) return entry.blind_spot_ranges;
+  return entry.blind_spot_range ? [entry.blind_spot_range] : [];
 }
 
 /** The mock battery sensor paired with a cover — `cover.foo` → `sensor.foo_battery`. */

--- a/harness/src/scenarios.ts
+++ b/harness/src/scenarios.ts
@@ -137,6 +137,7 @@ function makeEntry(
     min_elevation: overrides.min_elevation,
     max_elevation: overrides.max_elevation,
     blind_spot_range: overrides.blind_spot_range,
+    blind_spot_ranges: overrides.blind_spot_ranges,
     target_position: overrides.target_position ?? 40,
     target_tilt: overrides.target_tilt ?? 50,
     covers: overrides.covers ?? [
@@ -2358,7 +2359,7 @@ export const SCENARIOS: Scenario[] = [
     added: '2026-07-31',
     issue: 260,
     description:
-      "Battery reporting across all three states the card distinguishes. A cover's battery is NOT an ACP entity — it is a separate `device_class: battery` sensor on the cover's OWN device — so the card resolves it by walking `hass.entities` for the cover's device_id and finding the battery sensor beside it. That is why this scenario gives each cover its own mock device. Three entries: 'Healthy' at 82% (no overlay — the tile icon must stay clean, and the dialog's battery button shows a full-ish glyph reading '82% battery'); 'Low' at 8% (the tile icon gains a RED battery overlay at its BOTTOM-LEFT, diagonally opposite the occupancy symbol's top-right so the two never collide, tooltip 'Low battery — 8%'); and 'Unknown' whose sensor reads `unknown` (treated as LOW deliberately — a battery that has stopped reporting is exactly what a warning is for — so it also overlays, with mdi:battery-alert-variant-outline). The threshold is LOW_BATTERY_PCT = 20 in src/lib/battery.ts, shared by the tile overlay and the dialog readout so they cannot drift. Check the multi-cover path too: 'Low' has two covers at 8% and 64%, so the icon must follow the WORST cell while the dialog tooltip names both ('Left: 8% · Right: 64%'). Set any of it live from Managed covers → the batt: select (none/level/unknown) in the control panel. A mains-powered cover (batt: none) emits no sensor at all and must render nothing anywhere.",
+      "Battery reporting across all three states the card distinguishes. A cover's battery is NOT an ACP entity — it is a separate `device_class: battery` sensor on the cover's OWN device — so the card resolves it by walking `hass.entities` for the cover's device_id and finding the battery sensor beside it. That is why this scenario gives each cover its own mock device. Three entries: 'Healthy' at 82% (no overlay — the tile icon must stay clean, and the dialog's battery button shows a full-ish glyph reading '82% battery'); 'Low' at 8% (the tile icon gains a RED battery overlay at its BOTTOM-LEFT, diagonally opposite the occupancy symbol's top-right so the two never collide, tooltip 'Low battery — 8%'); and 'Unknown' whose sensor reads `unknown` (treated as LOW deliberately — a battery that has stopped reporting is exactly what a warning is for — so it also overlays, with mdi:battery-alert-variant-outline). The threshold is LOW_BATTERY_PCT = 20 in src/lib/battery.ts, shared by the tile overlay and the dialog readout so they cannot drift. Check the multi-cover path too: 'Low' has two covers at 8% and 64%, so the icon must follow the WORST cell while the dialog tooltip names both ('Left: 8% · Right: 64%'). Set any of it live from Managed covers → the batt: select (none/level/unknown) in the control panel. A mains-powered cover (batt: none) emits no sensor at all and must render nothing anywhere. The dialog battery is a BUTTON, not a readout: clicking it leaves for HA's own History panel at `/history?entity_id=…` with every battery source in the set comma-joined, and closes the dialog on the way out (in the harness there is no HA router, so the URL changes and nothing navigates — check the address bar). The fourth entry, 'Battery Group', is a Cover Group over all four battery covers from the three entries above, and its dialog header carries the SAME indicator — worst-cell glyph (here the unknown one), tooltip naming every member, and the same history link listing all four sensors.",
     build: () => {
       const c = baseConfig('2026-06-21', 12 * 60);
       c.scenario = 'cover-battery';
@@ -2418,6 +2419,124 @@ export const SCENARIOS: Scenario[] = [
               battery: null,
             },
           ],
+        }),
+        // A group over the three battery entries above, so the group dialog's
+        // battery indicator has a mixed roster to summarize: healthy, low and
+        // unknown together must resolve to the unknown cell.
+        makeGroupEntry({
+          entry_id: 'battery_group',
+          title: 'Battery Group',
+          group: {
+            member_positions: {
+              'cover.healthy_shade': 70,
+              'cover.low_left': 40,
+              'cover.low_right': 40,
+              'cover.unknown_shade': 55,
+            },
+            member_winners: {
+              'cover.healthy_shade': 'solar',
+              'cover.low_left': 'solar',
+            },
+            aggregate_position: 51,
+            state: 'open',
+            active_scene: 'none',
+            scene_option: 'auto',
+            locked: false,
+            automation: true,
+            climate_mode: 'summer_mode',
+          },
+        }),
+      ];
+      return c;
+    },
+  },
+  {
+    id: 'moving-to-indicator',
+    label: 'Moving to — destination shown while a cover travels',
+    added: '2026-08-12',
+    description:
+      "Setting a position returns immediately, but the cover takes seconds to get there — and every rail draws the LIVE value, so the instant a drag preview is released the rail snapped back to where the cover still was and the number just chosen vanished. The command was in flight with nothing on screen to say so. Now the destination stays: a STRIPED travel band spans the gap between where the cover is and where it is heading, capped by a diamond pip. Tap, drag, arrow-key or press the ↑/↓ buttons on any rail here and watch it — the harness has no real covers, so nothing travels and the band simply persists until it times out, which is exactly what a no-feedback cover looks like in the wild. STOP clears the indicator instead of setting one: wherever a cover halts IS its position, so a pip still pointing elsewhere would promise a move that was just abandoned. Four rails carry it and must look identical: the tile rail here, the tile's tilt track, the more-info dialog's Position bars, and the group tile's rail (open the group entry). The band is striped, never a flat tint, so it can never be mistaken for a second fill — the solid fill beside it is the only thing claiming the cover's real position. The pip is a different SHAPE from the orange solar-target marker, not merely a different colour, because the two share one track and colour alone would not separate them for a colour-blind user. Two rules worth checking: commanding a value the cover is ALREADY at draws NOTHING (a zero-width band and a stray pip would otherwise sit there for the full 60s, since a cover that does not move never reports arrival), and a value within 2% counts as arrived for the same reason — covers routinely stop a percent short. An AUTOMATIC move shows it too, without any command: set a cover's state to `opening` or `closing` in the control panel and its rail draws the band toward the target tick, because a pipeline move has no command echo to latch onto and the entity being in motion is the only evidence there is.",
+    build: () => {
+      const c = baseConfig('2026-06-21', 12 * 60);
+      c.scenario = 'moving-to-indicator';
+      c.tile.layout = 'detailed';
+      c.entries = [
+        makeEntry({
+          entry_id: 'travelling',
+          title: 'Travelling Shade',
+          window_azimuth: 180,
+          target_position: 40,
+          covers: [
+            {
+              entity_id: 'cover.travelling_shade',
+              friendly_name: 'Travelling Shade',
+              position: 100,
+              device_class: 'shade',
+            },
+          ],
+        }),
+        // Two rails, so the per-rail keying is visible: command one and the
+        // OTHER must stay untouched.
+        makeEntry({
+          entry_id: 'two_rail',
+          title: 'Two Rail Shade',
+          window_azimuth: 200,
+          target_position: 60,
+          covers: [
+            { entity_id: 'cover.two_rail_left', friendly_name: 'Left', position: 100 },
+            { entity_id: 'cover.two_rail_right', friendly_name: 'Right', position: 0 },
+          ],
+        }),
+      ];
+      return c;
+    },
+  },
+  {
+    id: 'blind-spot-slots',
+    label: 'Blind spot slots — slot 2/3 wedges the card used to drop (#269)',
+    added: '2026-08-08',
+    issue: 269,
+    description:
+      "The integration has carried THREE blind-spot slots since its #701 and publishes them all on the sun_position sensor's `blind_spot_ranges`. `blind_spot_range` (singular) is slot 1 alone, kept only for cards written before the list existed — and reading it as the whole truth is #269: a blind spot configured in slot 2 or 3 never appears, and editing one changes nothing the card looks at. Three entries. 'Slot 2 only' has a DEGENERATE slot 1 ([0, 0] — an enabled-but-unconfigured slot) and the real wedge in slot 2, which is the exact reported shape: the legacy attribute is present but spans zero degrees, so the old card drew an invisible path and the user saw no blind spot at all. It must now draw ONE wedge, from slot 2. 'Three slots' carries all three, and all three must draw, each its own grey wedge, with the tooltip listing one 'Blind spot A°–B°' line per slot under a single entry label. 'Legacy only' publishes `blind_spot_range` with NO list — an older integration — and must still draw its single wedge, proving the fallback. Ranges are SIGNED GAMMA pairs [lower, upper] measured from the window normal, positive toward the left acceptance edge, so a wedge maps to bearings [windowAzi − upper, windowAzi − lower] and lower must be < upper. Add, remove and drag slots live from Entries → Blind spot in the control panel; a slot dragged to lower == upper vanishes rather than drawing a zero-width sliver.",
+    build: () => {
+      const c = baseConfig('2026-06-21', 12 * 60);
+      c.scenario = 'blind-spot-slots';
+      c.entries = [
+        makeEntry({
+          entry_id: 'slot_two_only',
+          title: 'Slot 2 only',
+          window_azimuth: 180,
+          fov_left: 90,
+          fov_right: 90,
+          color: '#e53935',
+          // Slot 1 enabled but never configured → zero span. Slot 2 holds the
+          // wedge the user actually drew.
+          blind_spot_ranges: [
+            [0, 0],
+            [20, 45],
+          ],
+        }),
+        makeEntry({
+          entry_id: 'three_slots',
+          title: 'Three slots',
+          window_azimuth: 180,
+          fov_left: 90,
+          fov_right: 90,
+          color: '#1e88e5',
+          blind_spot_ranges: [
+            [-45, -30],
+            [-10, 15],
+            [25, 40],
+          ],
+        }),
+        makeEntry({
+          entry_id: 'legacy_only',
+          title: 'Legacy only',
+          window_azimuth: 180,
+          fov_left: 90,
+          fov_right: 90,
+          color: '#43a047',
+          blind_spot_range: [10, 30],
         }),
       ];
       return c;
@@ -2870,6 +2989,87 @@ export const SCENARIOS: Scenario[] = [
     },
   },
   {
+    id: 'group-member-order',
+    label: 'Group roster — reorder, hide and rename members',
+    added: '2026-08-08',
+    description:
+      "The roster's order and its membership are a per-CARD choice, not the integration's. `members` carries both: it lists the row keys to render, in order, so a key left out is a hidden member and there is no second 'hidden' list to keep in sync. This scenario ships all three levers at once — the group adopts two ACP entries plus one generic (non-ACP) hallway cover, and the card config reorders them, hides one, and renames another. What must render, in the group tile's dialog AND in the main-card group view (they share one helper and cannot drift): TWO rows, hallway FIRST even though the integration reports it last, labelled 'Hallway'; then the front entry labelled 'Bay Window' rather than its own 'Front Left Shade' title. The side entry is CONFIGURED OUT and must appear nowhere. Row keys are the owning ACP entry_id for an ACP member and the bare cover entity_id for a generic one — the same keys `member_names` already used, which is why one editor section now drives naming, ordering and visibility together instead of two that disagree about what a row is. Open the card's visual editor to drive it: the Members section is a sortable list — drag a row or use ↑/↓, the eye hides a member from this card without touching the group, and the name field on each row renames it (blank restores the entry's own title). Re-showing a hidden member puts it back where the INTEGRATION had it rather than on the end, so hide-then-show is a round trip and not a silent reorder. Unlike the rail list, the LAST member may be hidden — the dialog still carries the aggregate readout, the position track and the control row, so an empty roster is a usable card and the whole Members block simply disappears rather than leaving a bare heading over nothing. HIDING REACHES THE AGGREGATES, which is the point of this scenario: the side entry is UNAVAILABLE, and the tile must NOT read 'Mixed · 1 unavailable' for a cover it no longer shows. Everything derived from the roster is recomputed over the surviving members — the state line and its exception, the N/M who-won badge (denominator 2, not 3), the spread bar and its range, the aggregate percentage, the shared device_class the glyph comes from, and the battery indicator in the dialog header. Three of those arrive from the integration as finished scalars taken over the FULL roster (`group_position`, `group_state`, `group_who_won`), so they are recomputed the way the integration computes them — mean, unanimity-or-mixed, and a count of members a group handler owns. Show the side entry again and every number must return to what the integration published, exactly.",
+    build: () => {
+      const c = baseConfig('2026-06-21', 12 * 60);
+      c.scenario = 'group-member-order';
+      const front = makeEntry({
+        entry_id: 'front_shades',
+        title: 'Front Left Shade',
+        window_azimuth: 180,
+        target_position: 40,
+        covers: [
+          { entity_id: 'cover.front_left', friendly_name: 'Front Left Shade', position: 40 },
+          { entity_id: 'cover.front_center', friendly_name: 'Front Center Shade', position: 40 },
+        ],
+      });
+      const side = makeEntry({
+        entry_id: 'side_shades',
+        title: 'Side Left Shade',
+        window_azimuth: 250,
+        target_position: 0,
+        covers: [
+          {
+            entity_id: 'cover.side_left',
+            friendly_name: 'Side Left Shade',
+            position: 0,
+            // UNAVAILABLE on purpose: this is the member the card hides, and an
+            // unavailable one is the sharpest proof that hiding reaches the
+            // aggregates. Before the snapshot was restricted, the tile kept
+            // reading "Mixed · 1 unavailable" over a roster this cover was no
+            // longer part of.
+            state: 'unavailable',
+          },
+        ],
+      });
+      c.entries = [
+        front,
+        side,
+        makeGroupEntry({
+          entry_id: 'living_room',
+          title: 'Living Room',
+          group: {
+            // Integration order: front entry, side entry, then the generic
+            // cover. The card config below overrides all of it.
+            member_positions: {
+              'cover.front_left': 40,
+              'cover.front_center': 40,
+              'cover.side_left': 0,
+              'cover.hall_generic': 70,
+            },
+            member_winners: {
+              'cover.front_left': 'solar',
+              'cover.front_center': 'solar',
+              'cover.side_left': 'solar',
+            },
+            aggregate_position: 38,
+            state: 'mixed',
+            active_scene: 'none',
+            scene_option: 'auto',
+            locked: false,
+            automation: true,
+            climate_mode: 'summer_mode',
+          },
+        }),
+      ];
+      // Generic cover first, side entry configured out entirely. COVER ids —
+      // the key is deliberately not the roster's row key, so an unavailable
+      // member (like cover.side_left here) can still be matched.
+      c.tile.members = ['cover.hall_generic', 'cover.front_left', 'cover.front_center'];
+      c.tile.member_names = {
+        front_shades: 'Bay Window',
+        'cover.hall_generic': 'Hallway',
+      };
+      c.compass.enabled = false;
+      c.solarChart.enabled = false;
+      return c;
+    },
+  },
+  {
     id: 'goto-target-button',
     label: 'Snap to target — per-cover ⊙ button',
     description:
@@ -2903,7 +3103,7 @@ export const SCENARIOS: Scenario[] = [
     id: 'layered-rails-vs-separate-covers',
     label: 'Rail stack — layers of one cover vs. separate covers',
     description:
-      'THE side-by-side repro. Both tiles render a stack of position rails and until now looked identical — same glyph, same spacing — even though they mean completely different things. Tile 1 is a day/night shade: TWO RAILS OF ONE PHYSICAL SHADE (bottom rail carries the coverage, middle rail the sheer-vs-blackout fabric split), bound by the integration\'s dual_entity control model. Tile 2 is an ordinary blind entry someone attached THREE SEPARATE WINDOWS to. Tile 1 must now draw a BRACE — a hairline down the lane between the glyph column and the rails, spanning rail-center to rail-center — and its rows sit tighter (2px vs 5px). Tile 2 must be pixel-identical to before: no brace, 5px gaps, nothing changed on the common path. Check the geometry too: the brace is absolutely positioned so it adds no layout width, and the layered stack widens its glyph GAP (6→10px) to make room, which moves the stack\'s LEFT edge out while the rails keep their length and their right edge — the alignment invariant from issue #260. Both stacks carry a role="group" with an accessible name ("2 rails of one cover" / "3 covers"), so the distinction reaches a screen reader and not just the eye. The discriminator is the integration cover_type, NOT the rail count: cover_day_night_shade and cover_dual_panel are the two types whose managed covers are layers of one opening; every other type takes one cover per window. Switch tile 1\'s cover type to cover_blind in the control panel and the brace must vanish, because two blinds on one entry are two windows. Narrow it to a single rail ("First rail only" under covers) and the brace goes with the stack — a lone rail is one cover, and bracketing it would say something untrue.',
+      'THE side-by-side repro. Both tiles render a stack of position rails and until now looked identical — same glyph, same spacing — even though they mean completely different things. Tile 1 is a day/night shade: TWO RAILS OF ONE PHYSICAL SHADE (bottom rail carries the coverage, middle rail the sheer-vs-blackout fabric split), bound by the integration\'s dual_entity control model. Tile 2 is an ordinary blind entry someone attached THREE SEPARATE WINDOWS to. Tile 1 must now draw a BRACE — a hairline down the lane between the glyph column and the rails, spanning rail-center to rail-center — and its rows sit tighter (2px vs 5px). Tile 2 must be pixel-identical to before: no brace, 5px gaps, nothing changed on the common path. Check the geometry too: the brace is absolutely positioned so it adds no layout width, and the layered stack widens its glyph GAP (6→10px) to make room, which moves the stack\'s LEFT edge out while the rails keep their length and their right edge — the alignment invariant from issue #260. Both stacks carry a role="group" with an accessible name ("2 rails of one cover" / "3 covers"), so the distinction reaches a screen reader and not just the eye. The discriminator is the integration cover_type, NOT the rail count: cover_day_night_shade and cover_dual_panel are the two types whose managed covers are layers of one opening; every other type takes one cover per window. Switch tile 1\'s cover type to cover_blind in the control panel and the brace must vanish, because two blinds on one entry are two windows. Narrow it to a single rail ("First rail only" under covers) and the brace goes with the stack — a lone rail is one cover, and bracketing it would say something untrue. THE READOUT SPLITS TOO. A layered pair is one opening with two fabrics, and the state line used to describe only the RESOLVED cover — so a shade open at 60% with its middle rail at 25% read exactly like a plain shade at 60%, and the second fabric appeared nowhere in text. Tile 1 must now read \'Open 60% · Open 25%\', one segment per rail with its own state and position. Drag the two rails to the SAME value and the line must collapse back to the single \'Open 60%\' form: the split is a signal that the fabrics diverged, not a permanent second column. Tile 2 must NOT split no matter what its rails read — three separate windows disagree by a percent or two constantly, and a permanent multi-segment line there would be noise. Switch tile 1 to cover_blind and its split disappears with the brace, from the same cover_type discriminator. Detailed layout only: one-line has no room, and a VENETIAN is deliberately excluded because its second axis already has a bar directly under the line.',
     added: '2026-08-02',
     build: () => {
       const c = baseConfig('2026-06-21', 12 * 60);

--- a/harness/src/types.ts
+++ b/harness/src/types.ts
@@ -162,8 +162,16 @@ export interface HarnessEntry {
   min_elevation?: number;
   /** Optional elevation ceiling. */
   max_elevation?: number;
-  /** Optional [left, right] blind spot relative to window normal. */
+  /** Optional [left, right] blind spot relative to window normal — slot 1
+   *  shorthand. Ignored when {@link blind_spot_ranges} is set. */
   blind_spot_range?: [number, number];
+  /** Every configured blind-spot slot (the integration allows three). When set
+   *  it replaces {@link blind_spot_range}, and the mock emits it the way the
+   *  integration does: `blind_spot_ranges` carries the whole list while the
+   *  legacy `blind_spot_range` carries only the first entry. Use a degenerate
+   *  first slot (`[0, 0]`) to reproduce #269 — a card reading only the legacy
+   *  attribute then draws nothing. */
+  blind_spot_ranges?: Array<[number, number]>;
   /** Target position 0..100 (integration output). */
   target_position: number;
   /** Solar tilt target 0..100 for venetian dual-axis covers (integration
@@ -317,6 +325,10 @@ export interface TileCardOptions {
   /** Per-member roster display-name overrides, keyed by member entry_id (or a
    *  generic cover's entity_id). Mirrors the card's `member_names`. */
   member_names?: Record<string, string>;
+  /** Roster order + subset as COVER entity ids (NOT {@link member_names}'s
+   *  per-row keys). Absent = the integration's own order with every member
+   *  shown. Mirrors the card's `members`. */
+  members?: string[];
   show_position: boolean;
   show_state: boolean;
   show_decision_summary: boolean;

--- a/src/adaptive-cover-pro-card.ts
+++ b/src/adaptive-cover-pro-card.ts
@@ -398,6 +398,7 @@ export class AdaptiveCoverProCard extends LitElement {
               .hass=${this.hass}
               .discovered=${discovered}
               .memberNames=${this._config.member_names}
+              .members=${this._config.members}
               ?compact=${!!this._config.compact}
             ></acp-group-view>
           </div>

--- a/src/adaptive-cover-pro-tile-card-editor.ts
+++ b/src/adaptive-cover-pro-tile-card-editor.ts
@@ -15,7 +15,13 @@ import { discoverEntities } from './lib/entity-discovery';
 import { t } from './lib/i18n';
 import type { AdaptiveCoverProTileCardConfig, DiscoveredEntities } from './types';
 import { readGroup } from './lib/group-controls';
-import { buildRoster, rosterRowConfigKey, type RosterRow } from './lib/group-roster';
+import {
+  applyMemberOrder,
+  buildRoster,
+  rosterRowConfigKey,
+  rosterRowKey,
+  type RosterRow,
+} from './lib/group-roster';
 import { getCachedRegistry } from './lib/registry-store';
 
 interface ValueChangedEvent extends CustomEvent {
@@ -574,42 +580,201 @@ export class AdaptiveCoverProTileCardEditor extends LitElement implements Lovela
   }
 
   /**
-   * Per-member display names for a Cover Group roster.
+   * The Cover Group roster: per-row display name, order, and visibility in one
+   * widget.
    *
-   * A plain `ha-form` field cannot express this: the keys are entry ids the user
-   * has never seen and could not type, so the widget lists the roster itself and
-   * labels each field with the name the row resolves to today. Leaving a field
-   * empty removes the override rather than storing an empty string, so the
-   * entry's own title comes back instead of a blank row.
+   * A plain `ha-form` field cannot express any of it — the keys are entry ids
+   * the user has never seen and could not type — so the widget lists the roster
+   * itself and labels each row with the name it resolves to today. Order and
+   * visibility use the same list as the rail widget below (drag, ↑/↓, eye)
+   * because they are the same problem; the name input just rides along on each
+   * row, which is why naming and sorting are one section rather than two that
+   * disagree about what a row is.
+   *
+   * Leaving a name empty removes the override rather than storing an empty
+   * string, so the entry's own title comes back instead of a blank row.
    */
   private _renderMemberNames(): TemplateResult | typeof nothing {
-    const discovered = this._groupDiscovered;
-    if (!discovered || !this.hass) return nothing;
-    const snapshot = readGroup(this.hass, discovered);
-    const rows = buildRoster(
-      this.hass,
-      Object.keys(snapshot.memberPositions),
-      this._registry ?? undefined,
-    );
+    const rows = this._memberRows();
     if (rows.length === 0) return nothing;
     const drafts = this._memberDrafts ?? {};
+    const shownCount = rows.filter((r) => r.shown).length;
     return html`
       <div class="rail-order">
         <div class="rail-order-title">${t('editor.tile.member_names', this.hass)}</div>
         <div class="hint">${t('editor.tile.member_names_hint', this.hass)}</div>
-        <ha-form
-          .hass=${this.hass}
-          .data=${drafts}
-          .schema=${rows.map((row) => ({
-            name: rosterRowConfigKey(row),
-            selector: { text: {} },
-          }))}
-          .computeLabel=${(field: HaFormSchemaItem) => this._memberFieldLabel(field.name, rows)}
-          @value-changed=${(e: CustomEvent<{ value: Record<string, string> }>) =>
-            this._memberNamesChanged(e.detail.value)}
-        ></ha-form>
+        <ul>
+          ${rows.map((row, i) => {
+            const key = rosterRowConfigKey(row.row);
+            const label = this._memberRowLabel(row.row);
+            return html`
+              <li
+                class=${`rail member-row${row.shown ? '' : ' hidden-rail'}${
+                  this._memberDragFrom === i ? ' dragging' : ''
+                }`}
+                draggable=${row.shown ? 'true' : 'false'}
+                @dragstart=${() => (this._memberDragFrom = i)}
+                @dragend=${() => (this._memberDragFrom = null)}
+                @dragover=${(e: DragEvent) => {
+                  if (row.shown) e.preventDefault();
+                }}
+                @drop=${(e: DragEvent) => {
+                  e.preventDefault();
+                  if (this._memberDragFrom !== null && row.shown)
+                    this._moveMember(this._memberDragFrom, i);
+                  this._memberDragFrom = null;
+                }}
+              >
+                <ha-icon class="grip" icon="mdi:drag-horizontal-variant"></ha-icon>
+                <input
+                  class="member-name"
+                  type="text"
+                  .value=${drafts[key] ?? ''}
+                  placeholder=${label}
+                  aria-label=${label}
+                  @change=${(e: Event) =>
+                    this._memberNameChanged(key, (e.target as HTMLInputElement).value)}
+                />
+                <button
+                  type="button"
+                  class="rail-btn"
+                  aria-label=${t('editor.tile.covers_move_up', this.hass)}
+                  ?disabled=${!row.shown || i === 0}
+                  @click=${() => this._moveMember(i, i - 1)}
+                >
+                  <ha-icon icon="mdi:arrow-up"></ha-icon>
+                </button>
+                <button
+                  type="button"
+                  class="rail-btn"
+                  aria-label=${t('editor.tile.covers_move_down', this.hass)}
+                  ?disabled=${!row.shown || i >= shownCount - 1}
+                  @click=${() => this._moveMember(i, i + 1)}
+                >
+                  <ha-icon icon="mdi:arrow-down"></ha-icon>
+                </button>
+                <button
+                  type="button"
+                  class="rail-btn"
+                  aria-label=${t(
+                    row.shown ? 'editor.tile.members_hide' : 'editor.tile.members_show',
+                    this.hass,
+                  )}
+                  aria-pressed=${row.shown ? 'true' : 'false'}
+                  @click=${() => this._toggleMember(i)}
+                >
+                  <ha-icon icon=${row.shown ? 'mdi:eye' : 'mdi:eye-off'}></ha-icon>
+                </button>
+              </li>
+            `;
+          })}
+        </ul>
       </div>
     `;
+  }
+
+  /** Index currently being dragged in the member list, or null. Separate from
+   *  `_dragFrom`: both lists can be on screen for a group entry, and sharing
+   *  one index made a drag in either highlight a row in the other. */
+  @state() private _memberDragFrom: number | null = null;
+
+  /** The live roster in the order the card renders it. Shown rows first, in the
+   *  configured `members` order; then everything the key leaves out, which is
+   *  exactly the hidden set. Same shape as {@link _railRows} so the two lists
+   *  behave identically. */
+  private _memberRows(): { row: RosterRow; shown: boolean }[] {
+    const roster = this._naturalRoster();
+    const configured = this._config?.members;
+    if (!configured?.length) return roster.map((row) => ({ row, shown: true }));
+    const visible = new Set(configured);
+    // `applyMemberOrder` trims each row to its listed covers; the editor lists
+    // WHOLE rows, so re-attach the untrimmed row it came from — hiding and
+    // showing operate on the row, not on one of its rails.
+    const byKey = new Map(roster.map((row) => [rosterRowKey(row), row]));
+    const shown = applyMemberOrder(roster, configured).map((row) => ({
+      row: byKey.get(rosterRowKey(row)) ?? row,
+      shown: true,
+    }));
+    const hidden = roster
+      .filter((row) => !row.covers.some((id) => visible.has(id)))
+      .map((row) => ({ row, shown: false }));
+    return [...shown, ...hidden];
+  }
+
+  /** The roster in the integration's own order — the baseline both "is this
+   *  still the default?" and "where does a re-shown row go back to?" measure
+   *  against. Must NOT be `_memberRows()`, which is already re-ordered. */
+  private _naturalRoster(): RosterRow[] {
+    const discovered = this._groupDiscovered;
+    if (!discovered || !this.hass) return [];
+    return buildRoster(
+      this.hass,
+      Object.keys(readGroup(this.hass, discovered).memberPositions),
+      this._registry ?? undefined,
+    );
+  }
+
+  /** Write a reordered/re-filtered roster back to `members`. An all-shown list
+   *  in the integration's own order drops the key, so an untouched card keeps a
+   *  clean config — same rule as {@link _emitRails}. */
+  private _emitMembers(rows: { row: RosterRow; shown: boolean }[]): void {
+    if (!this._config) return;
+    // COVER ids, not row keys — see `hiddenMemberCovers`. A row key is the
+    // owning entry_id only while that cover's owner resolves, and an
+    // unavailable member (the kind most likely to be hidden) resolves to
+    // nothing, so a row-keyed list silently stopped matching.
+    const members = rows.filter((r) => r.shown).flatMap((r) => r.row.covers);
+    const fallback = this._naturalRoster().flatMap((row) => row.covers);
+    const isDefault =
+      members.length === fallback.length && members.every((id, i) => id === fallback[i]);
+    const { members: _drop, ...rest } = this._config;
+    this._emit(isDefault ? rest : { ...rest, members });
+  }
+
+  /** Reorder within the SHOWN block only — a hidden row has no position in the
+   *  persisted list, so moving it could not be represented. */
+  private _moveMember(from: number, to: number): void {
+    const rows = this._memberRows();
+    const shownCount = rows.filter((r) => r.shown).length;
+    if (to < 0 || to >= shownCount || from >= shownCount || from === to) return;
+    const next = [...rows];
+    const [moved] = next.splice(from, 1);
+    next.splice(to, 0, moved);
+    this._emitMembers(next);
+  }
+
+  /**
+   * Hide or re-show one roster row.
+   *
+   * Unlike a rail, the LAST member may be hidden: a group dialog with no roster
+   * still carries the aggregate readout, the position track and the control
+   * row, so hiding everything leaves a usable card rather than an empty one.
+   *
+   * Re-showing restores the row to its place in the integration's own roster
+   * order rather than appending, so hide-then-show is a round trip instead of a
+   * silent reorder.
+   */
+  private _toggleMember(index: number): void {
+    const rows = this._memberRows();
+    const target = rows[index];
+    if (!target) return;
+    if (target.shown) {
+      this._emitMembers(rows.map((r, i) => (i === index ? { ...r, shown: false } : r)));
+      return;
+    }
+    const natural = this._naturalRoster().map(rosterRowKey);
+    const home = natural.indexOf(rosterRowKey(target.row));
+    const shown = rows.filter((r) => r.shown);
+    const at = shown.filter((r) => natural.indexOf(rosterRowKey(r.row)) < home).length;
+    const restored = [...shown];
+    restored.splice(at, 0, { ...target, shown: true });
+    this._emitMembers(restored);
+  }
+
+  /** One member's name override. `ha-form` used to hand back the whole map at
+   *  once; a per-row input hands back one key, so patch rather than replace. */
+  private _memberNameChanged(key: string, raw: string): void {
+    this._memberNamesChanged({ ...(this._memberDrafts ?? {}), [key]: raw });
   }
 
   /** What this row is called today: its ACP entry's title, or a generic cover's
@@ -645,12 +810,6 @@ export class AdaptiveCoverProTileCardEditor extends LitElement implements Lovela
    * change an entry's resolved title.
    */
   private _memberLabels = new Map<string, string>();
-
-  /** Label for one member field: the name that row resolves to today. */
-  private _memberFieldLabel(key: string, rows: RosterRow[]): string {
-    const row = rows.find((r) => rosterRowConfigKey(r) === key);
-    return row ? this._memberRowLabel(row) : key;
-  }
 
   /**
    * Commit the whole member-name map from `ha-form`.
@@ -1020,6 +1179,40 @@ export class AdaptiveCoverProTileCardEditor extends LitElement implements Lovela
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
+    }
+    /* The member row's name field stands in for .rail-name, so it takes the
+       same flex slot. Borderless until hovered/focused so the list reads as a
+       list rather than as a stack of form fields. */
+    .rail-order .member-name {
+      flex: 1 1 auto;
+      min-width: 0;
+      font: inherit;
+      font-size: 0.88rem;
+      color: var(--primary-text-color);
+      background: transparent;
+      border: 1px solid transparent;
+      border-radius: 4px;
+      padding: 3px 6px;
+    }
+    .rail-order .member-name::placeholder {
+      color: var(--secondary-text-color);
+      opacity: 1;
+    }
+    .rail-order .member-name:hover {
+      border-color: var(--divider-color);
+    }
+    .rail-order .member-name:focus {
+      outline: none;
+      border-color: var(--primary-color);
+    }
+    .rail-order li.rail.hidden-rail .member-name {
+      opacity: 0.45;
+      text-decoration: line-through;
+    }
+    /* A text field inside a draggable row swallows click-to-place-caret on some
+       browsers unless the row's grab cursor yields to it. */
+    .rail-order li.member-row .member-name {
+      cursor: text;
     }
     .rail-order .rail-btn {
       flex: 0 0 auto;

--- a/src/adaptive-cover-pro-tile-card.ts
+++ b/src/adaptive-cover-pro-tile-card.ts
@@ -29,6 +29,8 @@ import { resolveTileName, isValidAcpName } from './lib/name-parts';
 import { makeEntitySuggestion } from './lib/entity-suggestion';
 import { axisDisplayValue, positionAxisFor, resolveAxes, type ResolvedAxis } from './lib/axes';
 import { railsAreOneCover } from './lib/rail-model';
+import { PendingMoves, isMovingState, isPendingVisible } from './lib/pending-move';
+import { renderRailOverlay, railOverlayStyles } from './components/rail-overlay';
 import { setAxes, engageManualOverride, hasEngageManualOverride } from './lib/services';
 import { buildOverridePresets } from './lib/override-presets';
 import './components/extend-override-dialog';
@@ -201,8 +203,17 @@ export class AdaptiveCoverProTileCard extends LitElement {
     }
   }
 
+  /** Moves this card commanded, keyed by cover id — see `lib/pending-move.ts`. */
+  private _posPending = new PendingMoves(this);
+
+  /** Live value per rail as of the last render. A plain field, deliberately not
+   *  `@state`: `updated()` reads it to retire arrived moves, and writing it must
+   *  not schedule another render. */
+  private _lastRailLive = new Map<string, number | null>();
+
   protected updated(changed: Map<string, unknown>): void {
     if (changed.has('hass') && this.hass) this._ensureRegistry();
+    this._posPending.settle((cover) => this._lastRailLive.get(cover) ?? null);
   }
 
   // Re-render only on hass ticks that touched one of this entry's entities (the union
@@ -317,6 +328,7 @@ export class AdaptiveCoverProTileCard extends LitElement {
             .hass=${this.hass}
             .discovered=${discovered}
             .name=${groupTitle}
+            .members=${this._config.members}
             .icon=${this._config.icon}
             .stateColor=${this._config.state_color !== false}
             .showControls=${this._config.show_controls !== false}
@@ -338,6 +350,7 @@ export class AdaptiveCoverProTileCard extends LitElement {
           .open=${this._dialogOpen}
           .name=${groupTitle}
           .memberNames=${this._config.member_names}
+          .members=${this._config.members}
           .icon=${this._config.icon}
           .stateColor=${this._config.state_color !== false}
           .showTilt=${this._config.show_tilt !== false}
@@ -611,6 +624,54 @@ export class AdaptiveCoverProTileCard extends LitElement {
     // Dedupe: when the winner badge is itself `auto` (default winner), render
     // the Auto line only and suppress the inline winner badge.
     const inlineWinnerBadge = !(showAutoBadge && winnerKind === 'auto');
+    // Rails are resolved HERE, above the readout, because the readout now
+    // describes them (see `railReadout`). The bar section below consumes the
+    // same two values rather than re-deriving them, so the text and the bars
+    // can never disagree about which covers the tile is showing or where they
+    // are.
+    //
+    // Default rails: the `cover` pin alone when one is set, else every managed
+    // cover. The editor's rail widget must agree with this exactly.
+    const defaultCovers = cfg.cover
+      ? [cfg.cover]
+      : discovered.managed_covers.length > 0
+        ? discovered.managed_covers
+        : cover
+          ? [cover]
+          : [];
+    // An explicit `covers` list picks the rails and their order; ids the entry
+    // no longer manages are dropped. If that leaves NOTHING — every listed cover
+    // was renamed or removed from the entry — fall back to the default rather
+    // than rendering a tile with no position bar: the editor hides its repair
+    // widget below two managed covers, so an empty result would be escapable
+    // only by hand-editing YAML.
+    const listed = cfg.covers?.length
+      ? discovered.managed_covers.length > 0
+        ? cfg.covers.filter((id) => discovered.managed_covers.includes(id))
+        : cfg.covers
+      : [];
+    const barCovers = listed.length > 0 ? listed : defaultCovers;
+    // Are the stacked rails layers of ONE cover, or separate covers? Keyed off
+    // the tile's own rail list, not the entry's, so narrowing a dual-rail shade
+    // to one rail drops the treatment with the stack.
+    const layeredRails = railsAreOneCover(discovered, barCovers.length);
+    // Live value for any rail. The resolved cover keeps the value the rest of
+    // the tile (icon, readout, controls) already agrees on; every other rail
+    // reproduces the same resolution for ITSELF rather than reading a raw
+    // attribute: the `unknown`-state gate from issue #232 (a stale
+    // `current_position` is not live truth), then the integration's own
+    // snapshot — which carries the assumed position for a no-feedback cover, and
+    // is exactly what the dialog's cover bars read, so the two agree.
+    const logicalActuals = coverLogicalActuals(this.hass, discovered);
+    const railLive = (id: string): number | null => {
+      if (id === cover) return livePosition;
+      const st = this.hass.states[id];
+      if (isOffline(st?.state)) return null;
+      const reported = isUnavailable(st?.state)
+        ? null
+        : logicalCoverPosition(this.hass, discovered, id);
+      return reported ?? logicalActuals[id] ?? null;
+    };
     // No-feedback covers publish an in-transit direction; surface it as the same
     // localized "Opening"/"Closing" state text a real position cover shows, by
     // overriding the entity's (final open/closed) state in the readout.
@@ -624,8 +685,56 @@ export class AdaptiveCoverProTileCard extends LitElement {
     // One-line has no room for the bar, so fold tilt into the readout as ⟂30%.
     const tiltText =
       showTilt && !detailed && liveTilt !== null ? `⟂${formatPercent(liveTilt)}` : null;
-    const labelParts = [stateText, positionText, tiltText].filter((p): p is string => !!p);
-    const hasStateLabel = !!stateText;
+    /**
+     * Per-rail readout for a LAYERED two-rail entry — a day/night shade's two
+     * fabrics, a dual-panel window's sheer and blackout.
+     *
+     * Layered only, deliberately. Two rails can also mean two separate windows
+     * on one entry, and those disagree constantly by a percent or two; giving
+     * them a permanent two-segment line would be noise, not information. A
+     * layered pair is one opening whose two fabrics are genuinely two axes of
+     * the same thing, which is the case with no other textual readout.
+     *
+     * The ordinary readout describes the RESOLVED cover only, so the second
+     * rail's state and position appeared nowhere in text: a shade whose fabrics
+     * sit at open-100% and closed-50% read exactly like one at open-100%.
+     *
+     * Rendered ONLY when the rails actually disagree. A tile whose fabrics are
+     * in sync keeps the shorter line it has always had, so the longer form is a
+     * signal rather than permanent noise.
+     *
+     * Detailed layout only — one-line has no room for two segments and already
+     * folds a venetian's tilt in as ⟂30%. A venetian is deliberately not
+     * covered here at all: its second axis is drawn as a bar immediately below
+     * this line, and repeating that number 20px above it states nothing new.
+     * This is about a second COVER, which has no other textual readout.
+     */
+    const railReadout = (): string[] | null => {
+      if (!detailed || offline || !layeredRails || barCovers.length !== 2) return null;
+      const parts = barCovers.map((id) => {
+        const state = isOffline(this.hass.states[id]?.state)
+          ? t('tile.unavailable', this.hass)
+          : formatCoverState(this.hass, id, id === cover ? (transitDir ?? undefined) : undefined);
+        const pos = railLive(id);
+        return {
+          state,
+          pos,
+          text: [showState ? state : null, showPosition && pos !== null ? formatPercent(pos) : null]
+            .filter((p): p is string => !!p)
+            .join(' '),
+        };
+      });
+      // Nothing to say for one of them (both readouts switched off, or a rail
+      // with neither a state nor a position) — fall back rather than render a
+      // lone segment that looks like the old line with a stray separator.
+      if (parts.some((p) => !p.text)) return null;
+      if (parts[0].state === parts[1].state && parts[0].pos === parts[1].pos) return null;
+      return parts.map((p) => p.text);
+    };
+    const railParts = railReadout();
+    const labelParts =
+      railParts ?? [stateText, positionText, tiltText].filter((p): p is string => !!p);
+    const hasStateLabel = railParts ? true : !!stateText;
 
     const activeFloor = resolveActiveMinModeFloor(traceAttrs, this.hass.states, calculatedPosition);
     const winnerNormalized = normalizeHandler(winner);
@@ -710,33 +819,6 @@ export class AdaptiveCoverProTileCard extends LitElement {
     // the config flow's entity-pick order, which the card cannot influence.
     // Unknown ids are dropped rather than rendered as dead rails. Failing that,
     // `cover` pins the tile to its single rail, as before.
-    // Default rails: the `cover` pin alone when one is set, else every managed
-    // cover. The editor's rail widget must agree with this exactly.
-    const defaultCovers = cfg.cover
-      ? [cfg.cover]
-      : discovered.managed_covers.length > 0
-        ? discovered.managed_covers
-        : cover
-          ? [cover]
-          : [];
-    // An explicit `covers` list picks the rails and their order; ids the entry
-    // no longer manages are dropped. If that leaves NOTHING — every listed cover
-    // was renamed or removed from the entry — fall back to the default rather
-    // than rendering a tile with no position bar: the editor hides its repair
-    // widget below two managed covers, so an empty result would be escapable
-    // only by hand-editing YAML.
-    const listed = cfg.covers?.length
-      ? discovered.managed_covers.length > 0
-        ? cfg.covers.filter((id) => discovered.managed_covers.includes(id))
-        : cfg.covers
-      : [];
-    const barCovers = listed.length > 0 ? listed : defaultCovers;
-    // Are the stacked rails layers of ONE cover, or separate covers? Both arrive
-    // here as a plain id list and rendered identically, which made a day/night
-    // shade's two rails indistinguishable from an entry someone attached three
-    // windows to. Keyed off the tile's own rail list, not the entry's, so
-    // narrowing a dual-rail shade to one rail drops the bracket with the stack.
-    const layeredRails = railsAreOneCover(discovered, barCovers.length);
     // Low-battery overlay on the tile icon, sibling to the motion overlay. Keyed
     // off the tile's OWN cover list, not the entry's: a tile narrowed to one rail
     // of a dual-rail shade must not warn about the battery of a cover it doesn't
@@ -745,23 +827,6 @@ export class AdaptiveCoverProTileCard extends LitElement {
       const worst = lowestBattery(resolveCoverBatteries(this.hass, barCovers));
       return isLowBattery(worst) ? worst : null;
     })();
-    // Live value for any rail. The resolved cover keeps the value the rest of
-    // the tile (icon, readout, controls) already agrees on; every other rail
-    // reproduces the same resolution for ITSELF rather than reading a raw
-    // attribute: the `unknown`-state gate from issue #232 (a stale
-    // `current_position` is not live truth), then the integration's own
-    // snapshot — which carries the assumed position for a no-feedback cover, and
-    // is exactly what the dialog's cover bars read, so the two agree.
-    const logicalActuals = coverLogicalActuals(this.hass, discovered);
-    const railLive = (id: string): number | null => {
-      if (id === cover) return livePosition;
-      const st = this.hass.states[id];
-      if (isOffline(st?.state)) return null;
-      const reported = isUnavailable(st?.state)
-        ? null
-        : logicalCoverPosition(this.hass, discovered, id);
-      return reported ?? logicalActuals[id] ?? null;
-    };
     // The resolved cover's tick stays the entry's pipeline target — the number
     // this tile has always shown, and the one the dialog's marker still shows.
     // Only the OTHER rails take the per-cover command target, because the entry
@@ -1061,6 +1126,21 @@ export class AdaptiveCoverProTileCard extends LitElement {
     // normalize here too.
     const shownFill = shown === null ? 0 : axisDisplayValue(shown, axis);
     const targetFill = target === null ? null : axisDisplayValue(target, axis);
+    // Remembered for `updated()`'s arrival check — see `_lastRailLive`.
+    this._lastRailLive.set(id, live);
+    // Suppressed mid-drag: the drag preview already paints where the finger is,
+    // and a band to the previous command underneath it is a second answer to
+    // the same question.
+    // An AUTOMATIC move has no command echo to latch onto — the pipeline moved
+    // the cover without this card asking — so the evidence is the entity saying
+    // it is in motion, and the destination is the tick the rail already draws.
+    // An explicit command from this card wins: if both are live, the value the
+    // user chose is the one they are waiting on.
+    const autoMoving = isMovingState(this.hass.states[id]?.state) ? target : null;
+    const commanded = dragging ? null : (this._posPending.get(id) ?? autoMoving);
+    // See `acp-axis-bar`: a destination the cover is already at never settles.
+    const pending = isPendingVisible(live, commanded) ? commanded : null;
+    const pendingFill = pending === null ? null : axisDisplayValue(pending, axis);
     const tip =
       target !== null
         ? `${formatPercent(shown)} · ${t('dialog.target', this.hass)} ${formatPercent(target)}`
@@ -1087,6 +1167,15 @@ export class AdaptiveCoverProTileCard extends LitElement {
     >
       <div class="pos-bar" ${tooltip(tip)}>
         <div class="pos-fill" style=${`width:${shownFill}%`}></div>
+        ${pending !== null && pendingFill !== null
+          ? renderRailOverlay({
+              hass: this.hass,
+              liveFrac: shownFill,
+              pendingFrac: pendingFill,
+              pending,
+              prefix: 'pos-',
+            })
+          : nothing}
         ${targetFill !== null
           ? html`<div
               class="pos-marker"
@@ -1224,6 +1313,10 @@ export class AdaptiveCoverProTileCard extends LitElement {
 
   private _stopCover(cover: string | undefined): void {
     if (!cover) return;
+    // Stop cancels the destination rather than becoming one: wherever the cover
+    // halts IS its position now, so an indicator still pointing somewhere else
+    // would promise a move that was just abandoned.
+    this._posPending.clear(cover);
     this.hass.callService(INTEGRATION_DOMAIN, 'stop', {}, { entity_id: cover });
   }
 
@@ -1232,6 +1325,13 @@ export class AdaptiveCoverProTileCard extends LitElement {
    *  service default preserves today's override semantics. */
   private _setAxis(cover: string | undefined, axisId: string, value: number): void {
     if (!cover) return;
+    // Arm the "moving to" indicator HERE rather than at the rail, because this
+    // is the one funnel every position command passes through: rail tap, drag
+    // release (which rides the trailing click), arrow keys, AND the ↑/↓
+    // buttons, which drive the axis straight to its max/min without going near
+    // the rail. Position only — a secondary axis is drawn by `acp-axis-bar`,
+    // which arms its own.
+    if (axisId === 'position') this._posPending.start(cover, value);
     setAxes(this.hass, cover, { [axisId]: value });
   }
 
@@ -1410,99 +1510,101 @@ export class AdaptiveCoverProTileCard extends LitElement {
     e.stopPropagation();
   }
 
-  public static styles = css`
-    :host {
-      display: block;
-      height: 100%;
-    }
-    ha-card {
-      padding: 6px 10px;
-      overflow: hidden;
-      height: 100%;
-      box-sizing: border-box;
-      /* Center the tile body vertically so a taller-than-default grid cell
+  public static styles = [
+    railOverlayStyles,
+    css`
+      :host {
+        display: block;
+        height: 100%;
+      }
+      ha-card {
+        padding: 6px 10px;
+        overflow: hidden;
+        height: 100%;
+        box-sizing: border-box;
+        /* Center the tile body vertically so a taller-than-default grid cell
          (Sections drag-resize) keeps the content centered rather than top-aligned. */
-      display: flex;
-      flex-direction: column;
-      justify-content: center;
-      /* In HA's "Sections" view the tile width is driven by the dashboard
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        /* In HA's "Sections" view the tile width is driven by the dashboard
          column, not the viewport, so @media can't see the squeeze. Make the
          card a query container (issue #136) so the detailed layout can reflow
          its controls onto their own row once the column gets narrow. */
-      container-type: inline-size;
-    }
-    .tile-body {
-      display: grid;
-      /* Position column is fixed-width so the controls land at the same x
+        container-type: inline-size;
+      }
+      .tile-body {
+        display: grid;
+        /* Position column is fixed-width so the controls land at the same x
          across stacked tiles regardless of the digit count (87% vs 100%). */
-      grid-template-columns: 24px minmax(0, 1fr) 3rem auto auto;
-      grid-template-areas: 'icon label position controls badge';
-      align-items: center;
-      column-gap: 8px;
-      row-gap: 2px;
-      cursor: pointer;
-      user-select: none;
-      min-width: 0;
-    }
-    /* When the state label is rendered ("Open · 12%") the position cell needs
+        grid-template-columns: 24px minmax(0, 1fr) 3rem auto auto;
+        grid-template-areas: 'icon label position controls badge';
+        align-items: center;
+        column-gap: 8px;
+        row-gap: 2px;
+        cursor: pointer;
+        user-select: none;
+        min-width: 0;
+      }
+      /* When the state label is rendered ("Open · 12%") the position cell needs
        to grow to fit variable-width text. Strict tile-to-tile alignment of the
        ▲ ■ ▼ controls is impossible once the label is variable, so we let
        the cell auto-size. */
-    .tile-body.has-state-label {
-      grid-template-columns: 24px minmax(0, 1fr) auto auto auto;
-    }
-    /* Detailed layout matches HA's native tile card: a tinted icon shape, a
+      .tile-body.has-state-label {
+        grid-template-columns: 24px minmax(0, 1fr) auto auto auto;
+      }
+      /* Detailed layout matches HA's native tile card: a tinted icon shape, a
        name-over-state label column, and inline control buttons on the right —
        all on one row. ACP's own chrome (Auto / winner / floor badges) and the
        position bar share a second row (.chrome-line): badges left, bar right.
        The icon spans both rows so it stays vertically centered (issue #208). */
-    .tile-body.detailed {
-      grid-template-columns: 36px minmax(0, 1fr) auto;
-      grid-template-rows: auto;
-      grid-template-areas: 'icon label controls';
-      align-items: center;
-      /* HA's ha-tile-container .content uses a 10px gap and a 56px row floor. */
-      column-gap: 10px;
-      min-height: var(--row-height, 56px);
-      /* Tight row gap pulls the chrome row (badges + position bar) up snug under
+      .tile-body.detailed {
+        grid-template-columns: 36px minmax(0, 1fr) auto;
+        grid-template-rows: auto;
+        grid-template-areas: 'icon label controls';
+        align-items: center;
+        /* HA's ha-tile-container .content uses a 10px gap and a 56px row floor. */
+        column-gap: 10px;
+        min-height: var(--row-height, 56px);
+        /* Tight row gap pulls the chrome row (badges + position bar) up snug under
          the name/state so the tile stays as short as possible when badges are
          present (issue #208). */
-      row-gap: 2px;
-    }
-    /* HA's inline features block is a hard 50% of the card, not a content-sized
+        row-gap: 2px;
+      }
+      /* HA's inline features block is a hard 50% of the card, not a content-sized
        or equal-share column — see the .controls rule below. The 12px subtrahend
        is its --ha-space-3 inline-end padding. Gated on .has-controls: with
        show_controls false the track is empty, and a 50% track would reserve half
        the tile for nothing where the auto above collapses to zero. */
-    .tile-body.detailed.has-controls {
-      grid-template-columns: 36px minmax(0, 1fr) calc(50% - 12px);
-    }
-    /* Row 2 = the chrome row: Auto/winner/floor badges on the left, position bar
+      .tile-body.detailed.has-controls {
+        grid-template-columns: 36px minmax(0, 1fr) calc(50% - 12px);
+      }
+      /* Row 2 = the chrome row: Auto/winner/floor badges on the left, position bar
        right-aligned. The icon spans both rows (grid-area repeated) so it stays
        vertically centered in the tile rather than pinned to the name row
        (issue #208). */
-    .tile-body.detailed.has-chrome-row {
-      grid-template-rows: auto auto;
-      grid-template-areas:
-        'icon label  controls'
-        'icon chrome chrome';
-    }
-    /* Row 2 (or 3) = the venetian tilt slider, indented under label; icon still
+      .tile-body.detailed.has-chrome-row {
+        grid-template-rows: auto auto;
+        grid-template-areas:
+          'icon label  controls'
+          'icon chrome chrome';
+      }
+      /* Row 2 (or 3) = the venetian tilt slider, indented under label; icon still
        spans every row so it stays centered. */
-    .tile-body.detailed.has-tilt {
-      grid-template-rows: auto auto;
-      grid-template-areas:
-        'icon label controls'
-        'icon tilt  tilt';
-    }
-    .tile-body.detailed.has-chrome-row.has-tilt {
-      grid-template-rows: auto auto auto;
-      grid-template-areas:
-        'icon label  controls'
-        'icon chrome chrome'
-        'icon tilt   tilt';
-    }
-    /* Bar-only (position bar, no badges) gets NO grid special-case: it uses the
+      .tile-body.detailed.has-tilt {
+        grid-template-rows: auto auto;
+        grid-template-areas:
+          'icon label controls'
+          'icon tilt  tilt';
+      }
+      .tile-body.detailed.has-chrome-row.has-tilt {
+        grid-template-rows: auto auto auto;
+        grid-template-areas:
+          'icon label  controls'
+          'icon chrome chrome'
+          'icon tilt   tilt';
+      }
+      /* Bar-only (position bar, no badges) gets NO grid special-case: it uses the
        same .has-chrome-row grid as a badged tile, so the bar spans label+controls
        at full tile width and the name/state sit in row 1. The old special-case
        confined the bar to the label column and spanned .label across both rows to
@@ -1510,98 +1612,98 @@ export class AdaptiveCoverProTileCard extends LitElement {
        bar then shared one cell and overlapped (issue #260), and the confined bar
        read as a different component from the badged tile's full-width one. A
        bar-only tile is now a badged tile minus the badges. */
-    /* Name over state, vertically centered against the icon (HA ha-tile-info).
+      /* Name over state, vertically centered against the icon (HA ha-tile-info).
        No gap: HA's .info stacks the two lines with no gap and lets the primary
        line-height (normal, 1.6) do the spacing. */
-    .tile-body.detailed .label {
-      display: flex;
-      flex-direction: column;
-      justify-content: center;
-    }
-    /* Match HA's ha-tile-info text through the same theme tokens the native
+      .tile-body.detailed .label {
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+      }
+      /* Match HA's ha-tile-info text through the same theme tokens the native
        tile card uses, so ACP inherits any theme font-scaling/recoloring
        instead of drifting with hardcoded values. Fallbacks are HA's own
        defaults: name 14px/500 at line-height normal with 0.1px tracking, state
        12px/400 at condensed with 0.4px. Note the primary and secondary lines
        use DIFFERENT line-heights upstream — normal for the name, condensed for
        the state. */
-    .tile-body.detailed .title {
-      font-size: var(--ha-font-size-m, 0.875rem);
-      font-weight: var(--ha-font-weight-medium, 500);
-      line-height: var(--ha-line-height-normal, 1.6);
-      letter-spacing: 0.1px;
-      color: var(--primary-text-color);
-    }
-    .tile-body.detailed .state {
-      font-size: var(--ha-font-size-s, 0.75rem);
-      font-weight: var(--ha-font-weight-normal, 400);
-      line-height: var(--ha-line-height-condensed, 1.2);
-      letter-spacing: 0.4px;
-      color: var(--secondary-text-color);
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      min-width: 0;
-    }
-    /* Chrome row: Auto/winner/floor badges (left) and the position bar (right)
+      .tile-body.detailed .title {
+        font-size: var(--ha-font-size-m, 0.875rem);
+        font-weight: var(--ha-font-weight-medium, 500);
+        line-height: var(--ha-line-height-normal, 1.6);
+        letter-spacing: 0.1px;
+        color: var(--primary-text-color);
+      }
+      .tile-body.detailed .state {
+        font-size: var(--ha-font-size-s, 0.75rem);
+        font-weight: var(--ha-font-weight-normal, 400);
+        line-height: var(--ha-line-height-condensed, 1.2);
+        letter-spacing: 0.4px;
+        color: var(--secondary-text-color);
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        min-width: 0;
+      }
+      /* Chrome row: Auto/winner/floor badges (left) and the position bar (right)
        share one row under the name/state. Kept on a single line (nowrap): the
        badges hold their size and the position bar shrinks to absorb the squeeze,
        so badges never spill onto a second row before the bar has given up its
        width (issue #208). */
-    .chrome-line {
-      grid-area: chrome;
-      display: flex;
-      flex-wrap: nowrap;
-      align-items: center;
-      gap: 6px;
-      min-width: 0;
-      /* Rail geometry, shared by the lone rail and the multi-cover stack so the
+      .chrome-line {
+        grid-area: chrome;
+        display: flex;
+        flex-wrap: nowrap;
+        align-items: center;
+        gap: 6px;
+        min-width: 0;
+        /* Rail geometry, shared by the lone rail and the multi-cover stack so the
          two stay the same length — see the .pos-stack note (issue #260). The
          glyph lane is the per-rail glyph plus the .pos-row gap that separates it
          from the rail. */
-      --acp-rail-basis: 170px;
-      --acp-rail-max: 55%;
-      --acp-rail-glyph-size: 15px;
-      --acp-rail-glyph-gap: 6px;
-      --acp-rail-glyph-lane: calc(var(--acp-rail-glyph-size) + var(--acp-rail-glyph-gap));
-      /* Reserve the badge pill's height even when no badge is present, so a
+        --acp-rail-basis: 170px;
+        --acp-rail-max: 55%;
+        --acp-rail-glyph-size: 15px;
+        --acp-rail-glyph-gap: 6px;
+        --acp-rail-glyph-lane: calc(var(--acp-rail-glyph-size) + var(--acp-rail-glyph-gap));
+        /* Reserve the badge pill's height even when no badge is present, so a
          bar-only tile is the same height as one with badges — the position bar
          just centers in the reserved space (issue #208). Matches the tile-badge
          height (0.75rem × 1.4 line + 2px×2 padding ≈ 22px). */
-      min-height: 22px;
-    }
-    /* Badges hold their intrinsic width so the bar (not the badges) absorbs any
+        min-height: 22px;
+      }
+      /* Badges hold their intrinsic width so the bar (not the badges) absorbs any
        shortage of room on the single chrome line. */
-    .chrome-line acp-tile-badge {
-      overflow: visible;
-      flex: 0 0 auto;
-    }
-    .chrome-line .acp-floor-chip {
-      flex: 0 0 auto;
-    }
-    /* Target-vs-actual mini bar: right-aligned (margin-left:auto) so it fills the
+      .chrome-line acp-tile-badge {
+        overflow: visible;
+        flex: 0 0 auto;
+      }
+      .chrome-line .acp-floor-chip {
+        flex: 0 0 auto;
+      }
+      /* Target-vs-actual mini bar: right-aligned (margin-left:auto) so it fills the
        otherwise-empty space beneath the ↑■↓ buttons. Fill = live openness in the
        state color; the tick marks the auto/solar target. */
-    /* Interactive wrapper: carries the flex sizing the rail used to own, so the
+      /* Interactive wrapper: carries the flex sizing the rail used to own, so the
        visible 6px rail below is unchanged while the gesture target is bigger. */
-    .chrome-line .pos-slider {
-      margin-left: auto;
-      align-self: center;
-      position: relative;
-      flex: 0 1 var(--acp-rail-basis);
-      max-width: var(--acp-rail-max);
-      cursor: pointer;
-      /* A touch-drag must move the fill, not scroll the dashboard. */
-      touch-action: none;
-    }
-    /* The rail is 6px tall — too thin to grab on a phone. Widen the hit area
+      .chrome-line .pos-slider {
+        margin-left: auto;
+        align-self: center;
+        position: relative;
+        flex: 0 1 var(--acp-rail-basis);
+        max-width: var(--acp-rail-max);
+        cursor: pointer;
+        /* A touch-drag must move the fill, not scroll the dashboard. */
+        touch-action: none;
+      }
+      /* The rail is 6px tall — too thin to grab on a phone. Widen the hit area
        vertically with an invisible absolute box, which adds no layout height. */
-    .chrome-line .pos-slider::before {
-      content: '';
-      position: absolute;
-      inset: -8px 0;
-    }
-    /* Multi-cover entry: the rails stack in the slot the single rail occupies,
+      .chrome-line .pos-slider::before {
+        content: '';
+        position: absolute;
+        inset: -8px 0;
+      }
+      /* Multi-cover entry: the rails stack in the slot the single rail occupies,
        each labelled with its cover's glyph. The stack owns the flex sizing so
        each rail below it can size itself to the full stack width.
 
@@ -1611,23 +1713,23 @@ export class AdaptiveCoverProTileCard extends LitElement {
        the left — a stacked rail and a lone rail are the same length and start at
        the same x (issue #260). Derive, never hardcode: the lane is the glyph's
        own width plus the .pos-row gap. */
-    .chrome-line .pos-stack {
-      margin-left: auto;
-      align-self: center;
-      flex: 0 1 calc(var(--acp-rail-basis) + var(--acp-rail-glyph-lane));
-      max-width: calc(var(--acp-rail-max) + var(--acp-rail-glyph-lane));
-      min-width: 0;
-      display: flex;
-      flex-direction: column;
-      gap: 5px;
-    }
-    .chrome-line .pos-stack .pos-row {
-      display: flex;
-      align-items: center;
-      gap: var(--acp-rail-glyph-gap);
-      min-width: 0;
-    }
-    /* Layers of ONE cover vs. separate covers. A day/night shade's two rails and
+      .chrome-line .pos-stack {
+        margin-left: auto;
+        align-self: center;
+        flex: 0 1 calc(var(--acp-rail-basis) + var(--acp-rail-glyph-lane));
+        max-width: calc(var(--acp-rail-max) + var(--acp-rail-glyph-lane));
+        min-width: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 5px;
+      }
+      .chrome-line .pos-stack .pos-row {
+        display: flex;
+        align-items: center;
+        gap: var(--acp-rail-glyph-gap);
+        min-width: 0;
+      }
+      /* Layers of ONE cover vs. separate covers. A day/night shade's two rails and
        a blind entry with three windows attached both render as a rail stack, and
        until now looked identical — same glyph, same spacing, same everything.
 
@@ -1640,134 +1742,134 @@ export class AdaptiveCoverProTileCard extends LitElement {
        stack widens its gap. That widens the derived glyph lane, which moves the
        stack's LEFT edge out; the rails keep their length and their right edge,
        which is the invariant issue #260 established. */
-    .chrome-line .pos-stack.layered {
-      --acp-rail-glyph-gap: 10px;
-      /* Re-declare the lane HERE, not just the gap. A custom property is
+      .chrome-line .pos-stack.layered {
+        --acp-rail-glyph-gap: 10px;
+        /* Re-declare the lane HERE, not just the gap. A custom property is
          substituted at computed-value time on the element that DECLARES it, so
          the lane inherited from .chrome-line is already frozen at the 6px gap —
          overriding the gap alone would leave the flex basis 4px short and the
          rails 4px stubbier than a lone rail. Redeclaring recomputes it against
          the local gap, which is the whole point of deriving it. */
-      --acp-rail-glyph-lane: calc(var(--acp-rail-glyph-size) + var(--acp-rail-glyph-gap));
-      position: relative;
-      gap: 2px;
-    }
-    .chrome-line .pos-stack.layered::before {
-      content: '';
-      position: absolute;
-      /* Centered in the gap between the glyph column and the rails. */
-      left: calc(var(--acp-rail-glyph-size) + (var(--acp-rail-glyph-gap) / 2) - 1px);
-      width: 2px;
-      /* Span rail-center to rail-center rather than the full box, so the brace
+        --acp-rail-glyph-lane: calc(var(--acp-rail-glyph-size) + var(--acp-rail-glyph-gap));
+        position: relative;
+        gap: 2px;
+      }
+      .chrome-line .pos-stack.layered::before {
+        content: '';
+        position: absolute;
+        /* Centered in the gap between the glyph column and the rails. */
+        left: calc(var(--acp-rail-glyph-size) + (var(--acp-rail-glyph-gap) / 2) - 1px);
+        width: 2px;
+        /* Span rail-center to rail-center rather than the full box, so the brace
          reads as joining the rails instead of boxing the stack. A row is the
          glyph's height, so half of one is the inset at each end. */
-      top: calc(var(--acp-rail-glyph-size) / 2);
-      bottom: calc(var(--acp-rail-glyph-size) / 2);
-      border-radius: 1px;
-      background: var(--secondary-text-color);
-      opacity: 0.45;
-    }
-    /* Per-rail glyph in place of a name: two rails of one shade have long,
+        top: calc(var(--acp-rail-glyph-size) / 2);
+        bottom: calc(var(--acp-rail-glyph-size) / 2);
+        border-radius: 1px;
+        background: var(--secondary-text-color);
+        opacity: 0.45;
+      }
+      /* Per-rail glyph in place of a name: two rails of one shade have long,
        near-identical names that ate the rail's width.
 
        ha-icon defaults to inline-flex and inherits the tile's line-height, so
        its glyph sits low inside its own box even though the row centers that
        box. Making it a zero-line-height flex box centers the glyph on the rail
        rather than on a text baseline the rail knows nothing about. */
-    .chrome-line .pos-stack .pos-glyph {
-      flex: 0 0 auto;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      align-self: center;
-      line-height: 0;
-      --mdc-icon-size: var(--acp-rail-glyph-size);
-      width: var(--acp-rail-glyph-size);
-      height: var(--acp-rail-glyph-size);
-      color: var(--secondary-text-color);
-    }
-    .chrome-line .pos-stack .pos-slider {
-      margin-left: 0;
-      flex: 1 1 auto;
-      max-width: none;
-    }
-    /* Rails sit tight in the stack, so the ±8px grab boxes would overlap and
+      .chrome-line .pos-stack .pos-glyph {
+        flex: 0 0 auto;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        align-self: center;
+        line-height: 0;
+        --mdc-icon-size: var(--acp-rail-glyph-size);
+        width: var(--acp-rail-glyph-size);
+        height: var(--acp-rail-glyph-size);
+        color: var(--secondary-text-color);
+      }
+      .chrome-line .pos-stack .pos-slider {
+        margin-left: 0;
+        flex: 1 1 auto;
+        max-width: none;
+      }
+      /* Rails sit tight in the stack, so the ±8px grab boxes would overlap and
        the upper rail would swallow the lower rail's top half. */
-    .chrome-line .pos-stack .pos-slider::before {
-      inset: -2px 0;
-    }
-    .chrome-line .pos-slider:focus-visible {
-      outline: 2px solid var(--primary-color);
-      outline-offset: 3px;
-      border-radius: 6px;
-    }
-    /* The 0.3s ease below smooths server-driven updates; mid-drag it would read
+      .chrome-line .pos-stack .pos-slider::before {
+        inset: -2px 0;
+      }
+      .chrome-line .pos-slider:focus-visible {
+        outline: 2px solid var(--primary-color);
+        outline-offset: 3px;
+        border-radius: 6px;
+      }
+      /* The 0.3s ease below smooths server-driven updates; mid-drag it would read
        as the fill lagging behind the finger. */
-    .chrome-line .pos-slider.dragging .pos-fill {
-      transition: none;
-    }
-    /* Live percentage while a drag is in flight. The hover tooltip carries the
+      .chrome-line .pos-slider.dragging .pos-fill {
+        transition: none;
+      }
+      /* Live percentage while a drag is in flight. The hover tooltip carries the
        same number, but a tooltip is mouse-only — on a phone, the finger setting
        the position is also the thing covering the rail, so without this the user
        is dragging blind. Sits in .pos-slider, NOT .pos-bar: the bar is
        overflow:hidden to clip the fill, which would clip this too. Pointer-events
        off so it never eats the drag it is reporting on. */
-    .chrome-line .pos-readout {
-      position: absolute;
-      bottom: calc(100% + 6px);
-      transform: translateX(-50%);
-      padding: 1px 5px;
-      border-radius: 4px;
-      background: var(--secondary-background-color, rgba(127, 127, 127, 0.9));
-      color: var(--primary-text-color);
-      font-size: var(--ha-font-size-s, 0.75rem);
-      line-height: var(--ha-line-height-condensed, 1.2);
-      white-space: nowrap;
-      pointer-events: none;
-      z-index: 2;
-    }
-    .chrome-line .pos-bar {
-      position: relative;
-      width: 100%;
-      height: 6px;
-      border-radius: 6px;
-      background: var(--secondary-background-color, rgba(127, 127, 127, 0.15));
-      overflow: hidden;
-    }
-    .chrome-line .pos-fill {
-      position: absolute;
-      inset: 0 auto 0 0;
-      /* One constant color for every rail, never the cover's state color: a rail
+      .chrome-line .pos-readout {
+        position: absolute;
+        bottom: calc(100% + 6px);
+        transform: translateX(-50%);
+        padding: 1px 5px;
+        border-radius: 4px;
+        background: var(--secondary-background-color, rgba(127, 127, 127, 0.9));
+        color: var(--primary-text-color);
+        font-size: var(--ha-font-size-s, 0.75rem);
+        line-height: var(--ha-line-height-condensed, 1.2);
+        white-space: nowrap;
+        pointer-events: none;
+        z-index: 2;
+      }
+      .chrome-line .pos-bar {
+        position: relative;
+        width: 100%;
+        height: 6px;
+        border-radius: 6px;
+        background: var(--secondary-background-color, rgba(127, 127, 127, 0.15));
+        overflow: hidden;
+      }
+      .chrome-line .pos-fill {
+        position: absolute;
+        inset: 0 auto 0 0;
+        /* One constant color for every rail, never the cover's state color: a rail
          that changed hue as it crossed open/closed read as a status light rather
          than a measurement, and on a multi-rail tile the rails disagreed with
          each other. The icon still carries state color (the state_color option),
          which is where that signal belongs. Overridable per-theme via
          --acp-pos-fill-color. */
-      background: var(--acp-pos-fill-color, ${unsafeCSS(COVER_ACTIVE_COLOR)});
-      opacity: 0.55;
-      border-radius: 6px;
-      transition: width 0.3s ease;
-    }
-    .chrome-line .pos-marker {
-      position: absolute;
-      top: 0;
-      width: 2px;
-      height: 100%;
-      background: var(--accent-color, #ff9800);
-      transform: translateX(-50%);
-      transition: left 0.3s ease;
-    }
-    .tilt-line {
-      grid-area: tilt;
-      min-width: 0;
-      margin-top: 2px;
-      cursor: default;
-    }
-    /* Optional decision summary stacks as a dim third line under the state. */
-    .tile-body.detailed .label .summary {
-      font-size: 0.72rem;
-    }
-    /* Mirror HA's tile card in features_position: inline mode, whose spec
+        background: var(--acp-pos-fill-color, ${unsafeCSS(COVER_ACTIVE_COLOR)});
+        opacity: 0.55;
+        border-radius: 6px;
+        transition: width 0.3s ease;
+      }
+      .chrome-line .pos-marker {
+        position: absolute;
+        top: 0;
+        width: 2px;
+        height: 100%;
+        background: var(--accent-color, #ff9800);
+        transform: translateX(-50%);
+        transition: left 0.3s ease;
+      }
+      .tilt-line {
+        grid-area: tilt;
+        min-width: 0;
+        margin-top: 2px;
+        cursor: default;
+      }
+      /* Optional decision summary stacks as a dim third line under the state. */
+      .tile-body.detailed .label .summary {
+        font-size: 0.72rem;
+      }
+      /* Mirror HA's tile card in features_position: inline mode, whose spec
        differs from the bottom feature row. ha-tile-container's
        .container.horizontal rule for the features slot sets
        --feature-height: var(--ha-space-9) — 36px, not the 42px of a bottom row —
@@ -1778,202 +1880,202 @@ export class AdaptiveCoverProTileCard extends LitElement {
        ha-control-button contributes a 20px glyph and a --disabled-color fill at
        20% opacity. Buttons are flex: 1 inside that block, so they widen with the
        tile exactly as HA's do. */
-    .tile-body.detailed .controls {
-      align-self: center;
-      /* --feature-button-spacing */
-      gap: 12px;
-      width: 100%;
-    }
-    .tile-body.detailed .controls button {
-      flex: 1 1 0;
-      width: auto;
-      height: var(--control-button-group-thickness, 36px);
-      border-radius: var(--control-button-border-radius, 12px);
-      border: none;
-      background: color-mix(
-        in srgb,
-        var(--control-button-background-color, var(--disabled-color, #7f7f7f)) 20%,
-        transparent
-      );
-    }
-    .tile-body.detailed .controls button ha-icon {
-      --mdc-icon-size: 20px;
-      color: var(--primary-text-color);
-    }
-    .tile-body.detailed .controls button:hover {
-      background: color-mix(
-        in srgb,
-        var(--control-button-background-color, var(--disabled-color, #7f7f7f)) 32%,
-        transparent
-      );
-    }
-    /* Bare 36px glyph by default — the state color carries the cover's status
+      .tile-body.detailed .controls {
+        align-self: center;
+        /* --feature-button-spacing */
+        gap: 12px;
+        width: 100%;
+      }
+      .tile-body.detailed .controls button {
+        flex: 1 1 0;
+        width: auto;
+        height: var(--control-button-group-thickness, 36px);
+        border-radius: var(--control-button-border-radius, 12px);
+        border: none;
+        background: color-mix(
+          in srgb,
+          var(--control-button-background-color, var(--disabled-color, #7f7f7f)) 20%,
+          transparent
+        );
+      }
+      .tile-body.detailed .controls button ha-icon {
+        --mdc-icon-size: 20px;
+        color: var(--primary-text-color);
+      }
+      .tile-body.detailed .controls button:hover {
+        background: color-mix(
+          in srgb,
+          var(--control-button-background-color, var(--disabled-color, #7f7f7f)) 32%,
+          transparent
+        );
+      }
+      /* Bare 36px glyph by default — the state color carries the cover's status
        with nothing behind it. HA does the same for covers, though by a
        different route: its shape is drawn only when the icon is interactive,
        and getEntityDefaultTileIconAction returns none for the cover domain.
        Setting icon_tap_action opts into the shape via .background below. */
-    .tile-body.detailed .cover-icon-wrap {
-      place-self: center;
-      width: 36px;
-      height: 36px;
-    }
-    /* HA's ha-tile-icon shape: a pill at --ha-border-radius-pill filled with the
+      .tile-body.detailed .cover-icon-wrap {
+        place-self: center;
+        width: 36px;
+        height: 36px;
+      }
+      /* HA's ha-tile-icon shape: a pill at --ha-border-radius-pill filled with the
        icon's own color at 0.2 opacity (0.35 on hover), painted as a ::before so
        the tint never dims the glyph on top of it. --acp-tile-icon-color is set
        inline from coverStateColor, so shape and glyph always agree. */
-    /* Scoped to .detailed: the one-line layout's glyph box is 24px around a 22px
+      /* Scoped to .detailed: the one-line layout's glyph box is 24px around a 22px
        icon, so a pill there would be a hairline of tint around the glyph. The
        tap action still works in one-line — only the shape is detailed-only. */
-    .tile-body.detailed .cover-icon-wrap.background {
-      position: relative;
-      border-radius: var(--ha-border-radius-pill, 9999px);
-      overflow: hidden;
-      cursor: pointer;
-    }
-    .tile-body.detailed .cover-icon-wrap.background::before {
-      content: '';
-      position: absolute;
-      inset: 0;
-      background-color: var(--acp-tile-icon-color, var(--disabled-color, #7f7f7f));
-      opacity: 0.2;
-      transition: opacity 180ms ease-in-out;
-    }
-    .tile-body.detailed .cover-icon-wrap.background:hover::before {
-      opacity: 0.35;
-    }
-    .cover-icon-wrap.background:focus-visible {
-      outline: none;
-      box-shadow: 0 0 0 2px var(--acp-tile-icon-color, var(--primary-text-color));
-      border-radius: var(--ha-border-radius-pill, 9999px);
-    }
-    /* The glyph must sit above the ::before wash. */
-    .tile-body.detailed .cover-icon-wrap.background .cover-icon {
-      position: relative;
-    }
-    .tile-body.detailed .cover-icon {
-      --mdc-icon-size: 24px;
-    }
-    .tile-body[role='group'] {
-      cursor: default;
-    }
-    /* Offline/unresponsive cover (issue #212): dim the whole tile so it reads
+      .tile-body.detailed .cover-icon-wrap.background {
+        position: relative;
+        border-radius: var(--ha-border-radius-pill, 9999px);
+        overflow: hidden;
+        cursor: pointer;
+      }
+      .tile-body.detailed .cover-icon-wrap.background::before {
+        content: '';
+        position: absolute;
+        inset: 0;
+        background-color: var(--acp-tile-icon-color, var(--disabled-color, #7f7f7f));
+        opacity: 0.2;
+        transition: opacity 180ms ease-in-out;
+      }
+      .tile-body.detailed .cover-icon-wrap.background:hover::before {
+        opacity: 0.35;
+      }
+      .cover-icon-wrap.background:focus-visible {
+        outline: none;
+        box-shadow: 0 0 0 2px var(--acp-tile-icon-color, var(--primary-text-color));
+        border-radius: var(--ha-border-radius-pill, 9999px);
+      }
+      /* The glyph must sit above the ::before wash. */
+      .tile-body.detailed .cover-icon-wrap.background .cover-icon {
+        position: relative;
+      }
+      .tile-body.detailed .cover-icon {
+        --mdc-icon-size: 24px;
+      }
+      .tile-body[role='group'] {
+        cursor: default;
+      }
+      /* Offline/unresponsive cover (issue #212): dim the whole tile so it reads
        as unavailable at a glance, matching HA's own unavailable-entity dimming. */
-    .tile-body.unavailable {
-      opacity: 0.5;
-    }
-    .cover-icon-wrap {
-      grid-area: icon;
-      position: relative;
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      width: 24px;
-      height: 24px;
-    }
-    .cover-icon {
-      --mdc-icon-size: 22px;
-      color: var(--primary-text-color);
-    }
-    .motion-overlay {
-      position: absolute;
-      top: -4px;
-      right: -6px;
-      --mdc-icon-size: 12px;
-      color: var(--warning-color, #f1c232);
-      background: var(--card-background-color, white);
-      border-radius: 50%;
-      padding: 1px;
-      line-height: 0;
-    }
-    /* Sibling of .motion-overlay, pinned to the opposite corner so a cover that
+      .tile-body.unavailable {
+        opacity: 0.5;
+      }
+      .cover-icon-wrap {
+        grid-area: icon;
+        position: relative;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 24px;
+        height: 24px;
+      }
+      .cover-icon {
+        --mdc-icon-size: 22px;
+        color: var(--primary-text-color);
+      }
+      .motion-overlay {
+        position: absolute;
+        top: -4px;
+        right: -6px;
+        --mdc-icon-size: 12px;
+        color: var(--warning-color, #f1c232);
+        background: var(--card-background-color, white);
+        border-radius: 50%;
+        padding: 1px;
+        line-height: 0;
+      }
+      /* Sibling of .motion-overlay, pinned to the opposite corner so a cover that
        is both occupied and low on battery shows both without them colliding —
        motion top-right, battery bottom-left. */
-    .battery-overlay {
-      position: absolute;
-      bottom: -4px;
-      left: -6px;
-      --mdc-icon-size: 12px;
-      color: var(--error-color, #db4437);
-      background: var(--card-background-color, white);
-      border-radius: 50%;
-      padding: 1px;
-      line-height: 0;
-    }
-    .label {
-      grid-area: label;
-      min-width: 0;
-    }
-    .title {
-      font-size: 0.95rem;
-      font-weight: 500;
-      color: var(--primary-text-color);
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-    }
-    .summary {
-      font-size: 0.78rem;
-      color: var(--secondary-text-color);
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      min-width: 0;
-    }
-    .position {
-      grid-area: position;
-      font-size: 0.85rem;
-      font-variant-numeric: tabular-nums;
-      color: var(--primary-text-color);
-      padding: 0 4px;
-      /* Right-align the digits so the % sign sits flush against the controls
+      .battery-overlay {
+        position: absolute;
+        bottom: -4px;
+        left: -6px;
+        --mdc-icon-size: 12px;
+        color: var(--error-color, #db4437);
+        background: var(--card-background-color, white);
+        border-radius: 50%;
+        padding: 1px;
+        line-height: 0;
+      }
+      .label {
+        grid-area: label;
+        min-width: 0;
+      }
+      .title {
+        font-size: 0.95rem;
+        font-weight: 500;
+        color: var(--primary-text-color);
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+      .summary {
+        font-size: 0.78rem;
+        color: var(--secondary-text-color);
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        min-width: 0;
+      }
+      .position {
+        grid-area: position;
+        font-size: 0.85rem;
+        font-variant-numeric: tabular-nums;
+        color: var(--primary-text-color);
+        padding: 0 4px;
+        /* Right-align the digits so the % sign sits flush against the controls
          column edge — combined with the fixed-width position grid column, this
          keeps the ▲ ■ ▼ row aligned across stacked tiles. */
-      text-align: right;
-    }
-    .controls {
-      grid-area: controls;
-      display: inline-flex;
-      gap: 2px;
-    }
-    .controls button {
-      width: 26px;
-      height: 26px;
-      border: 1px solid var(--divider-color, rgba(0, 0, 0, 0.12));
-      border-radius: 4px;
-      background: var(--card-background-color, white);
-      color: var(--primary-text-color);
-      cursor: pointer;
-      font-size: 0.8rem;
-      line-height: 1;
-      padding: 0;
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-    }
-    .controls button ha-icon {
-      --mdc-icon-size: 16px;
-      color: var(--primary-text-color);
-      line-height: 0;
-    }
-    .controls button:hover {
-      background: var(--secondary-background-color);
-    }
-    .controls button:disabled {
-      opacity: 0.4;
-      cursor: not-allowed;
-    }
-    acp-tile-badge {
-      grid-area: badge;
-      min-width: 0;
-      overflow: hidden;
-    }
-    .acp-floor-chip {
-      grid-area: floor-chip;
-      font-size: 0.7rem;
-      padding: 1px 6px;
-      border-radius: 999px;
-      background: color-mix(in srgb, var(--acp-floor-accent) ${ACCENT_BG_ALPHA}%, transparent);
-      /* The custom-position purple resolved AGAINST THE THEME'S OWN TEXT COLOR
+        text-align: right;
+      }
+      .controls {
+        grid-area: controls;
+        display: inline-flex;
+        gap: 2px;
+      }
+      .controls button {
+        width: 26px;
+        height: 26px;
+        border: 1px solid var(--divider-color, rgba(0, 0, 0, 0.12));
+        border-radius: 4px;
+        background: var(--card-background-color, white);
+        color: var(--primary-text-color);
+        cursor: pointer;
+        font-size: 0.8rem;
+        line-height: 1;
+        padding: 0;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+      }
+      .controls button ha-icon {
+        --mdc-icon-size: 16px;
+        color: var(--primary-text-color);
+        line-height: 0;
+      }
+      .controls button:hover {
+        background: var(--secondary-background-color);
+      }
+      .controls button:disabled {
+        opacity: 0.4;
+        cursor: not-allowed;
+      }
+      acp-tile-badge {
+        grid-area: badge;
+        min-width: 0;
+        overflow: hidden;
+      }
+      .acp-floor-chip {
+        grid-area: floor-chip;
+        font-size: 0.7rem;
+        padding: 1px 6px;
+        border-radius: 999px;
+        background: color-mix(in srgb, var(--acp-floor-accent) ${ACCENT_BG_ALPHA}%, transparent);
+        /* The custom-position purple resolved AGAINST THE THEME'S OWN TEXT COLOR
          rather than pinned to a literal. The literal it replaces (#6a1b9a) is a
          dark purple chosen for a light background; on HA's dark theme it landed
          at 1.6:1 filled and 1.3:1 hollow — the chip was legible only if you knew
@@ -1987,65 +2089,65 @@ export class AdaptiveCoverProTileCard extends LitElement {
          and is not — it lands at 4.35:1 on HA dark, under the 4.5:1 floor the
          badges beside it clear at 40%. Importing the constants is what stops the
          chip and the badges from drifting apart again. */
-      --acp-floor-accent: #9c27b0;
-      color: color-mix(
-        in srgb,
-        var(--acp-floor-accent) ${FG_ACCENT_MIX}%,
-        var(--primary-text-color, #212121)
-      );
-      /* Reserve the border so the outline (is-armed) state doesn't shift layout. */
-      border: 1px solid transparent;
-      white-space: nowrap;
-      align-self: center;
-    }
-    /* Floating-tooltip cursor lifecycle for the tooltip carriers inside the
+        --acp-floor-accent: #9c27b0;
+        color: color-mix(
+          in srgb,
+          var(--acp-floor-accent) ${FG_ACCENT_MIX}%,
+          var(--primary-text-color, #212121)
+        );
+        /* Reserve the border so the outline (is-armed) state doesn't shift layout. */
+        border: 1px solid transparent;
+        white-space: nowrap;
+        align-self: center;
+      }
+      /* Floating-tooltip cursor lifecycle for the tooltip carriers inside the
        tile (floor chip, title, inline summary, motion overlay). Help hint on
        hover, default once OUR bubble appears. */
-    [data-tooltip]:hover {
-      cursor: help;
-    }
-    [data-tooltip][acp-tt-shown] {
-      cursor: default;
-    }
-    /* Clamping axis: not-clamping → hollow/outline (transparent fill + purple border). */
-    .acp-floor-chip.is-armed {
-      background: transparent;
-      border-color: color-mix(in srgb, var(--acp-floor-accent) 60%, transparent);
-    }
-    /* Priority axis: bypassable (priority ≤ 80) → subdued.
+      [data-tooltip]:hover {
+        cursor: help;
+      }
+      [data-tooltip][acp-tt-shown] {
+        cursor: default;
+      }
+      /* Clamping axis: not-clamping → hollow/outline (transparent fill + purple border). */
+      .acp-floor-chip.is-armed {
+        background: transparent;
+        border-color: color-mix(in srgb, var(--acp-floor-accent) 60%, transparent);
+      }
+      /* Priority axis: bypassable (priority ≤ 80) → subdued.
        NOT opacity any more. Opacity multiplies into the TEXT as much as the
        chrome, and stacked on the hollow variant it was what took this chip to
        1.3:1 — a legibility cost paid to signal a secondary attribute. The
        priority axis already has a non-destructive carrier in font-weight (see
        .resists-manual), so bypassable states itself by NOT being emphasized,
        and softens its outline instead. Text contrast is untouched. */
-    .acp-floor-chip.is-bypassable {
-      font-weight: 400;
-    }
-    /* Scoped to the hollow variant on purpose: the filled one has a deliberately
+      .acp-floor-chip.is-bypassable {
+        font-weight: 400;
+      }
+      /* Scoped to the hollow variant on purpose: the filled one has a deliberately
        transparent border, and softening a border that isn't drawn would instead
        make one appear. */
-    .acp-floor-chip.is-armed.is-bypassable {
-      border-color: color-mix(in srgb, var(--acp-floor-accent) 35%, transparent);
-    }
-    /* Priority axis: resists manual ↓ (priority > 80) → emphasized. */
-    .acp-floor-chip.resists-manual {
-      font-weight: 600;
-    }
-    /* One-line layout: add a second row for the floor chip under the position cell */
-    .tile-body.has-floor-chip {
-      grid-template-rows: auto auto;
-      grid-template-areas:
-        'icon label     position  controls badge resume'
-        'icon label     floor-chip .        .     .';
-    }
-    .tile-body.has-state-label.has-floor-chip {
-      grid-template-rows: auto auto;
-      grid-template-areas:
-        'icon label     position  controls badge resume'
-        'icon label     floor-chip .        .     .';
-    }
-    /* Reflow (issues #136, #154): drop the ↑■▼ controls onto their own
+      .acp-floor-chip.is-armed.is-bypassable {
+        border-color: color-mix(in srgb, var(--acp-floor-accent) 35%, transparent);
+      }
+      /* Priority axis: resists manual ↓ (priority > 80) → emphasized. */
+      .acp-floor-chip.resists-manual {
+        font-weight: 600;
+      }
+      /* One-line layout: add a second row for the floor chip under the position cell */
+      .tile-body.has-floor-chip {
+        grid-template-rows: auto auto;
+        grid-template-areas:
+          'icon label     position  controls badge resume'
+          'icon label     floor-chip .        .     .';
+      }
+      .tile-body.has-state-label.has-floor-chip {
+        grid-template-rows: auto auto;
+        grid-template-areas:
+          'icon label     position  controls badge resume'
+          'icon label     floor-chip .        .     .';
+      }
+      /* Reflow (issues #136, #154): drop the ↑■▼ controls onto their own
        full-width row beneath the name so the cover name gets the whole column,
        with the badge and tilt rows stacked between. The same reflow fires from
        two independent triggers, because "the tile is narrow" alone can't tell a
@@ -2065,17 +2167,61 @@ export class AdaptiveCoverProTileCard extends LitElement {
        sync. Each detailed grid variant is re-asserted (placed after the wide
        rules so it wins when a query matches — the grid rules rely on source
        order, not just specificity). */
-    @media (max-width: 500px) {
-      @container (max-width: 480px) {
+      @media (max-width: 500px) {
+        @container (max-width: 480px) {
+          .tile-body.detailed {
+            grid-template-columns: 36px minmax(0, 1fr);
+            grid-template-areas:
+              'icon label'
+              'controls controls';
+          }
+          /* The 50% has-controls track is (0,3,0) and a query adds no specificity,
+           so without this it would keep a third column alive here and strand the
+           reflowed full-width controls row beside it. */
+          .tile-body.detailed.has-controls {
+            grid-template-columns: 36px minmax(0, 1fr);
+          }
+          .tile-body.detailed.has-chrome-row {
+            grid-template-areas:
+              'icon label'
+              'icon chrome'
+              'controls controls';
+          }
+          .tile-body.detailed.has-tilt {
+            grid-template-areas:
+              'icon label'
+              'icon tilt'
+              'controls controls';
+          }
+          .tile-body.detailed.has-chrome-row.has-tilt {
+            grid-template-areas:
+              'icon label'
+              'icon chrome'
+              'icon tilt'
+              'controls controls';
+          }
+          /* No bar-only re-assertion needed: the wide layout no longer special-cases
+           bar-only, so the .has-chrome-row reflow above already applies (#260). */
+          .tile-body.detailed .controls {
+            margin-top: 4px;
+            gap: 8px;
+            justify-content: space-between;
+          }
+          .tile-body.detailed .controls button {
+            flex: 1 1 0;
+            width: auto;
+            height: var(--control-button-group-thickness, 36px);
+          }
+        }
+      }
+      @container (max-width: 340px) {
         .tile-body.detailed {
           grid-template-columns: 36px minmax(0, 1fr);
           grid-template-areas:
             'icon label'
             'controls controls';
         }
-        /* The 50% has-controls track is (0,3,0) and a query adds no specificity,
-           so without this it would keep a third column alive here and strand the
-           reflowed full-width controls row beside it. */
+        /* Same re-assertion as the 480px block — see the note there. */
         .tile-body.detailed.has-controls {
           grid-template-columns: 36px minmax(0, 1fr);
         }
@@ -2095,11 +2241,10 @@ export class AdaptiveCoverProTileCard extends LitElement {
           grid-template-areas:
             'icon label'
             'icon chrome'
-            'icon tilt'
+            'tilt tilt'
             'controls controls';
         }
-        /* No bar-only re-assertion needed: the wide layout no longer special-cases
-           bar-only, so the .has-chrome-row reflow above already applies (#260). */
+        /* Same as the 480px block: no bar-only re-assertion needed (#260). */
         .tile-body.detailed .controls {
           margin-top: 4px;
           gap: 8px;
@@ -2111,58 +2256,16 @@ export class AdaptiveCoverProTileCard extends LitElement {
           height: var(--control-button-group-thickness, 36px);
         }
       }
-    }
-    @container (max-width: 340px) {
-      .tile-body.detailed {
-        grid-template-columns: 36px minmax(0, 1fr);
-        grid-template-areas:
-          'icon label'
-          'controls controls';
+      .empty {
+        padding: 12px;
+        text-align: center;
       }
-      /* Same re-assertion as the 480px block — see the note there. */
-      .tile-body.detailed.has-controls {
-        grid-template-columns: 36px minmax(0, 1fr);
+      .dim {
+        color: var(--secondary-text-color);
+        margin: 0;
       }
-      .tile-body.detailed.has-chrome-row {
-        grid-template-areas:
-          'icon label'
-          'icon chrome'
-          'controls controls';
-      }
-      .tile-body.detailed.has-tilt {
-        grid-template-areas:
-          'icon label'
-          'icon tilt'
-          'controls controls';
-      }
-      .tile-body.detailed.has-chrome-row.has-tilt {
-        grid-template-areas:
-          'icon label'
-          'icon chrome'
-          'tilt tilt'
-          'controls controls';
-      }
-      /* Same as the 480px block: no bar-only re-assertion needed (#260). */
-      .tile-body.detailed .controls {
-        margin-top: 4px;
-        gap: 8px;
-        justify-content: space-between;
-      }
-      .tile-body.detailed .controls button {
-        flex: 1 1 0;
-        width: auto;
-        height: var(--control-button-group-thickness, 36px);
-      }
-    }
-    .empty {
-      padding: 12px;
-      text-align: center;
-    }
-    .dim {
-      color: var(--secondary-text-color);
-      margin: 0;
-    }
-  `;
+    `,
+  ];
 }
 
 declare global {

--- a/src/components/battery-indicator.ts
+++ b/src/components/battery-indicator.ts
@@ -1,0 +1,113 @@
+import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import type { HomeAssistant } from 'custom-card-helpers';
+
+import { resolveCoverBatteries, lowestBattery, batteryIcon, isLowBattery } from '../lib/battery';
+import { t } from '../lib/i18n';
+import { tooltip } from '../lib/tooltip';
+
+/**
+ * Battery indicator for a set of covers, shared by the cover more-info dialog
+ * and the group dialog so the two can never drift.
+ *
+ * Renders nothing when no cover in the set reports a battery. The glyph tracks
+ * the WORST cell — a two-motor shade with one flat battery has to read as flat
+ * — while the tooltip names every cover so which one is low stays recoverable.
+ *
+ * Clicking it leaves the dashboard for HA's own History panel, preloaded with
+ * every battery source in the set, which is where an actual discharge curve
+ * lives. The card has no business re-plotting that.
+ */
+@customElement('acp-battery-indicator')
+export class BatteryIndicator extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+  /** Covers whose batteries this indicator summarizes. */
+  @property({ attribute: false }) public coverIds: string[] = [];
+
+  protected render(): TemplateResult | typeof nothing {
+    if (!this.hass) return nothing;
+    const batteries = resolveCoverBatteries(this.hass, this.coverIds ?? []);
+    const worst = lowestBattery(batteries);
+    if (!worst) return nothing;
+
+    const levels =
+      batteries.length === 1
+        ? worst.level === null
+          ? t('dialog.battery_unknown', this.hass)
+          : t('dialog.battery', this.hass, { level: worst.level })
+        : batteries
+            .map((b) =>
+              t('dialog.battery_named', this.hass, {
+                name: this._coverName(b.cover_id),
+                level: b.level === null ? '—' : b.level,
+              }),
+            )
+            .join(' · ');
+    const action = t('dialog.battery_history', this.hass);
+    const title = `${levels} · ${action}`;
+
+    return html`<button
+      class="battery${isLowBattery(worst) ? ' low' : ''}"
+      type="button"
+      aria-label=${title}
+      ${tooltip(title)}
+      @click=${this._openHistory}
+    >
+      <ha-icon icon=${batteryIcon(worst.level, worst.charging)}></ha-icon>
+    </button>`;
+  }
+
+  private _coverName(coverId: string): string {
+    return (this.hass?.states[coverId]?.attributes?.friendly_name as string | undefined) ?? coverId;
+  }
+
+  /**
+   * HA's History panel reads a comma-separated `entity_id` from the query
+   * string, so all of the entry's battery sources land on one chart. The
+   * sources are deduped — two covers on a single physical device share one
+   * battery sensor, and a repeated id makes the panel's target picker show the
+   * same row twice.
+   */
+  private _openHistory = (): void => {
+    const batteries = resolveCoverBatteries(this.hass, this.coverIds ?? []);
+    const sources = [...new Set(batteries.map((b) => b.source_id))];
+    if (sources.length === 0) return;
+    history.pushState(null, '', `/history?entity_id=${sources.join(',')}`);
+    window.dispatchEvent(new CustomEvent('location-changed', { detail: { replace: false } }));
+    this.dispatchEvent(new CustomEvent('acp-dialog-close', { bubbles: true, composed: true }));
+  };
+
+  public static styles = css`
+    :host {
+      display: contents;
+    }
+    /* Shares the dialogs' .icon-btn metrics so it lines up with the buttons
+       beside it in either header. */
+    .battery {
+      border: 0;
+      background: transparent;
+      cursor: pointer;
+      color: var(--secondary-text-color);
+      padding: 4px 6px;
+      display: inline-flex;
+      align-items: center;
+      --mdc-icon-size: 18px;
+    }
+    .battery:hover {
+      color: var(--primary-text-color);
+    }
+    .battery.low {
+      color: var(--error-color, #db4437);
+    }
+    .battery.low:hover {
+      color: var(--error-color, #db4437);
+      filter: brightness(1.2);
+    }
+  `;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'acp-battery-indicator': BatteryIndicator;
+  }
+}

--- a/src/components/cover-bar.ts
+++ b/src/components/cover-bar.ts
@@ -15,6 +15,8 @@ import { formatCoverState, formatPercent } from '../lib/formatters';
 import { AXIS_LABEL_I18N_KEYS } from '../const';
 import { axisDisplayValue, positionAxisFor, resolveAxes, type ResolvedAxis } from '../lib/axes';
 import { setAxes, hasSetAxes } from '../lib/services';
+import { PendingMoves, isMovingState, isPendingVisible } from '../lib/pending-move';
+import { renderRailOverlay, railOverlayStyles } from './rail-overlay';
 import { t } from '../lib/i18n';
 import { tooltip } from '../lib/tooltip';
 import './tilt-bar';
@@ -41,6 +43,19 @@ export class CoverBar extends LitElement {
    *  (the trailing native `click` after a drag commits via `_handleTrackClick`,
    *  exactly as it does for a plain tap today). */
   @state() private _dragPreview: { entityId: string; pct: number } | null = null;
+
+  /** Moves this bar commanded, keyed by cover entity_id — see
+   *  `lib/pending-move.ts`. Keyed because the dialog stacks one track per
+   *  managed cover and each must show only its own destination. */
+  private _pending = new PendingMoves(this);
+
+  /** Live position per cover as of the last render, for `updated()`'s arrival
+   *  check. Plain field, not `@state`: writing it must not schedule a render. */
+  private _lastLive = new Map<string, number | null>();
+
+  protected override updated(): void {
+    this._pending.settle((entityId) => this._lastLive.get(entityId) ?? null);
+  }
 
   // Live positions come from `coverLogicalActuals`, which reads the target sensor's
   // `linear_actual_positions` (falling back to `actual_positions`); mismatches from the
@@ -115,6 +130,9 @@ export class CoverBar extends LitElement {
    *  legacy per-axis service otherwise. Interactive drags omit `force` so the
    *  service default (no forced override) preserves today's semantics. */
   private _setAxis(entityId: string, axisId: string, value: number): void {
+    // Position only — a secondary axis is drawn by `acp-axis-bar`, which arms
+    // its own indicator.
+    if (axisId === 'position') this._pending.start(entityId, value);
     setAxes(this.hass, entityId, { [axisId]: value });
   }
 
@@ -141,6 +159,7 @@ export class CoverBar extends LitElement {
    * mirror the value on a blind and drive the cover to its complement.
    */
   private _gotoTarget(entityId: string, target: number): void {
+    this._pending.start(entityId, target);
     setAxes(this.hass, entityId, { position: target }, { force: true });
   }
 
@@ -311,6 +330,16 @@ export class CoverBar extends LitElement {
     // text to say it — otherwise the row states the same thing twice.
     // Null (and so omitted) for an unavailable cover, leaving the bare percent.
     const stateText = formatCoverState(this.hass, entityId, transitDir ?? undefined);
+    this._lastLive.set(entityId, actual);
+    // An explicit command wins over the automatic-move hint; an automatic move
+    // is evidenced by the entity being in motion, heading for the tick already
+    // drawn. Suppressed mid-drag, where the preview answers the same question.
+    const autoMoving =
+      isMovingState(this.hass.states[entityId]?.state) && target !== null ? targetPct : null;
+    const commanded = dragPct !== null ? null : (this._pending.get(entityId) ?? autoMoving);
+    // See `acp-axis-bar`: a destination the cover is already at never settles.
+    const pending = isPendingVisible(actual, commanded) ? commanded : null;
+    const pendingPct = pending === null ? null : axisDisplayValue(pending, axis);
     return html`
       <div class="cover ${mismatch ? 'mismatch' : ''}">
         <div
@@ -353,6 +382,14 @@ export class CoverBar extends LitElement {
         >
           <div class="fill" style="width:${fillPct}%"></div>
           <div class="fill-closed" style="width:${100 - fillPct}%"></div>
+          ${pending !== null && pendingPct !== null
+            ? renderRailOverlay({
+                hass: this.hass,
+                liveFrac: fillPct,
+                pendingFrac: pendingPct,
+                pending,
+              })
+            : nothing}
           ${target !== null
             ? html`<div
                 class="marker"
@@ -480,46 +517,48 @@ export class CoverBar extends LitElement {
     this._setAxis(entityId, 'position', axisDisplayValue(clamped, axis));
   }
 
-  public static styles = css`
-    :host {
-      display: block;
-    }
-    .wrap {
-      display: flex;
-      flex-direction: column;
-      gap: 6px;
-    }
-    .head {
-      display: flex;
-      justify-content: space-between;
-      font-size: 0.78rem;
-      color: var(--secondary-text-color);
-    }
-    .label {
-      letter-spacing: 0.05em;
-      text-transform: uppercase;
-    }
-    .targets {
-      display: flex;
-      gap: 12px;
-    }
-    .target {
-      font-variant-numeric: tabular-nums;
-    }
-    /* Position + (optional) tilt row stack for one cover. */
-    .cover-group {
-      display: flex;
-      flex-direction: column;
-      gap: 4px;
-    }
-    .cover-group acp-tilt-bar {
-      /* Indent the tilt row under the position track so the two read as one
+  public static styles = [
+    railOverlayStyles,
+    css`
+      :host {
+        display: block;
+      }
+      .wrap {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+      }
+      .head {
+        display: flex;
+        justify-content: space-between;
+        font-size: 0.78rem;
+        color: var(--secondary-text-color);
+      }
+      .label {
+        letter-spacing: 0.05em;
+        text-transform: uppercase;
+      }
+      .targets {
+        display: flex;
+        gap: 12px;
+      }
+      .target {
+        font-variant-numeric: tabular-nums;
+      }
+      /* Position + (optional) tilt row stack for one cover. */
+      .cover-group {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+      }
+      .cover-group acp-tilt-bar {
+        /* Indent the tilt row under the position track so the two read as one
          cover's two axes. Aligns roughly with the position bar's track column. */
-      padding-left: 0;
-    }
-    .cover {
-      display: grid;
-      /* Final column is fixed at the warn-icon size (16px) rather than auto so
+        padding-left: 0;
+      }
+      .cover {
+        display: grid;
+        /* Final column is fixed at the warn-icon size (16px) rather than auto so
          the track (3fr) keeps the same width whether or not the badge renders —
          a toggling badge no longer reflows the bar graph (#158).
 
@@ -535,41 +574,41 @@ export class CoverBar extends LitElement {
          would hand those pixels to the track and reflow the bar graph. A spacer
          holds the cell instead. Keep in lock-step with acp-tilt-bar's .row.cover
          grid — they are separate grids stacked in one .cover-group. */
-      grid-template-columns: minmax(80px, 1fr) 11ch 3fr 22px 16px;
-      gap: 8px;
-      align-items: center;
-      font-size: 0.82rem;
-    }
-    /* Snap this cover to the marker's value. Sized and coloured like the row's
+        grid-template-columns: minmax(80px, 1fr) 11ch 3fr 22px 16px;
+        gap: 8px;
+        align-items: center;
+        font-size: 0.82rem;
+      }
+      /* Snap this cover to the marker's value. Sized and coloured like the row's
        other glyphs rather than like a control, so a row of covers does not read
        as a row of buttons — it lights up on hover/focus. */
-    .goto-target {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      width: 22px;
-      height: 22px;
-      padding: 0;
-      border: none;
-      border-radius: 50%;
-      background: none;
-      cursor: pointer;
-      color: var(--secondary-text-color);
-      --mdc-icon-size: 16px;
-      transition:
-        color 0.15s ease,
-        background 0.15s ease;
-    }
-    .goto-target:hover {
-      color: var(--accent-color, var(--primary-color));
-      background: color-mix(in srgb, currentColor 14%, transparent);
-    }
-    .goto-target:focus-visible {
-      outline: 2px solid var(--primary-color);
-      outline-offset: 1px;
-      color: var(--accent-color, var(--primary-color));
-    }
-    /* Floating-tooltip cursor lifecycle for this shadow root's INERT tooltip
+      .goto-target {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 22px;
+        height: 22px;
+        padding: 0;
+        border: none;
+        border-radius: 50%;
+        background: none;
+        cursor: pointer;
+        color: var(--secondary-text-color);
+        --mdc-icon-size: 16px;
+        transition:
+          color 0.15s ease,
+          background 0.15s ease;
+      }
+      .goto-target:hover {
+        color: var(--accent-color, var(--primary-color));
+        background: color-mix(in srgb, currentColor 14%, transparent);
+      }
+      .goto-target:focus-visible {
+        outline: 2px solid var(--primary-color);
+        outline-offset: 1px;
+        color: var(--accent-color, var(--primary-color));
+      }
+      /* Floating-tooltip cursor lifecycle for this shadow root's INERT tooltip
        carriers: the transit arrow and the header target chip. Restated here
        because a shadow root cannot borrow its host's copy of this pair.
 
@@ -578,59 +617,59 @@ export class CoverBar extends LitElement {
        role="button" that opens more-info, and .track / the tilt track are
        drag-to-set sliders — so a blanket rule would replace three correct
        pointers with a help cursor that promises information instead of action. */
-    .transit[data-tooltip]:hover,
-    .target[data-tooltip]:hover {
-      cursor: help;
-    }
-    .transit[data-tooltip][acp-tt-shown],
-    .target[data-tooltip][acp-tt-shown] {
-      cursor: default;
-    }
-    /* The cover name is a tap target that opens the entry's more-info dialog,
+      .transit[data-tooltip]:hover,
+      .target[data-tooltip]:hover {
+        cursor: help;
+      }
+      .transit[data-tooltip][acp-tt-shown],
+      .target[data-tooltip][acp-tt-shown] {
+        cursor: default;
+      }
+      /* The cover name is a tap target that opens the entry's more-info dialog,
        so it carries a pointer cursor and a keyboard focus ring. It still hovers
        an entity-id tooltip, but click/Enter/Space open the dialog. */
-    .name {
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      cursor: pointer;
-      border-radius: 4px;
-    }
-    .name:focus-visible {
-      outline: 2px solid var(--primary-color);
-      outline-offset: 2px;
-    }
-    .track {
-      position: relative;
-      display: flex;
-      height: 10px;
-      background: var(--secondary-background-color, rgba(0, 0, 0, 0.08));
-      border-radius: 6px;
-      cursor: pointer;
-      overflow: hidden;
-      /* A touch-drag must move the fill, not the page — own the gesture. */
-      touch-action: none;
-    }
-    .track:focus-visible {
-      outline: 2px solid var(--primary-color);
-      outline-offset: 2px;
-    }
-    :host([compact]) .track {
-      height: 6px;
-    }
-    :host([compact]) .cover {
-      font-size: 0.75rem;
-      gap: 6px;
-    }
-    :host([compact]) .goto-target {
-      width: 18px;
-      height: 18px;
-      --mdc-icon-size: 14px;
-    }
-    :host([compact]) .head {
-      display: none;
-    }
-    /* Both segments derive from the cover colour (override, else --primary-color),
+      .name {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        cursor: pointer;
+        border-radius: 4px;
+      }
+      .name:focus-visible {
+        outline: 2px solid var(--primary-color);
+        outline-offset: 2px;
+      }
+      .track {
+        position: relative;
+        display: flex;
+        height: 10px;
+        background: var(--secondary-background-color, rgba(0, 0, 0, 0.08));
+        border-radius: 6px;
+        cursor: pointer;
+        overflow: hidden;
+        /* A touch-drag must move the fill, not the page — own the gesture. */
+        touch-action: none;
+      }
+      .track:focus-visible {
+        outline: 2px solid var(--primary-color);
+        outline-offset: 2px;
+      }
+      :host([compact]) .track {
+        height: 6px;
+      }
+      :host([compact]) .cover {
+        font-size: 0.75rem;
+        gap: 6px;
+      }
+      :host([compact]) .goto-target {
+        width: 18px;
+        height: 18px;
+        --mdc-icon-size: 14px;
+      }
+      :host([compact]) .head {
+        display: none;
+      }
+      /* Both segments derive from the cover colour (override, else --primary-color),
        distinguished by opacity: blocking is solid, clear is pale — "lighter =
        more open" — matching the compass FOV (light) vs cover wedge (solid) of
        the same hue. No gold, so nothing competes with the gold sun on the compass.
@@ -639,88 +678,97 @@ export class CoverBar extends LitElement {
        the track fills from the left as the cover closes — the same polarity as
        the tile rails and the compass wedge. Class names are kept (a rename buys
        nothing the comment does not) but the colours swapped with the meaning. */
-    .fill {
-      height: 100%;
-      flex-shrink: 0;
-      background: color-mix(in srgb, var(--acp-cover-color, var(--primary-color)) 50%, transparent);
-      transition: width 0.3s ease;
-    }
-    .fill-closed {
-      height: 100%;
-      flex-shrink: 0;
-      background: color-mix(in srgb, var(--acp-cover-color, var(--primary-color)) 18%, transparent);
-      transition: width 0.3s ease;
-    }
-    /* The marker is centred on its left value via translateX(-50%) and its
+      .fill {
+        height: 100%;
+        flex-shrink: 0;
+        background: color-mix(
+          in srgb,
+          var(--acp-cover-color, var(--primary-color)) 50%,
+          transparent
+        );
+        transition: width 0.3s ease;
+      }
+      .fill-closed {
+        height: 100%;
+        flex-shrink: 0;
+        background: color-mix(
+          in srgb,
+          var(--acp-cover-color, var(--primary-color)) 18%,
+          transparent
+        );
+        transition: width 0.3s ease;
+      }
+      /* The marker is centred on its left value via translateX(-50%) and its
        left is clamped 1px inside the rail (inline), so the 2px box never gets
        clipped by .track { overflow:hidden } at the 0%/100% extremes (#158). */
-    .marker {
-      position: absolute;
-      top: -2px;
-      width: 2px;
-      height: 14px;
-      background: var(--accent-color, red);
-      transform: translateX(-50%);
-      transition: left 0.3s ease;
-    }
-    .num {
-      font-variant-numeric: tabular-nums;
-      text-align: right;
-      display: inline-flex;
-      align-items: center;
-      justify-content: flex-end;
-      gap: 2px;
-      white-space: nowrap;
-      min-width: 0;
-      overflow: hidden;
-    }
-    /* The state word yields first; the percentage is the part that must never
+      .marker {
+        position: absolute;
+        top: -2px;
+        width: 2px;
+        height: 14px;
+        background: var(--accent-color, red);
+        transform: translateX(-50%);
+        transition: left 0.3s ease;
+      }
+      .num {
+        font-variant-numeric: tabular-nums;
+        text-align: right;
+        display: inline-flex;
+        align-items: center;
+        justify-content: flex-end;
+        gap: 2px;
+        white-space: nowrap;
+        min-width: 0;
+        overflow: hidden;
+      }
+      /* The state word yields first; the percentage is the part that must never
        be cut, so it holds its intrinsic width. */
-    .num-state {
-      min-width: 0;
-      overflow: hidden;
-      text-overflow: ellipsis;
-    }
-    .num-sep,
-    .num-pct {
-      flex: 0 0 auto;
-    }
-    /* In-transit motion indicator for no-feedback covers: a small direction
+      .num-state {
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+      .num-sep,
+      .num-pct {
+        flex: 0 0 auto;
+      }
+      /* In-transit motion indicator for no-feedback covers: a small direction
        arrow beside the percent, sized to the .num text. */
-    .transit {
-      --mdc-icon-size: 1em;
-      color: var(--primary-color);
-      flex-shrink: 0;
-    }
-    @media (prefers-reduced-motion: no-preference) {
       .transit {
-        animation: acp-transit-pulse 1.1s ease-in-out infinite;
+        --mdc-icon-size: 1em;
+        color: var(--primary-color);
+        flex-shrink: 0;
       }
-    }
-    @keyframes acp-transit-pulse {
-      0%,
-      100% {
-        opacity: 1;
+      @media (prefers-reduced-motion: no-preference) {
+        .transit {
+          animation: acp-transit-pulse 1.1s ease-in-out infinite;
+        }
       }
-      50% {
-        opacity: 0.35;
+      @keyframes acp-transit-pulse {
+        0%,
+        100% {
+          opacity: 1;
+        }
+        50% {
+          opacity: 0.35;
+        }
       }
-    }
-    .warn {
-      color: var(--warning-color, orange);
-      --mdc-icon-size: 16px;
-    }
-    /* On a position mismatch, recolour the leading (sun-blocking) segment with
+      .warn {
+        color: var(--warning-color, orange);
+        --mdc-icon-size: 16px;
+      }
+      /* On a position mismatch, recolour the leading (sun-blocking) segment with
        the error colour and lean on the warn icon at the end of the row. It is
        the segment that carries the cover hue, so tinting it is what reads as a
        divergence rather than as a second cover colour. */
-    .mismatch .fill {
-      background: color-mix(in srgb, var(--error-color, crimson) 35%, transparent);
-    }
-    .placeholder {
-      color: var(--secondary-text-color);
-      text-align: center;
-      padding: 16px;
-    }
-  `;
+      .mismatch .fill {
+        background: color-mix(in srgb, var(--error-color, crimson) 35%, transparent);
+      }
+      .placeholder {
+        color: var(--secondary-text-color);
+        text-align: center;
+        padding: 16px;
+      }
+    `,
+  ];
 }

--- a/src/components/group-dialog.ts
+++ b/src/components/group-dialog.ts
@@ -11,15 +11,24 @@ import { coverStateColor } from '../lib/icons';
 import {
   groupIcon,
   readGroup,
+  restrictSnapshot,
   setGroupPosition,
   setGroupTilt,
   stopGroup,
   type GroupSnapshot,
 } from '../lib/group-controls';
 import { t } from '../lib/i18n';
-import { createRosterMemo, rosterRowKey, rosterRowConfigKey } from '../lib/group-roster';
+import {
+  applyMemberOrder,
+  createRosterMemo,
+  hiddenMemberCovers,
+  rosterRowKey,
+  rosterRowConfigKey,
+  type RosterRow,
+} from '../lib/group-roster';
 import { getCachedRegistry } from '../lib/registry-store';
 
+import './battery-indicator';
 import './cover-move-buttons';
 import './group-controls-row';
 import './group-member-row';
@@ -54,16 +63,24 @@ export class GroupDialog extends LitElement {
   /** Card `member_names` — per-row display overrides, keyed by
    *  {@link rosterRowConfigKey}. */
   @property({ attribute: false }) public memberNames?: Record<string, string>;
+  /** Card `members` — roster order + subset, keyed like {@link memberNames}. */
+  @property({ attribute: false }) public members?: string[];
 
   /** Per-instance roster memo — see `createRosterMemo`. */
   private _roster = createRosterMemo();
 
   protected render(): TemplateResult | typeof nothing {
     if (!this.open || !this.hass || !this.discovered) return nothing;
-    const s = readGroup(this.hass, this.discovered);
+    // The roster is built from the FULL member list and the snapshot restricted
+    // afterwards — the memo keys on the id list, so resolving it against the
+    // already-filtered set would thrash the cache and re-walk the registry on
+    // every render.
+    const raw = readGroup(this.hass, this.discovered);
+    const memberIds = Object.keys(raw.memberPositions);
+    const rows = this._roster(this.hass, memberIds, getCachedRegistry() ?? undefined);
+    const s = restrictSnapshot(this.hass, raw, hiddenMemberCovers(memberIds, this.members));
 
     const iconColor = this.stateColor ? coverStateColor(s.aggregate) : '';
-    const members = Object.entries(s.memberPositions);
     const controllable = !!s.target;
     const badgeWinners = this.showMemberBadges ? memberBadgeWinners(s.memberWinners) : [];
     const closeLabel = t('dialog.close', this.hass);
@@ -89,6 +106,10 @@ export class GroupDialog extends LitElement {
             ${badgeWinners.map(
               (w) => html`<acp-tile-badge .hass=${this.hass} .winner=${w}></acp-tile-badge>`,
             )}
+            <acp-battery-indicator
+              .hass=${this.hass}
+              .coverIds=${Object.keys(s.memberPositions)}
+            ></acp-battery-indicator>
             <button class="close" type="button" aria-label=${closeLabel} @click=${this._emitClose}>
               ✕
             </button>
@@ -142,36 +163,52 @@ export class GroupDialog extends LitElement {
             .showClearOverrides=${this.showClearOverrides}
           ></acp-group-controls-row>
 
-          <div class="members">
-            <div class="members-head">${t('group.members', this.hass)}</div>
-            ${members.length === 0
-              ? html`<div class="member-placeholder">
-                  ${t('group.member_placeholder', this.hass)}
-                </div>`
-              : repeat(
-                  this._roster(
-                    this.hass,
-                    members.map(([id]) => id),
-                    getCachedRegistry() ?? undefined,
-                  ),
-                  rosterRowKey,
-                  (row) =>
-                    html`<acp-group-member-row
-                      .hass=${this.hass}
-                      .entityId=${row.covers[0]}
-                      .coverIds=${row.covers}
-                      .position=${s.memberPositions[row.covers[0]] ?? null}
-                      .winner=${s.memberWinners?.[row.covers[0]]}
-                      .openBlocksSun=${positionAxisFor(this.discovered).openBlocksSun}
-                      .acpManaged=${!!s.memberWinners && row.covers[0] in s.memberWinners}
-                      .displayName=${this.memberNames?.[rosterRowConfigKey(row)]}
-                      .showTilt=${this.showTilt}
-                    ></acp-group-member-row>`,
-                )}
-          </div>
+          ${this._membersTpl(s, memberIds, rows)}
         </div>
       </div>
     `;
+  }
+
+  /**
+   * The member roster, ordered and filtered by the card's `members` key.
+   *
+   * Three outcomes, deliberately distinct: no members at all is the
+   * integration's problem and says so; every member hidden is the user's own
+   * choice and renders nothing (a bare "Members" heading over an empty box
+   * reads as a bug); otherwise the rows in the configured order.
+   */
+  private _membersTpl(
+    s: GroupSnapshot,
+    memberIds: string[],
+    roster: RosterRow[],
+  ): TemplateResult | typeof nothing {
+    if (memberIds.length === 0) {
+      return html`<div class="members">
+        <div class="members-head">${t('group.members', this.hass)}</div>
+        <div class="member-placeholder">${t('group.member_placeholder', this.hass)}</div>
+      </div>`;
+    }
+    const rows = applyMemberOrder(roster, this.members);
+    if (rows.length === 0) return nothing;
+    return html`<div class="members">
+      <div class="members-head">${t('group.members', this.hass)}</div>
+      ${repeat(
+        rows,
+        rosterRowKey,
+        (row) =>
+          html`<acp-group-member-row
+            .hass=${this.hass}
+            .entityId=${row.covers[0]}
+            .coverIds=${row.covers}
+            .position=${s.memberPositions[row.covers[0]] ?? null}
+            .winner=${s.memberWinners?.[row.covers[0]]}
+            .openBlocksSun=${positionAxisFor(this.discovered).openBlocksSun}
+            .acpManaged=${!!s.memberWinners && row.covers[0] in s.memberWinners}
+            .displayName=${this.memberNames?.[rosterRowConfigKey(row)]}
+            .showTilt=${this.showTilt}
+          ></acp-group-member-row>`,
+      )}
+    </div>`;
   }
 
   private _move(e: CustomEvent<'open' | 'stop' | 'close'>, s: GroupSnapshot): void {

--- a/src/components/group-tile.ts
+++ b/src/components/group-tile.ts
@@ -12,11 +12,15 @@ import {
   groupIcon,
   memberException,
   readGroup,
+  restrictSnapshot,
   setGroupPosition,
   setGroupTilt,
   stopGroup,
   type GroupSnapshot,
 } from '../lib/group-controls';
+import { hiddenMemberCovers } from '../lib/group-roster';
+import { PendingMoves, isPendingVisible } from '../lib/pending-move';
+import { renderRailOverlay, railOverlayStyles } from './rail-overlay';
 import { t } from '../lib/i18n';
 import { tooltip } from '../lib/tooltip';
 
@@ -66,15 +70,48 @@ export class GroupTile extends LitElement {
   @property({ attribute: false }) public name?: string;
   /** Card config `icon` — overrides the member-derived glyph. */
   @property({ attribute: false }) public icon?: string;
+  /** Card `members` — the roster subset this card shows. The tile renders no
+   *  roster itself, but every number on it (state line, N/M badge, spread bar,
+   *  percentage) is derived from one, so a member hidden here has to be
+   *  excluded from those too or the tile describes covers the card does not
+   *  show. */
+  @property({ attribute: false }) public members?: string[];
 
   /** Live percentage while a slider drag is in flight; null when idle. Drives
    *  the fill + readout so the bar tracks the finger instead of waiting on the
    *  server round-trip (mirrors the cover tile's `_posDrag`). */
   @state() private _posDrag: number | null = null;
 
+  /** Where the group was last told to go, until it gets there — see
+   *  `lib/pending-move.ts`. A single key: a group write flattens every member
+   *  onto the same position, so there is only ever one destination. */
+  private _pending = new PendingMoves(this);
+  private static readonly PENDING_KEY = 'group';
+
+  protected override updated(): void {
+    if (!this.hass || !this.discovered) return;
+    // Arrival is judged on the AGGREGATE, which is what this rail draws and what
+    // the write drove every member to.
+    this._pending.settle(() => this._snapshot().position);
+  }
+
+  /** The group as this card shows it: the integration's snapshot with any
+   *  member the card hides removed, and every scalar recomputed over what is
+   *  left. `members` is a cover-id list, so this needs no roster and no
+   *  registry — the tile renders no roster of its own. */
+  private _snapshot(): GroupSnapshot {
+    const raw = readGroup(this.hass, this.discovered);
+    if (!this.members?.length) return raw;
+    return restrictSnapshot(
+      this.hass,
+      raw,
+      hiddenMemberCovers(Object.keys(raw.memberPositions), this.members),
+    );
+  }
+
   protected render(): TemplateResult | typeof nothing {
     if (!this.hass || !this.discovered) return nothing;
-    const s = readGroup(this.hass, this.discovered);
+    const s = this._snapshot();
 
     const stateText = t(`group.state_${s.aggregate}`, this.hass);
     const shownPosition = this._posDrag ?? s.position;
@@ -91,6 +128,14 @@ export class GroupTile extends LitElement {
     // to flatten every member onto it, and collapsing the spread as the finger
     // moves is the clearest possible statement of that.
     const dragging = this._posDrag !== null;
+    // A pending group move collapses the spread for the same reason a drag does:
+    // the write flattens every member onto one value, so the disagreement the
+    // band describes is about to stop existing. Suppressed mid-drag — the drag
+    // preview is already answering this question.
+    const commanded = dragging ? null : this._pending.get(GroupTile.PENDING_KEY);
+    // See `acp-axis-bar`: a destination the group is already at never settles.
+    const pending = isPendingVisible(s.position, commanded) ? commanded : null;
+    const pendingFill = pending === null ? null : axisDisplayValue(pending, posAxis);
     // Second line: what the covers are ACTUALLY at, or the one thing that is
     // wrong with them.
     //
@@ -212,7 +257,7 @@ export class GroupTile extends LitElement {
                 @keydown=${(e: KeyboardEvent) => this._onPosKeydown(e, s)}
               >
                 <div class="pos-bar">
-                  ${dragging || !spread
+                  ${dragging || pending !== null || !spread
                     ? html`<div class="pos-fill" style=${`width:${shownFill}%`}></div>`
                     : html`
                         <!-- Solid to the LEAST-covered member: the coverage every
@@ -234,6 +279,15 @@ export class GroupTile extends LitElement {
                             ></div>`,
                         )}
                       `}
+                  ${pending !== null && pendingFill !== null
+                    ? renderRailOverlay({
+                        hass: this.hass,
+                        liveFrac: shownFill,
+                        pendingFrac: pendingFill,
+                        pending,
+                        prefix: 'pos-',
+                      })
+                    : nothing}
                 </div>
               </div>`
             : nothing}
@@ -271,8 +325,17 @@ export class GroupTile extends LitElement {
   }
 
   private _move(e: CustomEvent<'open' | 'stop' | 'close'>, s: GroupSnapshot): void {
-    if (e.detail === 'stop') stopGroup(this.hass, this.discovered, s);
-    else setGroupPosition(this.hass, s, e.detail === 'open' ? 100 : 0);
+    if (e.detail === 'stop') {
+      // Stop cancels the destination rather than becoming one: wherever the
+      // group ends up IS the new position, so an indicator pointing anywhere
+      // else would be a promise the group just abandoned.
+      this._pending.clear(GroupTile.PENDING_KEY);
+      stopGroup(this.hass, this.discovered, s);
+      return;
+    }
+    const value = e.detail === 'open' ? 100 : 0;
+    this._pending.start(GroupTile.PENDING_KEY, value);
+    setGroupPosition(this.hass, s, value);
   }
 
   private _openMoreInfo = (): void => {
@@ -366,6 +429,7 @@ export class GroupTile extends LitElement {
     this._posDownX = null;
     this._posMoved = false;
     if (!moved || value === null || !s.target) return;
+    this._pending.start(GroupTile.PENDING_KEY, value);
     setGroupPosition(this.hass, s, value);
   };
 
@@ -421,255 +485,260 @@ export class GroupTile extends LitElement {
     e.preventDefault();
     e.stopPropagation();
     if (!s.target) return;
-    setGroupPosition(this.hass, s, axisDisplayValue(Math.max(0, Math.min(100, next)), posAxis));
+    const value = axisDisplayValue(Math.max(0, Math.min(100, next)), posAxis);
+    this._pending.start(GroupTile.PENDING_KEY, value);
+    setGroupPosition(this.hass, s, value);
   }
 
   private _stop(e: Event): void {
     e.stopPropagation();
   }
 
-  public static styles = css`
-    :host {
-      display: block;
-    }
-    /* Mirrors the cover tile's detailed grid: the glyph spans the label +
+  public static styles = [
+    railOverlayStyles,
+    css`
+      :host {
+        display: block;
+      }
+      /* Mirrors the cover tile's detailed grid: the glyph spans the label +
        chrome rows so it stays vertically centered, controls sit right. */
-    .group-tile {
-      display: grid;
-      grid-template-areas:
-        'icon label controls'
-        'icon chrome chrome'
-        'tilt tilt tilt'
-        'group group group';
-      grid-template-columns: 36px minmax(0, 1fr) auto;
-      /* HA's ha-tile-container .content: 10px gap, 56px row floor. */
-      column-gap: 10px;
-      min-height: var(--row-height, 56px);
-      row-gap: 2px;
-      align-items: center;
-      padding: 6px 4px;
-      cursor: pointer;
-    }
-    /* Same 50% controls track as the cover tile's detailed grid — HA's inline
+      .group-tile {
+        display: grid;
+        grid-template-areas:
+          'icon label controls'
+          'icon chrome chrome'
+          'tilt tilt tilt'
+          'group group group';
+        grid-template-columns: 36px minmax(0, 1fr) auto;
+        /* HA's ha-tile-container .content: 10px gap, 56px row floor. */
+        column-gap: 10px;
+        min-height: var(--row-height, 56px);
+        row-gap: 2px;
+        align-items: center;
+        padding: 6px 4px;
+        cursor: pointer;
+      }
+      /* Same 50% controls track as the cover tile's detailed grid — HA's inline
        features block is half the card. Gated so a show_controls: false tile
        doesn't reserve half its width for an empty area. */
-    .group-tile.has-controls {
-      grid-template-columns: 36px minmax(0, 1fr) calc(50% - 12px);
-    }
-    /* Unlike the cover tile this element has no reflow that moves the controls
+      .group-tile.has-controls {
+        grid-template-columns: 36px minmax(0, 1fr) calc(50% - 12px);
+      }
+      /* Unlike the cover tile this element has no reflow that moves the controls
        onto their own row, so the 50% track would keep squeezing the name all
        the way down. Below the cover tile's own narrow threshold, hand the track
        back to content and square the buttons off — flex-filling a content-sized
        track collapses them to the glyph width. The container is the host card's
        ha-card (container-type: inline-size); container queries resolve across
        the shadow boundary. */
-    @container (max-width: 340px) {
-      .group-tile.has-controls {
-        grid-template-columns: 36px minmax(0, 1fr) auto;
+      @container (max-width: 340px) {
+        .group-tile.has-controls {
+          grid-template-columns: 36px minmax(0, 1fr) auto;
+        }
+        acp-cover-move-buttons {
+          --acp-move-button-flex: 0 0 auto;
+          --acp-move-button-width: var(--control-button-group-thickness, 36px);
+        }
       }
-      acp-cover-move-buttons {
-        --acp-move-button-flex: 0 0 auto;
-        --acp-move-button-width: var(--control-button-group-thickness, 36px);
+      .group-tile:focus-visible {
+        outline: 2px solid var(--primary-color);
+        outline-offset: 2px;
+        border-radius: 8px;
       }
-    }
-    .group-tile:focus-visible {
-      outline: 2px solid var(--primary-color);
-      outline-offset: 2px;
-      border-radius: 8px;
-    }
-    .cover-icon-wrap {
-      grid-area: icon;
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      width: 36px;
-      height: 36px;
-    }
-    /* HA's ha-tile-icon shape, opt-in via icon_tap_action — see the matching
+      .cover-icon-wrap {
+        grid-area: icon;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 36px;
+        height: 36px;
+      }
+      /* HA's ha-tile-icon shape, opt-in via icon_tap_action — see the matching
        rule on the cover tile for the upstream trail. */
-    .cover-icon-wrap.background {
-      position: relative;
-      border-radius: var(--ha-border-radius-pill, 9999px);
-      overflow: hidden;
-      cursor: pointer;
-    }
-    .cover-icon-wrap.background::before {
-      content: '';
-      position: absolute;
-      inset: 0;
-      background-color: var(--acp-tile-icon-color, var(--disabled-color, #7f7f7f));
-      opacity: 0.2;
-      transition: opacity 180ms ease-in-out;
-    }
-    .cover-icon-wrap.background:hover::before {
-      opacity: 0.35;
-    }
-    .cover-icon-wrap.background:focus-visible {
-      outline: none;
-      box-shadow: 0 0 0 2px var(--acp-tile-icon-color, var(--primary-text-color));
-    }
-    .cover-icon-wrap.background .cover-icon {
-      position: relative;
-    }
-    .cover-icon {
-      --mdc-icon-size: 24px;
-    }
-    .label {
-      grid-area: label;
-      min-width: 0;
-      display: flex;
-      flex-direction: column;
-      justify-content: center;
-    }
-    /* Same theme tokens HA's ha-tile-info uses, matching the cover tile — see
+      .cover-icon-wrap.background {
+        position: relative;
+        border-radius: var(--ha-border-radius-pill, 9999px);
+        overflow: hidden;
+        cursor: pointer;
+      }
+      .cover-icon-wrap.background::before {
+        content: '';
+        position: absolute;
+        inset: 0;
+        background-color: var(--acp-tile-icon-color, var(--disabled-color, #7f7f7f));
+        opacity: 0.2;
+        transition: opacity 180ms ease-in-out;
+      }
+      .cover-icon-wrap.background:hover::before {
+        opacity: 0.35;
+      }
+      .cover-icon-wrap.background:focus-visible {
+        outline: none;
+        box-shadow: 0 0 0 2px var(--acp-tile-icon-color, var(--primary-text-color));
+      }
+      .cover-icon-wrap.background .cover-icon {
+        position: relative;
+      }
+      .cover-icon {
+        --mdc-icon-size: 24px;
+      }
+      .label {
+        grid-area: label;
+        min-width: 0;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+      }
+      /* Same theme tokens HA's ha-tile-info uses, matching the cover tile — see
        that rule for why the two lines take different line-heights. */
-    .title {
-      font-size: var(--ha-font-size-m, 0.875rem);
-      font-weight: var(--ha-font-weight-medium, 500);
-      line-height: var(--ha-line-height-normal, 1.6);
-      letter-spacing: 0.1px;
-      color: var(--primary-text-color);
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-    }
-    .state {
-      font-size: var(--ha-font-size-s, 0.75rem);
-      font-weight: var(--ha-font-weight-normal, 400);
-      line-height: var(--ha-line-height-condensed, 1.2);
-      letter-spacing: 0.4px;
-      color: var(--secondary-text-color);
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-    }
-    .controls {
-      grid-area: controls;
-      align-self: center;
-      display: inline-flex;
-    }
-    .chrome-line {
-      grid-area: chrome;
-      display: flex;
-      align-items: center;
-      gap: 6px;
-      min-width: 0;
-      /* Reserve the badge pill's height even with no badge, so the row keeps the
+      .title {
+        font-size: var(--ha-font-size-m, 0.875rem);
+        font-weight: var(--ha-font-weight-medium, 500);
+        line-height: var(--ha-line-height-normal, 1.6);
+        letter-spacing: 0.1px;
+        color: var(--primary-text-color);
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+      .state {
+        font-size: var(--ha-font-size-s, 0.75rem);
+        font-weight: var(--ha-font-weight-normal, 400);
+        line-height: var(--ha-line-height-condensed, 1.2);
+        letter-spacing: 0.4px;
+        color: var(--secondary-text-color);
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+      .controls {
+        grid-area: controls;
+        align-self: center;
+        display: inline-flex;
+      }
+      .chrome-line {
+        grid-area: chrome;
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        min-width: 0;
+        /* Reserve the badge pill's height even with no badge, so the row keeps the
          same height either way and the bar centers in it (cover tile parity). */
-      min-height: 22px;
-      /* The one deliberate divergence from the cover tile's nowrap: a group's
+        min-height: 22px;
+        /* The one deliberate divergence from the cover tile's nowrap: a group's
          badge count is unbounded (one per distinct member override), so the row
          wraps rather than crushing the slider. With the usual 0-1 badges the
          layout is identical. */
-      flex-wrap: wrap;
-    }
-    /* Badges hold their intrinsic width so the bar absorbs any shortage. */
-    .chrome-line acp-tile-badge {
-      overflow: visible;
-      flex: 0 0 auto;
-    }
-    /* Interactive wrapper carries the sizing; the visible rail below stays 6px.
+        flex-wrap: wrap;
+      }
+      /* Badges hold their intrinsic width so the bar absorbs any shortage. */
+      .chrome-line acp-tile-badge {
+        overflow: visible;
+        flex: 0 0 auto;
+      }
+      /* Interactive wrapper carries the sizing; the visible rail below stays 6px.
        Geometry is copied from the cover tile's .chrome-line .pos-slider rule so
        a group tile stacked under cover tiles lines its bar up with theirs,
        instead of stretching the full width of the row. */
-    .pos-slider {
-      margin-left: auto;
-      align-self: center;
-      position: relative;
-      flex: 0 1 170px;
-      max-width: 55%;
-      cursor: pointer;
-      /* A touch-drag must move the fill, not scroll the dashboard. */
-      touch-action: none;
-    }
-    /* The rail is too thin to grab on a phone — widen the hit area vertically
+      .pos-slider {
+        margin-left: auto;
+        align-self: center;
+        position: relative;
+        flex: 0 1 170px;
+        max-width: 55%;
+        cursor: pointer;
+        /* A touch-drag must move the fill, not scroll the dashboard. */
+        touch-action: none;
+      }
+      /* The rail is too thin to grab on a phone — widen the hit area vertically
        with an invisible absolute box, which adds no layout height. */
-    .pos-slider::before {
-      content: '';
-      position: absolute;
-      inset: -8px 0;
-    }
-    .pos-slider:focus-visible {
-      outline: 2px solid var(--primary-color);
-      outline-offset: 3px;
-      border-radius: 6px;
-    }
-    /* Nothing to drive: match the buttons rather than looking live and no-oping. */
-    .pos-slider.disabled {
-      cursor: default;
-      opacity: 0.4;
-      touch-action: auto;
-    }
-    .pos-bar {
-      position: relative;
-      width: 100%;
-      height: 6px;
-      border-radius: 6px;
-      background: var(--secondary-background-color, rgba(127, 127, 127, 0.15));
-      overflow: hidden;
-    }
-    .pos-fill {
-      position: absolute;
-      inset: 0 auto 0 0;
-      /* One constant color for every rail, never the cover's state color: a rail
+      .pos-slider::before {
+        content: '';
+        position: absolute;
+        inset: -8px 0;
+      }
+      .pos-slider:focus-visible {
+        outline: 2px solid var(--primary-color);
+        outline-offset: 3px;
+        border-radius: 6px;
+      }
+      /* Nothing to drive: match the buttons rather than looking live and no-oping. */
+      .pos-slider.disabled {
+        cursor: default;
+        opacity: 0.4;
+        touch-action: auto;
+      }
+      .pos-bar {
+        position: relative;
+        width: 100%;
+        height: 6px;
+        border-radius: 6px;
+        background: var(--secondary-background-color, rgba(127, 127, 127, 0.15));
+        overflow: hidden;
+      }
+      .pos-fill {
+        position: absolute;
+        inset: 0 auto 0 0;
+        /* One constant color for every rail, never the cover's state color: a rail
          that changed hue as it crossed open/closed read as a status light rather
          than a measurement. Overridable per-theme via --acp-pos-fill-color. */
-      background: var(--acp-pos-fill-color, ${unsafeCSS(COVER_ACTIVE_COLOR)});
-      opacity: 0.55;
-      border-radius: 6px;
-      transition: width 0.3s ease;
-    }
-    /* Disagreement band: from the least-covered member to the most-covered one.
+        background: var(--acp-pos-fill-color, ${unsafeCSS(COVER_ACTIVE_COLOR)});
+        opacity: 0.55;
+        border-radius: 6px;
+        transition: width 0.3s ease;
+      }
+      /* Disagreement band: from the least-covered member to the most-covered one.
        Same hue as the fill at a lower opacity, so it reads as "some of them are
        also this far" rather than as a second measurement. Zero-width when the
        members agree, which is why it isn't rendered at all in that case. */
-    .pos-band {
-      position: absolute;
-      top: 0;
-      bottom: 0;
-      background: var(--acp-pos-fill-color, ${unsafeCSS(COVER_ACTIVE_COLOR)});
-      opacity: 0.22;
-      transition:
-        left 0.3s ease,
-        width 0.3s ease;
-    }
-    /* One tick per DISTINCT member value. Two clusters of covers draw two ticks,
+      .pos-band {
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        background: var(--acp-pos-fill-color, ${unsafeCSS(COVER_ACTIVE_COLOR)});
+        opacity: 0.22;
+        transition:
+          left 0.3s ease,
+          width 0.3s ease;
+      }
+      /* One tick per DISTINCT member value. Two clusters of covers draw two ticks,
        which is the whole point: "Mixed" stops being a word and becomes a picture
        of where they actually are. Clamped inside the rail (inline) so the 2px box
        survives .pos-bar's overflow:hidden at either extreme, same as the cover
        bar's target marker. */
-    .pos-tick {
-      position: absolute;
-      top: -2px;
-      width: 2px;
-      height: 10px;
-      border-radius: 1px;
-      background: var(--acp-pos-fill-color, ${unsafeCSS(COVER_ACTIVE_COLOR)});
-      transform: translateX(-50%);
-      transition: left 0.3s ease;
-    }
-    /* The rail has to show the ticks that overhang it. Only the FILL and BAND
+      .pos-tick {
+        position: absolute;
+        top: -2px;
+        width: 2px;
+        height: 10px;
+        border-radius: 1px;
+        background: var(--acp-pos-fill-color, ${unsafeCSS(COVER_ACTIVE_COLOR)});
+        transform: translateX(-50%);
+        transition: left 0.3s ease;
+      }
+      /* The rail has to show the ticks that overhang it. Only the FILL and BAND
        need clipping to the rounded ends, so they round themselves instead. */
-    .pos-bar {
-      overflow: visible;
-    }
-    .pos-band {
-      border-radius: 6px;
-    }
-    /* The ease above smooths server-driven updates; mid-drag it reads as lag. */
-    .pos-slider.dragging .pos-fill {
-      transition: none;
-    }
-    .tilt-line {
-      grid-area: tilt;
-      min-width: 0;
-      cursor: default;
-    }
-    acp-group-controls-row {
-      grid-area: group;
-      margin-top: 4px;
-    }
-  `;
+      .pos-bar {
+        overflow: visible;
+      }
+      .pos-band {
+        border-radius: 6px;
+      }
+      /* The ease above smooths server-driven updates; mid-drag it reads as lag. */
+      .pos-slider.dragging .pos-fill {
+        transition: none;
+      }
+      .tilt-line {
+        grid-area: tilt;
+        min-width: 0;
+        cursor: default;
+      }
+      acp-group-controls-row {
+        grid-area: group;
+        margin-top: 4px;
+      }
+    `,
+  ];
 }
 
 declare global {

--- a/src/components/group-view.ts
+++ b/src/components/group-view.ts
@@ -9,13 +9,21 @@ import { positionAxisFor } from '../lib/axes';
 import { formatPercent } from '../lib/formatters';
 import {
   readGroup,
+  restrictSnapshot,
   setGroupPosition,
   setGroupTilt,
   stopGroup,
   type GroupSnapshot,
 } from '../lib/group-controls';
 import { t } from '../lib/i18n';
-import { createRosterMemo, rosterRowKey, rosterRowConfigKey } from '../lib/group-roster';
+import {
+  applyMemberOrder,
+  createRosterMemo,
+  hiddenMemberCovers,
+  rosterRowKey,
+  rosterRowConfigKey,
+  type RosterRow,
+} from '../lib/group-roster';
 import { getCachedRegistry } from '../lib/registry-store';
 
 import './cover-move-buttons';
@@ -47,14 +55,20 @@ export class GroupView extends LitElement {
   /** Card `member_names` — per-row display overrides, keyed by
    *  {@link rosterRowConfigKey}. */
   @property({ attribute: false }) public memberNames?: Record<string, string>;
+  /** Card `members` — roster order + subset, keyed like {@link memberNames}. */
+  @property({ attribute: false }) public members?: string[];
 
   /** Per-instance roster memo — see `createRosterMemo`. */
   private _roster = createRosterMemo();
 
   protected render(): TemplateResult | typeof nothing {
     if (!this.hass || !this.discovered) return nothing;
-    const s = readGroup(this.hass, this.discovered);
-    const members = Object.entries(s.memberPositions);
+    // Roster from the full list, snapshot restricted after — see the note on
+    // `acp-group-dialog`'s render.
+    const raw = readGroup(this.hass, this.discovered);
+    const memberIds = Object.keys(raw.memberPositions);
+    const rows = this._roster(this.hass, memberIds, getCachedRegistry() ?? undefined);
+    const s = restrictSnapshot(this.hass, raw, hiddenMemberCovers(memberIds, this.members));
     const controllable = !!s.target;
 
     return html`
@@ -108,35 +122,45 @@ export class GroupView extends LitElement {
           .snapshot=${s}
         ></acp-group-controls-row>
 
-        <div class="members">
-          <div class="members-head">${t('group.members', this.hass)}</div>
-          ${members.length === 0
-            ? html`<div class="member-placeholder">
-                ${t('group.member_placeholder', this.hass)}
-              </div>`
-            : repeat(
-                this._roster(
-                  this.hass,
-                  members.map(([id]) => id),
-                  getCachedRegistry() ?? undefined,
-                ),
-                rosterRowKey,
-                (row) =>
-                  html`<acp-group-member-row
-                    .hass=${this.hass}
-                    .entityId=${row.covers[0]}
-                    .coverIds=${row.covers}
-                    .position=${s.memberPositions[row.covers[0]] ?? null}
-                    .winner=${s.memberWinners?.[row.covers[0]]}
-                    .openBlocksSun=${positionAxisFor(this.discovered).openBlocksSun}
-                    .acpManaged=${!!s.memberWinners && row.covers[0] in s.memberWinners}
-                    .displayName=${this.memberNames?.[rosterRowConfigKey(row)]}
-                    .compact=${this.compact}
-                  ></acp-group-member-row>`,
-              )}
-        </div>
+        ${this._membersTpl(s, memberIds, rows)}
       </div>
     `;
+  }
+
+  /** The roster, ordered and filtered by `members`. Same three outcomes the
+   *  dialog draws — see `acp-group-dialog`'s `_membersTpl`. */
+  private _membersTpl(
+    s: GroupSnapshot,
+    memberIds: string[],
+    roster: RosterRow[],
+  ): TemplateResult | typeof nothing {
+    if (memberIds.length === 0) {
+      return html`<div class="members">
+        <div class="members-head">${t('group.members', this.hass)}</div>
+        <div class="member-placeholder">${t('group.member_placeholder', this.hass)}</div>
+      </div>`;
+    }
+    const rows = applyMemberOrder(roster, this.members);
+    if (rows.length === 0) return nothing;
+    return html`<div class="members">
+      <div class="members-head">${t('group.members', this.hass)}</div>
+      ${repeat(
+        rows,
+        rosterRowKey,
+        (row) =>
+          html`<acp-group-member-row
+            .hass=${this.hass}
+            .entityId=${row.covers[0]}
+            .coverIds=${row.covers}
+            .position=${s.memberPositions[row.covers[0]] ?? null}
+            .winner=${s.memberWinners?.[row.covers[0]]}
+            .openBlocksSun=${positionAxisFor(this.discovered).openBlocksSun}
+            .acpManaged=${!!s.memberWinners && row.covers[0] in s.memberWinners}
+            .displayName=${this.memberNames?.[rosterRowConfigKey(row)]}
+            .compact=${this.compact}
+          ></acp-group-member-row>`,
+      )}
+    </div>`;
   }
 
   private _move(e: CustomEvent<'open' | 'stop' | 'close'>, s: GroupSnapshot): void {

--- a/src/components/more-info-dialog.ts
+++ b/src/components/more-info-dialog.ts
@@ -38,7 +38,6 @@ import type {
   PositionHistorySample,
 } from '../types';
 import { formatPercent } from '../lib/formatters';
-import { resolveCoverBatteries, lowestBattery, batteryIcon, isLowBattery } from '../lib/battery';
 import { fetchPositionHistory } from '../lib/position-history';
 import { startOfDay } from '../lib/sun-model';
 import { t } from '../lib/i18n';
@@ -54,6 +53,7 @@ import './sky-compass';
 import './elevation-chart';
 import './solar-calc';
 import './history-dialog';
+import './battery-indicator';
 
 /**
  * ACP-specific more-info dialog rendered by the card (not HA's built-in
@@ -197,46 +197,6 @@ export class MoreInfoDialog extends LitElement {
     return coverStateColor(stateObj?.state);
   }
 
-  /**
-   * Battery indicator beside the History button, rendered only when at least one
-   * managed cover reports a battery. The icon tracks the WORST cell in the entry
-   * — a two-motor shade with one flat battery has to read as flat — while the
-   * tooltip names every cover so which one is low stays recoverable.
-   */
-  private _batteryTpl(): TemplateResult | typeof nothing {
-    const covers = this.coverOrder ?? this.discovered?.managed_covers ?? [];
-    const batteries = resolveCoverBatteries(this.hass, covers);
-    const worst = lowestBattery(batteries);
-    if (!worst) return nothing;
-
-    const title =
-      batteries.length === 1
-        ? worst.level === null
-          ? t('dialog.battery_unknown', this.hass)
-          : t('dialog.battery', this.hass, { level: worst.level })
-        : batteries
-            .map((b) =>
-              t('dialog.battery_named', this.hass, {
-                name: this._coverName(b.cover_id),
-                level: b.level === null ? '—' : b.level,
-              }),
-            )
-            .join(' · ');
-
-    return html`<div
-      class="icon-btn battery${isLowBattery(worst) ? ' low' : ''}"
-      role="img"
-      aria-label=${title}
-      ${tooltip(title)}
-    >
-      <ha-icon icon=${batteryIcon(worst.level, worst.charging)}></ha-icon>
-    </div>`;
-  }
-
-  private _coverName(coverId: string): string {
-    return (this.hass?.states[coverId]?.attributes?.friendly_name as string | undefined) ?? coverId;
-  }
-
   protected render(): TemplateResult | typeof nothing {
     if (!this.open || !this.hass || !this.discovered) return nothing;
     const winner = this._winner();
@@ -301,7 +261,10 @@ export class MoreInfoDialog extends LitElement {
                         ></acp-tile-badge>`,
                     )}
             </div>
-            ${this._batteryTpl()}
+            <acp-battery-indicator
+              .hass=${this.hass}
+              .coverIds=${this.coverOrder ?? this.discovered.managed_covers ?? []}
+            ></acp-battery-indicator>
             <button
               class="icon-btn history-link"
               type="button"
@@ -735,14 +698,6 @@ export class MoreInfoDialog extends LitElement {
       display: inline-flex;
       align-items: center;
       --mdc-icon-size: 18px;
-    }
-    /* The battery shares .icon-btn's metrics so it lines up with the buttons
-       beside it, but it is a readout, not a control — no pointer affordance. */
-    .icon-btn.battery {
-      cursor: default;
-    }
-    .icon-btn.battery.low {
-      color: var(--error-color, #db4437);
     }
     .icon-btn:hover {
       color: var(--primary-text-color);

--- a/src/components/rail-overlay.ts
+++ b/src/components/rail-overlay.ts
@@ -1,0 +1,138 @@
+import { css, html, nothing, type CSSResult, type TemplateResult } from 'lit';
+import type { HomeAssistant } from 'custom-card-helpers';
+
+import { t } from '../lib/i18n';
+import { travelBand } from '../lib/pending-move';
+import { tooltip } from '../lib/tooltip';
+
+/**
+ * The "moving to" overlay, shared by every position rail.
+ *
+ * Four surfaces draw position tracks — `acp-cover-bar`, `acp-axis-bar`, the
+ * cover tile's `_posBar` and the group tile's `pos-slider` — and the travel band
+ * and destination pip are pixel-identical on all of them. Written per-surface
+ * they were four copies of the same two elements and the same twenty lines of
+ * CSS, which is exactly how the four rails drifted apart in the first place.
+ *
+ * Deliberately a render helper plus a stylesheet fragment rather than its own
+ * custom element. The overlay is absolutely positioned against the track it
+ * belongs to, so as a nested element it would need the track's box passed in;
+ * and each rail's track lives in its own shadow root, so a nested element would
+ * also move `.fill` / `.marker` out of reach of the ~400 existing assertions
+ * that query them. This keeps one source of truth for the markup while leaving
+ * each rail's DOM exactly where its tests, and its own CSS, expect it.
+ *
+ * `prefix` names the classes so a rail keeps its existing vocabulary: the
+ * dialog bars use `travel`/`pending-marker`, the dense tile rails `pos-travel`/
+ * `pos-pending`.
+ */
+export interface RailOverlayOptions {
+  hass: HomeAssistant;
+  /** Where the cover is now, as a DRAWN track percentage. */
+  liveFrac: number;
+  /** Where it is heading, as a DRAWN track percentage. */
+  pendingFrac: number;
+  /** The destination in axis units — what the tooltip says, never the drawn
+   *  fraction: the two diverge the moment the axis is mirrored. */
+  pending: number;
+  /** Class prefix: '' → `travel` / `pending-marker`, 'pos-' → `pos-travel` /
+   *  `pos-pending`. */
+  prefix?: '' | 'pos-';
+}
+
+export function renderRailOverlay(opts: RailOverlayOptions): TemplateResult | typeof nothing {
+  const { hass, liveFrac, pendingFrac, pending } = opts;
+  const prefix = opts.prefix ?? '';
+  const band = travelBand(liveFrac, pendingFrac);
+  const label = t('covers.moving_to', hass, { pct: pending });
+  const bandClass = `${prefix}travel`;
+  const pipClass = prefix === '' ? 'pending-marker' : `${prefix}pending`;
+  return html`<div
+      class=${bandClass}
+      style="left:${band.left}%;width:${band.width}%"
+      ${tooltip(label)}
+    ></div>
+    <div
+      class=${pipClass}
+      style="left:clamp(1px, ${pendingFrac}%, calc(100% - 1px))"
+      ${tooltip(label)}
+    ></div>`;
+}
+
+/**
+ * The overlay's styles, for a rail's `static styles` array.
+ *
+ * Two rules, both load-bearing:
+ *
+ * The band is STRIPED rather than a flat tint so it never reads as a second
+ * fill — the solid fill beside it is the only thing claiming to be the cover's
+ * real position. Animating its width makes it visibly shrink as the cover
+ * closes the gap, which is the whole point of drawing a band instead of just a
+ * mark.
+ *
+ * The pip is a different SHAPE from the solar-target marker, not merely a
+ * different colour. The two share one track, and colour alone would not
+ * separate them for a colour-blind user.
+ *
+ * Colour resolves through each rail's OWN existing variable rather than making
+ * every host publish a new one: the dialog bars already thread
+ * `--acp-cover-color` (per-cover tint) and the tile rails `--acp-pos-fill-color`
+ * (theme override), so the chain picks up whichever the surrounding rail set.
+ * `--acp-rail-accent` overrides both when a host wants the overlay to differ
+ * from its fill.
+ */
+export const railOverlayStyles: CSSResult = css`
+  .travel,
+  .pos-travel {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    height: 100%;
+    pointer-events: none;
+    border-radius: inherit;
+    background: repeating-linear-gradient(
+      135deg,
+      var(
+          --acp-rail-accent,
+          var(--acp-cover-color, var(--acp-pos-fill-color, var(--primary-color)))
+        )
+        0 4px,
+      transparent 4px 8px
+    );
+    opacity: 0.45;
+    transition:
+      left 0.3s ease,
+      width 0.3s ease;
+  }
+  .pending-marker,
+  .pos-pending {
+    position: absolute;
+    top: 50%;
+    width: 8px;
+    height: 8px;
+    pointer-events: none;
+    background: var(
+      --acp-rail-accent,
+      var(--acp-cover-color, var(--acp-pos-fill-color, var(--primary-color)))
+    );
+    border: 1px solid var(--card-background-color, #fff);
+    transform: translate(-50%, -50%) rotate(45deg);
+    transition: left 0.3s ease;
+  }
+  /* The dense tile rails are 6px tall; a full-size pip would overhang them. */
+  .pos-pending {
+    width: 7px;
+    height: 7px;
+  }
+  .pos-travel {
+    background: repeating-linear-gradient(
+      135deg,
+      var(
+          --acp-rail-accent,
+          var(--acp-cover-color, var(--acp-pos-fill-color, var(--primary-color)))
+        )
+        0 3px,
+      transparent 3px 6px
+    );
+  }
+`;

--- a/src/components/sky-compass.ts
+++ b/src/components/sky-compass.ts
@@ -11,7 +11,7 @@ import {
   arcsOverlap,
   arrowheadPath,
   azimuthToCartesian,
-  blindSpotBearings,
+  blindSpotBearingList,
   clampActiveArcToFov,
   coverWedgeOuterRadius,
   elevationGatedFovBounds,
@@ -505,12 +505,16 @@ export class SkyCompass extends LitElement {
       o.actualPos !== null
         ? coverWedgeOuterRadius(o.actualPos, o.openBlocksSun, OUTER_R, fovOuterR)
         : null;
-    const bsBearings = o.sun.blind_spot_range
-      ? blindSpotBearings(windowAzi, o.sun.blind_spot_range as [number, number])
-      : null;
-    const blindSpot = bsBearings
-      ? wedgePath(bsBearings[0], bsBearings[1], OUTER_R, 0, northOffsetDeg)
-      : null;
+    // Every configured slot, not just slot 1 — see blindSpotBearingList (#269).
+    const blindSpots = blindSpotBearingList(
+      windowAzi,
+      o.sun.blind_spot_ranges,
+      o.sun.blind_spot_range,
+    ).map(([from, to]) => ({
+      from,
+      to,
+      path: wedgePath(from, to, OUTER_R, 0, northOffsetDeg),
+    }));
     const fovPath = wedgePath(wedgeStart, wedgeEnd, fovOuterR, fovInnerR, northOffsetDeg);
     // Static FOV underlay: the configured `windowAzi ± fov_left/right` envelope.
     // Shown dim beneath the active arc so the developer can see the "configured
@@ -597,12 +601,17 @@ export class SkyCompass extends LitElement {
       }
     }
     const ttCoverFill = ttCoverLines.join('\n');
-    const ttBlindSpot = bsBearings
-      ? `${label}${t('compass.blind_spot', this.hass, {
-          from: formatDegrees(bsBearings[0]),
-          to: formatDegrees(bsBearings[1]),
-        })}`
-      : '';
+    // One line per slot, the entry label only on the first — same shape as
+    // ttCoverLines above.
+    const ttBlindSpot = blindSpots
+      .map((b, i) => {
+        const line = t('compass.blind_spot', this.hass, {
+          from: formatDegrees(b.from),
+          to: formatDegrees(b.to),
+        });
+        return i === 0 ? `${label}${line}` : line;
+      })
+      .join('\n');
 
     // In multi-entry mode the entry color is an *identity* — the whole wedge
     // group (FOV, cover, blind, window) shares it so entries are distinguishable.
@@ -618,7 +627,7 @@ export class SkyCompass extends LitElement {
     const arrowBaseStyle = groupColor ? `fill: ${o.color};` : '';
 
     const showCover = this.showCoverFill && coverPath !== '';
-    const showBlind = this.showBlindSpot && !!blindSpot;
+    const showBlind = this.showBlindSpot && blindSpots.length > 0;
     const showArrow = this.showWindowArrow;
     const arrowPath = `M 0 0 L ${windowArrow.x} ${windowArrow.y}`;
     // Arrowhead at the rim end of the window line, pointing along the window
@@ -677,7 +686,9 @@ export class SkyCompass extends LitElement {
         }
       </g>
       <g class="blind-group" style=${showBlind ? '' : hideStyle} ${tooltip(ttBlindSpot)}>
-        <path class="blind-spot" style=${blindStyle} d=${blindSpot ?? ''}></path>
+        ${blindSpots.map(
+          (b) => svg`<path class="blind-spot" style=${blindStyle} d=${b.path}></path>`,
+        )}
       </g>
     </g>`;
   }

--- a/src/components/tilt-bar.ts
+++ b/src/components/tilt-bar.ts
@@ -1,9 +1,11 @@
-import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
+import { LitElement, html, css, nothing, type PropertyValues, type TemplateResult } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import type { HomeAssistant } from 'custom-card-helpers';
 
 import { formatPercent } from '../lib/formatters';
 import { t } from '../lib/i18n';
+import { PendingMoves, isPendingVisible } from '../lib/pending-move';
+import { renderRailOverlay, railOverlayStyles } from './rail-overlay';
 import { tooltip } from '../lib/tooltip';
 
 /**
@@ -74,6 +76,20 @@ export class AxisBar extends LitElement {
    *  whenever no gesture is active. */
   @state() private _dragValue: number | null = null;
 
+  /** Where the HOST knows this axis is heading when the move did not come from
+   *  this bar — an automatic pipeline move. The bar cannot derive it: it sees
+   *  only `actual`/`target` and has no entity to ask whether the cover is in
+   *  motion, so the surface that owns the cover passes it down. */
+  @property({ attribute: false }) public movingTo: number | null = null;
+
+  /** Moves this bar itself commanded, until the axis reports arrival. */
+  private _pending = new PendingMoves(this);
+  private static readonly PENDING_KEY = 'axis';
+
+  protected override updated(changed: PropertyValues): void {
+    if (changed.has('actual')) this._pending.settle(() => this.actual);
+  }
+
   /** True when driving this axis toward its maximum blocks MORE sun, so the
    *  track fills toward the maximum. False mirrors it, which is the slat-angle
    *  case: closing the slats blocks the sun but lowers the value.
@@ -108,6 +124,18 @@ export class AxisBar extends LitElement {
     const shownValue = this._dragValue ?? this.actual;
     const actualFrac = this._frac(shownValue);
     const targetFrac = this._frac(this.target);
+    // Hidden while a drag is in flight: the drag preview already paints where
+    // the finger is, and a band to the PREVIOUS command underneath it would be
+    // two answers to the same question.
+    // An explicit command from this bar wins over the host's automatic-move
+    // hint: if both are live the user's own value is the one they are waiting on.
+    const commanded = dragging ? null : (this._pending.get(AxisBar.PENDING_KEY) ?? this.movingTo);
+    // Drop a destination the axis is ALREADY at. Commanding a value within
+    // arrival tolerance of the current one moves nothing, so `actual` never
+    // changes and nothing ever settles the move — the indicator would sit there
+    // as a zero-width band and a stray pip until the timeout.
+    const pending = isPendingVisible(shownValue, commanded) ? commanded : null;
+    const pendingFrac = pending === null ? null : this._frac(pending);
     const label = this.label ?? t('covers.tilt_title', this.hass);
     return html`
       <div
@@ -140,6 +168,14 @@ export class AxisBar extends LitElement {
         >
           <div class="fill" style="width:${actualFrac}%"></div>
           <div class="fill-closed" style="width:${100 - actualFrac}%"></div>
+          ${pending !== null && pendingFrac !== null
+            ? renderRailOverlay({
+                hass: this.hass,
+                liveFrac: actualFrac,
+                pendingFrac,
+                pending,
+              })
+            : nothing}
           ${this.target !== null
             ? html`<div
                 class="marker"
@@ -175,6 +211,7 @@ export class AxisBar extends LitElement {
   }
 
   private _commit(value: number): void {
+    this._pending.start(AxisBar.PENDING_KEY, value);
     this.dispatchEvent(
       new CustomEvent<number>('acp-tilt-set', { detail: value, bubbles: true, composed: true }),
     );
@@ -253,18 +290,20 @@ export class AxisBar extends LitElement {
     this._commit(this._clamp(next));
   }
 
-  public static styles = css`
-    :host {
-      display: block;
-    }
-    .row {
-      display: grid;
-      align-items: center;
-    }
-    /* Cover-bar variant: mirror .cover's grid so the track + percentage line up
+  public static styles = [
+    railOverlayStyles,
+    css`
+      :host {
+        display: block;
+      }
+      .row {
+        display: grid;
+        align-items: center;
+      }
+      /* Cover-bar variant: mirror .cover's grid so the track + percentage line up
        with the Position row directly above (name | num | track | warn-spacer). */
-    .row.cover {
-      /* Must stay identical to acp-cover-bar's .cover grid — these are two
+      .row.cover {
+        /* Must stay identical to acp-cover-bar's .cover grid — these are two
          separate grids stacked in one .cover-group, so any divergence offsets
          this track from the position track directly above it. Fixed, not
          minmax: an auto track resolves per-grid to its own content.
@@ -273,89 +312,98 @@ export class AxisBar extends LitElement {
          no counterpart — the button drives the POSITION axis, and a tilt target
          is a separate value — so the column is present here purely as a spacer
          to keep the two tracks aligned. */
-      grid-template-columns: minmax(80px, 1fr) 11ch 3fr 22px 16px;
-      gap: 8px;
-      font-size: 0.82rem;
-    }
-    :host([compact]) .row.cover {
-      gap: 6px;
-      font-size: 0.75rem;
-    }
-    /* Tile variant: inline "TILT 35% [track]" — label then % then the bar. */
-    .row.tile {
-      grid-template-columns: auto auto 1fr;
-      gap: 6px;
-      font-size: 0.75rem;
-    }
-    .label {
-      letter-spacing: 0.05em;
-      text-transform: uppercase;
-      color: var(--secondary-text-color);
-    }
-    .num {
-      font-variant-numeric: tabular-nums;
-      color: var(--secondary-text-color);
-    }
-    .row.cover .num {
-      text-align: right;
-    }
-    /* Track mirrors the position bar: the LEADING segment carries the
+        grid-template-columns: minmax(80px, 1fr) 11ch 3fr 22px 16px;
+        gap: 8px;
+        font-size: 0.82rem;
+      }
+      :host([compact]) .row.cover {
+        gap: 6px;
+        font-size: 0.75rem;
+      }
+      /* Tile variant: inline "TILT 35% [track]" — label then % then the bar. */
+      .row.tile {
+        grid-template-columns: auto auto 1fr;
+        gap: 6px;
+        font-size: 0.75rem;
+      }
+      .label {
+        letter-spacing: 0.05em;
+        text-transform: uppercase;
+        color: var(--secondary-text-color);
+      }
+      .num {
+        font-variant-numeric: tabular-nums;
+        color: var(--secondary-text-color);
+      }
+      .row.cover .num {
+        text-align: right;
+      }
+      /* Track mirrors the position bar: the LEADING segment carries the
        sun-blocking portion and is solid, the trailing clear portion is pale —
        same hue as the cover wedge. The leading segment is sized from the drawn
        fraction, so on a mirrored axis it is the closed end. */
-    .track {
-      position: relative;
-      display: flex;
-      height: 10px;
-      background: var(--secondary-background-color, rgba(0, 0, 0, 0.08));
-      border-radius: 6px;
-      cursor: pointer;
-      overflow: hidden;
-      /* A touch-drag must move the fill, not scroll the page — own the gesture. */
-      touch-action: none;
-    }
-    .track:focus-visible {
-      outline: 2px solid var(--primary-color);
-      outline-offset: 2px;
-    }
-    /* The 0.3s ease below smooths server-driven updates; during a drag it would
+      .track {
+        position: relative;
+        display: flex;
+        height: 10px;
+        background: var(--secondary-background-color, rgba(0, 0, 0, 0.08));
+        border-radius: 6px;
+        cursor: pointer;
+        overflow: hidden;
+        /* A touch-drag must move the fill, not scroll the page — own the gesture. */
+        touch-action: none;
+      }
+      .track:focus-visible {
+        outline: 2px solid var(--primary-color);
+        outline-offset: 2px;
+      }
+      /* The 0.3s ease below smooths server-driven updates; during a drag it would
        read as the fill lagging behind the finger, so drop it for the gesture. */
-    .track.dragging .fill,
-    .track.dragging .fill-closed {
-      transition: none;
-    }
-    :host([compact]) .track,
-    .row.tile .track {
-      height: 6px;
-    }
-    /* Unavailable cover (issue #212): non-interactive track — no click-to-set,
+      .track.dragging .fill,
+      .track.dragging .fill-closed {
+        transition: none;
+      }
+      :host([compact]) .track,
+      .row.tile .track {
+        height: 6px;
+      }
+      /* Unavailable cover (issue #212): non-interactive track — no click-to-set,
        matching the up/stop/down controls disabled elsewhere on the tile. */
-    .track.disabled {
-      cursor: default;
-      touch-action: auto;
-    }
-    .fill {
-      height: 100%;
-      flex-shrink: 0;
-      background: color-mix(in srgb, var(--acp-cover-color, var(--primary-color)) 50%, transparent);
-      transition: width 0.3s ease;
-    }
-    .fill-closed {
-      height: 100%;
-      flex-shrink: 0;
-      background: color-mix(in srgb, var(--acp-cover-color, var(--primary-color)) 18%, transparent);
-      transition: width 0.3s ease;
-    }
-    .marker {
-      position: absolute;
-      top: -2px;
-      width: 2px;
-      height: 14px;
-      background: var(--accent-color, red);
-      transform: translateX(-50%);
-      transition: left 0.3s ease;
-    }
-  `;
+      .track.disabled {
+        cursor: default;
+        touch-action: auto;
+      }
+      .fill {
+        height: 100%;
+        flex-shrink: 0;
+        background: color-mix(
+          in srgb,
+          var(--acp-cover-color, var(--primary-color)) 50%,
+          transparent
+        );
+        transition: width 0.3s ease;
+      }
+      .fill-closed {
+        height: 100%;
+        flex-shrink: 0;
+        background: color-mix(
+          in srgb,
+          var(--acp-cover-color, var(--primary-color)) 18%,
+          transparent
+        );
+        transition: width 0.3s ease;
+      }
+      .marker {
+        position: absolute;
+        top: -2px;
+        width: 2px;
+        height: 14px;
+        background: var(--accent-color, red);
+        transform: translateX(-50%);
+        transition: left 0.3s ease;
+      }
+    `,
+  ];
 }
 
 /**

--- a/src/lib/geometry.ts
+++ b/src/lib/geometry.ts
@@ -575,3 +575,33 @@ export function blindSpotBearings(
 ): [number, number] {
   return [normalizeAzimuth(windowAziDeg - range[1]), normalizeAzimuth(windowAziDeg - range[0])];
 }
+
+/**
+ * Every blind spot the sun sensor publishes, as absolute compass bearings.
+ *
+ * The integration has carried three blind-spot slots since its #701 and emits
+ * `blind_spot_ranges` with one pair per configured slot. `blind_spot_range` is
+ * slot 1 alone, kept only so cards written before the list still draw
+ * something — reading it as the whole truth loses slots 2 and 3, which is what
+ * makes a blind spot configured there invisible (#269).
+ *
+ * A zero-span pair is dropped rather than drawn. The integration requires
+ * `left_gamma + right_gamma > 0` for a real wedge, so a `[n, n]` pair is an
+ * enabled-but-unconfigured slot; drawing it would put a degenerate path in the
+ * DOM and make the group read as present when nothing is visible.
+ */
+export function blindSpotBearingList(
+  windowAziDeg: number,
+  ranges: readonly (readonly [number, number])[] | undefined,
+  single: readonly [number, number] | undefined,
+): Array<[number, number]> {
+  const source = ranges?.length ? ranges : single ? [single] : [];
+  const out: Array<[number, number]> = [];
+  for (const range of source) {
+    if (!range || range.length !== 2) continue;
+    const [lower, upper] = range;
+    if (!Number.isFinite(lower) || !Number.isFinite(upper) || lower === upper) continue;
+    out.push(blindSpotBearings(windowAziDeg, [lower, upper]));
+  }
+  return out;
+}

--- a/src/lib/group-controls.ts
+++ b/src/lib/group-controls.ts
@@ -157,6 +157,94 @@ export function readGroup(hass: HomeAssistant, discovered: DiscoveredEntities): 
   };
 }
 
+/** The handlers the integration's group who-won sensor counts — its
+ *  `_GROUP_HANDLER_NAMES`. Kept here so {@link restrictSnapshot} can recount
+ *  that scalar over a subset instead of trusting a total taken over all
+ *  members. */
+const GROUP_DRIVEN_HANDLERS: ReadonlySet<string> = new Set(['group_scene', 'group_lock']);
+
+/**
+ * A snapshot with the hidden members removed — positions, winners, and every
+ * scalar the integration published over the FULL roster.
+ *
+ * The scalars are the reason this exists. `position`, `aggregate` and
+ * `whoWonCount` arrive as finished numbers from three sensors that know nothing
+ * about a per-card `members` key, so dropping keys from `memberPositions` alone
+ * would leave a tile reading "Mixed · 1 unavailable · 0/6" over a roster of two.
+ * Each is therefore recomputed from the surviving members using the same rule
+ * the integration uses: the aggregate percentage is their mean, the aggregate
+ * state is unanimity-or-mixed, and the who-won count is how many of them a
+ * group handler currently owns.
+ *
+ * A no-op when nothing is hidden — the common case keeps the integration's own
+ * numbers rather than round-tripping them through arithmetic that could only
+ * introduce disagreement.
+ */
+export function restrictSnapshot(
+  hass: HomeAssistant,
+  snapshot: GroupSnapshot,
+  hidden: ReadonlySet<string>,
+): GroupSnapshot {
+  if (hidden.size === 0) return snapshot;
+
+  const memberPositions: Record<string, number | null> = {};
+  for (const [id, pos] of Object.entries(snapshot.memberPositions)) {
+    if (!hidden.has(id)) memberPositions[id] = pos;
+  }
+
+  // Undefined and {} mean different things to `hasMemberOverrides`, so an
+  // absent map stays absent rather than collapsing to empty.
+  let memberWinners: Record<string, string | null> | undefined;
+  if (snapshot.memberWinners) {
+    memberWinners = {};
+    for (const [id, winner] of Object.entries(snapshot.memberWinners)) {
+      if (!hidden.has(id)) memberWinners[id] = winner;
+    }
+  }
+
+  const visible = Object.keys(memberPositions);
+  const known = visible.map((id) => memberPositions[id]).filter((p): p is number => p !== null);
+  const position = known.length ? known.reduce((a, b) => a + b, 0) / known.length : null;
+
+  // Unanimity or "mixed", read from the covers themselves — the group state
+  // sensor's answer describes members that are no longer on this card.
+  const states = new Set(visible.map((id) => hass.states[id]?.state));
+  const aggregate: GroupAggregateState =
+    states.size === 1 && (states.has('open') || states.has('closed'))
+      ? ([...states][0] as GroupAggregateState)
+      : visible.length === 0
+        ? 'unknown'
+        : 'mixed';
+
+  const classes = new Set<string>();
+  for (const id of visible) {
+    const dc = hass.states[id]?.attributes?.device_class as string | undefined;
+    if (dc) classes.add(dc);
+  }
+
+  return {
+    ...snapshot,
+    memberPositions,
+    memberWinners,
+    position,
+    aggregate,
+    rosterTotal: visible.length,
+    // NaN stays NaN: it is the "no who-won sensor" signal every surface gates
+    // its badge on, and 0 would render a live-looking "0/N" instead.
+    whoWonCount: Number.isNaN(snapshot.whoWonCount)
+      ? snapshot.whoWonCount
+      : Object.values(memberWinners ?? {}).filter(
+          (w) => w && GROUP_DRIVEN_HANDLERS.has(normalizeHandler(w)),
+        ).length,
+    memberAutomation: rollupMemberAutomation(
+      hass,
+      getCachedRegistry(),
+      Object.keys(memberWinners ?? {}),
+    ),
+    deviceClass: classes.size === 1 ? [...classes][0] : undefined,
+  };
+}
+
 /**
  * Glyph for a group, derived from its members.
  *
@@ -235,7 +323,16 @@ export function memberException(
     // unavailable for any non-admin — permanently replacing the range readout
     // that `memberSpread` had computed correctly from the attribute alone.
     const st = hass.states[id];
-    if (pos === null || (st !== undefined && isOffline(st.state))) unavailable += 1;
+    // HA's own verdict wins whenever there is one. A null position used to
+    // count on its own, which mislabelled every ONE-WAY / assumed-state cover:
+    // a Somfy-style RTS awning sits at `closed` with no `current_position` at
+    // all, so the group sensor has nothing to publish for it and the tile
+    // reported a perfectly reachable cover as unavailable, permanently. A
+    // missing position is "no position", not "no cover".
+    //
+    // The null still counts when HA has no state for the entity either — then
+    // nothing anywhere can see the member and unavailable is the honest word.
+    if (st === undefined ? pos === null : isOffline(st.state)) unavailable += 1;
   }
   if (unavailable > 0) return { kind: 'unavailable', count: unavailable };
 

--- a/src/lib/group-roster.ts
+++ b/src/lib/group-roster.ts
@@ -159,3 +159,94 @@ export function rosterRowKey(row: RosterRow): string {
 export function rosterRowConfigKey(row: RosterRow): string {
   return row.entryId ?? row.covers[0];
 }
+
+/**
+ * The member covers the card's `members` key leaves out.
+ *
+ * Hiding a member is not only a roster-rendering choice: a hidden member must
+ * also stop contributing to everything the group DERIVES from its roster — the
+ * unavailable/held exception line, the N/M who-won badge, the spread bar and
+ * range, the aggregate percentage. Otherwise a cover the user removed from the
+ * card keeps speaking through the summary line, which is the whole complaint.
+ *
+ * `members` holds COVER entity ids, deliberately not {@link rosterRowConfigKey}
+ * values. A row key is the owning `entry_id` when the cover resolves to an ACP
+ * entry and the bare `cover.*` id when it does not — and that resolution is not
+ * stable. HA strips an UNAVAILABLE entity down to its basic attributes, so the
+ * owner scan returns null for exactly the members a user is most likely to
+ * hide. The editor and the card could therefore key the same row differently,
+ * the omission would match nothing, and every member stayed visible with the
+ * roster count stuck at its full size. Cover ids cannot drift that way.
+ */
+export function hiddenMemberCovers(
+  memberIds: readonly string[],
+  members?: readonly string[],
+): Set<string> {
+  const hidden = new Set<string>();
+  if (!recognizesAnyMember(memberIds, members)) return hidden;
+  const visible = new Set(members);
+  for (const id of memberIds) {
+    if (!visible.has(id)) hidden.add(id);
+  }
+  return hidden;
+}
+
+/**
+ * Whether a `members` list is speaking the cover-id namespace at all.
+ *
+ * A list that names not one current member is not a request to hide every
+ * member — it is a list this card cannot interpret, and acting on it would
+ * blank the roster and zero every aggregate. That happens for real: a config
+ * written against the earlier row-key format, or a card pointed at a different
+ * group. Treating it as unconfigured leaves the integration's own numbers
+ * showing and lets the editor rewrite the key on the next edit.
+ *
+ * A list that matches SOME members is trusted as-is — that is just a group that
+ * has lost a member since the key was written.
+ */
+function recognizesAnyMember(
+  memberIds: readonly string[],
+  members?: readonly string[],
+): members is readonly string[] {
+  if (!members?.length) return false;
+  const present = new Set(memberIds);
+  return members.some((id) => present.has(id));
+}
+
+/**
+ * Apply the card's `members` key — the roster's order AND its subset.
+ *
+ * Absent or empty means "the integration's own order, everything shown", which
+ * is what every card rendered before this key existed.
+ *
+ * Present, it is an ordered list of visible COVER ids (see
+ * {@link hiddenMemberCovers} for why covers rather than row keys). A row keeps
+ * only its listed covers and disappears once none survive, so hiding one cover
+ * of a multi-cover entry drops that rail instead of the whole row. Rows then
+ * sort by their earliest listed cover — the same rule {@link rosterRows} uses
+ * to order an unconfigured roster, so a reorder means the same thing in both.
+ *
+ * A member the group gains AFTER the key is written is not listed, so it stays
+ * hidden until the user adds it — the same trade `covers` makes for rails. The
+ * editor keeps hidden rows in its list so there is always a way back.
+ */
+export function applyMemberOrder(rows: RosterRow[], members?: readonly string[]): RosterRow[] {
+  // Same unrecognized-list guard as `hiddenMemberCovers`, and for the same
+  // reason — the two must agree or the roster and the aggregates disagree about
+  // who is in the group.
+  if (
+    !recognizesAnyMember(
+      rows.flatMap((row) => row.covers),
+      members,
+    )
+  )
+    return rows;
+  const rank = new Map(members.map((id, i) => [id, i] as const));
+  const out: { row: RosterRow; at: number }[] = [];
+  for (const row of rows) {
+    const covers = row.covers.filter((id) => rank.has(id));
+    if (covers.length === 0) continue;
+    out.push({ row: { ...row, covers }, at: Math.min(...covers.map((id) => rank.get(id)!)) });
+  }
+  return out.sort((a, b) => a.at - b.at).map((entry) => entry.row);
+}

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -114,6 +114,7 @@ export const de: EnDict = {
     battery: 'Batterie {level}%',
     battery_named: '{name}: {level}%',
     battery_unknown: 'Batteriestand unbekannt',
+    battery_history: 'Batterieverlauf öffnen',
     extend: {
       title: 'Manuelle Übersteuerung verlängern',
       presets_label: 'Bis',
@@ -223,6 +224,7 @@ export const de: EnDict = {
     target: 'Ziel: {pct}',
     target_solar: 'Sonnenziel: {pct}',
     click_to_set: 'Klicken zum Festlegen der Position',
+    moving_to: 'Fährt auf {pct}%',
     position_slider_label: 'Positionsschieberegler',
     position_open_value: '{pct} offen',
     opening: 'Öffnet…',
@@ -466,9 +468,11 @@ export const de: EnDict = {
       covers: 'Positionsleisten (Reihenfolge)',
       covers_hint:
         'Ziehen Sie eine Zeile oder verwenden Sie die Pfeile, um die Reihenfolge der Positionsleisten festzulegen. Das Auge blendet eine Leiste aus, ohne den Behang zu entfernen.',
-      member_names: 'Mitgliedsnamen',
+      member_names: 'Mitglieder',
       member_names_hint:
-        'Benennen Sie ein Gruppenmitglied nur f\u00fcr diese Karte um. Leer lassen, um den Namen des Eintrags zu verwenden.',
+        'Ziehen Sie eine Zeile oder verwenden Sie die Pfeile, um die Reihenfolge der Mitglieder festzulegen. Das Auge blendet ein Mitglied auf dieser Karte aus, ohne es aus der Gruppe zu entfernen. Tippen Sie, um ein Mitglied umzubenennen; leer lassen, um den Namen des Eintrags zu verwenden.',
+      members_hide: 'Dieses Mitglied ausblenden',
+      members_show: 'Dieses Mitglied anzeigen',
       covers_move_up: 'Nach oben',
       covers_move_down: 'Nach unten',
       covers_hide: 'Diese Leiste ausblenden',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -114,6 +114,7 @@ export const en = {
     battery: '{level}% battery',
     battery_named: '{name}: {level}%',
     battery_unknown: 'Battery level unknown',
+    battery_history: 'Open battery history',
     extend: {
       title: 'Extend manual override',
       presets_label: 'Until',
@@ -223,6 +224,7 @@ export const en = {
     target: 'Target: {pct}',
     target_solar: 'Solar target: {pct}',
     click_to_set: 'Click to set position',
+    moving_to: 'Moving to {pct}%',
     position_slider_label: 'Cover position slider',
     position_open_value: '{pct} open',
     opening: 'Opening…',
@@ -461,9 +463,11 @@ export const en = {
       covers: 'Position bars (order)',
       covers_hint:
         'Drag a row, or use the arrows, to set the order the position bars appear in. The eye hides a bar without unbinding the cover.',
-      member_names: 'Member names',
+      member_names: 'Members',
       member_names_hint:
-        'Rename a group member as it appears on this card. Leave blank to use the entry\u2019s own name.',
+        'Drag a row, or use the arrows, to set the order members appear in. The eye hides a member from this card without removing it from the group. Type to rename a member here; leave blank to use the entry\u2019s own name.',
+      members_hide: 'Hide this member',
+      members_show: 'Show this member',
       covers_move_up: 'Move up',
       covers_move_down: 'Move down',
       covers_hide: 'Hide this bar',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -117,6 +117,7 @@ export const fr: EnDict = {
     battery: 'Batterie {level}%',
     battery_named: '{name} : {level}%',
     battery_unknown: 'Niveau de batterie inconnu',
+    battery_history: "Ouvrir l'historique de la batterie",
     extend: {
       title: 'Prolonger la dérogation manuelle',
       presets_label: "Jusqu'à",
@@ -228,6 +229,7 @@ export const fr: EnDict = {
     target: 'Cible : {pct}',
     target_solar: 'Cible solaire : {pct}',
     click_to_set: 'Cliquer pour définir la position',
+    moving_to: 'En route vers {pct}%',
     position_slider_label: 'Curseur de position du store',
     position_open_value: '{pct} ouvert',
     opening: 'Ouverture…',
@@ -475,9 +477,11 @@ export const fr: EnDict = {
       covers: 'Barres de position (ordre)',
       covers_hint:
         "Faites glisser une ligne, ou utilisez les flèches, pour définir l'ordre des barres de position. L'œil masque une barre sans dissocier le volet.",
-      member_names: 'Noms des membres',
+      member_names: 'Membres',
       member_names_hint:
-        "Renommer un membre du groupe tel qu'il appara\u00eet sur cette carte. Laisser vide pour utiliser le nom de l'instance.",
+        "Faites glisser une ligne, ou utilisez les fl\u00e8ches, pour d\u00e9finir l'ordre des membres. L'\u0153il masque un membre sur cette carte sans le retirer du groupe. Saisissez un texte pour renommer un membre ; laisser vide pour utiliser le nom de l'instance.",
+      members_hide: 'Masquer ce membre',
+      members_show: 'Afficher ce membre',
       covers_move_up: 'Monter',
       covers_move_down: 'Descendre',
       covers_hide: 'Masquer cette barre',

--- a/src/lib/pending-move.ts
+++ b/src/lib/pending-move.ts
@@ -1,0 +1,145 @@
+import type { ReactiveController, ReactiveControllerHost } from 'lit';
+
+/**
+ * The "moving to" indicator's shared rules.
+ *
+ * Setting a position by tap, drag or arrow key returns immediately, but the
+ * cover takes seconds to get there — and every rail draws the LIVE value, so
+ * the moment the drag preview is released the rail snaps back to where the
+ * cover still is and the number the user just chose disappears. The command is
+ * in flight with nothing on screen to say so.
+ *
+ * The integration does publish a per-cover command target, but only once it has
+ * dispatched (adaptive-cover-pro#1158), so it arrives late and is absent for a
+ * cover skipped as `same_position`. This is the OPTIMISTIC local record
+ * instead: the value this card just sent, held by the surface that sent it.
+ *
+ * Three rails render position tracks — `acp-axis-bar`, the cover tile's
+ * `_posBar`, the group tile's `pos-slider` — so the arrival rule and the band
+ * geometry live here rather than three times over.
+ */
+
+/**
+ * How long a pending move survives without the cover reporting arrival.
+ *
+ * Required, not belt-and-braces: a no-feedback / assumed-state cover (a Somfy
+ * RTS awning) never publishes a position at all, so an arrival-only rule would
+ * pin its indicator on screen forever. Generous enough for a slow shade to
+ * finish travelling first.
+ */
+export const PENDING_MOVE_TIMEOUT_MS = 60_000;
+
+/**
+ * How close counts as arrived, in axis units.
+ *
+ * Not zero: covers routinely stop a percent or two off the commanded value
+ * (interpolation, routing to a coarser step, or a motor that reports 39 for a
+ * commanded 40), and an exact-match rule would leave the indicator up until the
+ * timeout on every one of those moves.
+ */
+export const PENDING_MOVE_TOLERANCE = 2;
+
+/** Has the cover reached the value we sent it to? Unknown position → no: an
+ *  unreported cover has not arrived, it is simply silent, and the timeout is
+ *  what ends its indicator. */
+export function hasArrivedAt(live: number | null | undefined, pending: number): boolean {
+  if (live === null || live === undefined || Number.isNaN(live)) return false;
+  return Math.abs(live - pending) <= PENDING_MOVE_TOLERANCE;
+}
+
+/** Is this pending move still worth drawing against the current live value? */
+export function isPendingVisible(live: number | null | undefined, pending: number | null): boolean {
+  return pending !== null && !hasArrivedAt(live, pending);
+}
+
+/**
+ * The travel band, in DRAWN track percentages.
+ *
+ * Both inputs are already mapped through the rail's own polarity, so this is
+ * pure geometry and works unchanged on a mirrored axis: the band simply spans
+ * from wherever the fill ends to wherever the commanded marker sits, in
+ * whichever order they fall.
+ */
+export function travelBand(liveFrac: number, pendingFrac: number): { left: number; width: number } {
+  return {
+    left: Math.min(liveFrac, pendingFrac),
+    width: Math.abs(pendingFrac - liveFrac),
+  };
+}
+
+/** HA cover states that mean the cover is travelling under its own steam —
+ *  which is how an AUTOMATIC move announces itself. There is no command echo to
+ *  latch onto for those: the pipeline moved the cover without this card asking,
+ *  so the only evidence is the entity saying it is in motion. */
+const MOVING_STATES: ReadonlySet<string> = new Set(['opening', 'closing']);
+
+export function isMovingState(state: string | null | undefined): boolean {
+  return !!state && MOVING_STATES.has(state);
+}
+
+/**
+ * Per-key pending moves, as a Lit reactive controller.
+ *
+ * Four surfaces render position rails — `acp-cover-bar`, `acp-axis-bar`, the
+ * cover tile's `_posBar`, the group tile's `pos-slider` — and each needs the
+ * same three things: remember what was just commanded, retire it on arrival,
+ * and give up after a timeout. Hand-rolling that per component was three
+ * near-identical copies of timer bookkeeping before this existed, and the
+ * fourth would have been a fourth.
+ *
+ * Keyed because a multi-rail tile can have several covers in flight at once and
+ * each rail must show only its own destination. Single-rail hosts pass a
+ * constant key.
+ */
+export class PendingMoves implements ReactiveController {
+  private readonly host: ReactiveControllerHost;
+  private moves = new Map<string, number>();
+  private timers = new Map<string, ReturnType<typeof setTimeout>>();
+
+  constructor(host: ReactiveControllerHost) {
+    this.host = host;
+    host.addController(this);
+  }
+
+  /** Record what a rail was just told to do, and start its expiry. */
+  public start(key: string, value: number): void {
+    const existing = this.timers.get(key);
+    if (existing) clearTimeout(existing);
+    this.moves.set(key, value);
+    this.timers.set(
+      key,
+      setTimeout(() => this.clear(key), PENDING_MOVE_TIMEOUT_MS),
+    );
+    this.host.requestUpdate();
+  }
+
+  public get(key: string): number | null {
+    return this.moves.get(key) ?? null;
+  }
+
+  public clear(key: string): void {
+    const timer = this.timers.get(key);
+    if (timer) clearTimeout(timer);
+    this.timers.delete(key);
+    if (this.moves.delete(key)) this.host.requestUpdate();
+  }
+
+  /**
+   * Retire every move whose cover has arrived.
+   *
+   * Call from `updated()`, never from `render()`: dropping a move requests
+   * another update, and asking for one from inside a render is the
+   * update-during-update Lit warns about.
+   */
+  public settle(liveFor: (key: string) => number | null | undefined): void {
+    for (const [key, value] of [...this.moves]) {
+      if (hasArrivedAt(liveFor(key), value)) this.clear(key);
+    }
+  }
+
+  public hostDisconnected(): void {
+    for (const timer of this.timers.values()) clearTimeout(timer);
+    this.timers.clear();
+    this.moves.clear();
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -215,6 +215,18 @@ export interface AdaptiveCoverProTileCardConfig extends LovelaceCardConfig {
    *  always the label you want on a given dashboard, and it cannot be changed
    *  per-card without renaming the entry for everyone. */
   member_names?: Record<string, string>;
+  /** Which Cover Group members to render, in order, as COVER entity ids.
+   *  Absent means the integration's own roster order with every member shown;
+   *  present means EXACTLY these covers, so one left out is hidden — from the
+   *  roster AND from every aggregate the card derives from it. Mirrors how
+   *  `covers` carries rail order and subset for a cover entry, including the
+   *  consequence: a member the group gains after this key is written stays
+   *  hidden until it is added here.
+   *
+   *  Deliberately NOT keyed like {@link member_names}: those keys are per-ROW
+   *  and resolve to an owning `entry_id` only while the cover's owner can be
+   *  found, which fails for an unavailable member — see `hiddenMemberCovers`. */
+  members?: string[];
   /** Card-owned floating tooltip behavior. Defaults: enabled, offset [12,16],
    *  delay 400ms. Set `enabled: false` to use native browser tooltips. */
   tooltips?: TooltipsConfig;
@@ -629,7 +641,13 @@ export interface SunPositionAttributes {
   in_fov: boolean;
   min_elevation?: number;
   max_elevation?: number;
+  /** Slot 1's blind spot alone. The integration keeps emitting it for cards
+   *  that predate {@link blind_spot_ranges}; prefer the list. */
   blind_spot_range?: [number, number];
+  /** One `[lower, upper]` signed-gamma pair per CONFIGURED blind-spot slot —
+   *  the integration has had three since its #701. A card that reads only
+   *  `blind_spot_range` draws slot 1 and silently loses the rest. */
+  blind_spot_ranges?: Array<[number, number]>;
 }
 
 export interface StartEndSunAttributes {

--- a/tests/blind-spot-slots.test.ts
+++ b/tests/blind-spot-slots.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+
+import { blindSpotBearingList, blindSpotBearings } from '../src/lib/geometry';
+
+/**
+ * Issue #269 — a blind spot configured in slot 2 or 3 never appeared.
+ *
+ * The integration has carried three blind-spot slots since its #701 and
+ * publishes them all on `blind_spot_ranges`. `blind_spot_range` (singular) is
+ * slot 1 alone, kept only for cards written before the list existed — and
+ * reading it as the whole truth is the bug.
+ */
+describe('blindSpotBearingList', () => {
+  it('draws every configured slot, not just the first', () => {
+    const out = blindSpotBearingList(
+      180,
+      [
+        [-45, -30],
+        [-10, 15],
+        [25, 40],
+      ],
+      undefined,
+    );
+    expect(out).toHaveLength(3);
+    expect(out).toEqual([
+      blindSpotBearings(180, [-45, -30]),
+      blindSpotBearings(180, [-10, 15]),
+      blindSpotBearings(180, [25, 40]),
+    ]);
+  });
+
+  // The exact reported shape: slot 1 enabled but never configured stores
+  // left_gamma = right_gamma = 0, so the legacy attribute is PRESENT and spans
+  // zero degrees. The old card drew an invisible path and the user saw nothing.
+  it('skips a degenerate slot and still draws the real one behind it', () => {
+    const out = blindSpotBearingList(
+      180,
+      [
+        [0, 0],
+        [20, 45],
+      ],
+      [0, 0],
+    );
+    expect(out).toEqual([blindSpotBearings(180, [20, 45])]);
+  });
+
+  it('falls back to the legacy single range when no list is published', () => {
+    expect(blindSpotBearingList(180, undefined, [10, 30])).toEqual([
+      blindSpotBearings(180, [10, 30]),
+    ]);
+  });
+
+  it('draws nothing when the entry has no blind spot at all', () => {
+    expect(blindSpotBearingList(180, undefined, undefined)).toEqual([]);
+    expect(blindSpotBearingList(180, [], undefined)).toEqual([]);
+  });
+
+  it('drops a zero-span legacy range rather than drawing a sliver', () => {
+    expect(blindSpotBearingList(180, undefined, [12, 12])).toEqual([]);
+  });
+
+  it('ignores malformed and non-finite pairs', () => {
+    const out = blindSpotBearingList(
+      180,
+      [
+        [NaN, 20],
+        [10, Infinity],
+        [20, 45],
+      ],
+      undefined,
+    );
+    expect(out).toEqual([blindSpotBearings(180, [20, 45])]);
+  });
+});

--- a/tests/cover-bar.test.ts
+++ b/tests/cover-bar.test.ts
@@ -4,7 +4,6 @@ import { CoverBar } from '../src/components/cover-bar';
 import { INTEGRATION_DOMAIN } from '../src/const';
 import type { HomeAssistant } from 'custom-card-helpers';
 import type { DiscoveredEntities } from '../src/types';
-import type { CSSResult } from 'lit';
 import { t } from '../src/lib/i18n';
 import { formatPercent } from '../src/lib/formatters';
 
@@ -22,9 +21,17 @@ const baseDiscovered: DiscoveredEntities = {
   managed_covers: [],
 };
 
+/** A component's stylesheet as one string. `styles` became an ARRAY when the
+ *  rail overlay's shared fragment was factored out, so a single `.cssText` no
+ *  longer covers the whole sheet. */
+function sheetOf(ctor: unknown): string {
+  const styles = (ctor as { styles: { cssText: string } | { cssText: string }[] }).styles;
+  return Array.isArray(styles) ? styles.map((s) => s.cssText).join('\n') : styles.cssText;
+}
+
 describe('acp-cover-bar fill style — issue #135', () => {
   it('fill CSS uses color-mix for reduced opacity', () => {
-    const styles = (CoverBar as unknown as { styles: CSSResult }).styles.cssText;
+    const styles = sheetOf(CoverBar);
     expect(styles).toContain('color-mix');
   });
 
@@ -67,7 +74,7 @@ describe('acp-cover-bar fill style — issue #135', () => {
 
 describe('acp-cover-bar two-tone fill — issue #135 follow-up', () => {
   it('both segments derive from the cover colour — blocking solid, clear pale', () => {
-    const styles = (CoverBar as unknown as { styles: CSSResult }).styles.cssText;
+    const styles = sheetOf(CoverBar);
     // Both segments share the cover hue (override, else --primary-color); no
     // gold, so nothing competes with the gold sun on the compass. `.fill` is the
     // LEADING segment and now carries the sun-blocking portion, so it takes the
@@ -115,7 +122,7 @@ describe('acp-cover-bar two-tone fill — issue #135 follow-up', () => {
   });
 
   it('closed segment falls back to --primary-color when no cover colour is set', () => {
-    const styles = (CoverBar as unknown as { styles: CSSResult }).styles.cssText;
+    const styles = sheetOf(CoverBar);
     expect(styles).toMatch(/\.fill-closed\s*{[^}]*--acp-cover-color,\s*var\(--primary-color\)/);
   });
 
@@ -248,7 +255,7 @@ describe('acp-cover-bar manual-override divergence — issue #158', () => {
   });
 
   it('reserves fixed trailing columns so the track does not reflow', () => {
-    const styles = (CoverBar as unknown as { styles: CSSResult }).styles.cssText;
+    const styles = sheetOf(CoverBar);
     // Two fixed columns after the track: the go-to-target button (22px) and the
     // warn badge (16px). Both empty out on some rows, and an `auto` track would
     // hand those pixels to the 3fr and reflow the bar graph (#158).
@@ -391,7 +398,7 @@ describe('acp-cover-bar target marker clamp at extremes — issue #158 (trailing
   }
 
   it('centres the marker on its value via translateX(-50%)', () => {
-    const styles = (CoverBar as unknown as { styles: CSSResult }).styles.cssText;
+    const styles = sheetOf(CoverBar);
     expect(styles).toMatch(/\.marker\s*{[^}]*translateX\(-50%\)/);
   });
 
@@ -1061,7 +1068,7 @@ describe('acp-cover-bar position slider — issue #231', () => {
   });
 
   it('adds touch-action: none to .track so a touch drag does not fight page scroll', () => {
-    const styles = (CoverBar as unknown as { styles: CSSResult }).styles.cssText;
+    const styles = sheetOf(CoverBar);
     expect(styles).toMatch(/\.track\s*{[^}]*touch-action:\s*none/);
   });
 });

--- a/tests/group-members.test.ts
+++ b/tests/group-members.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi } from 'vitest';
+import '../src/adaptive-cover-pro-tile-card';
+import '../src/adaptive-cover-pro-tile-card-editor';
+import type { HomeAssistant } from 'custom-card-helpers';
+import type { AdaptiveCoverProTileCardConfig } from '../src/types';
+import type { EntityRegistryEntry } from '../src/lib/entity-registry';
+
+const TYPE = 'custom:adaptive-cover-pro-tile-card';
+const GROUP = 'group1';
+
+interface EditorLike extends HTMLElement {
+  updateComplete: Promise<boolean>;
+  hass?: HomeAssistant;
+  setConfig(config: AdaptiveCoverProTileCardConfig): void;
+  _registry: EntityRegistryEntry[] | null;
+}
+
+/** A group entry plus two member ACP entries, so the roster folds to
+ *  entry_a / entry_b rows and a generic third row. */
+const REGISTRY: EntityRegistryEntry[] = [
+  {
+    entity_id: 'sensor.group_position',
+    unique_id: `${GROUP}_group_position`,
+    config_entry_id: GROUP,
+    platform: 'adaptive_cover_pro',
+    device_id: null,
+  },
+  {
+    entity_id: 'sensor.group_state',
+    unique_id: `${GROUP}_group_state`,
+    config_entry_id: GROUP,
+    platform: 'adaptive_cover_pro',
+    device_id: null,
+  },
+  {
+    entity_id: 'sensor.group_who_won',
+    unique_id: `${GROUP}_group_who_won`,
+    config_entry_id: GROUP,
+    platform: 'adaptive_cover_pro',
+    device_id: null,
+  },
+  {
+    entity_id: 'sensor.group_active_scene',
+    unique_id: `${GROUP}_group_active_scene`,
+    config_entry_id: GROUP,
+    platform: 'adaptive_cover_pro',
+    device_id: null,
+  },
+  {
+    entity_id: 'sensor.entry_a_cover_position',
+    unique_id: 'entry_a_Cover_Position',
+    config_entry_id: 'entry_a',
+    platform: 'adaptive_cover_pro',
+    device_id: null,
+  },
+  {
+    entity_id: 'sensor.entry_b_cover_position',
+    unique_id: 'entry_b_Cover_Position',
+    config_entry_id: 'entry_b',
+    platform: 'adaptive_cover_pro',
+    device_id: null,
+  },
+];
+
+function hass(): HomeAssistant {
+  return {
+    states: {
+      'sensor.entry_a_cover_position': {
+        state: '40',
+        attributes: { actual_positions: { 'cover.a': 40 } },
+      },
+      'sensor.entry_b_cover_position': {
+        state: '60',
+        attributes: { actual_positions: { 'cover.b': 60 } },
+      },
+      'cover.a': { state: 'open', attributes: { current_position: 40 } },
+      'cover.b': { state: 'unavailable', attributes: {} },
+      'cover.generic': { state: 'closed', attributes: { current_position: 0 } },
+      'sensor.group_position': {
+        state: '20',
+        attributes: { member_positions: { 'cover.a': 40, 'cover.b': null, 'cover.generic': 0 } },
+      },
+      'sensor.group_state': { state: 'mixed', attributes: {} },
+      'sensor.group_who_won': {
+        state: '0',
+        attributes: { member_winners: { 'cover.a': 'solar', 'cover.b': 'solar' } },
+      },
+    },
+    callWS: vi.fn().mockResolvedValue(REGISTRY),
+    connection: { subscribeEvents: vi.fn().mockResolvedValue(() => {}) },
+    callService: vi.fn(),
+  } as unknown as HomeAssistant;
+}
+
+describe('group members — editor eye button persists `members`', () => {
+  it('emits a config carrying `members` when a row is hidden', async () => {
+    const el = document.createElement(
+      'adaptive-cover-pro-tile-card-editor',
+    ) as unknown as EditorLike;
+    el.hass = hass();
+    document.body.appendChild(el);
+    el.setConfig({ type: TYPE, entry_id: GROUP } as AdaptiveCoverProTileCardConfig);
+    el._registry = REGISTRY;
+    await el.updateComplete;
+    await el.updateComplete;
+
+    const emitted: AdaptiveCoverProTileCardConfig[] = [];
+    el.addEventListener('config-changed', (e) => {
+      emitted.push((e as CustomEvent).detail.config);
+    });
+
+    const rows = el.shadowRoot!.querySelectorAll('li.member-row');
+    expect(rows.length).toBe(3);
+
+    // Row 1 is entry_b, whose only cover is the UNAVAILABLE one — the case that
+    // broke the earlier row-key format, since an unavailable member's owner
+    // does not resolve and the editor and the card keyed it differently.
+    // The eye is the last button on the row.
+    const buttons = rows[1].querySelectorAll('button');
+    (buttons[buttons.length - 1] as HTMLButtonElement).click();
+    await el.updateComplete;
+
+    expect(emitted.length).toBe(1);
+    expect(emitted[0].members).toEqual(['cover.a', 'cover.generic']);
+  });
+});
+
+describe('group members — a hidden member leaves the tile aggregates', () => {
+  it('clears the unavailable exception and shrinks the denominator', async () => {
+    const { loadEntityRegistry } = await import('../src/lib/registry-store');
+    await loadEntityRegistry({
+      callWS: async () => REGISTRY,
+    } as unknown as Parameters<typeof loadEntityRegistry>[0]);
+
+    const discovered = {
+      entry_id: GROUP,
+      entry_title: 'Patio',
+      cover_type: 'cover_blind',
+      is_group: true,
+      managed_covers: ['cover.a', 'cover.b', 'cover.generic'],
+      entities: {
+        group_position_sensor: 'sensor.group_position',
+        group_state_sensor: 'sensor.group_state',
+        group_who_won_sensor: 'sensor.group_who_won',
+      },
+    };
+
+    const el = document.createElement('acp-group-tile') as HTMLElement & {
+      updateComplete: Promise<boolean>;
+      hass?: HomeAssistant;
+      discovered?: unknown;
+      members?: string[];
+    };
+    el.hass = hass();
+    el.discovered = discovered;
+    el.members = ['cover.a', 'cover.generic'];
+    document.body.appendChild(el);
+    await el.updateComplete;
+
+    const text = (el.shadowRoot!.textContent ?? '').replace(/\s+/g, ' ').trim();
+    expect(text).not.toContain('unavailable');
+  });
+});

--- a/tests/member-exception.test.ts
+++ b/tests/member-exception.test.ts
@@ -22,10 +22,24 @@ describe('memberException', () => {
     ).toBeNull();
   });
 
-  it('counts a null position as unavailable', () => {
+  it('does NOT count a null position when HA reports the cover live', () => {
+    // A one-way / assumed-state cover (Somfy RTS awning) sits at open/closed
+    // with no `current_position`, so the group sensor publishes null for it.
+    // That is "no position", not "no cover" — calling it unavailable pinned a
+    // permanent false warning on the tile of anyone owning such an awning.
     expect(
       memberException(LIVE, {
         memberPositions: { 'cover.a': 40, 'cover.b': null },
+        memberWinners: undefined,
+      }),
+    ).toBeNull();
+  });
+
+  it('counts a null position when HA has no state for the member either', () => {
+    // Nothing anywhere can see this member, so unavailable is the honest word.
+    expect(
+      memberException(LIVE, {
+        memberPositions: { 'cover.a': 40, 'cover.gone': null },
         memberWinners: undefined,
       }),
     ).toEqual({ kind: 'unavailable', count: 1 });

--- a/tests/member-order.test.ts
+++ b/tests/member-order.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+
+import { applyMemberOrder, hiddenMemberCovers, type RosterRow } from '../src/lib/group-roster';
+
+const ROWS: RosterRow[] = [
+  { entryId: 'entry_a', covers: ['cover.a1', 'cover.a2'] },
+  { entryId: 'entry_b', covers: ['cover.b'] },
+  { entryId: null, covers: ['cover.generic'] },
+];
+const ALL = ROWS.flatMap((r) => r.covers);
+
+describe('hiddenMemberCovers', () => {
+  it('hides nothing when the card has no members key', () => {
+    expect(hiddenMemberCovers(ALL, undefined).size).toBe(0);
+    expect(hiddenMemberCovers(ALL, []).size).toBe(0);
+  });
+
+  it('hides exactly the covers the key leaves out', () => {
+    expect([...hiddenMemberCovers(ALL, ['cover.a1', 'cover.a2', 'cover.generic'])]).toEqual([
+      'cover.b',
+    ]);
+  });
+
+  /**
+   * The #269-adjacent trap this whole namespace choice exists for.
+   *
+   * `members` used to hold roster ROW keys, which resolve to an owning entry_id
+   * only while the cover's owner can be found — and HA strips an UNAVAILABLE
+   * entity down to its basic attributes, so the owner scan returns null for
+   * exactly the members a user is most likely to hide. Editor and card then
+   * keyed the same row differently, the omission matched nothing, and every
+   * member stayed visible with the roster count stuck at full size.
+   */
+  it('is immune to entry-vs-cover key drift, because it only speaks cover ids', () => {
+    // An entry_id-shaped list matches no member at all.
+    expect(hiddenMemberCovers(ALL, ['entry_a', 'entry_b']).size).toBe(0);
+  });
+
+  it('ignores a list that names no current member rather than hiding everything', () => {
+    // A config written against the old row-key format, or aimed at another
+    // group. Acting on it would blank the roster and zero every aggregate.
+    expect(hiddenMemberCovers(ALL, ['cover.from_another_group']).size).toBe(0);
+  });
+
+  it('trusts a list that matches SOME members — that is just a departed member', () => {
+    expect([...hiddenMemberCovers(ALL, ['cover.a1', 'cover.gone'])].sort()).toEqual([
+      'cover.a2',
+      'cover.b',
+      'cover.generic',
+    ]);
+  });
+});
+
+describe('applyMemberOrder', () => {
+  it('leaves the roster alone when unconfigured', () => {
+    expect(applyMemberOrder(ROWS, undefined)).toBe(ROWS);
+  });
+
+  it('reorders rows by their earliest listed cover', () => {
+    const out = applyMemberOrder(ROWS, ['cover.generic', 'cover.b', 'cover.a1', 'cover.a2']);
+    expect(out.map((r) => r.entryId)).toEqual([null, 'entry_b', 'entry_a']);
+  });
+
+  it('drops a row whose covers are all hidden', () => {
+    const out = applyMemberOrder(ROWS, ['cover.a1', 'cover.a2', 'cover.generic']);
+    expect(out.map((r) => r.entryId)).toEqual(['entry_a', null]);
+  });
+
+  // Hiding one rail of a multi-cover entry trims that row rather than dropping
+  // the whole entry. Not reachable from the editor, which hides whole rows, but
+  // hand-written YAML can express it and it should mean something sane.
+  it('trims a row to just its listed covers', () => {
+    const out = applyMemberOrder(ROWS, ['cover.a2', 'cover.b']);
+    expect(out[0]).toEqual({ entryId: 'entry_a', covers: ['cover.a2'] });
+  });
+
+  it('does not mutate the rows it was handed', () => {
+    applyMemberOrder(ROWS, ['cover.a2']);
+    expect(ROWS[0].covers).toEqual(['cover.a1', 'cover.a2']);
+  });
+
+  it('ignores an unrecognized list, matching hiddenMemberCovers', () => {
+    // The two must agree or the roster and the aggregates disagree about who is
+    // in the group.
+    expect(applyMemberOrder(ROWS, ['entry_a', 'entry_b'])).toBe(ROWS);
+  });
+});

--- a/tests/more-info-dialog.test.ts
+++ b/tests/more-info-dialog.test.ts
@@ -997,12 +997,21 @@ describe('more-info dialog — battery indicator', () => {
     return h;
   }
 
-  const battery = (el: DialogLike): Element | null =>
-    el.shadowRoot!.querySelector('.icon-btn.battery');
+  /** The indicator moved into its own `acp-battery-indicator` element, so it
+   *  lives one shadow root deeper than it used to. Async because that child has
+   *  to finish its own update before its button exists. */
+  const battery = async (el: DialogLike): Promise<Element | null> => {
+    const host = el.shadowRoot!.querySelector('acp-battery-indicator') as
+      | (HTMLElement & { updateComplete: Promise<boolean> })
+      | null;
+    if (!host) return null;
+    await host.updateComplete;
+    return host.shadowRoot!.querySelector('button.battery');
+  };
 
   it('renders nothing when no managed cover reports a battery', async () => {
     const el = await mount({ hass: hass(), discovered: discovered(), open: true });
-    expect(battery(el)).toBeFalsy();
+    expect(await battery(el)).toBeFalsy();
   });
 
   it('renders the level for a single battery-backed cover', async () => {
@@ -1013,7 +1022,7 @@ describe('more-info dialog — battery indicator', () => {
       discovered: discovered(),
       open: true,
     });
-    const btn = battery(el)!;
+    const btn = (await battery(el))!;
     expect(btn).toBeTruthy();
     expect(btn.getAttribute('aria-label')).toContain('82');
     expect(btn.classList.contains('low')).toBe(false);
@@ -1028,7 +1037,7 @@ describe('more-info dialog — battery indicator', () => {
       discovered: discovered(),
       open: true,
     });
-    const btn = battery(el)!;
+    const btn = (await battery(el))!;
     expect(btn.classList.contains('low')).toBe(true);
     expect(btn.querySelector('ha-icon')!.getAttribute('icon')).toBe('mdi:battery-10');
   });
@@ -1059,7 +1068,7 @@ describe('more-info dialog — battery indicator', () => {
       discovered: d,
       open: true,
     });
-    const btn = battery(el)!;
+    const btn = (await battery(el))!;
     expect(btn.classList.contains('low')).toBe(true);
     expect(btn.querySelector('ha-icon')!.getAttribute('icon')).toBe('mdi:battery-outline');
     const label = btn.getAttribute('aria-label')!;
@@ -1069,16 +1078,39 @@ describe('more-info dialog — battery indicator', () => {
     expect(label).toContain('8');
   });
 
-  it('is a readout, not a control — no button element, no pointer affordance', async () => {
+  // Replaces an earlier "readout, not a control" assertion: the indicator is now
+  // a link to HA's own History panel, which is where a discharge curve actually
+  // lives. The card has no business re-plotting one.
+  it('is a button that opens HA history with every battery source', async () => {
+    const d = discovered();
+    d.managed_covers = ['cover.left', 'cover.right'];
     const el = await mount({
       hass: withBatteries(hass(), [
-        { cover: 'cover.left', sensor: 'sensor.left_batt', device: 'dev_l', state: '50' },
+        { cover: 'cover.left', sensor: 'sensor.l_batt', device: 'dev_l', state: '64' },
+        { cover: 'cover.right', sensor: 'sensor.r_batt', device: 'dev_r', state: '8' },
       ]),
-      discovered: discovered(),
+      discovered: d,
       open: true,
     });
-    const btn = battery(el)!;
-    expect(btn.tagName).not.toBe('BUTTON');
-    expect(btn.getAttribute('role')).toBe('img');
+    const btn = (await battery(el))! as HTMLElement;
+    expect(btn.tagName).toBe('BUTTON');
+
+    let navigated = '';
+    const onNav = (): void => {
+      navigated = window.location.pathname + window.location.search;
+    };
+    window.addEventListener('location-changed', onNav);
+    const closed = vi.fn();
+    el.addEventListener('acp-dialog-close', closed);
+    btn.click();
+    window.removeEventListener('location-changed', onNav);
+
+    expect(navigated).toContain('/history');
+    // BOTH sensors, comma-joined — the whole point is one chart per entry, not
+    // just the worst cell.
+    expect(navigated).toContain('sensor.l_batt');
+    expect(navigated).toContain('sensor.r_batt');
+    // Leaving for another panel closes the dialog behind it.
+    expect(closed).toHaveBeenCalled();
   });
 });

--- a/tests/pending-move.test.ts
+++ b/tests/pending-move.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  PENDING_MOVE_TOLERANCE,
+  hasArrivedAt,
+  isMovingState,
+  isPendingVisible,
+  travelBand,
+} from '../src/lib/pending-move';
+
+describe('pending-move — arrival', () => {
+  it('counts a cover within tolerance as arrived', () => {
+    expect(hasArrivedAt(40, 40)).toBe(true);
+    expect(hasArrivedAt(40 - PENDING_MOVE_TOLERANCE, 40)).toBe(true);
+    expect(hasArrivedAt(40 + PENDING_MOVE_TOLERANCE, 40)).toBe(true);
+  });
+
+  it('does not count a cover still short of tolerance', () => {
+    expect(hasArrivedAt(40 - PENDING_MOVE_TOLERANCE - 1, 40)).toBe(false);
+  });
+
+  // A no-feedback / assumed-state cover (a Somfy RTS awning) publishes no
+  // position at all. It has not arrived — it is silent — and the timeout, not
+  // this rule, is what ends its indicator.
+  it('treats an unreported position as NOT arrived', () => {
+    expect(hasArrivedAt(null, 40)).toBe(false);
+    expect(hasArrivedAt(undefined, 40)).toBe(false);
+    expect(hasArrivedAt(NaN, 40)).toBe(false);
+  });
+});
+
+describe('pending-move — visibility', () => {
+  // The bug this guard exists for: commanding a value the cover is ALREADY at
+  // moves nothing, so its position never changes and nothing ever settles the
+  // move. Without this the rail carried a zero-width band and a stray pip until
+  // the 60s timeout.
+  it('hides a destination the cover is already at', () => {
+    expect(isPendingVisible(40, 40)).toBe(false);
+    expect(isPendingVisible(41, 40)).toBe(false);
+  });
+
+  it('shows a destination the cover still has to travel to', () => {
+    expect(isPendingVisible(100, 40)).toBe(true);
+  });
+
+  it('shows a destination for a cover that reports nothing', () => {
+    expect(isPendingVisible(null, 40)).toBe(true);
+  });
+
+  it('is false when there is no destination at all', () => {
+    expect(isPendingVisible(40, null)).toBe(false);
+  });
+});
+
+describe('pending-move — travel band geometry', () => {
+  it('spans from the fill to the destination, whichever way round they fall', () => {
+    expect(travelBand(20, 80)).toEqual({ left: 20, width: 60 });
+    expect(travelBand(80, 20)).toEqual({ left: 20, width: 60 });
+  });
+
+  it('collapses to nothing once they coincide', () => {
+    expect(travelBand(50, 50)).toEqual({ left: 50, width: 0 });
+  });
+});
+
+describe('pending-move — automatic moves', () => {
+  // An automatic move has no command echo to latch onto, so the only evidence
+  // is the entity saying it is in motion.
+  it('recognizes the in-motion cover states', () => {
+    expect(isMovingState('opening')).toBe(true);
+    expect(isMovingState('closing')).toBe(true);
+  });
+
+  it('does not treat a settled or absent state as motion', () => {
+    for (const s of ['open', 'closed', 'unavailable', 'unknown', '', null, undefined]) {
+      expect(isMovingState(s)).toBe(false);
+    }
+  });
+});

--- a/tests/tile-card.test.ts
+++ b/tests/tile-card.test.ts
@@ -192,6 +192,16 @@ async function mountTilt(
   return el;
 }
 
+/** The tile's stylesheet as one string. `styles` is an ARRAY since the rail
+ *  overlay's shared fragment was factored out, so a single `.cssText` no longer
+ *  covers it — joining keeps these assertions checking the whole sheet. */
+function tileCss(): string {
+  const styles = AdaptiveCoverProTileCard.styles as unknown as
+    | { cssText: string }
+    | { cssText: string }[];
+  return Array.isArray(styles) ? styles.map((s) => s.cssText).join('\n') : styles.cssText;
+}
+
 describe('adaptive-cover-pro-tile-card setConfig', () => {
   it('throws when entry_id is missing', () => {
     const el = makeCard();
@@ -2072,12 +2082,12 @@ describe('adaptive-cover-pro-tile-card narrow-column responsiveness (#136)', () 
   });
 
   it('declares an inline-size container so the column width drives the layout', () => {
-    const css = (AdaptiveCoverProTileCard.styles as { cssText: string }).cssText;
+    const css = tileCss();
     expect(css).toContain('container-type: inline-size');
   });
 
   it('reflows the detailed controls onto their own full-width row at a narrow breakpoint', () => {
-    const css = (AdaptiveCoverProTileCard.styles as { cssText: string }).cssText;
+    const css = tileCss();
     expect(css).toContain('@container');
     // The narrow detailed grid (2 columns) moves controls to a row of their own
     // — this 'controls'-spanning template area exists only in the narrow reflow.
@@ -2089,7 +2099,7 @@ describe('adaptive-cover-pro-tile-card narrow-column responsiveness (#136)', () 
     // desktop dashboard — so a bare container query can't tell them apart and a
     // blanket raise made laptop tiles grow a control row. The phone reflow is
     // gated on a narrow *viewport* (≤500px) so only real phones trigger it.
-    const css = (AdaptiveCoverProTileCard.styles as { cssText: string }).cssText;
+    const css = tileCss();
     expect(css).toContain('@media (max-width: 500px)');
     expect(css).toContain('max-width: 480px');
   });
@@ -2097,7 +2107,7 @@ describe('adaptive-cover-pro-tile-card narrow-column responsiveness (#136)', () 
   it('still reflows a genuinely narrow desktop column via the container query (#136)', () => {
     // #136 is a column-driven squeeze on a wide viewport, where @media can't see
     // the narrow tile — the bare container query at ≤340px must remain.
-    const css = (AdaptiveCoverProTileCard.styles as { cssText: string }).cssText;
+    const css = tileCss();
     expect(css).toContain('@container (max-width: 340px)');
   });
 });
@@ -2532,7 +2542,7 @@ describe('adaptive-cover-pro-tile-card HA tile layout (detailed)', () => {
   });
 
   it('links detailed controls to HA ha-control-button CSS tokens', () => {
-    const css = (AdaptiveCoverProTileCard.styles as { cssText: string }).cssText;
+    const css = tileCss();
     // 36px is HA's inline-features thickness (--feature-height: --ha-space-9),
     // which is what ha-tile-container sets for a features block beside the
     // info column — not the 42px of a full-width bottom feature row.
@@ -3008,7 +3018,7 @@ describe('adaptive-cover-pro-tile-card — position bar drag slider', () => {
   });
 
   it('declares an expanded touch target and owns the touch gesture', () => {
-    const css = (AdaptiveCoverProTileCard.styles as { cssText: string }).cssText;
+    const css = tileCss();
     expect(css).toContain('touch-action: none');
     // The 6px rail is too thin to grab; an invisible ::before widens the hit
     // area without adding layout height.
@@ -3404,7 +3414,7 @@ describe('adaptive-cover-pro-tile-card — icon_tap_action', () => {
   });
 
   it('exposes the pill and 0.2 tint in the stylesheet', () => {
-    const css = (AdaptiveCoverProTileCard.styles as { cssText: string }).cssText;
+    const css = tileCss();
     expect(css).toContain('border-radius: var(--ha-border-radius-pill, 9999px)');
     expect(css).toContain('opacity: 0.2');
     expect(css).toContain('opacity: 0.35');
@@ -3921,5 +3931,90 @@ describe('tile card — drag position readout (#260)', () => {
     expect(AdaptiveCoverProTileCard.styles.toString()).toMatch(
       /\.pos-readout\s*\{[^}]*pointer-events:\s*none/,
     );
+  });
+});
+
+/**
+ * Two-rail readout for a LAYERED entry (day/night + dual-panel shades).
+ *
+ * The single readout describes the resolved cover only, so a shade whose two
+ * fabrics sit at different positions read exactly like one at a single
+ * position. These pin both halves of the rule: the split appears when the
+ * fabrics disagree, and does NOT appear when they agree or when the two rails
+ * are separate windows rather than layers of one opening.
+ */
+const LAYERED_REGISTRY: EntityRegistryEntry[] = [
+  ...REGISTRY,
+  {
+    entity_id: 'sensor.control_status',
+    unique_id: `${ENTRY}_control_status`,
+    config_entry_id: ENTRY,
+    platform: 'adaptive_cover_pro',
+    device_id: null,
+  },
+];
+
+function layeredHass(opts: {
+  leftState: string;
+  leftPos: number;
+  rightState: string;
+  rightPos: number;
+  coverType?: string;
+}): HomeAssistant {
+  const h = makeHass();
+  const s = h.states as unknown as Record<string, unknown>;
+  s['sensor.control_status'] = {
+    state: 'auto',
+    attributes: { cover_type: opts.coverType ?? 'cover_day_night_shade' },
+  };
+  s['sensor.cover_position'] = {
+    state: String(opts.leftPos),
+    attributes: { actual_positions: { 'cover.left': opts.leftPos, 'cover.right': opts.rightPos } },
+  };
+  s['cover.left'] = { state: opts.leftState, attributes: { current_position: opts.leftPos } };
+  s['cover.right'] = { state: opts.rightState, attributes: { current_position: opts.rightPos } };
+  return h;
+}
+
+async function mountLayered(hass: HomeAssistant): Promise<CardLike> {
+  const el = makeCard();
+  el.setConfig({ type: TYPE, entry_id: ENTRY, layout: 'detailed' });
+  el.hass = hass;
+  document.body.appendChild(el);
+  el._registry = LAYERED_REGISTRY;
+  await el.updateComplete;
+  return el;
+}
+
+describe('tile readout — layered two-rail entries', () => {
+  it('splits into per-rail state + position when the fabrics disagree', async () => {
+    const el = await mountLayered(
+      layeredHass({ leftState: 'open', leftPos: 100, rightState: 'closed', rightPos: 50 }),
+    );
+    expect(el.shadowRoot!.querySelector('.state')?.textContent?.trim()).toBe(
+      'Open 100% · Closed 50%',
+    );
+  });
+
+  it('keeps the single readout when the fabrics agree', async () => {
+    const el = await mountLayered(
+      layeredHass({ leftState: 'open', leftPos: 100, rightState: 'open', rightPos: 100 }),
+    );
+    expect(el.shadowRoot!.querySelector('.state')?.textContent?.trim()).toBe('Open · 100%');
+  });
+
+  it('leaves SEPARATE-cover entries alone even when their rails differ', async () => {
+    // Two windows on one entry, not two layers of one opening. They disagree by
+    // a couple of percent all the time; splitting the line there would be noise.
+    const el = await mountLayered(
+      layeredHass({
+        leftState: 'open',
+        leftPos: 42,
+        rightState: 'open',
+        rightPos: 45,
+        coverType: 'cover_blind',
+      }),
+    );
+    expect(el.shadowRoot!.querySelector('.state')?.textContent?.trim()).toBe('Open · 42%');
   });
 });

--- a/tests/tilt-bar.test.ts
+++ b/tests/tilt-bar.test.ts
@@ -27,6 +27,14 @@ async function mount(props: Partial<TiltBarLike>): Promise<TiltBarLike> {
   return el;
 }
 
+/** A component's stylesheet as one string. `styles` became an ARRAY when the
+ *  rail overlay's shared fragment was factored out, so a single `.cssText` no
+ *  longer covers the whole sheet. */
+function sheetOf(ctor: unknown): string {
+  const styles = (ctor as { styles: { cssText: string } | { cssText: string }[] }).styles;
+  return Array.isArray(styles) ? styles.map((s) => s.cssText).join('\n') : styles.cssText;
+}
+
 describe('acp-tilt-bar', () => {
   it('splits the track into open + closed widths summing to 100%', async () => {
     const el = await mount({ actual: 35, target: 70 });
@@ -261,8 +269,7 @@ describe('acp-axis-bar drag slider', () => {
   });
 
   it('declares touch-action: none so a touch drag does not scroll the page', () => {
-    const css = (customElements.get('acp-axis-bar') as unknown as { styles: { cssText: string } })
-      .styles.cssText;
+    const css = sheetOf(customElements.get('acp-axis-bar'));
     expect(css).toContain('touch-action: none');
     expect(css).toContain('.track.dragging');
   });


### PR DESCRIPTION
## Summary

Six related changes to the tile and group surfaces, prototyped against a live install and verified
there each round.

**Battery → history.** The dialog's battery readout was a static `role="img"`. It is now a button
opening HA's own History panel with every battery source in the entry (deduped — two covers on one
device share a sensor). The group dialog gains the same indicator, which it never had.

**Blind spot slots 2 and 3 — #269.** The integration has carried three blind-spot slots since its
#701 and publishes them all on `blind_spot_ranges`; `blind_spot_range` is slot 1 alone, kept for
cards written before the list. The card read the singular one as the whole truth, so a spot
configured in slot 2 or 3 was invisible and editing it changed nothing. Zero-span slots are dropped
too: an enabled-but-unconfigured slot 1 stores `0/0` and drew an invisible wedge while the real one
sat in slot 2 — the exact reported shape.

**Group roster order / hide / rename.** New `members` key carrying order *and* subset, driven from a
sortable editor list that also holds the per-row rename. Hiding reaches the **aggregates**:
`position`, `aggregate` and `whoWonCount` arrive from three sensors computed over the full roster,
so they are recomputed over the survivors the way the integration does.

`members` holds **cover entity ids**, not roster row keys. A row key resolves to an owning
`entry_id` only while the cover's owner can be found, and HA strips an unavailable entity to its
basic attributes — so the scan fails for exactly the members people hide. A row-keyed list silently
matched nothing and the roster count never moved. A list naming no current member is ignored rather
than hiding everything.

**Two-axis state line.** A layered entry (`cover_day_night_shade`, `cover_dual_panel`) whose fabrics
disagree reads `Open 100% · Closed 50%`. Detailed layout only, and only when they differ — separate
windows disagree constantly and are untouched. Venetian is excluded; its tilt bar is right below.

**"Moving to" indicator.** A striped band spans from where the cover is to where it was told to go,
capped by a diamond pip, clearing on arrival (±2%) or after 60s. The timeout is load-bearing: a
no-feedback cover never reports arrival. Armed from every commit path — tap, drag, arrow keys, the
↑/↓ buttons — and by automatic pipeline moves, evidenced by `opening`/`closing`. Stop clears it.

**Rail overlay extracted.** Four independent rail implementations now share `lib/pending-move.ts`
(the `PendingMoves` controller, arrival rule, band geometry) and `components/rail-overlay.ts`
(overlay markup + styles). Remaining consolidation — chiefly the slider/ARIA contract — is #271,
with the measured test-churn numbers for the markup merge.

**Also fixed:** a cover reporting no position was labelled *unavailable* on the group tile.
`memberException` now lets HA's own verdict win, so a one-way RTS awning sitting at `closed` with no
`current_position` stops being a permanent false warning.

## Testing

- ✅ `npm run test` — **2055 passing**, 78 files, 0 failing
- ✅ `npm run lint` — eslint + prettier clean
- ✅ `npm run build` — `dist/` rebuilt from final source
- ✅ Deployed to a live HA and verified each round; the roster, blind-spot and unavailable fixes were
  each confirmed against real entities via Developer Tools

New test files: `pending-move`, `blind-spot-slots`, `member-order`, `group-members`. The four battery
tests asserting the old readout contract were rewritten for the new one.

Harness: new `blind-spot-slots`, `group-member-order` and `moving-to-indicator` scenarios;
`layered-rails-vs-separate-covers` extended for the two-rail readout; control panel gained
blind-spot slots; mock i18n mirrored.

## Reviewer notes

- `members` lists exactly the rows to render, so a member the group gains later stays hidden until
  added — the same trade `covers` already makes for rails.
- The design review for this branch was run inline rather than by an independent model, so it is
  weaker evidence than usual. One finding it produced (a stray pip when commanding a position the
  cover already holds) is fixed here and covered by a test.

## Related Issues

Closes #272
Refs #269, #271

https://claude.ai/code/session_01QK1pxbBoWYuGwELv1B11fm
